### PR TITLE
fix: correct webhook test assertion to match endpoint behavior

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -438,9 +438,11 @@ class TestAPIEndpoints:
         data = r.json()
         assert data.get("symbol") == "BTCUSDT"
 
-    def test_webhook_test_sin_config_400(self, client):
+    def test_webhook_test_sin_config(self, client):
         r = client.get("/webhook/test")
-        assert r.status_code == 400
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ok"] is False
 
     def test_webhook_test_con_url(self, client, tmp_path, monkeypatch):
         import btc_api


### PR DESCRIPTION
## Summary
- Fixed `test_webhook_test_sin_config_400` which incorrectly expected HTTP 400 from `GET /webhook/test`
- The endpoint actually returns HTTP 200 with `{"ok": false}` when Telegram is not configured
- Renamed test to `test_webhook_test_sin_config` and updated assertions accordingly

Closes #33

## Test plan
- [ ] Run `python -m pytest tests/test_api.py -v -k test_webhook_test_sin_config` and verify it passes
- [ ] Confirm no other tests are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>