### PR TITLE
fix: replace hardcoded sandbox path in btc_report.py

### DIFF
--- a/btc_report.py
+++ b/btc_report.py
@@ -5,6 +5,7 @@ Genera un reporte HTML con métricas clave de trading para BTC/USDT
 Fuentes: Binance Futures API, Coinglass (si disponible), Farside (ETF flows)
 """
 
+import os
 import requests
 import pandas as pd
 import json
@@ -763,7 +764,9 @@ def main():
     html = generate_html_report(charts, summary)
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M")
-    out_path = f"/sessions/bold-wonderful-planck/mnt/Trading/BTC_Report_{timestamp}.html"
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    out_dir = os.environ.get("BTC_REPORT_DIR", script_dir)
+    out_path = os.path.join(out_dir, f"BTC_Report_{timestamp}.html")
     with open(out_path, "w", encoding="utf-8") as f:
         f.write(html)
 
@@ -771,4 +774,11 @@ def main():
     return out_path
 
 if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="BTC Market Intelligence Report")
+    parser.add_argument("--output-dir", "-o", default=None,
+                        help="Directorio de salida (default: directorio del script)")
+    args = parser.parse_args()
+    if args.output_dir:
+        os.environ["BTC_REPORT_DIR"] = args.output_dir
     main()


### PR DESCRIPTION
## Summary
- Replaced hardcoded sandbox session path (`/sessions/bold-wonderful-planck/mnt/Trading/`) in `btc_report.py` with a configurable output directory
- Defaults to the script's own directory, supports `--output-dir` / `-o` CLI flag, and `BTC_REPORT_DIR` environment variable
- The old path didn't exist on any real machine, making the report generator completely unusable

## Test plan
- [ ] Run `python btc_report.py` and verify the report is saved in the script's directory
- [ ] Run `python btc_report.py --output-dir /tmp` and verify the report is saved in `/tmp`
- [ ] Set `BTC_REPORT_DIR=/tmp` and run `python btc_report.py` to verify env var support

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)