### PR TITLE
fix: remove hardcoded developer paths from trading_webhook.py

### DIFF
--- a/trading_webhook.py
+++ b/trading_webhook.py
@@ -14,9 +14,35 @@ import sys
 
 # Configuration
 PORT = 9000
-TELEGRAM_TARGET = "380882623"  # Simon's Telegram chat ID
 _DIR     = os.path.dirname(os.path.abspath(__file__))
 LOG_FILE = os.path.join(_DIR, "logs", "webhook.log")
+
+def _load_webhook_config():
+    """Load telegram_chat_id and openclaw path from config.json."""
+    cfg_path = os.path.join(_DIR, "config.json")
+    cfg = {}
+    if os.path.exists(cfg_path):
+        try:
+            with open(cfg_path) as f:
+                cfg = json.load(f)
+        except Exception:
+            pass
+    return cfg
+
+def _get_telegram_target():
+    return _load_webhook_config().get("telegram_chat_id", "")
+
+def _get_openclaw_cmd():
+    cfg = _load_webhook_config()
+    configured = cfg.get("openclaw_path", "")
+    if configured and os.path.isfile(configured):
+        return configured
+    import shutil
+    found = shutil.which("openclaw")
+    if found:
+        return found
+    return "openclaw"
+
 os.makedirs(os.path.join(_DIR, "logs"), exist_ok=True)
 
 logging.basicConfig(
@@ -83,9 +109,12 @@ def construct_fallback_message(payload):
 def send_via_openclaw(message):
     """Send message to Telegram using OpenClaw CLI."""
     try:
-        # Use absolute path to openclaw.cmd
-        openclaw_cmd = r"C:\Users\simon\AppData\Roaming\npm\openclaw.cmd"
-        cmd = [openclaw_cmd, "message", "send", "--channel", "telegram", "--target", TELEGRAM_TARGET, "--message", message]
+        openclaw_cmd = _get_openclaw_cmd()
+        telegram_target = _get_telegram_target()
+        if not telegram_target:
+            logger.error("telegram_chat_id not configured in config.json")
+            return False
+        cmd = [openclaw_cmd, "message", "send", "--channel", "telegram", "--target", telegram_target, "--message", message]
         logger.info(f"Executing: {' '.join(cmd)}")
         
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)


### PR DESCRIPTION
## Summary
- Removed hardcoded Telegram chat ID (`380882623`) and Windows-specific OpenClaw path (`C:\Users\simon\...`) from `trading_webhook.py`
- Both values are now read from `config.json` at runtime (`telegram_chat_id` and `openclaw_path` keys)
- Added automatic OpenClaw binary detection via `shutil.which()` as fallback when no path is configured

## Test plan
- [ ] Verify webhook starts without errors when `config.json` has `telegram_chat_id` set
- [ ] Verify `logger.error` is emitted when `telegram_chat_id` is missing from config
- [ ] Verify OpenClaw is found via PATH when `openclaw_path` is not in config
- [ ] Verify explicit `openclaw_path` in config is used when present and valid

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)