### PR TITLE
fix: close log file handle leak in watchdog restarts

### DIFF
--- a/watchdog.py
+++ b/watchdog.py
@@ -198,6 +198,7 @@ def start_service(svc: dict):
         stdout=log_fh,
         stderr=log_fh,
     )
+    log_fh.close()  # subprocess inherits the fd; Python handle no longer needed
     svc["process"] = proc
 
     # 5. Guardar PID


### PR DESCRIPTION
## Summary
- Close the log file handle in `watchdog.py` after passing it to `subprocess.Popen`, preventing file descriptor accumulation on each service restart.

Closes #25

## Test plan
- [ ] Verify watchdog starts services correctly after the change
- [ ] Monitor file descriptor count across multiple service restarts to confirm no leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)