### PR TITLE
fix: resolve SQL injection in get_scans()

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -566,20 +566,24 @@ def save_scan(rep: dict) -> int:
 def get_scans(limit=50, only_signals=False, only_setups=False,
               since_hours: Optional[float] = None,
               symbol: Optional[str] = None) -> list:
-    con   = get_db()
-    conds = []
+    con    = get_db()
+    conds  = []
+    params = []
     if symbol:
-        conds.append(f"symbol = '{symbol.upper()}'")
+        conds.append("symbol = ?")
+        params.append(symbol.upper())
     if only_signals:
         conds.append("señal = 1")
     elif only_setups:
         conds.append("(señal = 1 OR setup = 1)")
     if since_hours:
         cutoff = (datetime.now(timezone.utc) - timedelta(hours=since_hours)).isoformat()
-        conds.append(f"ts >= '{cutoff}'")
+        conds.append("ts >= ?")
+        params.append(cutoff)
     where = ("WHERE " + " AND ".join(conds)) if conds else ""
+    params.append(limit)
     rows  = con.execute(
-        f"SELECT * FROM scans {where} ORDER BY id DESC LIMIT ?", (limit,)
+        f"SELECT * FROM scans {where} ORDER BY id DESC LIMIT ?", params
     ).fetchall()
     con.close()
     return [dict(r) for r in rows]


### PR DESCRIPTION
## Summary
- Replace string-interpolated SQL parameters in `get_scans()` with `?` placeholders to prevent SQL injection
- The `symbol` and `ts` (since_hours cutoff) values were previously concatenated directly into the query string via f-strings
- Now all user-supplied values are passed as a parameterized list to `con.execute()`

Closes #2

## Test plan
- [ ] Verify `/signals` endpoint still returns correct results when filtering by symbol
- [ ] Verify `since_hours` filtering works correctly
- [ ] Verify `only_signals` and `only_setups` filters still work
- [ ] Confirm that SQL injection payloads in the `symbol` parameter are safely escaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)