### PR TITLE
fix: guard stdout reconfigure in btc_scanner.py

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -23,11 +23,15 @@ import time
 import os
 import sys
 import json
+import io
 import logging
 
 # Reconfigure stdout for Windows Unicode support
-sys.stdout.reconfigure(encoding='utf-8')
-sys.stderr.reconfigure(encoding='utf-8')
+try:
+    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stderr.reconfigure(encoding='utf-8')
+except (AttributeError, io.UnsupportedOperation):
+    pass
 
 log = logging.getLogger("btc_scanner")
 


### PR DESCRIPTION
## Summary
- Wrapped `sys.stdout.reconfigure()` and `sys.stderr.reconfigure()` in a `try/except` block to handle `AttributeError` (Python < 3.7) and `io.UnsupportedOperation` (binary/piped streams)
- Added `import io` to support the exception type

## Test plan
- [ ] Run `python btc_scanner.py --once` normally to verify no regression
- [ ] Run `python btc_scanner.py --once | cat` (piped stdout) to verify it no longer crashes
- [ ] Verify on Python < 3.7 if available

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)