### PR TITLE
fix: connect push_webhook() to scanner loop and force scan

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -843,6 +843,8 @@ def scanner_loop():
 
                 if should_notify_signal(rep, cfg):
                     push_telegram_direct(rep, cfg)
+                    if cfg.get("webhook_url", "").strip():
+                        push_webhook(rep, scan_id, cfg)
                 else:
                     log.info(f"{sym}: {estado[:55]}")
 
@@ -994,6 +996,8 @@ def force_scan(
 
             if should_notify_signal(rep, cfg):
                 push_telegram_direct(rep, cfg)
+                if cfg.get("webhook_url", "").strip():
+                    push_webhook(rep, scan_id, cfg)
 
             results.append({
                 "symbol":    sym,


### PR DESCRIPTION
## Summary
- Connected the existing `push_webhook()` function to both `scanner_loop` and `force_scan` endpoint
- Previously, webhook notifications were silently skipped even when `webhook_url` was configured

## Changes
- `btc_api.py`: Added `push_webhook()` call after `push_telegram_direct()` in both notification paths, gated on `webhook_url` being configured

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)