### PR TITLE
fix: guard json.loads against malformed payload data

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -1054,7 +1054,10 @@ def latest_signal(
     if not row:
         msg = f"Sin señales para {symbol}." if symbol else "Sin señales registradas."
         return {"message": msg, "señal": None}
-    payload = json.loads(row["payload"]) if row.get("payload") else {}
+    try:
+        payload = json.loads(row["payload"]) if row.get("payload") else {}
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
     return {
         "id":            row["id"],
         "ts":            row["ts"],
@@ -1082,7 +1085,10 @@ def latest_message(
     row = get_latest_signal(symbol)
     if not row:
         return {"message": "Sin señales registradas aun."}
-    payload = json.loads(row["payload"]) if row.get("payload") else {}
+    try:
+        payload = json.loads(row["payload"]) if row.get("payload") else {}
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
     return {
         "scan_id": row["id"],
         "symbol":  row["symbol"],

--- a/btc_api.py
+++ b/btc_api.py
@@ -1105,7 +1105,10 @@ def signal_by_id(scan_id: int):
     if not row:
         raise HTTPException(status_code=404, detail=f"Escaneo #{scan_id} no encontrado")
     row     = dict(row)
-    payload = json.loads(row["payload"]) if row.get("payload") else {}
+    try:
+        payload = json.loads(row["payload"]) if row.get("payload") else {}
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
     return {**row, "full_report": payload,
             "telegram_message": build_telegram_message(payload)}
 


### PR DESCRIPTION
## Summary
- Wrapped `json.loads(row["payload"])` in try/except in two signal endpoints
- Prevents HTTP 500 when payload column contains empty strings or corrupted JSON

## Changes
- `btc_api.py`: Added `JSONDecodeError`/`TypeError` handling in `/signals/latest` and `/signals/latest/message`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)