### PR TITLE
fix: declare missing CSS custom properties --accent and --page-pad

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -37,6 +37,8 @@
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
 
+  --accent: #63b3ed;
+  --page-pad: 20px;
   --header-height: 64px;
   --transition: 150ms ease;
 }


### PR DESCRIPTION
## Summary
- Added `--accent: #63b3ed` and `--page-pad: 20px` to `:root` in App.css
- These variables were referenced throughout the stylesheet but never declared

## Changes
- `frontend/src/App.css`: Two new CSS custom properties in `:root` block

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)