### PR TITLE
fix: correct SymbolCard label from 'Macro' to 'Trigger'

### DIFF
--- a/frontend/src/components/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard.tsx
@@ -155,7 +155,7 @@ const SymbolCard: React.FC<SymbolCardProps> = ({ symbol, onClick }) => {
       {/* Footer: macro + time */}
       <div className="card-footer">
         <span className={`macro-badge ${symbol.gatillo ? 'macro-badge--ok' : 'macro-badge--ko'}`}>
-          Macro {symbol.gatillo ? '✓' : '✗'}
+          Trigger {symbol.gatillo ? '✓' : '✗'}
         </span>
         <span className="card-time" title={tsFormatted}>
           {symbol.ts ? timeAgo(symbol.ts) : '—'}


### PR DESCRIPTION
## Summary
- Changed the footer label in SymbolCard from "Macro" to "Trigger"
- The `gatillo` field is the 5M entry trigger, not the 4H macro filter — label was misleading

## Changes
- `frontend/src/components/SymbolCard.tsx`: Label text corrected

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)