### PR TITLE
fix: validate exit price before closing position

### DIFF
--- a/frontend/src/components/PositionsPanel.tsx
+++ b/frontend/src/components/PositionsPanel.tsx
@@ -102,7 +102,11 @@ const CloseRow: React.FC<CloseRowProps> = ({ pos, currentPrice, onConfirm, onCan
       </div>
       <button
         className="btn btn-sm btn-danger"
-        onClick={() => onConfirm(parseFloat(exitPrice) || 0)}
+        onClick={() => {
+          const price = parseFloat(exitPrice);
+          if (isNaN(price) || price <= 0) { alert('Ingresa un precio de salida válido'); return; }
+          onConfirm(price);
+        }}
       >Confirmar</button>
       <button className="btn btn-sm btn-secondary" onClick={onCancel}>Cancelar</button>
     </div>


### PR DESCRIPTION
## Summary
- Added validation to prevent exit price of 0 when closing a position
- Previously, clearing the input and confirming would set `exit_price = 0` via `parseFloat("") || 0`

## Changes
- `frontend/src/components/PositionsPanel.tsx`: Added `isNaN` and `<= 0` check before calling `onConfirm`

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)