### PR TITLE
fix: use population std (ddof=0) for Bollinger Bands consistency

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -325,7 +325,7 @@ def calc_rsi(close: pd.Series, period=14):
 
 def calc_bb(close: pd.Series, period=20, k=2.0):
     sma = close.rolling(period).mean()
-    std = close.rolling(period).std()
+    std = close.rolling(period).std(ddof=0)
     return sma + k * std, sma, sma - k * std   # upper, mid, lower
 
 


### PR DESCRIPTION
## Summary
- Changed `close.rolling(period).std()` to `close.rolling(period).std(ddof=0)` in `calc_bb()` (btc_scanner.py line 328)
- Charting platforms like TradingView and MetaTrader use population standard deviation (ddof=0) for Bollinger Bands, while pandas defaults to sample standard deviation (ddof=1)
- This caused subtle differences in band width calculations compared to reference platforms

Closes #19

## Test plan
- [ ] Run `python -m pytest tests/ -v` to verify no regressions
- [ ] Compare BB values against TradingView for a sample symbol to confirm alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)