### PR TITLE
feat: add GitHub Actions CI for backend tests and frontend type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements_scanner.txt
+          pip install fastapi uvicorn httpx pytest
+
+      - name: Run tests
+        run: python -m pytest tests/ -v --tb=short
+
+  frontend-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: TypeScript type check
+        working-directory: frontend
+        run: npx tsc --noEmit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements_scanner.txt
-          pip install fastapi uvicorn httpx pytest
+          pip install -r requirements.txt
+          pip install httpx pytest
 
       - name: Run tests
         run: python -m pytest tests/ -v --tb=short


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with two jobs: `backend-tests` (Python 3.11, pytest) and `frontend-typecheck` (Node 20, tsc --noEmit)
- Runs automatically on every push to `main` and every pull request targeting `main`
- Uses pip/npm caching for faster CI runs

## Test plan
- [ ] Verify the workflow triggers on PR creation
- [ ] Confirm `backend-tests` job installs dependencies from `requirements_scanner.txt` and runs pytest successfully
- [ ] Confirm `frontend-typecheck` job runs `npm ci` and `npx tsc --noEmit` without errors

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)