### PR TITLE
fix: correct score range from 0-10 to 0-9 in docs and logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ python -m pytest tests/test_api.py -v       # API endpoints only
 ```
 Binance API (Bybit fallback)
   → btc_scanner.py: fetch OHLCV, calculate LRC/RSI/BB/SMA100
-  → Multi-timeframe scoring (0–10)
+  → Multi-timeframe scoring (0–9)
   → btc_api.py: store to signals.db (SQLite), evaluate notification filters
   → trading_webhook.py (port 9000) → OpenClaw CLI → Telegram
      OR n8n workflow (port 5678) → Telegram node

--- a/btc_api.py
+++ b/btc_api.py
@@ -231,7 +231,7 @@ def append_signal_log(rep: dict, scan_id: int):
             f"[{ts} UTC]  {tipo}  {sym}  (scan_id={scan_id})",
             sep,
             f"  Precio : ${price:>12,.4f}",
-            f"  LRC 1H : {lrc}%   Score: {score}/10  {slabel}",
+            f"  LRC 1H : {lrc}%   Score: {score}/9  {slabel}",
             f"  Macro  : {macro_s}",
         ]
         if is_sig:
@@ -661,7 +661,7 @@ def build_telegram_message(rep: dict) -> str:
         "",
         f"*Precio:* `${price:,.2f}`",
         f"*LRC 1H:* `{lrc.get('pct')}%`  _(zona <= 25% = LONG)_",
-        f"*Score:* `{score}/10`  _{slabel}_",
+        f"*Score:* `{score}/9`  _{slabel}_",
         f"*Macro 4H:* `{'Alcista' if macro.get('price_above') else 'Adversa'}`  _(Precio vs SMA100)_",
         "",
     ]
@@ -832,12 +832,12 @@ def scanner_loop():
 
                 if is_signal:
                     _scanner_state["signals_total"] += 1
-                    log.info(f"SENAL {sym} — score {rep.get('score')}/10  "
+                    log.info(f"SENAL {sym} — score {rep.get('score')}/9  "
                              f"precio ${rep.get('price')}")
                     append_signal_log(rep, scan_id)
                     append_signal_csv(rep, scan_id)
                 elif is_setup:
-                    log.info(f"SETUP {sym} — score {rep.get('score')}/10 (sin gatillo)")
+                    log.info(f"SETUP {sym} — score {rep.get('score')}/9 (sin gatillo)")
                     append_signal_log(rep, scan_id)
                     append_signal_csv(rep, scan_id)
 

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -664,7 +664,7 @@ def fmt(rep):
         f"  Precio > SMA100  : {ok(rep['macro_4h']['price_above'])}  "
         f"({'alcista ✅' if rep['macro_4h']['price_above'] else 'bajista ⚠️ — solo operar si hay confluencia fuerte'})",
         DIV,
-        f"  ── SCORE 1H : {rep['score']}/10  ({rep['score_label']}) ──────────────────",
+        f"  ── SCORE 1H : {rep['score']}/9  ({rep['score_label']}) ──────────────────",
     ]
 
     for k, v in rep.get("confirmations", {}).items():


### PR DESCRIPTION
## Summary
- Corrected all score range references from "0-10" to "0-9" across documentation and log messages
- The maximum automated score is 9 (C1=2 + C2=2 + C3=1 + C4=1 + C5=1 + C6=1 + C7=1). C8 (DXY) is a manual placeholder that never contributes to the score
- Updated references in `CLAUDE.md` (architecture section), `btc_api.py` (4 log/message strings), and `btc_scanner.py` (1 console output string)
- No logic changes — only documentation, comments, and log message strings were modified

Closes #20

## Test plan
- [ ] Verify no actual scoring logic was changed (only strings)
- [ ] Confirm `btc_scanner.py` score output displays `/9` instead of `/10`
- [ ] Confirm `btc_api.py` log messages and Telegram messages display `/9`
- [ ] Confirm `CLAUDE.md` architecture section says "0-9"

🤖 Generated with [Claude Code](https://claude.com/claude-code)