### PR TITLE
feat: add React Error Boundary to prevent full app crashes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2296,3 +2296,17 @@ button:focus-visible {
   .pos-form-row { flex-direction: column; }
   .pos-dir-toggle { max-width: 200px; }
 }
+
+/* Error Boundary */
+.error-boundary {
+  padding: 32px;
+  text-align: center;
+  background: var(--bg-card);
+  border: 1px solid var(--red-dim);
+  border-radius: var(--radius-lg);
+  margin: 16px 0;
+}
+.error-boundary-content { max-width: 400px; margin: 0 auto; }
+.error-boundary-icon { font-size: 2rem; display: block; margin-bottom: 8px; }
+.error-boundary h3 { color: var(--text-primary); margin: 0 0 8px; }
+.error-boundary-msg { color: var(--text-secondary); font-size: 0.85rem; margin: 0 0 16px; word-break: break-word; }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { getSymbols, getStatus, getSignals, forceScan } from './api';
 import type { SymbolStatus, StatusResponse, Signal } from './types';
 import ChartModal from './components/ChartModal';
+import ErrorBoundary from './components/ErrorBoundary';
 import Header from './components/Header';
 import StatusBar from './components/StatusBar';
 import SymbolsGrid from './components/SymbolsGrid';
@@ -134,28 +135,34 @@ const App: React.FC = () => {
         {/* ── Mercado tab ──────────────────────────────────── */}
         {mainTab === 'mercado' && (
           <>
-            <SymbolsGrid
-              symbols={symbols}
-              loading={loading}
-              filter={filter}
-              onFilterChange={setFilter}
-              onSymbolClick={setSelectedSymbol}
-            />
-            <SignalsTable
-              signals={signals}
-              loading={loading}
-              onOpenPosition={handleOpenFromSignal}
-            />
+            <ErrorBoundary fallbackLabel="Error en el grid de simbolos">
+              <SymbolsGrid
+                symbols={symbols}
+                loading={loading}
+                filter={filter}
+                onFilterChange={setFilter}
+                onSymbolClick={setSelectedSymbol}
+              />
+            </ErrorBoundary>
+            <ErrorBoundary fallbackLabel="Error en la tabla de senales">
+              <SignalsTable
+                signals={signals}
+                loading={loading}
+                onOpenPosition={handleOpenFromSignal}
+              />
+            </ErrorBoundary>
           </>
         )}
 
         {/* ── Posiciones tab ───────────────────────────────── */}
         {mainTab === 'posiciones' && (
-          <PositionsPanel
-            symbols={symbols}
-            onOpenFromSignal={signalForPos}
-            onSignalConsumed={() => setSignalForPos(null)}
-          />
+          <ErrorBoundary fallbackLabel="Error en el panel de posiciones">
+            <PositionsPanel
+              symbols={symbols}
+              onOpenFromSignal={signalForPos}
+              onSignalConsumed={() => setSignalForPos(null)}
+            />
+          </ErrorBoundary>
         )}
       </main>
 

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React, { Component, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallbackLabel?: string;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="error-boundary">
+          <div className="error-boundary-content">
+            <span className="error-boundary-icon">⚠</span>
+            <h3>{this.props.fallbackLabel ?? 'Algo salio mal'}</h3>
+            <p className="error-boundary-msg">{this.state.error?.message}</p>
+            <button
+              className="btn btn-primary"
+              onClick={() => this.setState({ hasError: false, error: null })}
+            >
+              Reintentar
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- Created `ErrorBoundary` class component (`frontend/src/components/ErrorBoundary.tsx`) that catches render errors and displays a localized fallback UI with a retry button
- Wrapped `SymbolsGrid`, `SignalsTable`, and `PositionsPanel` independently in `App.tsx` so a crash in one section does not kill the entire dashboard
- Added minimal CSS styles for the error boundary fallback UI to `App.css`

## Test plan
- [ ] Verify `npx tsc --noEmit` passes with no errors
- [ ] Simulate a render error in one component (e.g., throw in `SymbolsGrid`) and confirm only that section shows the error fallback while the rest of the app remains functional
- [ ] Click the "Reintentar" button and confirm the component re-renders correctly
- [ ] Verify no visual regressions in normal operation (no errors present)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)