### PR TITLE
feat: add log rotation to prevent unbounded log file growth

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -29,6 +29,7 @@ import time
 import requests as req_lib
 from datetime import datetime, timezone, timedelta
 import logging
+from logging.handlers import RotatingFileHandler
 
 import sys
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/trading_webhook.py
+++ b/trading_webhook.py
@@ -7,6 +7,7 @@ Uses the preformatted telegram_message from the scanner payload.
 
 import json
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import subprocess
@@ -23,7 +24,12 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler(LOG_FILE, encoding='utf-8'),
+        RotatingFileHandler(
+            LOG_FILE,
+            maxBytes=5 * 1024 * 1024,  # 5 MB per file
+            backupCount=5,              # keep 5 old files
+            encoding="utf-8",
+        ),
         logging.StreamHandler()
     ]
 )

--- a/watchdog.py
+++ b/watchdog.py
@@ -14,6 +14,7 @@ import sys
 import os
 import time
 import logging
+from logging.handlers import RotatingFileHandler
 from datetime import datetime, timezone
 
 SCRIPT_DIR     = os.path.dirname(os.path.abspath(__file__))
@@ -40,7 +41,12 @@ logging.basicConfig(
     format="%(asctime)s  %(levelname)-8s  %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
     handlers=[
-        logging.FileHandler(LOG_FILE, encoding="utf-8"),
+        RotatingFileHandler(
+            LOG_FILE,
+            maxBytes=5 * 1024 * 1024,  # 5 MB per file
+            backupCount=5,              # keep 5 old files
+            encoding="utf-8",
+        ),
         logging.StreamHandler(sys.stdout),
     ],
 )


### PR DESCRIPTION
## Summary
- Replaced `logging.FileHandler` with `RotatingFileHandler` (5 MB max, 5 backups) in `watchdog.py` and `trading_webhook.py`
- Added `from logging.handlers import RotatingFileHandler` import to `btc_api.py` for consistency (its stdout is already redirected to a log file by the watchdog)
- Prevents disk exhaustion in a 24/7 system scanning every 5 minutes

## Test plan
- [ ] Verify `watchdog.py` starts without import errors
- [ ] Verify `trading_webhook.py` starts without import errors
- [ ] Confirm logs rotate when they exceed 5 MB (can lower `maxBytes` temporarily to test)
- [ ] Confirm up to 5 backup files are kept (e.g., `watchdog.log.1` through `watchdog.log.5`)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)