### PR TITLE
feat: add signal deduplication to prevent repeated notifications

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -78,6 +78,7 @@ def load_config() -> dict:
             "min_score":       0,      # score mínimo para enviar (0 = sin filtro)
             "require_macro_ok": False, # exigir macro 4H alcista
             "notify_setup":    False,  # enviar también setups sin gatillo
+            "dedup_window_minutes": 30, # ventana de deduplicación (minutos)
         },
     }
     if os.path.exists(CONFIG_FILE):
@@ -134,6 +135,30 @@ def should_notify_signal(rep: dict, cfg: dict) -> bool:
         return True
 
     return False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  DEDUPLICACIÓN DE SEÑALES
+# ─────────────────────────────────────────────────────────────────────────────
+
+_notified_signals: dict = {}  # symbol -> last_notified_iso
+
+
+def _is_duplicate_signal(symbol: str, cfg: dict) -> bool:
+    """Check if we already notified for this symbol within the dedup window."""
+    filters = cfg.get("signal_filters", {})
+    window_minutes = filters.get("dedup_window_minutes", 30)
+    last = _notified_signals.get(symbol)
+    if not last:
+        return False
+    last_dt = datetime.fromisoformat(last)
+    now = datetime.now(timezone.utc)
+    return (now - last_dt).total_seconds() < window_minutes * 60
+
+
+def _mark_notified(symbol: str):
+    """Mark a symbol as notified now."""
+    _notified_signals[symbol] = datetime.now(timezone.utc).isoformat()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -842,7 +867,11 @@ def scanner_loop():
                     append_signal_csv(rep, scan_id)
 
                 if should_notify_signal(rep, cfg):
-                    push_telegram_direct(rep, cfg)
+                    if not _is_duplicate_signal(sym, cfg):
+                        push_telegram_direct(rep, cfg)
+                        _mark_notified(sym)
+                    else:
+                        log.info(f"{sym}: senal duplicada, notificacion omitida")
                 else:
                     log.info(f"{sym}: {estado[:55]}")
 
@@ -993,7 +1022,11 @@ def force_scan(
                 append_signal_csv(rep, scan_id)
 
             if should_notify_signal(rep, cfg):
-                push_telegram_direct(rep, cfg)
+                if not _is_duplicate_signal(sym, cfg):
+                    push_telegram_direct(rep, cfg)
+                    _mark_notified(sym)
+                else:
+                    log.info(f"{sym}: senal duplicada, notificacion omitida (force_scan)")
 
             results.append({
                 "symbol":    sym,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ import pytest
 import sqlite3
 import tempfile
 from unittest.mock import patch, MagicMock
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -569,3 +569,85 @@ class TestLoadConfig:
         # notify_setup_only debe tener valor por defecto
         assert "notify_setup_only" in cfg
         assert cfg["notify_setup_only"] is False
+
+    def test_dedup_window_default(self, tmp_path, monkeypatch):
+        import btc_api
+        cfg_path = str(tmp_path / "config.json")
+        with open(cfg_path, "w") as f:
+            json.dump({}, f)
+        monkeypatch.setattr(btc_api, "CONFIG_FILE", cfg_path)
+        cfg = btc_api.load_config()
+        assert cfg["signal_filters"]["dedup_window_minutes"] == 30
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  TESTS — Signal deduplication
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSignalDeduplication:
+    @pytest.fixture(autouse=True)
+    def clear_notified(self):
+        """Clear the in-memory dedup tracker before each test."""
+        import btc_api
+        btc_api._notified_signals.clear()
+        yield
+        btc_api._notified_signals.clear()
+
+    def test_first_signal_is_not_duplicate(self):
+        import btc_api
+        cfg = {"signal_filters": {"dedup_window_minutes": 30}}
+        assert btc_api._is_duplicate_signal("BTCUSDT", cfg) is False
+
+    def test_same_symbol_is_duplicate_within_window(self):
+        import btc_api
+        cfg = {"signal_filters": {"dedup_window_minutes": 30}}
+        btc_api._mark_notified("BTCUSDT")
+        assert btc_api._is_duplicate_signal("BTCUSDT", cfg) is True
+
+    def test_different_symbol_is_not_duplicate(self):
+        import btc_api
+        cfg = {"signal_filters": {"dedup_window_minutes": 30}}
+        btc_api._mark_notified("BTCUSDT")
+        assert btc_api._is_duplicate_signal("ETHUSDT", cfg) is False
+
+    def test_signal_outside_window_is_not_duplicate(self):
+        import btc_api
+        cfg = {"signal_filters": {"dedup_window_minutes": 30}}
+        # Simulate a notification from 31 minutes ago
+        old_ts = (datetime.now(timezone.utc) - timedelta(minutes=31)).isoformat()
+        btc_api._notified_signals["BTCUSDT"] = old_ts
+        assert btc_api._is_duplicate_signal("BTCUSDT", cfg) is False
+
+    def test_signal_inside_window_is_duplicate(self):
+        import btc_api
+        cfg = {"signal_filters": {"dedup_window_minutes": 30}}
+        # Simulate a notification from 10 minutes ago
+        recent_ts = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+        btc_api._notified_signals["BTCUSDT"] = recent_ts
+        assert btc_api._is_duplicate_signal("BTCUSDT", cfg) is True
+
+    def test_custom_dedup_window(self):
+        import btc_api
+        cfg = {"signal_filters": {"dedup_window_minutes": 5}}
+        # 6 minutes ago should be outside a 5-minute window
+        old_ts = (datetime.now(timezone.utc) - timedelta(minutes=6)).isoformat()
+        btc_api._notified_signals["BTCUSDT"] = old_ts
+        assert btc_api._is_duplicate_signal("BTCUSDT", cfg) is False
+
+    def test_mark_notified_updates_timestamp(self):
+        import btc_api
+        cfg = {"signal_filters": {"dedup_window_minutes": 30}}
+        btc_api._mark_notified("BTCUSDT")
+        ts1 = btc_api._notified_signals["BTCUSDT"]
+        assert ts1 is not None
+        # Mark again — timestamp should be present
+        btc_api._mark_notified("BTCUSDT")
+        ts2 = btc_api._notified_signals["BTCUSDT"]
+        assert ts2 >= ts1
+
+    def test_default_window_from_config(self):
+        """When dedup_window_minutes is not set, default to 30."""
+        import btc_api
+        cfg = {"signal_filters": {}}
+        btc_api._mark_notified("BTCUSDT")
+        assert btc_api._is_duplicate_signal("BTCUSDT", cfg) is True


### PR DESCRIPTION
## Summary
- Adds in-memory signal deduplication to prevent the same symbol from triggering repeated Telegram notifications within a configurable time window (default 30 minutes)
- Integrates dedup check into both the background `scanner_loop()` and the manual `/scan` endpoint notification paths
- Adds `dedup_window_minutes` to `signal_filters` config (default 30), making the window configurable via `config.json` or the `/config` API

## Changes
- **`btc_api.py`**: Added `_is_duplicate_signal()`, `_mark_notified()`, and `_notified_signals` in-memory tracker. Both `scanner_loop()` and `force_scan()` now check for duplicates before calling `push_telegram_direct()`. Added `dedup_window_minutes` to `load_config()` defaults.
- **`tests/test_api.py`**: Added 9 new tests covering dedup logic (first signal not duplicate, same symbol duplicate within window, different symbol not duplicate, outside window not duplicate, custom window, default config, mark updates timestamp).

## Test plan
- [x] All 8 `TestSignalDeduplication` tests pass
- [x] `TestLoadConfig::test_dedup_window_default` passes
- [x] All pre-existing tests unaffected (54 pass, 2 pre-existing failures unchanged)
- [ ] Manual verification: configure `signal_filters.dedup_window_minutes` via `/config` endpoint and confirm repeated scans of same symbol only notify once within window

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)