### PR TITLE
fix: clamp LRC percentage to 0-100 range

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -309,7 +309,11 @@ def calc_lrc(close: pd.Series, period=100, k=2.0):
     lower = reg[-1] - k * std
     mid   = reg[-1]
     price = close.iloc[-1]
-    lrc_pct = (price - lower) / (upper - lower) * 100 if upper != lower else 50.0
+    if abs(upper - lower) < 1e-10:
+        lrc_pct = 50.0
+    else:
+        lrc_pct = (price - lower) / (upper - lower) * 100
+        lrc_pct = max(0.0, min(100.0, lrc_pct))
     return round(lrc_pct, 2), round(upper, 2), round(lower, 2), round(mid, 2)
 
 


### PR DESCRIPTION
## Summary
- Clamps `lrc_pct` to [0, 100] range in `calc_lrc()` when price is outside the regression channel bands, matching standard charting platform behavior (e.g., TradingView)
- Replaces exact `upper != lower` equality check with floating-point tolerance (`abs(upper - lower) < 1e-10`) to correctly handle constant price series
- Fixes the failing `test_precio_bajo_da_pct_bajo` test

## Details
The `lrc_pct` value in `calc_lrc()` could exceed 100% or go below 0% when price was outside the channel bands. For example, a constant price series produced `lrc_pct = 166.67` due to floating-point precision making `std` slightly non-zero, bypassing the `upper != lower` guard.

The fix:
1. Uses `abs(upper - lower) < 1e-10` tolerance check instead of exact equality -- returns 50.0 for effectively flat channels
2. Clamps `lrc_pct` to `max(0.0, min(100.0, lrc_pct))` for all other cases -- standard behavior where price outside the channel maps to boundary (0% or 100%)

## Test plan
- [x] `python -m pytest tests/test_scanner.py::TestCalcLRC -v` -- all 5 tests pass

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)