### PR TITLE
feat: add retry with exponential backoff for Telegram notifications

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -704,27 +704,42 @@ def build_telegram_message(rep: dict) -> str:
 _TELEGRAM_API = "https://api.telegram.org/bot{token}/sendMessage"
 
 
-def push_telegram_direct(rep: dict, cfg: dict):
-    """Envía señal directo a Telegram (sin n8n). Usa telegram_bot_token del config."""
+def push_telegram_direct(rep: dict, cfg: dict, max_retries: int = 3):
+    """Envía señal directo a Telegram con retry y backoff exponencial."""
     token   = cfg.get("telegram_bot_token", "").strip()
     chat_id = cfg.get("telegram_chat_id", "").strip()
     if not token or not chat_id:
         log.debug("Telegram directo no configurado (falta bot_token o chat_id)")
-        return
+        return False
+
     msg = build_telegram_message(rep)
     url = _TELEGRAM_API.format(token=token)
-    try:
-        r = req_lib.post(url, json={
-            "chat_id":    chat_id,
-            "text":       msg,
-            "parse_mode": "Markdown",
-        }, timeout=10)
-        if r.ok:
-            log.info(f"Telegram directo OK [{rep.get('symbol')}] -> chat {chat_id}")
-        else:
+
+    for attempt in range(max_retries):
+        try:
+            r = req_lib.post(url, json={
+                "chat_id":    chat_id,
+                "text":       msg,
+                "parse_mode": "Markdown",
+            }, timeout=10)
+            if r.ok:
+                log.info(f"Telegram directo OK [{rep.get('symbol')}] -> chat {chat_id}")
+                return True
+            if r.status_code == 429:  # Rate limited
+                retry_after = int(r.headers.get("Retry-After", 2 ** attempt))
+                log.warning(f"Telegram rate limited, retry in {retry_after}s")
+                time.sleep(retry_after)
+                continue
             log.warning(f"Telegram directo fallo HTTP {r.status_code}: {r.text[:120]}")
-    except Exception as e:
-        log.warning(f"Telegram directo error: {e}")
+            if attempt < max_retries - 1:
+                time.sleep(2 ** attempt)
+        except Exception as e:
+            log.warning(f"Telegram directo error (attempt {attempt+1}/{max_retries}): {e}")
+            if attempt < max_retries - 1:
+                time.sleep(2 ** attempt)
+
+    log.error(f"Telegram: todos los intentos fallaron para [{rep.get('symbol')}]")
+    return False
 
 
 def push_webhook(rep: dict, scan_id: int, cfg: dict):


### PR DESCRIPTION
## Summary
- Add retry logic (up to 3 attempts) with exponential backoff to `push_telegram_direct()` in `btc_api.py`
- Handle Telegram rate-limit responses (HTTP 429) by respecting the `Retry-After` header
- Return `True`/`False` from the function to indicate delivery success, preventing permanent message loss on transient failures

## Test plan
- [ ] Verify normal Telegram sending still works via `GET /webhook/test`
- [ ] Simulate network timeout to confirm retry attempts are logged and backoff is applied
- [ ] Simulate HTTP 429 response to confirm `Retry-After` header is respected
- [ ] Confirm existing callers (`push_telegram_direct(rep, cfg)`) work without changes (default `max_retries=3`)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)