### PR TITLE
feat: add security headers to nginx configuration

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -7,6 +7,13 @@ server {
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;
 
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
     # Archivos estáticos de React
     location / {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
## Summary
- Adds five non-breaking security headers to `frontend/nginx.conf`: X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, and Permissions-Policy.
- Headers are placed at the `server` block level so they apply to all responses.
- CSP and HSTS are intentionally omitted: CSP may break inline styles/scripts, and HSTS requires HTTPS which is not yet configured.

## Test plan
- [ ] Rebuild the Docker frontend image and verify headers appear on responses (`curl -I http://localhost:3000`)
- [ ] Confirm the dashboard loads without errors (no broken inline styles or scripts)
- [ ] Verify API proxy responses at `/api/` still work correctly

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)