### PR TITLE
feat: add environment variable overrides for configuration

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -89,7 +89,36 @@ def load_config() -> dict:
         if "signal_filters" in stored:
             sf_defaults.update(stored["signal_filters"])
         defaults["signal_filters"] = sf_defaults
-    return defaults
+
+    # ENV var overrides (for Docker/container deployments)
+    cfg = defaults
+    _env_map = {
+        "TRADING_WEBHOOK_URL":       "webhook_url",
+        "TRADING_TELEGRAM_CHAT_ID":  "telegram_chat_id",
+        "TRADING_TELEGRAM_BOT_TOKEN": "telegram_bot_token",
+        "TRADING_WEBHOOK_SECRET":    "webhook_secret",
+        "TRADING_API_KEY":           "api_key",
+        "TRADING_PROXY":             "proxy",
+    }
+    _env_map_int = {
+        "TRADING_SCAN_INTERVAL": "scan_interval_sec",
+        "TRADING_NUM_SYMBOLS":   "num_symbols",
+    }
+
+    for env_key, cfg_key in _env_map.items():
+        val = os.environ.get(env_key)
+        if val is not None:
+            cfg[cfg_key] = val
+
+    for env_key, cfg_key in _env_map_int.items():
+        val = os.environ.get(env_key)
+        if val is not None:
+            try:
+                cfg[cfg_key] = int(val)
+            except ValueError:
+                pass
+
+    return cfg
 
 
 def save_config(updates: dict) -> dict:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -569,3 +569,23 @@ class TestLoadConfig:
         # notify_setup_only debe tener valor por defecto
         assert "notify_setup_only" in cfg
         assert cfg["notify_setup_only"] is False
+
+    def test_env_var_override(self, tmp_path, monkeypatch):
+        import btc_api
+        cfg_path = str(tmp_path / "config.json")
+        with open(cfg_path, "w") as f:
+            json.dump({"telegram_chat_id": "from_file"}, f)
+        monkeypatch.setattr(btc_api, "CONFIG_FILE", cfg_path)
+        monkeypatch.setenv("TRADING_TELEGRAM_CHAT_ID", "from_env")
+        cfg = btc_api.load_config()
+        assert cfg["telegram_chat_id"] == "from_env"  # ENV takes precedence
+
+    def test_env_var_int_conversion(self, tmp_path, monkeypatch):
+        import btc_api
+        cfg_path = str(tmp_path / "config.json")
+        with open(cfg_path, "w") as f:
+            json.dump({}, f)
+        monkeypatch.setattr(btc_api, "CONFIG_FILE", cfg_path)
+        monkeypatch.setenv("TRADING_SCAN_INTERVAL", "120")
+        cfg = btc_api.load_config()
+        assert cfg["scan_interval_sec"] == 120


### PR DESCRIPTION
## Summary
- Add `TRADING_*` environment variable overrides to `load_config()` in `btc_api.py`, so config values can be injected via environment (e.g. in Docker/container deployments)
- String vars: `TRADING_WEBHOOK_URL`, `TRADING_TELEGRAM_CHAT_ID`, `TRADING_TELEGRAM_BOT_TOKEN`, `TRADING_WEBHOOK_SECRET`, `TRADING_API_KEY`, `TRADING_PROXY`
- Integer vars: `TRADING_SCAN_INTERVAL`, `TRADING_NUM_SYMBOLS`
- ENV vars take precedence over `config.json` values
- Added 2 tests in `TestLoadConfig`: `test_env_var_override` and `test_env_var_int_conversion`

## Test plan
- [x] `test_env_var_override` — verifies ENV takes precedence over file value
- [x] `test_env_var_int_conversion` — verifies integer ENV vars are properly converted
- [x] All existing `TestLoadConfig` tests still pass (5/5)
- [x] Full test suite: 47/49 pass (2 pre-existing failures in `test_webhook_test_*` unrelated to this change)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)