### PR TITLE
feat: add automatic DB backup every ~24h with 7-backup retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ config.json
 signals.db
 signals.db-journal
 signals.db-wal
+backups/
 data/symbols_status.json
 data/signals_history.csv
 data/positions_summary.json

--- a/btc_api.py
+++ b/btc_api.py
@@ -26,6 +26,8 @@ import sqlite3
 import json
 import os
 import time
+import shutil
+import glob
 import requests as req_lib
 from datetime import datetime, timezone, timedelta
 import logging
@@ -466,6 +468,30 @@ def get_active_symbols(n: int = 20) -> List[str]:
 #  BASE DE DATOS  (SQLite)
 # ─────────────────────────────────────────────────────────────────────────────
 
+_BACKUP_DIR = os.path.join(SCRIPT_DIR, "backups")
+_BACKUP_INTERVAL_SCANS = 288  # ~24h at 5min intervals
+_BACKUP_MAX_FILES = 7
+
+
+def backup_db():
+    """Create a timestamped backup of signals.db. Keeps last 7 backups."""
+    if not os.path.exists(DB_FILE):
+        return
+    os.makedirs(_BACKUP_DIR, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = os.path.join(_BACKUP_DIR, f"signals_{timestamp}.db")
+    try:
+        shutil.copy2(DB_FILE, backup_path)
+        log.info(f"DB backup: {backup_path}")
+        # Cleanup old backups
+        backups = sorted(glob.glob(os.path.join(_BACKUP_DIR, "signals_*.db")))
+        for old in backups[:-_BACKUP_MAX_FILES]:
+            os.remove(old)
+            log.info(f"DB backup removed: {old}")
+    except Exception as e:
+        log.warning(f"DB backup failed: {e}")
+
+
 def get_db():
     con = sqlite3.connect(DB_FILE)
     con.row_factory = sqlite3.Row
@@ -474,6 +500,7 @@ def get_db():
 
 def init_db():
     con = get_db()
+    con.execute("PRAGMA journal_mode=WAL")
     con.execute("""
         CREATE TABLE IF NOT EXISTS scans (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -864,6 +891,10 @@ def scanner_loop():
             update_positions_json()
         except Exception as e:
             log.warning(f"update_positions_json error en ciclo: {e}")
+
+        # Periodic DB backup (~every 24h)
+        if _scanner_state["scans_total"] % _BACKUP_INTERVAL_SCANS == 0 and _scanner_state["scans_total"] > 0:
+            backup_db()
 
         elapsed    = time.time() - cycle_start
         sleep_time = max(5, interval - elapsed)


### PR DESCRIPTION
## Summary

- Adds a `backup_db()` function that creates timestamped copies of `signals.db` into a `backups/` directory, keeping the 7 most recent backups and cleaning up older ones
- Integrates backup into the scanner loop, triggering every 288 scan cycles (~24h at the default 5-minute scan interval)
- Enables SQLite WAL (Write-Ahead Logging) mode in `init_db()` for better concurrent read/write performance
- Adds `backups/` to `.gitignore`

## Test plan

- [ ] Verify `backup_db()` creates a timestamped `.db` file in `backups/` directory
- [ ] Verify old backups beyond the 7-file limit are cleaned up
- [ ] Verify backup triggers at the correct scan count interval (every 288 scans)
- [ ] Verify WAL mode is enabled by checking `PRAGMA journal_mode` after init
- [ ] Verify `backups/` directory is ignored by git

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)