### PR TITLE
feat: add inline position editing UI for SL/TP/notes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2019,6 +2019,39 @@ button:focus-visible {
   color: var(--text-secondary);
 }
 
+/* Inline edit row */
+.pos-edit-row td {
+  padding: 0;
+}
+
+.pos-edit-inline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: rgba(59,130,246,0.05);
+  border-top: 1px solid rgba(59,130,246,0.2);
+  border-bottom: 1px solid rgba(59,130,246,0.2);
+}
+
+.pos-edit-field {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pos-edit-field label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.pos-input-group {
+  display: flex;
+  align-items: center;
+}
+
 /* Empty state */
 .pos-empty {
   padding: 48px 24px;

--- a/frontend/src/components/PositionsPanel.tsx
+++ b/frontend/src/components/PositionsPanel.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useCallback, useEffect } from 'react';
 import type { Position, SymbolStatus, Signal } from '../types';
-import { getPositions, closePosition, cancelPosition } from '../api';
+import { getPositions, closePosition, cancelPosition, updatePosition } from '../api';
 import OpenPositionModal from './OpenPositionModal';
 
 interface PositionsPanelProps {
@@ -113,6 +113,62 @@ const CloseRow: React.FC<CloseRowProps> = ({ pos, currentPrice, onConfirm, onCan
   );
 };
 
+// ── Inline edit row ───────────────────────────────────────────
+
+interface EditRowProps {
+  pos: Position;
+  onSave: (id: number, changes: Record<string, unknown>) => void;
+  onCancel: () => void;
+}
+
+const EditRow: React.FC<EditRowProps> = ({ pos, onSave, onCancel }) => {
+  const [sl, setSl] = useState(String(pos.sl_price ?? ''));
+  const [tp, setTp] = useState(String(pos.tp_price ?? ''));
+  const [notes, setNotes] = useState(pos.notes ?? '');
+
+  return (
+    <tr className="pos-edit-row">
+      <td colSpan={99}>
+        <div className="pos-edit-inline">
+          <div className="pos-edit-field">
+            <label>SL</label>
+            <div className="pos-input-group">
+              <span className="pos-input-prefix">$</span>
+              <input type="number" step="any" className="pos-input pos-input--sm"
+                value={sl} onChange={e => setSl(e.target.value)} />
+            </div>
+          </div>
+          <div className="pos-edit-field">
+            <label>TP</label>
+            <div className="pos-input-group">
+              <span className="pos-input-prefix">$</span>
+              <input type="number" step="any" className="pos-input pos-input--sm"
+                value={tp} onChange={e => setTp(e.target.value)} />
+            </div>
+          </div>
+          <div className="pos-edit-field">
+            <label>Notas</label>
+            <input type="text" className="pos-input pos-input--sm"
+              value={notes} onChange={e => setNotes(e.target.value)} />
+          </div>
+          <button className="btn btn-sm btn-primary" onClick={() => {
+            const changes: Record<string, unknown> = {};
+            const slVal = parseFloat(sl);
+            const tpVal = parseFloat(tp);
+            if (!isNaN(slVal)) changes.sl_price = slVal;
+            else if (sl === '') changes.sl_price = null;
+            if (!isNaN(tpVal)) changes.tp_price = tpVal;
+            else if (tp === '') changes.tp_price = null;
+            if (notes !== (pos.notes ?? '')) changes.notes = notes;
+            onSave(pos.id, changes);
+          }}>Guardar</button>
+          <button className="btn btn-sm btn-secondary" onClick={onCancel}>Cancelar</button>
+        </div>
+      </td>
+    </tr>
+  );
+};
+
 // ── Main component ─────────────────────────────────────────────
 
 const PositionsPanel: React.FC<PositionsPanelProps> = ({
@@ -125,6 +181,7 @@ const PositionsPanel: React.FC<PositionsPanelProps> = ({
   const [tab,         setTab]         = useState<'open' | 'closed'>('open');
   const [openModal,   setOpenModal]   = useState(false);
   const [closingId,   setClosingId]   = useState<number | null>(null);
+  const [editingId,   setEditingId]   = useState<number | null>(null);
   type PrefillData = { symbol: string; price?: number | null; sl?: number | null; tp?: number | null; scan_id?: number | null };
   const [prefill,     setPrefill]     = useState<PrefillData | undefined>();
 
@@ -178,6 +235,16 @@ const PositionsPanel: React.FC<PositionsPanelProps> = ({
       await cancelPosition(id);
       await load();
     } catch (e) { console.error(e); }
+  };
+
+  const handleEdit = async (id: number, changes: Record<string, unknown>) => {
+    try {
+      await updatePosition(id, changes as import('../types').PositionUpdatePayload);
+      setEditingId(null);
+      await load();
+    } catch (e) {
+      console.error(e);
+    }
   };
 
   // ── Computed stats ──────────────────────────────────────────
@@ -324,8 +391,20 @@ const PositionsPanel: React.FC<PositionsPanelProps> = ({
                         <td>
                           <div className="pos-actions">
                             <button
+                              className="btn btn-sm btn-secondary"
+                              onClick={() => {
+                                setEditingId(editingId === pos.id ? null : pos.id);
+                                setClosingId(null);
+                              }}
+                            >
+                              Editar
+                            </button>
+                            <button
                               className="btn btn-sm btn-danger"
-                              onClick={() => setClosingId(closingId === pos.id ? null : pos.id)}
+                              onClick={() => {
+                                setClosingId(closingId === pos.id ? null : pos.id);
+                                setEditingId(null);
+                              }}
                             >
                               Cerrar
                             </button>
@@ -339,6 +418,13 @@ const PositionsPanel: React.FC<PositionsPanelProps> = ({
                           </div>
                         </td>
                       </tr>
+                      {editingId === pos.id && (
+                        <EditRow
+                          pos={pos}
+                          onSave={handleEdit}
+                          onCancel={() => setEditingId(null)}
+                        />
+                      )}
                       {closingId === pos.id && (
                         <tr className="pos-close-row">
                           <td colSpan={10}>


### PR DESCRIPTION
## Summary
- Adds an inline `EditRow` component to `PositionsPanel.tsx` that lets traders modify SL, TP, and notes on open positions directly from the dashboard table
- Adds an "Editar" button to each open position row, alongside the existing "Cerrar" and cancel buttons
- Wires the existing `updatePosition()` API function (previously defined but never called) to the new UI
- Adds minimal CSS styling for the edit row, consistent with the existing close-row pattern

## Test plan
- [ ] Open the positions panel with at least one open position
- [ ] Click "Editar" on an open position — verify the edit row appears with current SL/TP/notes pre-filled
- [ ] Modify SL and TP values, click "Guardar" — verify the position updates and the edit row closes
- [ ] Clear SL/TP fields and save — verify null values are sent correctly
- [ ] Click "Cancelar" — verify the edit row closes without changes
- [ ] Verify clicking "Editar" dismisses any open "Cerrar" row, and vice versa
- [ ] Run `npx tsc --noEmit` — passes with zero errors

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)