### PR TITLE
fix: prevent secret exposure in /status and /config endpoints

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -223,6 +223,14 @@ async def verify_api_key(key: str = Security(_api_key_header)):
         raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
 
+_SECRET_KEYS = {"webhook_secret", "telegram_bot_token", "api_key"}
+
+
+def _strip_secrets(cfg: dict) -> dict:
+    """Remove sensitive fields from a config dict before returning to clients."""
+    return {k: v for k, v in cfg.items() if k not in _SECRET_KEYS}
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  CONFIG VALIDATION (Pydantic)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1298,7 +1306,8 @@ def list_symbols():
     return {"total": len(result), "symbols": result}
 
 
-@app.get("/status", summary="Estado detallado del scanner")
+@app.get("/status", summary="Estado detallado del scanner",
+         dependencies=[Depends(verify_api_key)])
 def status():
     latest = get_latest_scan()
     return {
@@ -1311,8 +1320,7 @@ def status():
             "lrc_pct": latest["lrc_pct"] if latest else None,
             "score":   latest["score"]   if latest else None,
         } if latest else None,
-        "config": {k: v for k, v in load_config().items()
-                   if k not in ("webhook_secret",)},
+        "config": _strip_secrets(load_config()),
     }
 
 
@@ -1489,12 +1497,10 @@ def signal_by_id(scan_id: int):
             "telegram_message": build_telegram_message(payload)}
 
 
-@app.get("/config", summary="Leer configuracion actual")
+@app.get("/config", summary="Leer configuracion actual",
+         dependencies=[Depends(verify_api_key)])
 def get_config():
-    cfg = load_config()
-    # nunca exponer el secreto del webhook
-    cfg.pop("webhook_secret", None)
-    return cfg
+    return _strip_secrets(load_config())
 
 
 @app.post("/config", summary="Actualizar configuracion", dependencies=[Depends(verify_api_key)])
@@ -1508,8 +1514,7 @@ def update_config(body: ConfigUpdate):
         }
     try:
         updated = save_config(updates)
-        updated.pop("webhook_secret", None)
-        return {"ok": True, "config": updated}
+        return {"ok": True, "config": _strip_secrets(updated)}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -262,7 +262,8 @@ class TestAPIEndpoints:
         monkeypatch.setattr(btc_api, "DB_FILE", tmp_db)
         cfg_path = str(tmp_path / "config.json")
         with open(cfg_path, "w") as f:
-            json.dump({"webhook_url": "", "webhook_secret": "",
+            json.dump({"webhook_url": "", "webhook_secret": "s3cret",
+                       "telegram_bot_token": "tok123", "api_key": "",
                        "notify_setup_only": False, "scan_interval_sec": 300}, f)
         monkeypatch.setattr(btc_api, "CONFIG_FILE", cfg_path)
 
@@ -288,6 +289,7 @@ class TestAPIEndpoints:
         test_app.get("/signals/latest")(btc_api.latest_signal)
         test_app.get("/signals/latest/message")(btc_api.latest_message)
         test_app.get("/signals/{scan_id}")(btc_api.signal_by_id)
+        test_app.get("/config")(btc_api.get_config)
         test_app.get("/webhook/test")(btc_api.test_webhook)
 
         return TestClient(test_app)
@@ -304,6 +306,20 @@ class TestAPIEndpoints:
         assert r.status_code == 200
         data = r.json()
         assert "scanner_state" in data
+
+    def test_status_strips_secrets(self, client):
+        r = client.get("/status")
+        assert r.status_code == 200
+        cfg = r.json()["config"]
+        for key in ("webhook_secret", "telegram_bot_token", "api_key"):
+            assert key not in cfg, f"{key} should not be exposed in /status"
+
+    def test_config_strips_secrets(self, client):
+        r = client.get("/config")
+        assert r.status_code == 200
+        cfg = r.json()
+        for key in ("webhook_secret", "telegram_bot_token", "api_key"):
+            assert key not in cfg, f"{key} should not be exposed in GET /config"
 
     def test_signals_vacio(self, client):
         r = client.get("/signals")


### PR DESCRIPTION
## Summary

- Add centralized `_strip_secrets()` that filters `webhook_secret`, `telegram_bot_token`, and `api_key` from config responses
- Protect `GET /status` and `GET /config` with `verify_api_key` authentication (previously unauthenticated)
- Apply `_strip_secrets()` consistently to `/status`, `GET /config`, and `POST /config` responses

Fixes #103

## Test plan

- [x] New test `test_status_strips_secrets` — verifies none of the 3 secret keys appear in `/status` response
- [x] New test `test_config_strips_secrets` — verifies none of the 3 secret keys appear in `GET /config` response
- [x] Full test suite passes (174/174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)