### PR TITLE
fix: remove legacy hardcoded values from webhook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,5 @@ Proxy format when needed: `socks5://127.0.0.1:1080`
 - `data/signals_history.csv` — CSV export of all signals
 
 ## Known Limitations
-- `trading_webhook.py` has a hardcoded path to OpenClaw (`C:\Users\simon\AppData\Roaming\npm\openclaw.cmd`)
 - `watchdog.py` uses Windows-specific commands (`tasklist`, `taskkill`, `wmic`, `netstat`) and won't run on Linux/Mac
 - The webhook process itself is not supervised by the watchdog (only btc_api.py is)

--- a/docs/informe_vpn_toronto.md
+++ b/docs/informe_vpn_toronto.md
@@ -52,14 +52,14 @@ El sistema está **operativo** y enviando señales a Telegram correctamente. Tod
 - **Puerto:** 9000 (TCP LISTEN).
 - **Logs:** `webhook.log` muestra recepción de payload y envío exitoso a Telegram.
 - **Prueba directa:** Envío de payload de prueba → respuesta `{"status":"ok"}`.
-- **Integración OpenClaw:** Usa `openclaw.cmd` con ruta absoluta; envía al chat de Telegram (`--target 380882623`).
+- **Integración OpenClaw:** Usa `openclaw` (detectado via PATH o `openclaw_path` en config); envía al chat de Telegram configurado en `telegram_chat_id`.
 
 ### 4. Prueba de Flujo Completo
 
 1. **Escaneo forzado:** `POST /scan?force_notify=true`
 2. **Scanner** consulta Binance, calcula indicadores, construye payload con `telegram_message`.
 3. **API** llama a `push_webhook` con payload.
-4. **Webhook receptor** recibe POST, extrae `telegram_message`, ejecuta `openclaw message send --channel telegram --target 380882623`.
+4. **Webhook receptor** recibe POST, extrae `telegram_message`, ejecuta `openclaw message send --channel telegram --target <chat_id>`.
 5. **Telegram:** Mensaje recibido en el chat personal.
 
 **Resultado:** ✅ Señal recibida en Telegram con formato completo (score, precio, estado, confirmaciones).
@@ -73,7 +73,7 @@ El sistema está **operativo** y enviando señales a Telegram correctamente. Tod
 ## Problemas Identificados
 
 1. **Contador de errores no resetado:** El campo `errors: 1` persiste, aunque los errores pueden ser históricos (previos al cambio de VPN). No afecta funcionalidad.
-2. **Dependencia de ruta absoluta en webhook:** El script `trading_webhook.py` usa `C:\Users\simon\AppData\Roaming\npm\openclaw.cmd`. Si OpenClaw se reinstala en otra ubicación, fallará.
+2. **~~Dependencia de ruta absoluta en webhook:~~** Resuelto — ahora usa `openclaw_path` de config o detección automática via PATH.
 3. **Webhook como proceso independiente:** No está supervisado; si el proceso termina, las señales no se entregarán.
 4. **Logs limitados:** No hay logs detallados de los intentos de escaneo automático; sólo se ve el total de escaneos y errores.
 
@@ -81,7 +81,7 @@ El sistema está **operativo** y enviando señales a Telegram correctamente. Tod
 
 ### Correcciones Inmediatas
 - **Resetear contador de errores** después de confirmar que el VPN funciona (opcional, pero limpia métricas).
-- **Cambiar ruta de OpenClaw** a variable de entorno o detectar automáticamente (ej. `where openclaw`).
+- **~~Cambiar ruta de OpenClaw~~** Resuelto — detecta automáticamente via PATH.
 - **Implementar supervisión básica** para el proceso webhook (ej. reinicio si puerto 9000 deja de escuchar).
 
 ### Mejoras a Mediano Plazo

--- a/trading_webhook.py
+++ b/trading_webhook.py
@@ -33,20 +33,13 @@ def load_config():
 
 def _get_telegram_target():
     cfg = load_config()
-    # 380882623 is the legacy hardcoded target for Simon
-    return cfg.get("telegram_chat_id", "380882623")
+    return cfg.get("telegram_chat_id", "").strip() or None
 
 def _get_openclaw_cmd():
     cfg = load_config()
-    configured = cfg.get("openclaw_path", "")
+    configured = cfg.get("openclaw_path", "").strip()
     if configured and os.path.isfile(configured):
         return configured
-    
-    # Fallback to absolute path or just 'openclaw' if not on Windows
-    openclaw_cmd = r"C:\Users\simon\AppData\Roaming\npm\openclaw.cmd"
-    if os.path.exists(openclaw_cmd):
-        return openclaw_cmd
-        
     import shutil
     return shutil.which("openclaw") or "openclaw"
 
@@ -76,10 +69,6 @@ class WebhookHandler(BaseHTTPRequestHandler):
         secret = cfg.get("webhook_secret", "").strip()
         if secret:
             received_secret = self.headers.get("X-Scanner-Secret", "").strip()
-            # fallback to X-Webhook-Secret if someone used the other name
-            if not received_secret:
-                received_secret = self.headers.get("X-Webhook-Secret", "").strip()
-            
             import hmac
             if not hmac.compare_digest(received_secret, secret):
                 logger.warning(f"Unauthorized webhook attempt from {self.address_string()}")


### PR DESCRIPTION
## Summary

- Remove hardcoded `telegram_chat_id` (`380882623`) — now requires `config.json`
- Remove hardcoded OpenClaw path (`C:\Users\simon\...`) — uses `openclaw_path` from config or PATH detection
- Remove redundant `X-Webhook-Secret` header fallback (only `X-Scanner-Secret` used by sender)
- Update docs and CLAUDE.md to reflect resolved limitations

## Test plan

- [x] Full test suite passes (174/174)
- [x] No remaining references to hardcoded values in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)