### PR TITLE
feat(data): market data layer — Phase 4 (fetcher orchestration)

### DIFF
--- a/data/_fetcher.py
+++ b/data/_fetcher.py
@@ -157,3 +157,91 @@ def fetch_with_failover(symbol: str, timeframe: str, start_ms: int, end_ms: int)
     raise AllProvidersFailedError(
         f"All providers failed for {symbol} {timeframe} [{start_ms}, {end_ms}]"
     )
+
+
+CHUNK_SIZE = 1000
+
+
+def ensure_fresh(
+    symbol: str, timeframe: str, limit: int,
+    cached_max: int | None, expected_max: int,
+) -> None:
+    """Fetch incremental bars if cache is stale, using double-checked locking."""
+    lock = _get_or_create_lock(symbol, timeframe)
+    with lock:
+        # Re-check cache inside lock — another thread may have just filled it
+        new_cached_max = _storage.max_open_time(symbol, timeframe)
+        new_count = _storage.count_tail(symbol, timeframe, expected_max, limit)
+        if (
+            new_cached_max is not None
+            and new_cached_max >= expected_max
+            and new_count >= limit
+        ):
+            metrics.inc("double_checked_hits_total")
+            return
+
+        delta = delta_ms(timeframe)
+        if new_cached_max is None:
+            start_ms = expected_max - (limit - 1) * delta
+        else:
+            start_ms = new_cached_max + delta
+        end_ms = expected_max
+
+        if start_ms > end_ms:
+            return
+
+        bars = fetch_with_failover(symbol, timeframe, start_ms, end_ms)
+        if bars:
+            _storage.upsert_many(bars)
+
+
+def _backfill_range(symbol: str, timeframe: str, start_ms: int, end_ms: int) -> int:
+    """Bulk fetch + persist of [start_ms, end_ms] inclusive in CHUNK_SIZE-bar chunks."""
+    delta = delta_ms(timeframe)
+    earliest = _storage.first_bar_ms(symbol, timeframe)
+    if earliest is not None:
+        start_ms = max(start_ms, earliest)
+    if start_ms > end_ms:
+        return 0
+
+    cur = start_ms
+    total = 0
+    estimated = max(1, (end_ms - start_ms) // delta + 1)
+    while cur <= end_ms:
+        chunk_end = min(cur + (CHUNK_SIZE - 1) * delta, end_ms)
+        bars = fetch_with_failover(symbol, timeframe, cur, chunk_end)
+        if not bars:
+            # Empty response — mark pre-listing and stop
+            _storage.set_first_bar_ms(symbol, timeframe, chunk_end + delta)
+            break
+        persisted = _storage.upsert_many(bars)
+        total += persisted
+        cur = bars[-1].open_time + delta
+        if total > 0 and total % 1000 == 0:
+            log.info(
+                "Backfill %s %s: %d/%d (%.1f%%)",
+                symbol, timeframe, total, estimated, total / estimated * 100.0,
+            )
+    metrics.inc("backfill_bars_total", total, labels={"symbol": symbol, "tf": timeframe})
+    return total
+
+
+def _fill_internal_gaps(symbol: str, timeframe: str, start_ms: int, end_ms: int) -> int:
+    """Detect and fill holes inside [start_ms, end_ms] inclusive."""
+    delta = delta_ms(timeframe)
+    existing = set(_storage.times_in_range(symbol, timeframe, start_ms, end_ms))
+    total = 0
+    gap_start = None
+    cur = start_ms
+    while cur <= end_ms:
+        if cur not in existing:
+            if gap_start is None:
+                gap_start = cur
+        else:
+            if gap_start is not None:
+                total += _backfill_range(symbol, timeframe, gap_start, cur - delta)
+                gap_start = None
+        cur += delta
+    if gap_start is not None:
+        total += _backfill_range(symbol, timeframe, gap_start, end_ms)
+    return total

--- a/data/_fetcher.py
+++ b/data/_fetcher.py
@@ -1,1 +1,75 @@
-"""Provider failover + rate-limit logic. Drives fetching via ProviderAdapter implementations."""
+"""Fetcher: orchestrates providers with failover, dedup, rate limiting."""
+import threading
+import time
+import logging
+
+from data.providers.base import (
+    ProviderAdapter, ProviderError, ProviderInvalidSymbol,
+    ProviderRateLimited, ProviderTemporaryError, AllProvidersFailedError, Bar,
+)
+from data.providers.binance import BinanceAdapter
+from data.providers.bybit import BybitAdapter
+from data import metrics, _storage
+from data.timeframes import delta_ms, last_closed_bar_time
+
+
+log = logging.getLogger("data.market")
+
+
+# ─── Provider registry ──────────────────────────────────────────────────────
+_PROVIDERS: list[ProviderAdapter] = [BinanceAdapter(), BybitAdapter()]
+
+
+# ─── Failover state (module-level, guarded) ─────────────────────────────────
+_state_lock = threading.Lock()
+_active_idx: int = 0
+_consecutive_failures: int = 0
+_last_probe_ms: int = 0
+
+FAILOVER_THRESHOLD = 3
+RECOVERY_PROBE_INTERVAL_MS = 300_000   # 5 minutes
+
+
+# ─── Per-(symbol, timeframe) lock registry ──────────────────────────────────
+_fetch_locks: dict[tuple[str, str], threading.Lock] = {}
+_registry_guard = threading.Lock()
+
+
+def _get_or_create_lock(symbol: str, timeframe: str) -> threading.Lock:
+    """Return per-(symbol, timeframe) lock for in-process fetch dedup."""
+    key = (symbol, timeframe)
+    with _registry_guard:
+        return _fetch_locks.setdefault(key, threading.Lock())
+
+
+# ─── Rate limiter (minimal token bucket; compatible with existing project API) ──
+class _RateLimiter:
+    """Per-key token bucket. If the existing project rate limiter is available,
+    substitute it here. This simple version refills tokens proportionally by
+    elapsed time and blocks with a short sleep when empty."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._tokens: dict[str, float] = {}
+        self._last_refill: dict[str, float] = {}
+
+    def acquire(self, key: str, limit_per_min: int) -> None:
+        while True:
+            with self._lock:
+                now = time.time()
+                refill_rate = limit_per_min / 60.0  # tokens per second
+                last = self._last_refill.get(key, now)
+                self._tokens[key] = min(
+                    limit_per_min,
+                    self._tokens.get(key, limit_per_min) + (now - last) * refill_rate,
+                )
+                self._last_refill[key] = now
+                if self._tokens[key] >= 1.0:
+                    self._tokens[key] -= 1.0
+                    return
+                deficit = 1.0 - self._tokens[key]
+                sleep_for = deficit / refill_rate
+            time.sleep(min(sleep_for, 1.0))
+
+
+_rate_limiter = _RateLimiter()

--- a/data/_fetcher.py
+++ b/data/_fetcher.py
@@ -73,3 +73,87 @@ class _RateLimiter:
 
 
 _rate_limiter = _RateLimiter()
+
+
+def _maybe_probe_primary_recovery() -> None:
+    """If we're on a fallback, probe primary health periodically; revert on success."""
+    global _active_idx, _last_probe_ms
+    with _state_lock:
+        if _active_idx == 0:
+            return
+        now_ms = int(time.time() * 1000)
+        if now_ms - _last_probe_ms < RECOVERY_PROBE_INTERVAL_MS:
+            return
+        _last_probe_ms = now_ms
+        primary_to_probe = _PROVIDERS[0]
+
+    healthy = False
+    try:
+        healthy = primary_to_probe.is_healthy()
+    except Exception:
+        pass
+    if healthy:
+        with _state_lock:
+            _active_idx = 0
+        metrics.inc("provider_recoveries_total", labels={"provider": primary_to_probe.name})
+        log.info("Primary provider %s recovered — reverting active", primary_to_probe.name)
+
+
+def fetch_with_failover(symbol: str, timeframe: str, start_ms: int, end_ms: int) -> list[Bar]:
+    """Try providers in priority order (sticky). On failure thresholds, switch active."""
+    global _active_idx, _consecutive_failures
+
+    _maybe_probe_primary_recovery()
+
+    with _state_lock:
+        ordering = list(range(_active_idx, len(_PROVIDERS))) + list(range(_active_idx))
+        primary_name = _PROVIDERS[ordering[0]].name
+
+    for position, idx in enumerate(ordering):
+        provider = _PROVIDERS[idx]
+        try:
+            _rate_limiter.acquire(provider.name, provider.rate_limit_per_min)
+            t0 = time.time()
+            bars = provider.fetch_klines(symbol, timeframe, start_ms, end_ms)
+            latency_ms = int((time.time() - t0) * 1000)
+            metrics.observe("fetch_latency_ms", latency_ms, labels={"provider": provider.name})
+            metrics.inc("fetches_total", labels={"provider": provider.name, "tf": timeframe})
+            if position == 0:
+                # Only reset on primary success so fallback coverage still
+                # accumulates consecutive primary failures across calls.
+                with _state_lock:
+                    _consecutive_failures = 0
+            else:
+                metrics.inc(
+                    "fallback_fetches_total",
+                    labels={"from": primary_name, "to": provider.name},
+                )
+            return bars
+        except ProviderInvalidSymbol:
+            raise
+        except (ProviderRateLimited, ProviderTemporaryError) as e:
+            metrics.inc(
+                "provider_errors_total",
+                labels={"provider": provider.name, "kind": type(e).__name__},
+            )
+            log.warning("%s failed (%s): %s", provider.name, type(e).__name__, e)
+            if position == 0:
+                with _state_lock:
+                    _consecutive_failures += 1
+                    if _consecutive_failures >= FAILOVER_THRESHOLD:
+                        new_idx = (idx + 1) % len(_PROVIDERS)
+                        metrics.inc(
+                            "provider_switches_total",
+                            labels={"from": provider.name, "to": _PROVIDERS[new_idx].name},
+                        )
+                        log.warning(
+                            "Switching active provider %s → %s after %d consecutive failures",
+                            provider.name, _PROVIDERS[new_idx].name, _consecutive_failures,
+                        )
+                        _active_idx = new_idx
+                        _consecutive_failures = 0
+            continue
+
+    raise AllProvidersFailedError(
+        f"All providers failed for {symbol} {timeframe} [{start_ms}, {end_ms}]"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def tmp_ohlcv_db(tmp_path, monkeypatch):
 def fake_provider(monkeypatch):
     """Inject a deterministic FakeProvider as the only provider in data._fetcher."""
     from data import _fetcher
-    from tests._fakes import FakeProvider
+    from _fakes import FakeProvider
 
     fake = FakeProvider()
     monkeypatch.setattr(_fetcher, "_PROVIDERS", [fake])
@@ -47,7 +47,7 @@ def fake_provider(monkeypatch):
 def fake_providers(monkeypatch):
     """Inject two fake providers to test failover."""
     from data import _fetcher
-    from tests._fakes import FakeProvider
+    from _fakes import FakeProvider
 
     primary = FakeProvider(name="primary")
     fallback = FakeProvider(name="fallback")

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -93,3 +93,83 @@ class TestFetchWithFailover:
         primary.set_bars("BTCUSDT", "1h", [make_bar("BTCUSDT", "1h", 1000)])
         _fetcher.fetch_with_failover("BTCUSDT", "1h", 0, 2000)
         assert _fetcher._active_idx == 0  # recovered
+
+
+from data import _storage
+
+
+class TestEnsureFresh:
+    def test_cold_fetches_limit_bars(self, tmp_ohlcv_db, fake_provider):
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(10)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        _fetcher.ensure_fresh("BTCUSDT", "1h", limit=5, cached_max=None, expected_max=9 * 3600_000)
+        stored = _storage._conn().execute("SELECT COUNT(*) FROM ohlcv").fetchone()[0]
+        # Requested last 5 bars: open_times 5..9 inclusive
+        assert stored == 5
+        got = _storage.tail("BTCUSDT", "1h", 100)
+        assert list(got["open_time"]) == [5 * 3600_000, 6 * 3600_000, 7 * 3600_000, 8 * 3600_000, 9 * 3600_000]
+
+    def test_warm_fetches_only_increment(self, tmp_ohlcv_db, fake_provider):
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(10)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        _storage.upsert_many([bars[i] for i in range(5)])  # cached up to 4
+        _fetcher.ensure_fresh("BTCUSDT", "1h", limit=10, cached_max=4 * 3600_000, expected_max=9 * 3600_000)
+        # Only bars 5..9 were newly requested
+        assert fake_provider.calls[-1] == ("BTCUSDT", "1h", 5 * 3600_000, 9 * 3600_000)
+
+    def test_double_checked_lock_dedup(self, tmp_ohlcv_db, fake_provider):
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(10)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        # Two threads calling ensure_fresh simultaneously
+        results = []
+        def worker():
+            _fetcher.ensure_fresh("BTCUSDT", "1h", limit=5, cached_max=None, expected_max=9 * 3600_000)
+            results.append("done")
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        assert len(results) == 4
+        # With double-checked locking, first thread fetches; others see fresh cache and return
+        assert len(fake_provider.calls) == 1
+
+
+class TestBackfillRange:
+    def test_full_backfill(self, tmp_ohlcv_db, fake_provider):
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(100)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        n = _fetcher._backfill_range("BTCUSDT", "1h", 0, 99 * 3600_000)
+        assert n == 100
+        assert _storage.max_open_time("BTCUSDT", "1h") == 99 * 3600_000
+
+    def test_chunks_respect_size(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        # CHUNK_SIZE=1000 → 1500 bars = 2 chunks
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(1500)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        _fetcher._backfill_range("BTCUSDT", "1h", 0, 1499 * 3600_000)
+        # 2 chunks = 2 provider calls
+        assert len(fake_provider.calls) == 2
+
+    def test_pre_listing_stops_and_marks_earliest(self, tmp_ohlcv_db, fake_provider):
+        # Provider has data starting at t=500*3600_000 only
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(500, 600)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        _fetcher._backfill_range("BTCUSDT", "1h", 0, 100 * 3600_000)
+        # Our requested range [0, 100] is entirely pre-listing → empty response → stop + mark earliest
+        assert _storage.first_bar_ms("BTCUSDT", "1h") is not None
+
+
+class TestFillInternalGaps:
+    def test_fills_single_gap(self, tmp_ohlcv_db, fake_provider):
+        all_bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(10)]
+        fake_provider.set_bars("BTCUSDT", "1h", all_bars)
+        # Seed storage with bars 0-3 and 7-9 (gap in the middle: 4-6)
+        _storage.upsert_many([all_bars[i] for i in [0, 1, 2, 3, 7, 8, 9]])
+        fake_provider.calls.clear()
+        _fetcher._fill_internal_gaps("BTCUSDT", "1h", 0, 9 * 3600_000)
+        assert _storage.max_open_time("BTCUSDT", "1h") == 9 * 3600_000
+        count = _storage._conn().execute(
+            "SELECT COUNT(*) FROM ohlcv WHERE symbol='BTCUSDT' AND timeframe='1h'").fetchone()[0]
+        assert count == 10
+        # Should have fetched only the gap range (4..6 inclusive)
+        assert fake_provider.calls[0][2] == 4 * 3600_000
+        assert fake_provider.calls[0][3] == 6 * 3600_000

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,32 @@
+import threading
+import pytest
+from data import _fetcher
+
+
+class TestLockRegistry:
+    def test_returns_lock_instance(self):
+        lock = _fetcher._get_or_create_lock("BTCUSDT", "1h")
+        assert hasattr(lock, "acquire") and hasattr(lock, "release")
+
+    def test_same_key_returns_same_lock(self):
+        a = _fetcher._get_or_create_lock("BTCUSDT", "1h")
+        b = _fetcher._get_or_create_lock("BTCUSDT", "1h")
+        assert a is b
+
+    def test_different_keys_different_locks(self):
+        a = _fetcher._get_or_create_lock("BTCUSDT", "1h")
+        b = _fetcher._get_or_create_lock("ETHUSDT", "1h")
+        c = _fetcher._get_or_create_lock("BTCUSDT", "5m")
+        assert a is not b
+        assert a is not c
+        assert b is not c
+
+    def test_thread_safe_registry(self):
+        # Concurrent creation of the same lock must return the same object
+        results = []
+        def worker():
+            results.append(_fetcher._get_or_create_lock("CONCURRENT", "1h"))
+        threads = [threading.Thread(target=worker) for _ in range(16)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        assert len(set(id(r) for r in results)) == 1

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -30,3 +30,66 @@ class TestLockRegistry:
         for t in threads: t.start()
         for t in threads: t.join()
         assert len(set(id(r) for r in results)) == 1
+
+
+from data.providers.base import (
+    ProviderRateLimited, ProviderTemporaryError, ProviderInvalidSymbol,
+    AllProvidersFailedError,
+)
+from _fakes import make_bar
+
+
+class TestFetchWithFailover:
+    def test_primary_success(self, fake_providers):
+        primary, fallback = fake_providers
+        bars = [make_bar("BTCUSDT", "1h", 1000)]
+        primary.set_bars("BTCUSDT", "1h", bars)
+        result = _fetcher.fetch_with_failover("BTCUSDT", "1h", 0, 2000)
+        assert len(result) == 1
+        assert len(primary.calls) == 1
+        assert len(fallback.calls) == 0
+
+    def test_primary_temporary_error_triggers_counter(self, fake_providers):
+        primary, fallback = fake_providers
+        primary.set_error("BTCUSDT", "1h", ProviderTemporaryError("503"))
+        fallback.set_bars("BTCUSDT", "1h", [make_bar("BTCUSDT", "1h", 1000)])
+        result = _fetcher.fetch_with_failover("BTCUSDT", "1h", 0, 2000)
+        assert len(result) == 1
+        assert len(fallback.calls) == 1
+        # Counter accumulates on primary failure — fallback success does NOT
+        # reset it, otherwise the threshold could never trigger.
+        assert _fetcher._consecutive_failures == 1
+
+    def test_threshold_triggers_sticky_switch(self, fake_providers):
+        primary, fallback = fake_providers
+        primary.set_error("BTCUSDT", "1h", ProviderRateLimited("429"))
+        fallback.set_bars("BTCUSDT", "1h", [make_bar("BTCUSDT", "1h", 1000)])
+        for _ in range(_fetcher.FAILOVER_THRESHOLD):
+            _fetcher.fetch_with_failover("BTCUSDT", "1h", 0, 2000)
+        assert _fetcher._active_idx == 1  # switched to fallback
+
+    def test_invalid_symbol_does_not_trigger_failover(self, fake_providers):
+        primary, fallback = fake_providers
+        primary.set_error("FAKE", "1h", ProviderInvalidSymbol("not found"))
+        with pytest.raises(ProviderInvalidSymbol):
+            _fetcher.fetch_with_failover("FAKE", "1h", 0, 2000)
+        assert _fetcher._active_idx == 0
+        assert _fetcher._consecutive_failures == 0
+
+    def test_all_providers_fail_raises(self, fake_providers):
+        primary, fallback = fake_providers
+        primary.set_error("BTCUSDT", "1h", ProviderTemporaryError("503"))
+        fallback.set_error("BTCUSDT", "1h", ProviderTemporaryError("504"))
+        with pytest.raises(AllProvidersFailedError):
+            _fetcher.fetch_with_failover("BTCUSDT", "1h", 0, 2000)
+
+    def test_recovery_probe_reverts_active(self, fake_providers, monkeypatch):
+        primary, fallback = fake_providers
+        # Force active_idx = 1 (fallback) and simulate probe interval elapsed
+        _fetcher._active_idx = 1
+        _fetcher._last_probe_ms = 0
+        primary.healthy = True
+        fallback.set_bars("BTCUSDT", "1h", [make_bar("BTCUSDT", "1h", 1000)])
+        primary.set_bars("BTCUSDT", "1h", [make_bar("BTCUSDT", "1h", 1000)])
+        _fetcher.fetch_with_failover("BTCUSDT", "1h", 0, 2000)
+        assert _fetcher._active_idx == 0  # recovered


### PR DESCRIPTION
## Summary

Phase 4 of the market-data-layer plan: provider orchestration sitting between the adapter layer (Phase 3) and the storage layer (Phase 2). No production code is wired to this yet — that comes in Phase 6.

- **Task 10 (07a0a1b):** `data/_fetcher.py` scaffold — per-(symbol, timeframe) lock registry + thread-safe token-bucket rate limiter
- **Task 11 (01e19cc):** `fetch_with_failover` — sticky provider switch after `FAILOVER_THRESHOLD` consecutive primary failures + 5-minute `is_healthy()` recovery probe that reverts active on success. Raises `ProviderInvalidSymbol` without failover.
- **Task 12 (ba6b9be):** orchestration functions — `ensure_fresh` (double-checked locking for incremental freshness), `_backfill_range` (chunked bulk fetch with pre-listing handling), `_fill_internal_gaps` (gap-filling via `times_in_range` diff)

## Deviations from the plan

1. **Counter-reset semantics** (Task 11): the plan reset `_consecutive_failures` on any provider success, which made the sticky-switch threshold unreachable whenever fallback worked. Gated the reset on `position == 0` (primary success) so the counter accumulates consecutive primary failures across calls — matching the "N consecutive primary failures" design intent in the spec. Updated `test_primary_temporary_error_triggers_counter` assertion to `== 1` with explanatory comment.

2. **`_fakes` import path**: `tests/` is not a Python package (no `__init__.py`). Changed `from tests._fakes import …` to `from _fakes import …` in `conftest.py` fixtures (previously unused — first consumer is `test_fetcher.py`) and in the new test file.

## Test plan

- [x] Full suite locally: `python -m pytest tests/ -q` → **344 passed** (was 327 pre-Phase-4)
- [x] Fetcher tests: 17 new (TestLockRegistry 4, TestFetchWithFailover 6, TestEnsureFresh 3, TestBackfillRange 3, TestFillInternalGaps 1)
- [ ] CI (GitHub Actions) backend-tests + frontend-typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)