### PR TITLE
feat(data): market data layer — Phase 5 (public API + CLI)

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,5 +1,32 @@
 """Market Data Layer — unified OHLCV cache + fetch for all modules.
 
-Public API is defined in data.market_data. See
-docs/superpowers/specs/en/2026-04-18-market-data-layer-design.md for design.
+Public entrypoints:
+    get_klines(symbol, timeframe, limit, force_refresh=False) -> DataFrame
+    get_klines_range(symbol, timeframe, start, end)          -> DataFrame
+    get_klines_live(symbol, timeframe, limit)                -> DataFrame
+    prefetch(symbols, timeframes, limit=210)                 -> None
+    backfill(symbol, timeframe, start, end=None)             -> int
+    repair(symbol, timeframe, start, end=None)               -> int
+
+Utilities:
+    get_stats()                                              -> dict
+    last_closed_bar_time(timeframe, now=None)                -> int ms
+
+See docs/superpowers/specs/en/2026-04-18-market-data-layer-design.md
 """
+from data.market_data import (
+    get_klines,
+    get_klines_range,
+    get_klines_live,
+    prefetch,
+    backfill,
+    repair,
+    get_stats,
+)
+from data.timeframes import last_closed_bar_time
+
+__all__ = [
+    "get_klines", "get_klines_range", "get_klines_live",
+    "prefetch", "backfill", "repair",
+    "get_stats", "last_closed_bar_time",
+]

--- a/data/cli.py
+++ b/data/cli.py
@@ -1,1 +1,73 @@
-"""CLI entry point for the Market Data Layer (backfill, inspect, prune commands)."""
+"""Convenience CLI: python -m data.cli {backfill, repair, stats, init}"""
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+
+from data import market_data as md
+from data import _storage
+
+
+def _parse_date(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=timezone.utc) if "+" not in s and "Z" not in s \
+        else datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def cmd_backfill(args):
+    start = _parse_date(args.start)
+    end = _parse_date(args.end) if args.end else None
+    n = md.backfill(args.symbol, args.timeframe, start, end)
+    print(f"Backfilled {n} bars for {args.symbol} {args.timeframe}")
+
+
+def cmd_repair(args):
+    start = _parse_date(args.start)
+    end = _parse_date(args.end) if args.end else None
+    n = md.repair(args.symbol, args.timeframe, start, end)
+    print(f"Repaired {n} bars for {args.symbol} {args.timeframe}")
+
+
+def _jsonable(v):
+    if isinstance(v, dict):
+        return {str(k): _jsonable(val) for k, val in v.items()}
+    if isinstance(v, (list, tuple)):
+        return [_jsonable(x) for x in v]
+    return v
+
+
+def cmd_stats(args):
+    stats = md.get_stats()
+    print(json.dumps(_jsonable(stats), indent=2, default=str))
+
+
+def cmd_init(args):
+    _storage.init_schema()
+    print(f"Schema initialized at {_storage.DB_PATH}")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="python -m data.cli")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_b = sub.add_parser("backfill", help="Bulk historical fetch")
+    p_b.add_argument("symbol"); p_b.add_argument("timeframe")
+    p_b.add_argument("start"); p_b.add_argument("end", nargs="?")
+    p_b.set_defaults(func=cmd_backfill)
+
+    p_r = sub.add_parser("repair", help="Force re-fetch overwriting a range")
+    p_r.add_argument("symbol"); p_r.add_argument("timeframe")
+    p_r.add_argument("start"); p_r.add_argument("end", nargs="?")
+    p_r.set_defaults(func=cmd_repair)
+
+    p_s = sub.add_parser("stats", help="Print metrics snapshot")
+    p_s.set_defaults(func=cmd_stats)
+
+    p_i = sub.add_parser("init", help="Create ohlcv.db with schema (usually auto)")
+    p_i.set_defaults(func=cmd_init)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/data/market_data.py
+++ b/data/market_data.py
@@ -99,3 +99,51 @@ def _bars_to_df(bars) -> pd.DataFrame:
         [(b.open_time, b.open, b.high, b.low, b.close, b.volume, b.provider, b.fetched_at) for b in bars],
         columns=cols,
     )
+
+
+def get_klines_range(
+    symbol: str,
+    timeframe: str,
+    start: datetime,
+    end: datetime,
+) -> pd.DataFrame:
+    """Closed bars with open_time in [start, end] inclusive (clamped to last closed bar).
+
+    Auto-detects gaps in the cache and backfills only what's missing.
+    Raises AllProvidersFailedError if a gap cannot be filled.
+    """
+    if timeframe not in TIMEFRAMES:
+        raise ValueError(f"Unknown timeframe: {timeframe}")
+    _ensure_schema_once()
+
+    d = delta_ms(timeframe)
+    start_ms = _to_ms(start)
+    end_ms = last_closed_bar_time(timeframe, end)
+
+    # Clamp start to known first bar
+    earliest = _storage.first_bar_ms(symbol, timeframe)
+    if earliest is not None and start_ms < earliest:
+        start_ms = earliest
+
+    if start_ms > end_ms:
+        return _storage.range_(symbol, timeframe, start_ms, end_ms)
+
+    expected_count = (end_ms - start_ms) // d + 1
+    min_t, max_t, count = _storage.range_stats(symbol, timeframe, start_ms, end_ms)
+
+    if count == expected_count:
+        return _storage.range_(symbol, timeframe, start_ms, end_ms)
+
+    if count == 0:
+        _fetcher._backfill_range(symbol, timeframe, start_ms, end_ms)
+    else:
+        if min_t > start_ms:
+            _fetcher._backfill_range(symbol, timeframe, start_ms, min_t - d)
+        if max_t < end_ms:
+            _fetcher._backfill_range(symbol, timeframe, max_t + d, end_ms)
+        # Re-check; run internal gap fill if still short
+        _, _, count2 = _storage.range_stats(symbol, timeframe, start_ms, end_ms)
+        if count2 < expected_count:
+            _fetcher._fill_internal_gaps(symbol, timeframe, start_ms, end_ms)
+
+    return _storage.range_(symbol, timeframe, start_ms, end_ms)

--- a/data/market_data.py
+++ b/data/market_data.py
@@ -1,1 +1,101 @@
-"""Public API for the Market Data Layer. Unified OHLCV cache + fetch interface."""
+"""Market Data Layer — public API.
+
+All functions in this module are the only supported entrypoints.
+Underscore-prefixed modules are private implementation.
+"""
+from datetime import datetime, timezone
+from typing import Iterable
+import logging
+
+import pandas as pd
+
+from data import _storage, _fetcher, metrics
+from data.timeframes import TIMEFRAMES, delta_ms, last_closed_bar_time
+
+
+log = logging.getLogger("data.market")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_ms(dt: datetime) -> int:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _ensure_schema_once():
+    _storage.init_schema()
+
+
+def get_klines(
+    symbol: str,
+    timeframe: str,
+    limit: int,
+    force_refresh: bool = False,
+) -> pd.DataFrame:
+    """Last `limit` CLOSED bars for (symbol, timeframe). Never includes in-progress bar.
+
+    Serves from cache; fetches incremental bars when stale. Column schema:
+    ['open_time', 'open', 'high', 'low', 'close', 'volume', 'provider', 'fetched_at'].
+    """
+    if timeframe not in TIMEFRAMES:
+        raise ValueError(f"Unknown timeframe: {timeframe}")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    _ensure_schema_once()
+
+    expected_max = last_closed_bar_time(timeframe, _utcnow())
+    cached_max = _storage.max_open_time(symbol, timeframe)
+    cached_count = _storage.count_tail(symbol, timeframe, expected_max, limit)
+    sufficient = (
+        cached_max is not None
+        and cached_max >= expected_max
+        and cached_count >= limit
+    )
+    if force_refresh:
+        # Bypass ensure_fresh's double-checked cache-hit return.
+        delta = delta_ms(timeframe)
+        start_ms = expected_max - (limit - 1) * delta
+        _fetcher._backfill_range(symbol, timeframe, start_ms, expected_max)
+    elif not sufficient:
+        _fetcher.ensure_fresh(symbol, timeframe, limit, cached_max, expected_max)
+    else:
+        metrics.inc("cache_hits_total", labels={"tf": timeframe})
+
+    return _storage.tail(symbol, timeframe, limit)
+
+
+def get_klines_live(
+    symbol: str,
+    timeframe: str,
+    limit: int,
+) -> pd.DataFrame:
+    """Last `limit` bars INCLUDING the in-progress bar. Bypasses cache fully.
+
+    Only legitimate consumer: /ohlcv endpoint for animated chart. Does NOT persist.
+    """
+    if timeframe not in TIMEFRAMES:
+        raise ValueError(f"Unknown timeframe: {timeframe}")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
+    d = delta_ms(timeframe)
+    now_ms = int(_utcnow().timestamp() * 1000)
+    # Current (in-progress) bar open_time:
+    current_open_time = (now_ms // d) * d
+    start_ms = current_open_time - (limit - 1) * d
+    end_ms = current_open_time
+
+    bars = _fetcher.fetch_with_failover(symbol, timeframe, start_ms, end_ms)
+    return _bars_to_df(bars)
+
+
+def _bars_to_df(bars) -> pd.DataFrame:
+    cols = ["open_time", "open", "high", "low", "close", "volume", "provider", "fetched_at"]
+    return pd.DataFrame(
+        [(b.open_time, b.open, b.high, b.low, b.close, b.volume, b.provider, b.fetched_at) for b in bars],
+        columns=cols,
+    )

--- a/data/market_data.py
+++ b/data/market_data.py
@@ -147,3 +147,80 @@ def get_klines_range(
             _fetcher._fill_internal_gaps(symbol, timeframe, start_ms, end_ms)
 
     return _storage.range_(symbol, timeframe, start_ms, end_ms)
+
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+MAX_PARALLEL_FETCH = 5
+
+
+def prefetch(
+    symbols: Iterable[str],
+    timeframes: Iterable[str],
+    limit: int = 210,
+) -> None:
+    """Batch-prefetch cache entries for all (symbol, timeframe) combinations in parallel.
+
+    Internal workers call get_klines, so all freshness/locking semantics are preserved.
+    Per-(sym, tf) failures are logged and recorded as metrics but do NOT abort the batch.
+    """
+    tasks = [(s, tf) for s in symbols for tf in timeframes]
+    with ThreadPoolExecutor(max_workers=MAX_PARALLEL_FETCH) as ex:
+        futures = {ex.submit(get_klines, s, tf, limit): (s, tf) for s, tf in tasks}
+        for fut in as_completed(futures):
+            s, tf = futures[fut]
+            try:
+                fut.result()
+            except Exception as e:
+                log.warning("Prefetch failed for %s/%s: %s", s, tf, e)
+                metrics.inc("prefetch_errors_total", labels={"symbol": s, "tf": tf})
+
+
+def backfill(
+    symbol: str,
+    timeframe: str,
+    start: datetime,
+    end: datetime | None = None,
+) -> int:
+    """Explicit bulk historical fetch + persist. Idempotent, resumable, pre-listing-aware."""
+    if timeframe not in TIMEFRAMES:
+        raise ValueError(f"Unknown timeframe: {timeframe}")
+    _ensure_schema_once()
+
+    end = end or _utcnow()
+    end_ms = last_closed_bar_time(timeframe, end)
+    start_ms = _to_ms(start)
+    return _fetcher._backfill_range(symbol, timeframe, start_ms, end_ms)
+
+
+def repair(
+    symbol: str,
+    timeframe: str,
+    start: datetime,
+    end: datetime | None = None,
+) -> int:
+    """Force re-fetch + overwrite of a range. Use when data anomaly is detected.
+
+    Internally reuses _backfill_range; INSERT OR REPLACE semantics overwrite existing bars.
+    """
+    if timeframe not in TIMEFRAMES:
+        raise ValueError(f"Unknown timeframe: {timeframe}")
+    _ensure_schema_once()
+
+    end = end or _utcnow()
+    end_ms = last_closed_bar_time(timeframe, end)
+    start_ms = _to_ms(start)
+
+    metrics.inc("repairs_requested_total", labels={"symbol": symbol, "tf": timeframe})
+    before_count = _storage.range_stats(symbol, timeframe, start_ms, end_ms)[2]
+    persisted = _fetcher._backfill_range(symbol, timeframe, start_ms, end_ms)
+    after_count = _storage.range_stats(symbol, timeframe, start_ms, end_ms)[2]
+    metrics.inc("bars_overwritten_total", max(0, persisted - (after_count - before_count)),
+                labels={"symbol": symbol, "tf": timeframe})
+    return persisted
+
+
+def get_stats() -> dict:
+    """Snapshot of market data metrics. Exposed via /status endpoint integration."""
+    return metrics.get_stats()

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -60,3 +60,49 @@ class TestGetKlinesLive:
         # Nothing was persisted to the DB
         count = _storage._conn().execute("SELECT COUNT(*) FROM ohlcv").fetchone()[0]
         assert count == 0
+
+
+from datetime import timedelta
+
+
+class TestGetKlinesRange:
+    def test_cache_hit_no_fetch(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(10)]
+        _storage.upsert_many(bars)
+        fake_provider.calls.clear()
+        df = md.get_klines_range(
+            "BTCUSDT", "1h",
+            datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=9),
+        )
+        assert len(df) == 10
+        assert fake_provider.calls == []
+
+    def test_cold_backfills_whole_range(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(10)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        df = md.get_klines_range(
+            "BTCUSDT", "1h",
+            datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=9),
+        )
+        assert len(df) == 10
+
+    def test_left_edge_gap_filled(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        all_bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(10)]
+        fake_provider.set_bars("BTCUSDT", "1h", all_bars)
+        # Cache has only bars 5..9
+        _storage.upsert_many(all_bars[5:])
+        fake_provider.calls.clear()
+        df = md.get_klines_range(
+            "BTCUSDT", "1h",
+            datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=9),
+        )
+        assert len(df) == 10
+        # Left edge fetch: [0, 4]
+        assert fake_provider.calls[0][2] == 0
+        assert fake_provider.calls[0][3] == 4 * 3600_000

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timezone
+import pytest
+from data import market_data as md
+from data import _storage, _fetcher
+from data.timeframes import last_closed_bar_time, delta_ms
+from _fakes import make_bar
+
+
+def _seed(fake, symbol, tf, count, delta_hours=1):
+    bars = [make_bar(symbol, tf, t * delta_hours * 3600_000, price=100.0 + t) for t in range(count)]
+    fake.set_bars(symbol, tf, bars)
+    return bars
+
+
+class TestGetKlines:
+    def test_cold_fetches_limit(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        # Freeze "now" such that expected_max = 9 * 3600_000 (last closed 1h bar)
+        def fake_last_closed(tf, now=None):
+            return 9 * 3600_000
+        monkeypatch.setattr(md, "last_closed_bar_time", fake_last_closed)
+        monkeypatch.setattr(_fetcher, "last_closed_bar_time", fake_last_closed)
+        _seed(fake_provider, "BTCUSDT", "1h", 10)
+        df = md.get_klines("BTCUSDT", "1h", 5)
+        assert len(df) == 5
+        assert list(df["open_time"]) == [5 * 3600_000, 6 * 3600_000, 7 * 3600_000, 8 * 3600_000, 9 * 3600_000]
+
+    def test_warm_no_fetch(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        monkeypatch.setattr(_fetcher, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        bars = _seed(fake_provider, "BTCUSDT", "1h", 10)
+        _storage.upsert_many(bars)
+        fake_provider.calls.clear()
+        df = md.get_klines("BTCUSDT", "1h", 5)
+        assert len(df) == 5
+        assert fake_provider.calls == []
+
+    def test_force_refresh_bypasses_cache(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        monkeypatch.setattr(_fetcher, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        bars = _seed(fake_provider, "BTCUSDT", "1h", 10)
+        _storage.upsert_many(bars)
+        fake_provider.calls.clear()
+        md.get_klines("BTCUSDT", "1h", 5, force_refresh=True)
+        assert len(fake_provider.calls) >= 1
+
+
+class TestGetKlinesLive:
+    def test_bypasses_cache_includes_current(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        # Pin "now" so the requested range aligns with the seeded bars; the
+        # FakeProvider filters by open_time range.
+        pinned_now = datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr(md, "_utcnow", lambda: pinned_now)
+        d = 3600_000
+        pinned_ms = int(pinned_now.timestamp() * 1000)
+        current = (pinned_ms // d) * d
+        bars = [make_bar("BTCUSDT", "1h", current - (4 - i) * d) for i in range(5)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        df = md.get_klines_live("BTCUSDT", "1h", 5)
+        assert len(df) == 5
+        # Nothing was persisted to the DB
+        count = _storage._conn().execute("SELECT COUNT(*) FROM ohlcv").fetchone()[0]
+        assert count == 0

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -106,3 +106,58 @@ class TestGetKlinesRange:
         # Left edge fetch: [0, 4]
         assert fake_provider.calls[0][2] == 0
         assert fake_provider.calls[0][3] == 4 * 3600_000
+
+
+class TestPrefetch:
+    def test_parallel_cache_fill(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        monkeypatch.setattr(_fetcher, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        for sym in ["BTCUSDT", "ETHUSDT"]:
+            _seed(fake_provider, sym, "1h", 10)
+            _seed(fake_provider, sym, "4h", 10)
+        md.prefetch(["BTCUSDT", "ETHUSDT"], ["1h", "4h"], limit=5)
+        # After prefetch, each (sym, tf) should have data cached
+        for sym in ["BTCUSDT", "ETHUSDT"]:
+            for tf in ["1h", "4h"]:
+                assert _storage.max_open_time(sym, tf) is not None
+
+    def test_exception_does_not_abort_batch(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        from data.providers.base import ProviderInvalidSymbol
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        monkeypatch.setattr(_fetcher, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        _seed(fake_provider, "GOODCOIN", "1h", 10)
+        fake_provider.set_error("BADCOIN", "1h", ProviderInvalidSymbol("not listed"))
+        md.prefetch(["GOODCOIN", "BADCOIN"], ["1h"], limit=5)
+        assert _storage.max_open_time("GOODCOIN", "1h") is not None
+        assert _storage.max_open_time("BADCOIN", "1h") is None
+
+
+class TestBackfill:
+    def test_idempotent(self, tmp_ohlcv_db, fake_provider):
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(50)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        start = datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=49)
+        md.backfill("BTCUSDT", "1h", start, end)
+        count1 = _storage._conn().execute("SELECT COUNT(*) FROM ohlcv").fetchone()[0]
+        md.backfill("BTCUSDT", "1h", start, end)
+        count2 = _storage._conn().execute("SELECT COUNT(*) FROM ohlcv").fetchone()[0]
+        assert count1 == count2
+        assert count1 >= 1
+
+
+class TestRepair:
+    def test_overwrites_existing_bars(self, tmp_ohlcv_db, fake_provider):
+        original = [make_bar("BTCUSDT", "1h", t * 3600_000, price=100.0) for t in range(10)]
+        revised = [make_bar("BTCUSDT", "1h", t * 3600_000, price=200.0) for t in range(10)]
+        _storage.upsert_many(original)
+        fake_provider.set_bars("BTCUSDT", "1h", revised)
+        # end=10h so last_closed_bar_time caps at 9h and repair covers bars 0..9
+        md.repair(
+            "BTCUSDT", "1h",
+            datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=10),
+        )
+        rows = _storage._conn().execute(
+            "SELECT close FROM ohlcv WHERE symbol='BTCUSDT' AND timeframe='1h' ORDER BY open_time").fetchall()
+        assert all(r[0] == 200.0 for r in rows)

--- a/tests/test_market_data_integration.py
+++ b/tests/test_market_data_integration.py
@@ -1,0 +1,95 @@
+"""End-to-end scenarios using FakeProvider + tmp_ohlcv_db."""
+from datetime import datetime, timezone, timedelta
+import threading
+import pytest
+from data import market_data as md
+from data import _storage, _fetcher
+from _fakes import make_bar
+
+
+class TestScannerCycleSimulation:
+    def test_prefetch_then_get_klines_cache_hit(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        monkeypatch.setattr(_fetcher, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        for sym in ["BTCUSDT", "ETHUSDT"]:
+            for tf in ["1h", "4h"]:
+                bars = [make_bar(sym, tf, t * 3600_000) for t in range(10)]
+                fake_provider.set_bars(sym, tf, bars)
+        md.prefetch(["BTCUSDT", "ETHUSDT"], ["1h", "4h"], limit=5)
+        fake_provider.calls.clear()
+        for sym in ["BTCUSDT", "ETHUSDT"]:
+            for tf in ["1h", "4h"]:
+                df = md.get_klines(sym, tf, 5)
+                assert len(df) == 5
+        # Zero fetches after prefetch
+        assert len(fake_provider.calls) == 0
+
+
+class TestBackfillAndRangeQuery:
+    def test_backfill_then_range_cache_hit(self, tmp_ohlcv_db, fake_provider):
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(100)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        md.backfill(
+            "BTCUSDT", "1h",
+            datetime(1970, 1, 1, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=100),
+        )
+        fake_provider.calls.clear()
+        # end=91h so last_closed_bar_time caps at 90h; range [10h, 90h] = 81 bars
+        df = md.get_klines_range(
+            "BTCUSDT", "1h",
+            datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=10),
+            datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=91),
+        )
+        assert len(df) == 81
+        assert len(fake_provider.calls) == 0
+
+
+class TestConcurrentScanCycles:
+    def test_many_threads_dedup_fetches(self, tmp_ohlcv_db, fake_provider, monkeypatch):
+        monkeypatch.setattr(md, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        monkeypatch.setattr(_fetcher, "last_closed_bar_time", lambda tf, now=None: 9 * 3600_000)
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(10)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        results = []
+        def worker():
+            df = md.get_klines("BTCUSDT", "1h", 5)
+            results.append(len(df))
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        assert all(n == 5 for n in results)
+        # Cold start — expected 1 actual fetch, dedup handles the rest
+        assert len(fake_provider.calls) == 1
+
+
+class TestResumableBackfill:
+    def test_partial_backfill_then_restart(self, tmp_ohlcv_db, fake_provider):
+        bars = [make_bar("BTCUSDT", "1h", t * 3600_000) for t in range(50)]
+        fake_provider.set_bars("BTCUSDT", "1h", bars)
+        # Simulate partial: seed only bars 0..24
+        _storage.upsert_many(bars[:25])
+        fake_provider.calls.clear()
+        md.backfill(
+            "BTCUSDT", "1h",
+            datetime(1970, 1, 1, tzinfo=timezone.utc),
+            datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(hours=50),
+        )
+        total = _storage._conn().execute("SELECT COUNT(*) FROM ohlcv").fetchone()[0]
+        assert total == 50
+
+
+class TestCLI:
+    def test_init_creates_db(self, tmp_ohlcv_db):
+        from data import cli
+        cli.main(["init"])
+        import os
+        assert os.path.exists(_storage.DB_PATH)
+
+    def test_stats_prints_json(self, tmp_ohlcv_db, capsys):
+        from data import cli
+        cli.main(["stats"])
+        out = capsys.readouterr().out
+        import json
+        data = json.loads(out)
+        assert "counters" in data


### PR DESCRIPTION
## Summary

Phase 5 of the market-data-layer plan: the public surface callers will use after Phase 6 migration. No production module wires these in yet.

- **Task 13 (494053a):** `get_klines` (last N closed bars, cache-first, `force_refresh` routes through `_backfill_range`) + `get_klines_live` (includes in-progress bar, never persists)
- **Task 14 (0f6c18e):** `get_klines_range` — auto-detects gaps via `_storage.range_stats`, fills left/right edges, then `_fill_internal_gaps` if still short
- **Task 15 (e0dccda):** `prefetch` (parallel via `ThreadPoolExecutor`, per-task failures logged not raised), `backfill`, `repair` (overwrite semantics + `bars_overwritten_total` metric), `get_stats`
- **Task 16 (4686677):** `data/__init__.py` re-exports; `data/cli.py` with `backfill|repair|stats|init` subcommands; end-to-end integration tests (scanner cycle, concurrent dedup, resumable backfill, CLI)

## Deviations from the plan

1. **`force_refresh` wiring** (Task 13): plan routed `force_refresh` through `ensure_fresh`, but `ensure_fresh`'s double-checked-lock returns early on cache hit — defeating the refresh intent. Routed through `_backfill_range` directly instead.
2. **`get_klines_live` test** (Task 13): plan seeded bars at epoch-0 but the function queries around real `_utcnow()`. `FakeProvider` range-filters results, so the test would have returned 0 bars. Monkeypatched `md._utcnow` to a pinned datetime and aligned seeded bars to that window.
3. **Datetime hour>23** (Tasks 14-16): plan's tests used `datetime(1970, 1, 1, 49, 0, ...)` / `hour=90` / `hour=99`, which raise `ValueError` (hour must be 0-23). Converted to `datetime(1970, 1, 1) + timedelta(hours=N)`.
4. **Repair test end boundary** (Task 15): `last_closed_bar_time('1h', 9h)` returns 8h (9h bar is in-progress at 9h sharp), so the original test's `end=9h` never repaired bar 9. Extended `end` to `10h` so the full 10-bar window is overwritten.
5. **CLI stats JSON** (Task 16): `metrics.get_stats()` stores label-keyed counters with tuple keys (`{('a','b'): 1}`); `json.dumps` can't serialize dict-with-tuple-keys even with `default=str`. Added a small `_jsonable` helper in `cli.py` that stringifies keys recursively.

## Test plan

- [x] Full suite locally: `python -m pytest tests/ -q` → **361 passed** (was 344 pre-Phase-5)
- [x] Market-data-layer tests: 17 new (TestGetKlines 3, TestGetKlinesLive 1, TestGetKlinesRange 3, TestPrefetch 2, TestBackfill 1, TestRepair 1, integration 6)
- [x] `python -c "from data import get_klines, ...; print('OK')"` confirms public API
- [ ] CI (GitHub Actions) backend-tests + frontend-typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)