### PR TITLE
refactor(scanner): migrate to data.market_data layer (Phase 6)

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -347,9 +347,27 @@ def detect_bear_engulfing(df: pd.DataFrame):
 
 
 def calc_cvd_delta(df: pd.DataFrame, n=3):
-    """Proxy CVD: volumen taker buy − sell últimas n barras."""
-    buy  = df["taker_buy_base"].tail(n)
-    sell = (df["volume"] - df["taker_buy_base"]).tail(n)
+    """Proxy CVD: volumen taker buy − sell últimas n barras.
+
+    Data layer bars carry only OHLCV (no taker-side metadata), so
+    approximate taker_buy_base from the bar's close position within
+    its high-low range, same heuristic the old bybit adapter used.
+    """
+    if "taker_buy_base" in df.columns:
+        taker_buy = df["taker_buy_base"]
+    else:
+        hl = (df["high"] - df["low"]).replace(0, 1e-9)
+        bullish = df["close"] >= df["open"]
+        taker_buy = pd.Series(
+            np.where(
+                bullish,
+                df["volume"] * (df["close"] - df["low"]) / hl,
+                df["volume"] * (df["high"] - df["close"]) / hl,
+            ),
+            index=df.index,
+        )
+    buy  = taker_buy.tail(n)
+    sell = (df["volume"] - taker_buy).tail(n)
     return float((buy - sell).sum())
 
 

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -151,25 +151,6 @@ def get_top_symbols(n: int = 20, quote: str = "USDT") -> list:
 #  Proxy: configurar en config.json  →  "proxy": "socks5://127.0.0.1:1080"
 #         o variable de entorno  HTTPS_PROXY / HTTP_PROXY
 
-BINANCE_URLS = [
-    "https://api.binance.com",
-    "https://api1.binance.com",
-    "https://api2.binance.com",
-    "https://api3.binance.com",
-    "https://api4.binance.com",
-]
-
-# Intervalos Bybit  (distintos a Binance)
-_BYBIT_INTERVAL = {"1m":"1","3m":"3","5m":"5","15m":"15","30m":"30",
-                   "1h":"60","2h":"120","4h":"240","6h":"360","12h":"720",
-                   "1d":"D","1w":"W","1M":"M"}
-
-_active_provider = None   # "binance" | "bybit"  — se detecta la primera vez
-_provider_lock = threading.Lock()           # protege escrituras a _active_provider
-_provider_fail_count = 0                    # llamadas en modo Bybit desde el último intento de Binance
-_RECOVERY_INTERVAL = 10                     # cada N llamadas en Bybit, reintentar Binance
-
-
 def _load_proxy() -> dict:
     """Lee proxy de config.json o de variables de entorno."""
     cfg_path = os.path.join(SCRIPT_DIR, "config.json")
@@ -205,143 +186,17 @@ def _rate_limit():
         _last_api_call = time.time()
 
 
-def _get(url: str, params: dict = None) -> dict:
-    """HTTP GET con soporte de proxy, timeout y rate limiting."""
-    _rate_limit()
-    proxies = _load_proxy()
-    r = requests.get(url, params=params, proxies=proxies or None,
-                     timeout=12, headers={"User-Agent": "btc-scanner/1.0"})
-    r.raise_for_status()
-    return r.json()
-
-
-# ── Binance ───────────────────────────────────────────────────────────────────
-
-def _klines_binance(symbol: str, interval: str, limit: int) -> pd.DataFrame:
-    """
-    Intenta cada URL mirror de Binance en orden.
-    Devuelve DataFrame normalizado o lanza excepción si todos fallan.
-    """
-    last_err = None
-    for base in BINANCE_URLS:
-        try:
-            data = _get(f"{base}/api/v3/klines",
-                        {"symbol": symbol, "interval": interval, "limit": limit})
-            df = pd.DataFrame(data, columns=[
-                "ts","open","high","low","close","volume",
-                "close_time","quote_vol","trades",
-                "taker_buy_base","taker_buy_quote","ignore"
-            ])
-            for c in ["open","high","low","close","volume",
-                      "taker_buy_base","taker_buy_quote"]:
-                df[c] = df[c].astype(float)
-            df["ts"] = pd.to_datetime(df["ts"], unit="ms")
-            df.set_index("ts", inplace=True)
-            log.debug(f"Binance OK ({base})")
-            return df
-        except Exception as e:
-            log.warning(f"Binance {base} → {type(e).__name__}: {e}")
-            last_err = e
-    raise last_err
-
-
-# ── Bybit ─────────────────────────────────────────────────────────────────────
-
-def _klines_bybit(symbol: str, interval: str, limit: int) -> pd.DataFrame:
-    """
-    Bybit V5 Spot klines → mismo formato de DataFrame que Binance.
-
-    Bybit no provee taker_buy_base directamente en klines;
-    se aproxima con el ratio (close-low)/(high-low) × volume
-    para velas alcistas, y el inverso para bajistas.
-    Esta aproximación es suficiente para el cálculo de CVD delta.
-    """
-    byt_interval = _BYBIT_INTERVAL.get(interval, interval.replace("m","").replace("h","60"))
-    data = _get("https://api.bybit.com/v5/market/kline",
-                {"category": "spot", "symbol": symbol,
-                 "interval": byt_interval, "limit": limit})
-    if data.get("retCode", -1) != 0:
-        raise RuntimeError(f"Bybit error: {data.get('retMsg')}")
-
-    rows = data["result"]["list"]          # orden: más reciente primero
-    rows = list(reversed(rows))            # → cronológico
-    df = pd.DataFrame(rows, columns=[
-        "ts","open","high","low","close","volume","turnover"
-    ])
-    for c in ["open","high","low","close","volume","turnover"]:
-        df[c] = df[c].astype(float)
-    df["ts"] = pd.to_datetime(df["ts"].astype(float), unit="ms")
-    df.set_index("ts", inplace=True)
-
-    # Aproximar taker_buy_base
-    hl = (df["high"] - df["low"]).replace(0, 1e-9)
-    bullish = df["close"] >= df["open"]
-    df["taker_buy_base"] = np.where(
-        bullish,
-        df["volume"] * (df["close"] - df["low"]) / hl,
-        df["volume"] * (df["high"] - df["close"]) / hl,
-    )
-    df["taker_buy_quote"] = df["taker_buy_base"] * df["close"]
-    log.debug("Bybit OK")
-    return df
-
-
-# ── Punto de entrada unificado ────────────────────────────────────────────────
-
 def get_klines(symbol: str, interval: str, limit: int = 210) -> pd.DataFrame:
-    """
-    Obtiene velas OHLCV con detección automática de proveedor.
-
-    Intenta Binance primero (todos los mirrors). Si todos fallan con
-    error de red o HTTP >= 400, cambia a Bybit automáticamente y
-    registra el proveedor activo para los siguientes ciclos.
-
-    Cuando el proveedor activo es Bybit, cada _RECOVERY_INTERVAL
-    llamadas se reintenta Binance. Si responde, se restaura como
-    proveedor principal.
-    """
-    global _active_provider, _provider_fail_count
-
-    # Si ya sabemos que Bybit funciona, ir directo — pero reintentar
-    # Binance periódicamente para recuperar el proveedor preferido.
-    if _active_provider == "bybit":
-        with _provider_lock:
-            _provider_fail_count += 1
-            should_retry = (_provider_fail_count >= _RECOVERY_INTERVAL)
-            if should_retry:
-                _provider_fail_count = 0
-
-        if should_retry:
-            try:
-                df = _klines_binance(symbol, interval, limit)
-                with _provider_lock:
-                    _active_provider = "binance"
-                log.info("✅ Binance recuperado — volviendo a proveedor principal")
-                return df
-            except Exception:
-                log.debug("Binance sigue sin responder, manteniendo Bybit")
-
-        return _klines_bybit(symbol, interval, limit)
-
-    # Intentar Binance
-    try:
-        df = _klines_binance(symbol, interval, limit)
-        if _active_provider != "binance":
-            with _provider_lock:
-                _active_provider = "binance"
-            log.info("✅ Proveedor de datos: Binance")
+    """Compatibility shim: returns the legacy shape (DatetimeIndex, includes
+    in-progress bar) on top of the new data layer. btc_api's /ohlcv and
+    performance tracker still consume this shape; full removal lives in
+    Phase 7 Task 23."""
+    df = md.get_klines_live(symbol, interval, limit)
+    if df.empty:
         return df
-    except Exception as binance_err:
-        log.warning(f"⚠️  Todos los mirrors de Binance fallaron ({binance_err}). "
-                    f"Cambiando a Bybit…")
-
-    # Fallback a Bybit
-    df = _klines_bybit(symbol, interval, limit)
-    if _active_provider != "bybit":
-        with _provider_lock:
-            _active_provider = "bybit"
-            _provider_fail_count = 0
-        log.info("✅ Proveedor de datos: Bybit (fallback automático)")
+    df = df.copy()
+    df["ts"] = pd.to_datetime(df["open_time"], unit="ms")
+    df.set_index("ts", inplace=True)
     return df
 
 

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -27,6 +27,8 @@ import io
 import logging
 import threading
 
+from data import market_data as md
+
 # Reconfigure stdout for Windows Unicode support
 try:
     sys.stdout.reconfigure(encoding='utf-8')
@@ -664,7 +666,7 @@ def detect_regime() -> dict:
     # ── 1. Price Structure (40% weight) ──────────────────────────────────────
     price_score = 100  # default bullish
     try:
-        df1d = get_klines("BTCUSDT", "1d", limit=250)
+        df1d = md.get_klines("BTCUSDT", "1d", limit=250)
         if len(df1d) >= 200:
             sma50  = calc_sma(df1d["close"], 50).iloc[-1]
             sma200 = calc_sma(df1d["close"], 200).iloc[-1]
@@ -792,9 +794,9 @@ def scan(symbol: str = None):
     rep = {"timestamp": ts, "symbol": symbol, "errors": []}
 
     # ── Datos de mercado ──────────────────────────────────────────────────────
-    df5  = get_klines(symbol, "5m",  limit=210)   # gatillo
-    df1h = get_klines(symbol, "1h",  limit=210)   # señal principal
-    df4h = get_klines(symbol, "4h",  limit=150)   # contexto macro
+    df5  = md.get_klines(symbol, "5m",  limit=210)   # gatillo
+    df1h = md.get_klines(symbol, "1h",  limit=210)   # señal principal
+    df4h = md.get_klines(symbol, "4h",  limit=150)   # contexto macro
     price = df1h["close"].iloc[-1]   # precio de cierre de la última vela 1H
 
     # ── Régimen de mercado (compuesto, cacheado por detect_regime()) ──────────
@@ -1231,6 +1233,11 @@ def main():
 
     while True:
         symbols = [sym_arg] if sym_arg else get_top_symbols(20)
+        # Warm cache in parallel so subsequent per-symbol get_klines are cache-hits
+        try:
+            md.prefetch(symbols, ["5m", "1h", "4h"], limit=210)
+        except Exception as e:
+            log.warning("prefetch batch failed: %s", e)
         try:
             for sym in symbols:
                 try:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -725,64 +725,6 @@ class TestLoadProxy:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-#  TESTS — _klines_bybit (formato de DataFrame)
-# ─────────────────────────────────────────────────────────────────────────────
-
-class TestKlinesBybit:
-    @patch("btc_scanner._get")
-    def test_retorna_dataframe_correcto(self, mock_get):
-        """Verifica que el DataFrame de Bybit tenga el mismo formato que Binance."""
-        # Simular respuesta de Bybit (formato: más reciente primero)
-        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
-        rows = []
-        for i in range(5):
-            ts = now_ms - (4 - i) * 5 * 60 * 1000  # cada 5 min
-            rows.append([str(ts), "85000", "85500", "84800", "85200", "10.5", "892650"])
-        rows_reversed = list(reversed(rows))  # Bybit envía más reciente primero
-
-        mock_get.return_value = {
-            "retCode": 0,
-            "result": {"list": rows_reversed},
-        }
-
-        df = scanner._klines_bybit("BTCUSDT", "5m", 5)
-
-        assert isinstance(df, pd.DataFrame)
-        assert "open" in df.columns
-        assert "close" in df.columns
-        assert "taker_buy_base" in df.columns
-        assert len(df) == 5
-
-    @patch("btc_scanner._get")
-    def test_bybit_error_lanza_excepcion(self, mock_get):
-        mock_get.return_value = {
-            "retCode": 10001,
-            "retMsg": "Invalid symbol",
-        }
-        with pytest.raises(RuntimeError, match="Bybit error"):
-            scanner._klines_bybit("INVALID", "5m", 10)
-
-    @patch("btc_scanner._get")
-    def test_taker_buy_base_aproximado(self, mock_get):
-        """Verifica que taker_buy_base esté entre 0 y volume."""
-        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
-        rows = []
-        for i in range(10):
-            ts = now_ms - (9 - i) * 60 * 1000
-            rows.append([str(ts), "85000", "85500", "84500", "85200", "100", "8520000"])
-        rows_reversed = list(reversed(rows))
-
-        mock_get.return_value = {
-            "retCode": 0,
-            "result": {"list": rows_reversed},
-        }
-
-        df = scanner._klines_bybit("BTCUSDT", "1m", 10)
-        assert (df["taker_buy_base"] >= 0).all()
-        assert (df["taker_buy_base"] <= df["volume"] + 1e-6).all()
-
-
-# ─────────────────────────────────────────────────────────────────────────────
 #  TESTS — fmt() (formato de salida)
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -571,7 +571,7 @@ class TestScan:
 
         return df1h, df4h, df5m
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_retorna_dict_con_claves(self, mock_klines):
         df1h, df4h, df5m = self._make_scan_mock()
         mock_klines.side_effect = [df5m, df1h, df4h, df1h]  # 5m, 1h, 4h, 1d
@@ -586,7 +586,7 @@ class TestScan:
         for clave in claves:
             assert clave in rep, f"Clave faltante: {clave}"
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_precio_es_float(self, mock_klines):
         df1h, df4h, df5m = self._make_scan_mock()
         mock_klines.side_effect = [df5m, df1h, df4h, df1h]
@@ -595,7 +595,7 @@ class TestScan:
         assert isinstance(rep["price"], float)
         assert rep["symbol"] == "ETHUSDT"
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_señal_activa_es_bool(self, mock_klines):
         df1h, df4h, df5m = self._make_scan_mock()
         mock_klines.side_effect = [df5m, df1h, df4h, df1h]
@@ -603,7 +603,7 @@ class TestScan:
         rep = scanner.scan()
         assert isinstance(rep["señal_activa"], bool)
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_sin_zona_lrc_no_señal(self, mock_klines):
         """Si LRC% > 25, no debe haber señal ni setup."""
         n = 210
@@ -620,7 +620,7 @@ class TestScan:
         if not rep["señal_activa"]:
             assert "✅ SEÑAL" not in rep["estado"] or not rep["señal_activa"]
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_sizing_coherente(self, mock_klines):
         """Verifica que el sizing no supere el 98% del capital."""
         df1h, df4h, df5m = self._make_scan_mock()
@@ -632,7 +632,7 @@ class TestScan:
         assert sz["capital_usd"] == 1000.0
         assert sz["riesgo_usd"] == pytest.approx(10.0, abs=0.01)
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_sl_tp_coherentes(self, mock_klines):
         """SL debe ser menor al precio, TP mayor."""
         df1h, df4h, df5m = self._make_scan_mock()
@@ -644,7 +644,7 @@ class TestScan:
         assert sz["sl_precio"] < price
         assert sz["tp_precio"] > price
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_json_serializable(self, mock_klines):
         """El reporte debe ser completamente serializable a JSON."""
         df1h, df4h, df5m = self._make_scan_mock()
@@ -655,7 +655,7 @@ class TestScan:
         serialized = json.dumps(rep, ensure_ascii=False)
         assert len(serialized) > 0
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_score_en_rango(self, mock_klines):
         """El score debe estar entre 0 y 10."""
         df1h, df4h, df5m = self._make_scan_mock()
@@ -664,7 +664,7 @@ class TestScan:
         rep = scanner.scan()
         assert 0 <= rep["score"] <= 10
 
-    @patch("btc_scanner.get_klines")
+    @patch("btc_scanner.md.get_klines")
     def test_scan_sizing_uses_atr(self, mock_klines):
         df1h, df4h, df5m = self._make_scan_mock()
         mock_klines.side_effect = [df5m, df1h, df4h, df1h]


### PR DESCRIPTION
## Summary

**First production-code phase.** btc_scanner.py and tests/test_scanner.py now route all OHLCV through the new data layer.

- **Task 17 (0556789)**: `from data import market_data as md` added; `md.prefetch(symbols, ['5m','1h','4h'], limit=210)` warms the cache at the start of each scan cycle; `df5/df1h/df4h` in `scan()` and `df1d` in `detect_regime()` call `md.get_klines(...)`. All 9 `@patch("btc_scanner.get_klines")` decorators in `test_scanner.py` re-targeted to `btc_scanner.md.get_klines`.
- **Task 18 (97d73e6)**: removed the internal fetch stack — `BINANCE_URLS`, `_BYBIT_INTERVAL`, `_active_provider`/`_provider_lock`/`_provider_fail_count`/`_RECOVERY_INTERVAL`, `_get`, `_klines_binance`, `_klines_bybit`. `TestKlinesBybit` (3 tests on the removed helper) deleted. Scanner shrunk 1257 → 1119 lines.
- **Task 19 (b10e62c)**: golden-path live validation on BTCUSDT — scanner ran end-to-end against real Binance data and produced a valid report.

## Deviations from the plan

1. **`get_klines` kept as a compat shim** (Task 18 Step 1 expected full removal): `btc_api.py:42` imports `get_klines` and the `/ohlcv` endpoint at line 1625 depends on the legacy DataFrame shape (DatetimeIndex + in-progress bar). The shim delegates to `md.get_klines_live` and re-attaches a `pd.to_datetime(open_time)` index. Full removal scheduled in Phase 7 Task 23 when `/ohlcv` is migrated to `md.get_klines_live` directly.

2. **`calc_cvd_delta` taker-side approximation** (new fix, Task 19): the data layer's `Bar` contract is OHLCV + provider metadata only — no `taker_buy_base` column. The old scanner got this directly from Binance klines and approximated it for Bybit. Uniformized the approximation (close position within high-low range × volume) inside `calc_cvd_delta`. Minor accuracy loss for Binance source acceptable — CVD delta is a 3-bar proxy already.

## Test plan

- [x] Full suite: `python -m pytest tests/ -q` → **358 passed** (was 361 pre-Phase-6: -3 deleted `TestKlinesBybit` tests, same scanner + data-layer coverage otherwise)
- [x] Live end-to-end scan: `python scripts/golden_diff_scanner.py BTCUSDT` produced a well-formed report (score=5, señal_activa=false under current market; no tracebacks)
- [x] `python -c "import btc_scanner, btc_api"` imports cleanly
- [ ] CI (GitHub Actions) backend-tests + frontend-typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)