### PR TITLE
refactor(consumers): migrate backtest, report, api to data.market_data (Phase 7)

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -27,6 +27,8 @@ import pandas as pd
 import numpy as np
 import requests
 
+from data import market_data as md
+
 # Import scanner functions
 from btc_scanner import (
     calc_lrc, calc_rsi, calc_bb, calc_sma, calc_atr, calc_adx,
@@ -56,7 +58,6 @@ FEE_PCT = 0.001  # 0.1% per trade (Binance spot)
 #  DATA DOWNLOAD
 # ─────────────────────────────────────────────────────────────────────────────
 
-_dl_last_call = 0.0
 
 
 def get_historical_fear_greed() -> pd.DataFrame:
@@ -136,100 +137,31 @@ def get_historical_funding_rate() -> pd.DataFrame:
     log.info(f"Funding rate saved: {len(df)} entries ({df.index[0].date()} → {df.index[-1].date()})")
     return df
 
-def download_klines(symbol: str, interval: str, start_ts: int, end_ts: int) -> pd.DataFrame:
-    """Download historical klines from Binance with pagination and rate limiting."""
-    global _dl_last_call
-    all_data = []
-    current_start = start_ts
-    limit = 1000
-
-    while current_start < end_ts:
-        url = (
-            f"https://api.binance.com/api/v3/klines"
-            f"?symbol={symbol}&interval={interval}"
-            f"&startTime={current_start}&endTime={end_ts}&limit={limit}"
-        )
-        try:
-            r = requests.get(url, timeout=30)
-            r.raise_for_status()
-            data = r.json()
-        except Exception as e:
-            log.warning(f"Binance error: {e}, retrying in 5s...")
-            time.sleep(5)
-            continue
-
-        if not data:
-            break
-
-        all_data.extend(data)
-        current_start = int(data[-1][0]) + 1  # next ms after last candle
-
-        if len(data) < limit:
-            break
-
-        # Rate limit: max 5 requests/sec to Binance
-        elapsed = time.time() - _dl_last_call
-        if elapsed < 0.2:
-            time.sleep(0.2 - elapsed)
-        _dl_last_call = time.time()
-
-    if not all_data:
-        return pd.DataFrame()
-
-    df = pd.DataFrame(all_data, columns=[
-        "ts", "open", "high", "low", "close", "volume",
-        "close_time", "quote_volume", "trades",
-        "taker_buy_base", "taker_buy_quote", "ignore"
-    ])
-    for c in ["open", "high", "low", "close", "volume", "taker_buy_base", "taker_buy_quote"]:
-        df[c] = df[c].astype(float)
-    df["ts"] = pd.to_datetime(df["ts"], unit="ms")
-    df.set_index("ts", inplace=True)
-    df = df[~df.index.duplicated(keep='first')]
-    return df
-
-
 def get_cached_data(symbol: str, interval: str, start_date: datetime = None) -> pd.DataFrame:
-    """Download data or load from cache. Extends cache in both directions as needed."""
-    cache_file = os.path.join(DATA_DIR, f"{symbol}_{interval}.csv")
+    """Historical bars fetched via data.market_data (SQLite cache + provider failover).
+
+    Previously kept its own per-symbol CSV cache with bidirectional pagination —
+    that's now handled by the unified data layer. Returns the legacy DataFrame
+    shape (DatetimeIndex + OHLCV columns) for backward compatibility with
+    simulate_strategy and the downstream auto_tune / grid_search scripts.
+    """
     want_start = start_date or DEFAULT_START
-    start_ms = int(want_start.timestamp() * 1000)
-    end_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    now = datetime.now(timezone.utc)
 
-    if os.path.exists(cache_file):
-        df = pd.read_csv(cache_file, index_col="ts", parse_dates=True)
-        changed = False
-
-        # Extend backwards if cache starts later than requested
-        first_ts = int(df.index[0].timestamp() * 1000)
-        if first_ts > start_ms + 86400_000:
-            log.info(f"Extending cache backwards for {symbol} {interval} to {want_start.date()}...")
-            old_df = download_klines(symbol, interval, start_ms, first_ts - 1)
-            if not old_df.empty:
-                df = pd.concat([old_df, df])
-                changed = True
-
-        # Extend forward if cache is older than 24h
-        last_ts = int(df.index[-1].timestamp() * 1000)
-        if (end_ms - last_ts) > 86400_000:
-            log.info(f"Updating cache forward for {symbol} {interval}...")
-            new_df = download_klines(symbol, interval, last_ts + 1, end_ms)
-            if not new_df.empty:
-                df = pd.concat([df, new_df])
-                changed = True
-
-        if changed:
-            df = df[~df.index.duplicated(keep='first')].sort_index()
-            df.to_csv(cache_file)
-
-        log.info(f"Cache: {cache_file} ({len(df)} candles, {df.index[0].date()} → {df.index[-1].date()})")
+    # Bulk-backfill ahead of the range query so the first read doesn't
+    # trigger piecewise fetches inside get_klines_range.
+    md.backfill(symbol, interval, want_start, now)
+    df = md.get_klines_range(symbol, interval, want_start, now)
+    if df.empty:
         return df
 
-    log.info(f"Downloading {symbol} {interval} from {want_start.date()}...")
-    df = download_klines(symbol, interval, start_ms, end_ms)
-    if not df.empty:
-        df.to_csv(cache_file)
-        log.info(f"Saved {len(df)} candles to {cache_file}")
+    df = df.copy()
+    df["ts"] = pd.to_datetime(df["open_time"], unit="ms")
+    df = (
+        df.drop(columns=["open_time", "provider", "fetched_at"], errors="ignore")
+          .set_index("ts")
+    )
+    log.info(f"{symbol} {interval}: {len(df)} candles ({df.index[0].date()} → {df.index[-1].date()})")
     return df
 
 

--- a/btc_api.py
+++ b/btc_api.py
@@ -39,7 +39,8 @@ from logging.handlers import RotatingFileHandler
 import sys
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPT_DIR)
-from btc_scanner import scan, get_top_symbols, get_klines
+from btc_scanner import scan, get_top_symbols
+from data import market_data as md
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -97,7 +98,7 @@ def check_pending_signal_outcomes(current_prices: dict[str, float]):
             if age_hours <= 25.0:
                 if symbol not in _klines_cache:
                     try:
-                        _klines_cache[symbol] = get_klines(symbol, "1h", limit=25)
+                        _klines_cache[symbol] = md.get_klines(symbol, "1h", limit=25)
                     except Exception:
                         _klines_cache[symbol] = None
 
@@ -1409,6 +1410,7 @@ def status():
             "score":   latest["score"]   if latest else None,
         } if latest else None,
         "config": _strip_secrets(load_config()),
+        "market_data": md.get_stats(),
     }
 
 
@@ -1617,12 +1619,12 @@ def get_ohlcv(
     limit:    int = Query(300,       ge=1, le=1000, description="Número de velas"),
 ):
     """Retorna datos OHLCV listos para lightweight-charts (timestamps en segundos UTC).
-    Usa get_klines() del scanner (proxy + fallback a Bybit integrados)."""
+    Usa md.get_klines_live() — incluye la barra en curso para el gráfico animado."""
     VALID = {"1m","3m","5m","15m","30m","1h","2h","4h","6h","8h","12h","1d","3d","1w","1M"}
     if interval not in VALID:
         raise HTTPException(status_code=400, detail=f"Intervalo invalido: {interval}")
     try:
-        df = get_klines(symbol.upper(), interval, limit=limit)
+        df = md.get_klines_live(symbol.upper(), interval, limit=limit)
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"Error obteniendo OHLCV: {e}")
 
@@ -1631,7 +1633,7 @@ def get_ohlcv(
 
     candles, volumes = [], []
     for _, row in df.iterrows():
-        ts = int(row.name.timestamp()) if hasattr(row.name, 'timestamp') else 0
+        ts = int(row["open_time"]) // 1000  # ms → seconds for lightweight-charts
         o, h, l, c = float(row["open"]), float(row["high"]), float(row["low"]), float(row["close"])
         v = float(row["volume"])
         candles.append({"time": ts, "open": o, "high": h, "low": l, "close": c})

--- a/btc_report.py
+++ b/btc_report.py
@@ -12,6 +12,8 @@ import json
 import base64
 import io
 import sys
+
+from data import market_data as md
 from datetime import datetime, timezone, timedelta
 import warnings
 warnings.filterwarnings('ignore')
@@ -95,18 +97,15 @@ def get_open_interest_hist(period="1h", limit=48):
     return df.sort_values("timestamp")
 
 def get_klines(interval="1h", limit=168):
-    """Velas OHLCV de BTC/USDT - Binance Spot"""
-    r = safe_get(
-        "https://api.binance.com/api/v3/klines",
-        params={"symbol": SYMBOL, "interval": interval, "limit": limit}
-    )
-    if r is None: return None
-    cols = ["open_time","open","high","low","close","volume",
-            "close_time","quote_vol","trades","taker_buy_base","taker_buy_quote","ignore"]
-    df = pd.DataFrame(r.json(), columns=cols)
+    """Velas OHLCV de BTC/USDT via data.market_data (incluye barra en curso)."""
+    try:
+        df = md.get_klines_live(SYMBOL, interval, limit)
+    except Exception:
+        return None
+    if df.empty:
+        return None
+    df = df.copy()
     df["open_time"] = pd.to_datetime(df["open_time"].astype(int), unit="ms", utc=True)
-    for c in ["open","high","low","close","volume","quote_vol","taker_buy_base","taker_buy_quote"]:
-        df[c] = df[c].astype(float)
     return df.sort_values("open_time")
 
 def get_funding_rate(limit=8):

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -186,20 +186,6 @@ def _rate_limit():
         _last_api_call = time.time()
 
 
-def get_klines(symbol: str, interval: str, limit: int = 210) -> pd.DataFrame:
-    """Compatibility shim: returns the legacy shape (DatetimeIndex, includes
-    in-progress bar) on top of the new data layer. btc_api's /ohlcv and
-    performance tracker still consume this shape; full removal lives in
-    Phase 7 Task 23."""
-    df = md.get_klines_live(symbol, interval, limit)
-    if df.empty:
-        return df
-    df = df.copy()
-    df["ts"] = pd.to_datetime(df["open_time"], unit="ms")
-    df.set_index("ts", inplace=True)
-    return df
-
-
 # ─────────────────────────────────────────────────────────────────────────────
 #  INDICADORES
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1622,7 +1622,7 @@ class TestSignalPerformance:
         con.close()
 
         # Pass current price — should fill price_1h without calling get_klines for milestones
-        with patch.object(btc_api, "get_klines") as mock_klines:
+        with patch.object(btc_api.md, "get_klines") as mock_klines:
             # get_klines only needed for runup/drawdown (1h candles)
             import pandas as pd
             mock_klines.return_value = pd.DataFrame({
@@ -1661,7 +1661,7 @@ class TestSignalPerformance:
         con.commit()
         con.close()
 
-        with patch.object(btc_api, "get_klines") as mock_klines:
+        with patch.object(btc_api.md, "get_klines") as mock_klines:
             import pandas as pd
             mock_klines.return_value = pd.DataFrame({
                 "open": [2900.0], "high": [3100.0],


### PR DESCRIPTION
## Summary

Phase 7 closes the migration: every remaining OHLCV consumer now routes through `data.market_data`, the scanner compat shim from Phase 6 is removed, and `/status` exposes data-layer metrics.

- **Task 20 (7ae400f)**: `backtest.get_cached_data` → `md.backfill` + `md.get_klines_range` with DatetimeIndex shape transform. Deleted `download_klines` and `_dl_last_call` (pagination + rate-limit now owned by the data layer). 90 lines removed.
- **Task 21** (verification only, no code): `auto_tune.py`, `grid_search_tf.py`, `optimize_new_tokens.py` all import `get_cached_data` from backtest — they inherit the migration for free. `test_auto_tune.py` 22/22 passing.
- **Task 22 (dfb6aff)**: `btc_report.get_klines` → `md.get_klines_live`. Dropped direct Binance `/api/v3/klines` call and the manual column casting. Non-OHLCV Binance futures endpoints (funding rate, long/short, open-interest) unchanged.
- **Task 23 (2b4a918)**: `/ohlcv` endpoint → `md.get_klines_live` directly (column-based `open_time` instead of DatetimeIndex + `row.name.timestamp()`). `/status` response now includes `market_data: md.get_stats()` with counters + latency histograms. Performance tracker at `btc_api.py:100` → `md.get_klines`. Finally removed the `get_klines` compatibility shim that had lived in `btc_scanner.py` since Phase 6.

## Test plan

- [x] Full suite: `python -m pytest tests/ -q` → **358 passed** (same as pre-Phase-7; nothing broken, nothing new since coverage is via existing tests)
- [x] `data/` test coverage: **92%** via `coverage run -m pytest tests/ && coverage report --include='data/*'` (plan target ≥85%). Per-module: `_fetcher.py` 94%, `_storage.py` 96%, `market_data.py` 89%, `providers/base.py` 100%, `providers/binance.py` 94%, `providers/bybit.py` 92%, `timeframes.py` 100%, `metrics.py` 97%. Only `cli.py` (78%) is below 85% — acceptable for an argparse entry point.
- [x] `python -c "import backtest, btc_report, btc_api, btc_scanner, auto_tune, grid_search_tf, optimize_new_tokens"` imports cleanly
- [ ] CI (GitHub Actions) backend-tests + frontend-typecheck green

## Deferred

**Task 24 Step 4 — 1-week production observation window** (`fetches_total` growth rate, `fallback_fetches_total` near zero, `invalid_bars_dropped_total` zero, unchanged signal output). Operational, not automated. Phase 8 (Issue #125 consumer, `annualized_vol_yang_zhang` + `vol_mult` sizing) is gated behind this observation window per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)