### PR TITLE
feat: vol-normalized position sizing — Phase 8 / Issue #125

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -39,6 +39,8 @@ from btc_scanner import (
     SCORE_MIN_HALF, SCORE_STANDARD, SCORE_PREMIUM,
     ATR_PERIOD, ATR_SL_MULT, ATR_TP_MULT, ATR_BE_MULT,
     ADX_THRESHOLD,
+    annualized_vol_yang_zhang,
+    TARGET_VOL_ANNUAL, VOL_LOOKBACK_DAYS, VOL_MIN_FLOOR, VOL_MAX_CEIL,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)-8s  %(message)s")
@@ -244,7 +246,7 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                     pnl_pct = (position["entry_price"] - exit_price) / position["entry_price"] * 100
                 else:
                     pnl_pct = (exit_price - position["entry_price"]) / position["entry_price"] * 100
-                risk_amount = capital * RISK_PER_TRADE * position["size_mult"]
+                risk_amount = capital * RISK_PER_TRADE * position["size_mult"] * position["vol_mult"]
                 sl_pct_actual = abs(position["entry_price"] - position["sl_orig"]) / position["entry_price"] * 100
                 pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0
 
@@ -448,6 +450,19 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                 tp_price = round(price * (1 + TP_PCT / 100), 2)
             be_threshold = None
 
+        # Vol-normalized sizing (#125). Computed at entry, no look-ahead —
+        # uses daily bars with open_time ≤ bar_time.
+        try:
+            df_daily_slice = md.get_klines_range(
+                symbol, "1d",
+                bar_time - pd.Timedelta(days=VOL_LOOKBACK_DAYS + 5),
+                bar_time,
+            )
+            asset_vol = annualized_vol_yang_zhang(df_daily_slice)
+        except Exception:
+            asset_vol = TARGET_VOL_ANNUAL
+        vol_mult = max(VOL_MAX_CEIL, min(1.0, TARGET_VOL_ANNUAL / max(asset_vol, VOL_MIN_FLOOR)))
+
         position = {
             "entry_price": price,
             "entry_time": bar_time,
@@ -457,6 +472,7 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
             "sl_orig": sl_price,
             "tp": tp_price,
             "size_mult": size_mult,
+            "vol_mult": vol_mult,
             "be_threshold": be_threshold,
         }
 
@@ -465,7 +481,7 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         last_bar = df1h.iloc[-1]
         exit_price = float(last_bar["close"])
         pnl_pct = (exit_price - position["entry_price"]) / position["entry_price"] * 100
-        risk_amount = capital * RISK_PER_TRADE * position["size_mult"]
+        risk_amount = capital * RISK_PER_TRADE * position["size_mult"] * position["vol_mult"]
         sl_pct_actual = (position["entry_price"] - position["sl_orig"]) / position["entry_price"] * 100
         pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0
         trades.append({

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -72,6 +72,38 @@ ATR_SL_MULT    = 1.0    # SL = entry - 1.0x ATR (optimizado para mean-reversion)
 ATR_TP_MULT    = 4.0    # TP = entry + 4.0x ATR (ratio 4:1, adaptativo)
 ATR_BE_MULT    = 1.5    # Mover SL a breakeven cuando profit >= 1.5x ATR
 
+# ── Volatility-normalized sizing (#125) ─────────────────────────────────────
+TARGET_VOL_ANNUAL = 0.15   # 15% target portfolio contribution per position
+VOL_LOOKBACK_DAYS = 30
+VOL_MIN_FLOOR = 0.05       # clamp for assets with near-zero vol
+VOL_MAX_CEIL = 0.20        # never risk less than 20% of base per position
+
+
+def annualized_vol_yang_zhang(df_daily: pd.DataFrame) -> float:
+    """Yang-Zhang annualized vol over daily bars.
+
+    Crypto note: 24/7 markets collapse the overnight term toward zero, but YZ still
+    correctly weights open-close and Rogers-Satchell components.
+    Returns TARGET_VOL_ANNUAL if too few bars (neutral sizing fallback).
+    """
+    if len(df_daily) < 5:
+        return TARGET_VOL_ANNUAL
+    o = df_daily["open"].astype(float)
+    h = df_daily["high"].astype(float)
+    l = df_daily["low"].astype(float)
+    c = df_daily["close"].astype(float)
+    log_ho = np.log(h / o)
+    log_lo = np.log(l / o)
+    log_co = np.log(c / o)
+    log_oc_prev = np.log(o / c.shift(1)).dropna()
+    n = len(df_daily) - 1
+    k = 0.34 / (1.34 + (n + 1) / (n - 1))
+    sigma_on = log_oc_prev.var(ddof=1) if len(log_oc_prev) >= 2 else 0.0
+    sigma_oc = log_co.var(ddof=1)
+    sigma_rs = (log_ho * (log_ho - log_co) + log_lo * (log_lo - log_co)).mean()
+    var_daily = max(sigma_on + k * sigma_oc + (1 - k) * sigma_rs, 1e-10)
+    return float(np.sqrt(var_daily * 365))
+
 # ── Parámetros de la estrategia Spot 1H ────────────────────────────────────
 LRC_LONG_MAX   = 25.0     # LRC% ≤ 25  →  zona de entrada
 LRC_SHORT_MIN  = 75.0     # LRC% >= 75  →  zona de entrada SHORT

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -850,7 +850,17 @@ def scan(symbol: str = None):
     # ── Sizing informativo ────────────────────────────────────────────────────
     atr_val    = float(calc_atr(df1h, ATR_PERIOD).iloc[-1])
     capital    = 1000.0
-    risk_usd   = capital * 0.01
+
+    # Vol-normalized risk (#125): fetch daily bars, compute vol, scale risk per symbol
+    try:
+        df_daily = md.get_klines(symbol, "1d", VOL_LOOKBACK_DAYS + 5)
+        asset_vol = annualized_vol_yang_zhang(df_daily)
+    except Exception as e:
+        log.warning("Vol calc failed for %s: %s — using neutral sizing", symbol, e)
+        asset_vol = TARGET_VOL_ANNUAL
+
+    vol_mult = max(VOL_MAX_CEIL, min(1.0, TARGET_VOL_ANNUAL / max(asset_vol, VOL_MIN_FLOOR)))
+    risk_usd = capital * 0.01 * vol_mult
 
     # Per-symbol ATR overrides from config
     _cfg_path = os.path.join(SCRIPT_DIR, "config.json")
@@ -955,6 +965,9 @@ def scan(symbol: str = None):
             "qty_btc":     round(qty_btc, 6),
             "valor_pos":   round(val_pos, 2),
             "pct_capital": round(val_pos / capital * 100, 1),
+            "asset_vol":   round(asset_vol, 4),
+            "vol_mult":    round(vol_mult, 3),
+            "target_vol":  TARGET_VOL_ANNUAL,
         },
     })
     # Convertir tipos numpy a tipos Python nativos para serialización JSON

--- a/docs/superpowers/specs/es/2026-04-18-vol-normalized-resultados.md
+++ b/docs/superpowers/specs/es/2026-04-18-vol-normalized-resultados.md
@@ -1,0 +1,78 @@
+# Resultados de Vol-Normalized Position Sizing — #125
+
+**Fecha:** 2026-04-20
+**Spec:** `docs/superpowers/specs/en/2026-04-18-market-data-layer-design.md`
+**Plan:** `docs/superpowers/plans/2026-04-18-market-data-layer.md` (Fase 8)
+**Issue:** #125
+
+## Qué cambió
+
+- `btc_scanner.annualized_vol_yang_zhang(df_daily)` — estimador Yang-Zhang con fallback a `TARGET_VOL_ANNUAL` cuando hay < 5 barras.
+- Constantes: `TARGET_VOL_ANNUAL = 0.15`, `VOL_LOOKBACK_DAYS = 30`, `VOL_MIN_FLOOR = 0.05`, `VOL_MAX_CEIL = 0.20` (clamp inferior del multiplicador).
+- **Scanner** (`btc_scanner.py:scan`): en el bloque de sizing, después de calcular ATR, consulta `md.get_klines(symbol, "1d", VOL_LOOKBACK_DAYS + 5)`, deriva `asset_vol` y `vol_mult`, y escala `risk_usd`. Expuesto en `sizing_1h`: `asset_vol`, `vol_mult`, `target_vol`.
+- **Backtest** (`backtest.py:simulate_strategy`): al abrir la posición, calcula `vol_mult` usando `md.get_klines_range(..., bar_time - timedelta(days=35), bar_time)` (sin look-ahead) y lo guarda en el dict de la posición. En el cierre, `risk_amount = capital * RISK_PER_TRADE * size_mult * vol_mult`.
+
+## Fórmula
+
+```
+vol_mult = clamp(
+    TARGET_VOL_ANNUAL / max(asset_vol, VOL_MIN_FLOOR),
+    VOL_MAX_CEIL,   # floor del multiplicador = 0.20 → nunca menos del 20% del riesgo base
+    1.0,            # ceiling del multiplicador = 1.0 → nunca más del 100% del riesgo base
+)
+risk_usd = capital * 0.01 * vol_mult
+```
+
+Intuición: activos con vol anualizada > 15% reciben menos riesgo; activos con vol ≤ 15% reciben el riesgo base. El cap inferior (20%) evita que una vol extrema reduzca el sizing a niveles operativamente inviables.
+
+## Comparativa
+
+> **Nota:** la corrida comparativa completa (2022-01-01 → 2026-04-18, 10 símbolos) requiere varias horas de _backfill_ + simulación contra Binance. Los valores `[FILL]` se completan al ejecutar:
+>
+> ```bash
+> # Baseline (antes de Fase 8)
+> git checkout $(git merge-base HEAD origin/main)~1
+> python backtest.py --start 2022-01-01 --end 2026-04-18 --output /tmp/baseline.json
+>
+> # Con vol-normalized sizing
+> git checkout -
+> python backtest.py --start 2022-01-01 --end 2026-04-18 --output /tmp/vol_sized.json
+>
+> python scripts/diff_backtest.py /tmp/baseline.json /tmp/vol_sized.json
+> ```
+
+| Métrica | Baseline (sin vol) | Con vol sizing | Delta |
+|---|---|---|---|
+| Total P&L ($) | [FILL] | [FILL] | [FILL] |
+| Max drawdown (%) | [FILL] | [FILL] | [FILL] |
+| Sharpe | [FILL] | [FILL] | [FILL] |
+| Profit Factor | [FILL] | [FILL] | [FILL] |
+| Trades | [FILL] | [FILL] | [FILL] |
+
+## Contribución por símbolo
+
+| Símbolo | Baseline ($) | Vol sizing ($) | Delta ($) | Vol anualizada |
+|---|---|---|---|---|
+| BTCUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| ETHUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| ADAUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| AVAXUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| DOGEUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| UNIUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| XLMUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| PENDLEUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| JUPUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| RUNEUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+
+## Conclusión
+
+- **Hipótesis del épico #121**: pasar de -$14,655 (pérdida histórica con sizing fijo) a un rango de +$25,000–$40,000 al escalar inversamente al riesgo.
+- **Validación**: pendiente de la corrida comparativa. Si el swing total P&L se acerca al objetivo: VALIDADO, cerrar #125. Si no: iterar sobre los clamps (`VOL_MIN_FLOOR`, `VOL_MAX_CEIL`, lookback, `target_vol`).
+
+## Próximos pasos
+
+- [ ] Corrida comparativa completa (bloqueado por tiempo de cómputo, ~horas contra Binance live).
+- [ ] Llenar tablas `[FILL]` y rehacer este documento con números reales.
+- [ ] Observación en producción (4 semanas) antes de ajustar capital real.
+- [ ] Revisión de épica #121 con los resultados.
+- [ ] Si validado: `gh issue close 125`.

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -624,13 +624,15 @@ class TestScan:
     def test_scan_sizing_coherente(self, mock_klines):
         """Verifica que el sizing no supere el 98% del capital."""
         df1h, df4h, df5m = self._make_scan_mock()
-        mock_klines.side_effect = [df5m, df1h, df4h, df1h]
+        mock_klines.side_effect = [df5m, df1h, df4h, df1h, df1h]  # +1 for vol 1d lookup
 
         rep = scanner.scan()
         sz = rep["sizing_1h"]
         assert sz["pct_capital"] <= 98.0
         assert sz["capital_usd"] == 1000.0
-        assert sz["riesgo_usd"] == pytest.approx(10.0, abs=0.01)
+        # riesgo = capital * 0.01 * vol_mult, where vol_mult ∈ [VOL_MAX_CEIL, 1.0]
+        assert scanner.VOL_MAX_CEIL * 10.0 <= sz["riesgo_usd"] <= 10.0
+        assert sz["riesgo_usd"] == pytest.approx(10.0 * sz["vol_mult"], abs=0.01)
 
     @patch("btc_scanner.md.get_klines")
     def test_scan_sl_tp_coherentes(self, mock_klines):
@@ -978,3 +980,22 @@ class TestCheckTrigger5MShort:
         active, details = check_trigger_5m_short(df5)
         assert active is False
         assert details == {}
+
+
+class TestVolMultIntegration:
+    def test_high_vol_series_lowers_sizing(self):
+        """High-vol synthetic series should push vol_mult below 1 (#125)."""
+        from btc_scanner import annualized_vol_yang_zhang, TARGET_VOL_ANNUAL
+
+        # High-volatility synthetic series (5% daily σ)
+        n = 35
+        rng = np.random.default_rng(0)
+        prices = 100.0 * np.exp(rng.normal(0, 0.05, n).cumsum())
+        df = pd.DataFrame({
+            "open": prices,
+            "high": prices * 1.03,
+            "low": prices * 0.97,
+            "close": prices,
+        })
+        vol = annualized_vol_yang_zhang(df)
+        assert vol > TARGET_VOL_ANNUAL  # high-vol series → mult < 1

--- a/tests/test_vol_calc.py
+++ b/tests/test_vol_calc.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _daily_df(opens, highs, lows, closes):
+    return pd.DataFrame({
+        "open": opens, "high": highs, "low": lows, "close": closes,
+    })
+
+
+class TestYangZhangVol:
+    def test_zero_variance_bars_returns_tiny_floor(self):
+        from btc_scanner import annualized_vol_yang_zhang
+        # All bars identical → variance zero → result near zero
+        df = _daily_df([100.0] * 30, [100.0] * 30, [100.0] * 30, [100.0] * 30)
+        vol = annualized_vol_yang_zhang(df)
+        assert 0.0 <= vol < 0.01
+
+    def test_short_series_returns_fallback(self):
+        from btc_scanner import annualized_vol_yang_zhang, TARGET_VOL_ANNUAL
+        df = _daily_df([100.0] * 3, [101.0] * 3, [99.0] * 3, [100.0] * 3)
+        vol = annualized_vol_yang_zhang(df)
+        assert vol == TARGET_VOL_ANNUAL
+
+    def test_typical_crypto_volatility_in_range(self):
+        from btc_scanner import annualized_vol_yang_zhang
+        # Simulate ~2% daily range, 1% daily drift noise
+        rng = np.random.default_rng(42)
+        n = 30
+        closes = 100.0 * np.exp(rng.normal(0, 0.02, n).cumsum())
+        opens = np.concatenate([[closes[0]], closes[:-1]])
+        highs = np.maximum(opens, closes) * (1 + np.abs(rng.normal(0, 0.01, n)))
+        lows = np.minimum(opens, closes) * (1 - np.abs(rng.normal(0, 0.01, n)))
+        df = _daily_df(opens, highs, lows, closes)
+        vol = annualized_vol_yang_zhang(df)
+        # Expect roughly 20-50% annualized for such a series
+        assert 0.1 <= vol <= 1.0


### PR DESCRIPTION
## Summary

Final phase of the market-data-layer epic. Builds Issue #125's volatility-adjusted sizing on top of the now-unified data layer.

- **Task 25 (ede1b46)**: `btc_scanner.annualized_vol_yang_zhang(df_daily)` — Yang-Zhang annualized-vol estimator with a `TARGET_VOL_ANNUAL` fallback when < 5 bars are available. Plus constants `TARGET_VOL_ANNUAL=0.15`, `VOL_LOOKBACK_DAYS=30`, `VOL_MIN_FLOOR=0.05`, `VOL_MAX_CEIL=0.20`. 3 tests covering zero-variance, short-series fallback, and typical-crypto-range.
- **Task 26 (2024f20)**: scanner's `scan()` now pulls 35 daily bars via `md.get_klines`, computes `vol_mult = clamp(TARGET_VOL_ANNUAL / max(asset_vol, VOL_MIN_FLOOR), VOL_MAX_CEIL, 1.0)`, and scales `risk_usd`. Exposed as `asset_vol`/`vol_mult`/`target_vol` in the `sizing_1h` report dict. Plus integration test for high-vol series → mult < 1.
- **Task 27 (f9072fd)**: backtest simulation computes vol_mult at entry (no look-ahead — `end=bar_time` on the range query), stores on the position dict, and applies at both exit sites. Faithful to "risk decided at entry."
- **Task 28 (0a1829c)**: results doc template + methodology in `docs/superpowers/specs/es/2026-04-18-vol-normalized-resultados.md`. The full 2022-2026 comparative backtest across 10 symbols needs hours of live Binance backfill — doc is pre-populated with commands and the expected table shape so the numbers can drop in on a dedicated run.

## Deviations from plan

1. **Backtest vol_mult timing** (Task 27): plan re-computed vol at each exit; I compute it at entry and store on the position. Risk is a sizing decision made when opening — re-computing at exit would make `risk_amount` inconsistent with the trade that actually opened. Cleaner and also avoids redundant daily lookups per exit.

2. **Soak window** (Task 24 Step 4 from Phase 7 + Phase 8 gate): plan says Phase 8 is gated behind ≥1 week of Phase 6 in production. User overrode — "go for it asap." Phase 8 is code-complete; recommend exercising caution with real capital until live prod metrics (fallback_fetches_total near zero, signal output unchanged) confirm the data layer is stable.

3. **Test update** (Task 26): `test_scan_sizing_coherente` used to assert `riesgo_usd == 10.0` (hardcoded); with `vol_mult` now applied, the value is variable. Replaced with a band check `VOL_MAX_CEIL*10 ≤ riesgo_usd ≤ 10.0` plus the invariant `riesgo_usd == 10.0 * vol_mult`. Also added a 5th mock return for the new 1d get_klines call.

## Test plan

- [x] Full suite: `python -m pytest tests/ -q` → **362 passed** (was 358 pre-Phase-8; +3 vol_calc + 1 integration)
- [x] New tests: `tests/test_vol_calc.py` (3 tests) + `tests/test_scanner.py::TestVolMultIntegration::test_high_vol_series_lowers_sizing` (1 test)
- [x] `python -c "import btc_scanner, backtest; print('OK')"` clean
- [ ] CI (GitHub Actions) backend-tests + frontend-typecheck green
- [ ] **User**: comparative backtest run (see `docs/superpowers/specs/es/2026-04-18-vol-normalized-resultados.md`) to validate the #121 hypothesis (-$14,655 → +$25k–$40k). Close #125 once results land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)