### PR TITLE
fix: rescue production — revert vol_mult, fix curated-list bypass, wire prefetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,11 +70,15 @@ Binance API (Bybit fallback)
 | `signals.db` | SQLite: `signals` + `positions` tables | — |
 
 ### Key Backend Logic (`btc_scanner.py`)
-- **Indicators:** LRC (100-bar Linear Regression Channel), RSI, Bollinger Bands, SMA100
-- **Entry zone:** LRC_LONG_MAX = 25% (price within 25% of lower channel band)
+- **Indicators:** LRC (100-bar Linear Regression Channel), RSI, Bollinger Bands, SMA100, ATR, ADX
+- **Entry zone:** LRC_LONG_MAX = 25% (long), LRC_SHORT_MIN = 75% (short, gated by regime=BEAR)
 - **Score tiers:** 0–1 = 50% size, 2–3 = normal, ≥4 = premium signal
-- **Default symbols:** BTC, ETH, BNB, SOL, XRP, ADA, AVAX, DOGE, DOT, MATIC, LINK, LTC, UNI, ATOM, XLM, NEAR, FIL, APT, OP, ARB (top 20, dynamically fetched from CoinGecko with fallback)
-- **Scan interval:** 300 seconds (configurable in config.json)
+- **Risk per trade:** fixed 1% of capital. **Do not add multiplicative risk scalers on top** — per-symbol volatility adaptation is handled by the tuned `atr_sl_mult/tp/be` values in `config.json["symbol_overrides"]` (epic #121).
+- **Curated symbols (static, 10 coins):** `DEFAULT_SYMBOLS` in `btc_scanner.py` — BTC, ETH, ADA, AVAX, DOGE, UNI, XLM, PENDLE, JUP, RUNE. This list is static since epic #135 confirmed via 768+ backtest combinations that the 13 removed tokens (BNB, SOL, XRP, DOT, MATIC, LINK, LTC, ATOM, NEAR, FIL, APT, OP, ARB) are not profitable with this strategy regardless of parameters.
+- **SHORT is bidirectional and auto-gated** by `detect_regime()` — contributes ~50% of the validated 4-year backtest P&L. See `docs/superpowers/specs/es/2026-04-17-formula-ganadora-resultados-finales.md`.
+- **Regime detector** (`detect_regime`, once daily, cached in `data/regime_cache.json`): composite score = 40% price (SMA50/200, 30d momentum) + 30% Fear & Greed + 30% Binance Futures funding rate. Scores >60 = BULL/LONG, <40 = BEAR/SHORT-enabled, 40–60 = NEUTRAL/LONG-only.
+- **Scan interval:** 300 seconds (configurable in `config.json`)
+- **Authoritative system doc:** `docs/superpowers/specs/es/2026-04-18-documento-completo-sistema-trading.md` — read this before touching sizing, symbol selection, or the regime detector.
 
 ### Key API Endpoints (`btc_api.py`)
 - `GET /symbols` — real-time status for all monitored symbols

--- a/backtest.py
+++ b/backtest.py
@@ -39,8 +39,6 @@ from btc_scanner import (
     SCORE_MIN_HALF, SCORE_STANDARD, SCORE_PREMIUM,
     ATR_PERIOD, ATR_SL_MULT, ATR_TP_MULT, ATR_BE_MULT,
     ADX_THRESHOLD,
-    annualized_vol_yang_zhang,
-    TARGET_VOL_ANNUAL, VOL_LOOKBACK_DAYS, VOL_MIN_FLOOR, VOL_MAX_CEIL,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)-8s  %(message)s")
@@ -246,7 +244,7 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                     pnl_pct = (position["entry_price"] - exit_price) / position["entry_price"] * 100
                 else:
                     pnl_pct = (exit_price - position["entry_price"]) / position["entry_price"] * 100
-                risk_amount = capital * RISK_PER_TRADE * position["size_mult"] * position["vol_mult"]
+                risk_amount = capital * RISK_PER_TRADE * position["size_mult"]
                 sl_pct_actual = abs(position["entry_price"] - position["sl_orig"]) / position["entry_price"] * 100
                 pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0
 
@@ -450,19 +448,6 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                 tp_price = round(price * (1 + TP_PCT / 100), 2)
             be_threshold = None
 
-        # Vol-normalized sizing (#125). Computed at entry, no look-ahead —
-        # uses daily bars with open_time ≤ bar_time.
-        try:
-            df_daily_slice = md.get_klines_range(
-                symbol, "1d",
-                bar_time - pd.Timedelta(days=VOL_LOOKBACK_DAYS + 5),
-                bar_time,
-            )
-            asset_vol = annualized_vol_yang_zhang(df_daily_slice)
-        except Exception:
-            asset_vol = TARGET_VOL_ANNUAL
-        vol_mult = max(VOL_MAX_CEIL, min(1.0, TARGET_VOL_ANNUAL / max(asset_vol, VOL_MIN_FLOOR)))
-
         position = {
             "entry_price": price,
             "entry_time": bar_time,
@@ -472,7 +457,6 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
             "sl_orig": sl_price,
             "tp": tp_price,
             "size_mult": size_mult,
-            "vol_mult": vol_mult,
             "be_threshold": be_threshold,
         }
 
@@ -481,7 +465,7 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         last_bar = df1h.iloc[-1]
         exit_price = float(last_bar["close"])
         pnl_pct = (exit_price - position["entry_price"]) / position["entry_price"] * 100
-        risk_amount = capital * RISK_PER_TRADE * position["size_mult"] * position["vol_mult"]
+        risk_amount = capital * RISK_PER_TRADE * position["size_mult"]
         sl_pct_actual = (position["entry_price"] - position["sl_orig"]) / position["entry_price"] * 100
         pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0
         trades.append({

--- a/btc_api.py
+++ b/btc_api.py
@@ -1291,6 +1291,14 @@ def scanner_loop():
         _scanner_state["symbols_active"] = symbols
         log.info(f"Ciclo iniciado — {len(symbols)} simbolos")
 
+        # Calentar el caché OHLCV en paralelo para que los scans por símbolo
+        # siguientes sean hits del caché en lugar de cold fetches a Binance.
+        # El diagnóstico per-símbolo luego hace md.get_klines en 5m/1h/4h/1d.
+        try:
+            md.prefetch(symbols, ["5m", "1h", "4h"], limit=210)
+        except Exception as e:
+            log.warning(f"prefetch batch fallo: {e}")
+
         cycle_prices = {}
         for sym in symbols:
             if not _scanner_state["running"]:

--- a/btc_api.py
+++ b/btc_api.py
@@ -710,19 +710,29 @@ def _get_binance_usdt_symbols() -> set:
 
 
 def get_active_symbols(n: int = 20) -> List[str]:
-    """Retorna la lista de símbolos validados contra Binance, refrescada cada hora."""
+    """Retorna la lista CURADA de 10 símbolos rentables (epic #135).
+
+    Previamente pedía top-N por market cap a CoinGecko, lo que reinsertaba
+    los 13 tokens confirmados no rentables (BNB, SOL, XRP, DOT, MATIC,
+    LINK, LTC, ATOM, NEAR, FIL, APT, OP, ARB) en cada refresh.
+
+    Diseño actual (epic #121/#135): la lista es ESTÁTICA y vive en
+    `btc_scanner.DEFAULT_SYMBOLS`. La validación contra Binance spot se
+    mantiene como guarda adicional para evitar scanear pares delisted.
+    """
+    from btc_scanner import DEFAULT_SYMBOLS
     global _symbols_cache, _symbols_fetched_at
     if not _symbols_cache or (time.time() - _symbols_fetched_at) > SYMBOLS_REFRESH_SEC:
-        log.info("Actualizando lista de símbolos desde CoinGecko...")
-        # Pedir el doble para tener margen al filtrar
-        candidates   = get_top_symbols(n * 2)
+        candidates = DEFAULT_SYMBOLS[:n]
         valid_on_binance = _get_binance_usdt_symbols()
         if valid_on_binance:
+            dropped = [s for s in candidates if s not in valid_on_binance]
+            if dropped:
+                log.warning(f"Símbolos curados no listados en Binance (serán omitidos): {dropped}")
             candidates = [s for s in candidates if s in valid_on_binance]
-            log.info(f"Simbolos validos en Binance: {len(candidates)} de {n*2} candidatos")
-        _symbols_cache = candidates[:n]
+        _symbols_cache = candidates
         _symbols_fetched_at = time.time()
-        log.info(f"Simbolos activos: {_symbols_cache}")
+        log.info(f"Símbolos activos (curados): {_symbols_cache}")
     return _symbols_cache
 
 

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -72,19 +72,21 @@ ATR_SL_MULT    = 1.0    # SL = entry - 1.0x ATR (optimizado para mean-reversion)
 ATR_TP_MULT    = 4.0    # TP = entry + 4.0x ATR (ratio 4:1, adaptativo)
 ATR_BE_MULT    = 1.5    # Mover SL a breakeven cuando profit >= 1.5x ATR
 
-# ── Volatility-normalized sizing (#125) ─────────────────────────────────────
-TARGET_VOL_ANNUAL = 0.15   # 15% target portfolio contribution per position
+# ── Yang-Zhang vol estimator (diagnostic utility only — NOT applied to sizing) ──
+# The vol-normalized sizing idea of #125 was found to regress P&L in comparative
+# backtest: the per-symbol atr_sl_mult/tp tuning from epic #121 (735 sims) already
+# adapts to volatility structurally. Multiplying a flat vol_mult on top shrinks
+# the effective risk of the highest-validated symbols (DOGE, BTC, RUNE) and
+# undoes the gains. Function kept available for telemetry / future dashboards.
+TARGET_VOL_ANNUAL = 0.15   # reference target (not currently applied)
 VOL_LOOKBACK_DAYS = 30
-VOL_MIN_FLOOR = 0.05       # clamp for assets with near-zero vol
-VOL_MAX_CEIL = 0.20        # never risk less than 20% of base per position
 
 
 def annualized_vol_yang_zhang(df_daily: pd.DataFrame) -> float:
-    """Yang-Zhang annualized vol over daily bars.
+    """Yang-Zhang annualized vol over daily bars (diagnostic utility).
 
-    Crypto note: 24/7 markets collapse the overnight term toward zero, but YZ still
-    correctly weights open-close and Rogers-Satchell components.
-    Returns TARGET_VOL_ANNUAL if too few bars (neutral sizing fallback).
+    Not wired into position sizing — see note above. Returns TARGET_VOL_ANNUAL
+    when fewer than 5 bars are available.
     """
     if len(df_daily) < 5:
         return TARGET_VOL_ANNUAL
@@ -850,17 +852,7 @@ def scan(symbol: str = None):
     # ── Sizing informativo ────────────────────────────────────────────────────
     atr_val    = float(calc_atr(df1h, ATR_PERIOD).iloc[-1])
     capital    = 1000.0
-
-    # Vol-normalized risk (#125): fetch daily bars, compute vol, scale risk per symbol
-    try:
-        df_daily = md.get_klines(symbol, "1d", VOL_LOOKBACK_DAYS + 5)
-        asset_vol = annualized_vol_yang_zhang(df_daily)
-    except Exception as e:
-        log.warning("Vol calc failed for %s: %s — using neutral sizing", symbol, e)
-        asset_vol = TARGET_VOL_ANNUAL
-
-    vol_mult = max(VOL_MAX_CEIL, min(1.0, TARGET_VOL_ANNUAL / max(asset_vol, VOL_MIN_FLOOR)))
-    risk_usd = capital * 0.01 * vol_mult
+    risk_usd   = capital * 0.01
 
     # Per-symbol ATR overrides from config
     _cfg_path = os.path.join(SCRIPT_DIR, "config.json")
@@ -965,9 +957,6 @@ def scan(symbol: str = None):
             "qty_btc":     round(qty_btc, 6),
             "valor_pos":   round(val_pos, 2),
             "pct_capital": round(val_pos / capital * 100, 1),
-            "asset_vol":   round(asset_vol, 4),
-            "vol_mult":    round(vol_mult, 3),
-            "target_vol":  TARGET_VOL_ANNUAL,
         },
     })
     # Convertir tipos numpy a tipos Python nativos para serialización JSON

--- a/docs/superpowers/specs/es/2026-04-18-vol-normalized-resultados.md
+++ b/docs/superpowers/specs/es/2026-04-18-vol-normalized-resultados.md
@@ -1,78 +1,118 @@
-# Resultados de Vol-Normalized Position Sizing — #125
+# Vol-Normalized Sizing — Investigación y Decisión Final (#125)
 
 **Fecha:** 2026-04-20
-**Spec:** `docs/superpowers/specs/en/2026-04-18-market-data-layer-design.md`
-**Plan:** `docs/superpowers/plans/2026-04-18-market-data-layer.md` (Fase 8)
-**Issue:** #125
+**Issue:** #125 (cerrado — implementación revertida)
+**Spec de referencia:** `docs/superpowers/specs/en/2026-04-18-market-data-layer-design.md`
+**Doc canónico del sistema:** `docs/superpowers/specs/es/2026-04-18-documento-completo-sistema-trading.md`
 
-## Qué cambió
+## TL;DR
 
-- `btc_scanner.annualized_vol_yang_zhang(df_daily)` — estimador Yang-Zhang con fallback a `TARGET_VOL_ANNUAL` cuando hay < 5 barras.
-- Constantes: `TARGET_VOL_ANNUAL = 0.15`, `VOL_LOOKBACK_DAYS = 30`, `VOL_MIN_FLOOR = 0.05`, `VOL_MAX_CEIL = 0.20` (clamp inferior del multiplicador).
-- **Scanner** (`btc_scanner.py:scan`): en el bloque de sizing, después de calcular ATR, consulta `md.get_klines(symbol, "1d", VOL_LOOKBACK_DAYS + 5)`, deriva `asset_vol` y `vol_mult`, y escala `risk_usd`. Expuesto en `sizing_1h`: `asset_vol`, `vol_mult`, `target_vol`.
-- **Backtest** (`backtest.py:simulate_strategy`): al abrir la posición, calcula `vol_mult` usando `md.get_klines_range(..., bar_time - timedelta(days=35), bar_time)` (sin look-ahead) y lo guarda en el dict de la posición. En el cierre, `risk_amount = capital * RISK_PER_TRADE * size_mult * vol_mult`.
+Se investigó e implementó position sizing normalizado por volatilidad (Yang-Zhang) en Fase 8 del epic market-data-layer (PR #148). **La implementación fue revertida** porque en el backtest comparativo sobre 9 símbolos curados × 6.5 meses se observó una **regresión agregada de −$7,505** en P&L vs. el sistema original.
 
-## Fórmula
+**La causa raíz es de diseño**, no de implementación: el sistema ya normaliza riesgo por volatilidad a través del tuning per-symbol de `atr_sl_mult/tp/be` (epic #121/#122/#124, 735+ simulaciones). Aplicar un `vol_mult` multiplicativo encima rompe esa calibración.
 
-```
-vol_mult = clamp(
-    TARGET_VOL_ANNUAL / max(asset_vol, VOL_MIN_FLOOR),
-    VOL_MAX_CEIL,   # floor del multiplicador = 0.20 → nunca menos del 20% del riesgo base
-    1.0,            # ceiling del multiplicador = 1.0 → nunca más del 100% del riesgo base
-)
-risk_usd = capital * 0.01 * vol_mult
-```
+## Qué se construyó y qué se revirtió
 
-Intuición: activos con vol anualizada > 15% reciben menos riesgo; activos con vol ≤ 15% reciben el riesgo base. El cap inferior (20%) evita que una vol extrema reduzca el sizing a niveles operativamente inviables.
+### Construido (PR #148, commits `ede1b46`, `2024f20`, `f9072fd`)
 
-## Comparativa
+- `btc_scanner.annualized_vol_yang_zhang(df_daily)` — estimador Yang-Zhang con fallback a `TARGET_VOL_ANNUAL` cuando hay < 5 barras
+- Constantes `TARGET_VOL_ANNUAL = 0.15`, `VOL_LOOKBACK_DAYS = 30`, `VOL_MIN_FLOOR = 0.05`, `VOL_MAX_CEIL = 0.20`
+- Scanner: cálculo de `asset_vol`, derivación de `vol_mult`, aplicación sobre `risk_usd`. Campos nuevos en `sizing_1h`
+- Backtest: `vol_mult` computado al entrar (sin look-ahead, `end=bar_time`), guardado en el dict de la posición, aplicado en ambos sitios de `risk_amount`
 
-> **Nota:** la corrida comparativa completa (2022-01-01 → 2026-04-18, 10 símbolos) requiere varias horas de _backfill_ + simulación contra Binance. Los valores `[FILL]` se completan al ejecutar:
->
-> ```bash
-> # Baseline (antes de Fase 8)
-> git checkout $(git merge-base HEAD origin/main)~1
-> python backtest.py --start 2022-01-01 --end 2026-04-18 --output /tmp/baseline.json
->
-> # Con vol-normalized sizing
-> git checkout -
-> python backtest.py --start 2022-01-01 --end 2026-04-18 --output /tmp/vol_sized.json
->
-> python scripts/diff_backtest.py /tmp/baseline.json /tmp/vol_sized.json
-> ```
+### Revertido (commit `f39b686`)
 
-| Métrica | Baseline (sin vol) | Con vol sizing | Delta |
+- Aplicación de `vol_mult` al `risk_usd` del scanner: eliminada. `risk_usd = capital * 0.01` restaurado
+- `vol_mult` y campos relacionados en `sizing_1h` del reporte: eliminados
+- `vol_mult` en el position dict del backtest: eliminado. `risk_amount = capital * RISK_PER_TRADE * size_mult` restaurado
+- Constantes `VOL_MIN_FLOOR` y `VOL_MAX_CEIL`: eliminadas del scanner (sólo tenían sentido con la fórmula clamp)
+
+### Retenido como utilidad diagnóstica
+
+- `annualized_vol_yang_zhang()` y `TARGET_VOL_ANNUAL` / `VOL_LOOKBACK_DAYS` permanecen en `btc_scanner.py` con un comentario explicando que **NO** están conectados a sizing. Son útiles para futura telemetría, dashboards, o investigación
+
+## Backtest comparativo — evidencia
+
+**Metodología:** `scripts/compare_vol_sizing_batch.py` parchea `annualized_vol_yang_zhang` para devolver `TARGET_VOL_ANNUAL` en el baseline, forzando `vol_mult = 1.0`. Así ambos runs comparten el mismo camino de código y las mismas velas OHLCV; la única variable es el escalamiento de riesgo.
+
+**Ventana:** 2025-10-01 → 2026-04-20 (~6.5 meses)
+**Símbolos:** 9 de los 10 curados (JUPUSDT sin datos en Binance spot para la ventana)
+
+### Resultados agregados
+
+| Métrica | Baseline | Con vol_mult | Delta |
 |---|---|---|---|
-| Total P&L ($) | [FILL] | [FILL] | [FILL] |
-| Max drawdown (%) | [FILL] | [FILL] | [FILL] |
-| Sharpe | [FILL] | [FILL] | [FILL] |
-| Profit Factor | [FILL] | [FILL] | [FILL] |
-| Trades | [FILL] | [FILL] | [FILL] |
+| Total P&L (9 símbolos) | +$9,185 | +$1,680 | **−$7,505** |
+| BTC Max Drawdown | −23.46% | −7.51% | +15.95 pp (DD más pequeño) |
 
-## Contribución por símbolo
+### Contribución por símbolo
 
-| Símbolo | Baseline ($) | Vol sizing ($) | Delta ($) | Vol anualizada |
+| Símbolo | Trades | Baseline ($) | Vol sizing ($) | Delta ($) | Lectura |
+|---|---|---|---|---|---|
+| BTCUSDT | 66 | −847 | +9 | +856 | recorta la pérdida |
+| ETHUSDT | 57 | −2,453 | −648 | +1,805 | recorta la pérdida |
+| ADAUSDT | 80 | +2,832 | +554 | **−2,278** | recorta el beneficio |
+| AVAXUSDT | 55 | −1,119 | −235 | +884 | recorta la pérdida |
+| DOGEUSDT | 80 | +7,908 | +1,331 | **−6,577** | recorta el beneficio (DOGE dominó la ventana) |
+| UNIUSDT | 63 | +28 | +31 | +3 | neutro |
+| XLMUSDT | 75 | +752 | +177 | −575 | recorta el beneficio |
+| PENDLEUSDT | 68 | +209 | +59 | −151 | recorta el beneficio |
+| RUNEUSDT | 65 | +1,875 | +402 | −1,473 | recorta el beneficio |
+| **TOTAL** | **609** | **+9,185** | **+1,680** | **−7,505** | |
+
+## Por qué no funciona (análisis del diseño)
+
+El diseño canónico del sistema (ver `2026-04-17-formula-ganadora-resultados-finales.md`) ya resuelve el problema que #125 quería atacar, pero con una herramienta diferente y superior:
+
+**Epic #121/#122/#124 — optimización per-symbol:**
+
+| Tipo de token | σ anual aprox | SL óptimo | TP óptimo | Lógica |
 |---|---|---|---|---|
-| BTCUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| ETHUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| ADAUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| AVAXUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| DOGEUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| UNIUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| XLMUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| PENDLEUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| JUPUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
-| RUNEUSDT | [FILL] | [FILL] | [FILL] | [FILL] |
+| Baja vol, rebote limpio (ADA, XLM, PENDLE, JUP) | 40-60% | 0.5x ATR | 3-4x ATR | SL tight, TP moderado |
+| Media vol (BTC, DOGE) | 45-80% | 0.7-1.0x ATR | 4x ATR | parámetros estándar |
+| Alta vol, explosiva (AVAX, RUNE) | 80-100% | 0.7-1.5x ATR | 4-6x ATR | SL ancho, TP muy ancho |
+| DeFi (UNI) | 50-70% | 1.0x ATR | 3x ATR | TP corto |
 
-## Conclusión
+Esta tabla es volatilidad-normalización **estructural**, descubierta vía 735+ backtests. No confunde "vol alta = riesgo malo": reconoce que RUNE tiene vol alta **buena** (capturada por TP 6x) y que el problema con los tokens descartados (BNB, SOL, XRP, DOT...) no era su volatilidad sino la ausencia de ciclos mean-reversion explotables.
 
-- **Hipótesis del épico #121**: pasar de -$14,655 (pérdida histórica con sizing fijo) a un rango de +$25,000–$40,000 al escalar inversamente al riesgo.
-- **Validación**: pendiente de la corrida comparativa. Si el swing total P&L se acerca al objetivo: VALIDADO, cerrar #125. Si no: iterar sobre los clamps (`VOL_MIN_FLOOR`, `VOL_MAX_CEIL`, lookback, `target_vol`).
+**`vol_mult` multiplicativo falla** porque:
 
-## Próximos pasos
+1. Contradice el resultado de 735+ simulaciones
+2. No distingue "vol buena" de "vol mala" — sólo mide σ
+3. Cap especialmente el upside en los símbolos que generan el P&L (DOGE aporta 60% del P&L histórico y es high-vol)
+4. Duplica el trabajo que ya hacen los `atr_sl_mult/tp` per-symbol, restando en lugar de sumar
 
-- [ ] Corrida comparativa completa (bloqueado por tiempo de cómputo, ~horas contra Binance live).
-- [ ] Llenar tablas `[FILL]` y rehacer este documento con números reales.
-- [ ] Observación en producción (4 semanas) antes de ajustar capital real.
-- [ ] Revisión de épica #121 con los resultados.
-- [ ] Si validado: `gh issue close 125`.
+## La hipótesis del Issue #121 ya estaba resuelta
+
+Del `2026-04-18-documento-completo-sistema-trading.md` §7 Historial de Mejoras:
+
+> **Abr 15** — Parámetros iguales → optimizados per-symbol (735 sims): **−$14,655 → +$54,706 portfolio**
+
+La cifra `−$14,655 → +$25-40k` de la descripción del épico #121 ya se superó antes de llegar al punto #125. El camino real hasta el +$98,446 (o +$168,692 en 4 años con SHORT) fue:
+
+1. SL/TP fijo → ATR dinámico: +33% → +53%
+2. Parámetros iguales → per-symbol tuning: **+$54,706** (resuelve #121)
+3. Regime detector multi-signal: +53% → +62%
+4. Portfolio curado (7 ganadoras): +$54,706
+5. 3 nuevos tokens (PENDLE, JUP, RUNE): +$54,706 → +$86,596
+6. Umbrales de régimen 70/30 → 60/40: +$86,596 → +$98,446
+
+No hay un paso 7 con vol-normalized sizing — y al intentar agregarlo, el sistema pierde dinero.
+
+## Decisión
+
+- **Issue #125 permanece CERRADO** (la implementación se hizo y se evaluó — la evaluación dijo "no").
+- **Aplicación del `vol_mult` revertida** en `btc_scanner.py` y `backtest.py`.
+- **Yang-Zhang vol estimator retenido** como utilidad disponible (por si se quiere añadir a un dashboard futuro).
+- **Spec con esta decisión:** este documento.
+
+## Próximos pasos (si se quiere mejorar sizing)
+
+Alternativas que **sí** podrían aportar encima del per-symbol tuning (sin reemplazarlo):
+
+1. **Sizing por convicción del score** — ya existe (`size_mult` 0.5/1.0/1.5). Puede refinarse con datos históricos por tier de score.
+2. **Kill-switch por deterioro** — pausar un símbolo si su Profit Factor rolling cae bajo 1.0 durante N trades. Es el Próximo Paso #2 del doc canónico.
+3. **Re-tuning automático trimestral** — Issue #137 (sistema de auto-tuning per-symbol). Ya hay base de datos `tune_results` y endpoints.
+4. **Corrida comparativa 2022-2026 completa** del per-symbol tuning vs. baseline plano — para documentar oficialmente la contribución de +$54,706 a +$98,446.
+
+Ninguna de estas usa un multiplicador flat sobre `risk_usd`.

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -624,15 +624,13 @@ class TestScan:
     def test_scan_sizing_coherente(self, mock_klines):
         """Verifica que el sizing no supere el 98% del capital."""
         df1h, df4h, df5m = self._make_scan_mock()
-        mock_klines.side_effect = [df5m, df1h, df4h, df1h, df1h]  # +1 for vol 1d lookup
+        mock_klines.side_effect = [df5m, df1h, df4h, df1h]
 
         rep = scanner.scan()
         sz = rep["sizing_1h"]
         assert sz["pct_capital"] <= 98.0
         assert sz["capital_usd"] == 1000.0
-        # riesgo = capital * 0.01 * vol_mult, where vol_mult ∈ [VOL_MAX_CEIL, 1.0]
-        assert scanner.VOL_MAX_CEIL * 10.0 <= sz["riesgo_usd"] <= 10.0
-        assert sz["riesgo_usd"] == pytest.approx(10.0 * sz["vol_mult"], abs=0.01)
+        assert sz["riesgo_usd"] == pytest.approx(10.0, abs=0.01)
 
     @patch("btc_scanner.md.get_klines")
     def test_scan_sl_tp_coherentes(self, mock_klines):


### PR DESCRIPTION
## Context

Rescue PR after auditing the market-data-layer epic (PRs #143–#148) against the canonical design in `docs/superpowers/specs/es/`:
- `2026-04-18-documento-completo-sistema-trading.md` (system authority)
- `2026-04-17-formula-ganadora-resultados-finales.md` (+$168,692 / +241% 4-year backtest)
- `2026-04-18-informe-nuevos-tokens-para-simon.md` (PENDLE/JUP/RUNE integration + per-symbol tuning table)
- Issue #121 + #135 (curated portfolio)

Four problems were found. Three were introduced or left unfixed by this week's epic; one was a pre-existing gap that the epic exposed. This PR fixes all four without touching the legitimately useful parts of the data layer (Phases 0–7).

## Fixes

### 1. Revert `vol_mult` application (`f39b686`)

The Phase 8 vol-normalized sizing multiplied `risk_usd = capital * 0.01 * vol_mult` on top of the per-symbol `atr_sl_mult/tp/be` tuning from epic #121/#122/#124 (735+ backtest simulations). That tuning **is** the volatility normalization of the system — expressed structurally, not as a flat scalar.

Comparative backtest (6.5 months, 9 curated symbols) showed **−$7,505 aggregate P&L regression** from applying vol_mult. The winners (DOGE, ADA, RUNE) are the most volatile — vol_mult capped their upside, losing more than it saved on BTC/ETH/AVAX downside.

The `−$14,655 → +$25-40k` hypothesis of Issue #125/#121 was already resolved at an earlier step in the system's history — the `2026-04-17-formula-ganadora-resultados-finales.md` spec shows per-symbol tuning alone lifted portfolio P&L from `−$14,655` to `+$54,706`. Subsequent improvements (regime detector, curated portfolio, new tokens, regime-threshold tuning) brought that to +$98,446 (2.5y) / +$168,692 (4y). No step in the documented trajectory uses vol-normalized sizing.

- Scanner: `risk_usd = capital * 0.01` restored. `asset_vol`/`vol_mult`/`target_vol` removed from `sizing_1h` report.
- Backtest: `vol_mult` removed from position dict; both `risk_amount` sites back to `capital * RISK_PER_TRADE * size_mult`.
- Constants `VOL_MIN_FLOOR` / `VOL_MAX_CEIL` removed from `btc_scanner.py` (only used by the removed clamp).
- `annualized_vol_yang_zhang`, `TARGET_VOL_ANNUAL`, `VOL_LOOKBACK_DAYS` **retained as diagnostic utility** with a comment explaining they are intentionally NOT wired to sizing.
- `test_scan_sizing_coherente` restored to its pre-Phase-8 assertion (`riesgo_usd == 10.0` exact).

### 2. `btc_api.get_active_symbols` honors the curated list (`dc88d04`)

Epic #135 curated `DEFAULT_SYMBOLS` from 23 coins down to 10 profitable (BTC, ETH, ADA, AVAX, DOGE, UNI, XLM, PENDLE, JUP, RUNE) after backtest-confirming the other 13 unprofitable across 768+ parameter combinations each. **But the commit only touched `btc_scanner.DEFAULT_SYMBOLS`**; the production scanner loop in `btc_api.get_active_symbols` continued to pull CoinGecko top-20 by market cap, reinserting BNB/SOL/XRP/DOT/MATIC/LINK/LTC/ATOM/NEAR/FIL/APT/OP/ARB every hourly refresh.

In production, the curated list was only used as the CoinGecko-failure fallback. Since #135 merged on April 18, every production scan cycle has been analyzing the wrong list.

Fix: `get_active_symbols(n)` now returns `DEFAULT_SYMBOLS[:n]` directly. Binance exchangeInfo validation retained as a safety guard against delisted pairs (warns if any curated symbol is missing).

### 3. Wire `md.prefetch` into `btc_api.scanner_loop` (`eedebc1`)

Phase 6 of the market-data-layer epic added `md.prefetch(symbols, ['5m','1h','4h'], limit=210)` to `btc_scanner.main()` (the standalone CLI) but **not** to `btc_api.scanner_loop()` — the loop that `watchdog.py` actually runs in production. Consequence: every production scan cycle started with cold cache misses per symbol × timeframe.

Fix: added `md.prefetch(...)` at the top of each cycle in `scanner_loop`, before the per-symbol loop. Failures are logged and don't abort.

### 4. Update `CLAUDE.md` + rewrite results doc (`b335143`)

`CLAUDE.md:76` was stale since #135 — still described "top 20 dynamically fetched from CoinGecko" with the 20 pre-curation symbols. Replaced with:
- The curated 10-coin list
- Explicit warning not to add multiplicative risk scalers on top of per-symbol tuning
- Regime detector description + SHORT bidirectional note
- Pointer to the authoritative doc in `specs/es/`

`docs/superpowers/specs/es/2026-04-18-vol-normalized-resultados.md` rewritten end-to-end to document the investigation, the comparative-backtest evidence, the decision to revert, and the design reason (per-symbol tuning already resolved #121 from a different angle). Lists alternatives that could legitimately improve sizing without the vol_mult error.

## What this PR does NOT touch

- Data layer core (`data/` package, PRs #143–#145): legitimately useful — unified OHLCV fetch + SQLite cache + provider failover. Stays.
- Scanner migration to `md.get_klines` (PR #146): correct. Stays.
- Backtest / `btc_api` / `btc_report` migrations to `data.market_data` (PR #147): correct. Stays.
- SHORT path, regime detector, per-symbol symbol_overrides, trailing breakeven: all intact and verified.

## Test plan

- [x] Full suite: `python -m pytest tests/ -q` → **362 passed** (same count as pre-rescue; nothing broken)
- [x] `python -c "import btc_scanner, btc_api, backtest"` imports cleanly
- [x] `test_scan_sizing_coherente` asserts `riesgo_usd == 10.0` (pre-Phase-8 invariant)
- [x] `test_backtest_dual` still green (no vol_mult in position dict)
- [ ] CI (GitHub Actions) backend-tests + frontend-typecheck green

## Upgrade impact for deployed users

When Simon's dad pulls:
- **Scanner list drops from 20 CoinGecko-top to the 10 curated**. Tokens previously scanned (BNB, SOL, XRP, DOT, MATIC, LINK, LTC, ATOM, NEAR, FIL, APT, OP, ARB) stop receiving signals. Historical trades in `signals.db` and open positions are unaffected — they already exist and continue to be tracked; just no new signals on those tokens.
- **Risk per trade reverts to 1% fixed** (as the +$98k/+$168k backtests were validated). Any position still open is unaffected; only new position sizing changes.
- **First cycle after upgrade fires `md.prefetch`** — you'll see "prefetch batch" log line for ~1-2s, then normal scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)