### PR TITLE
fix(api): /status 500 — stringify tuple metric keys (#153)

### DIFF
--- a/data/metrics.py
+++ b/data/metrics.py
@@ -43,20 +43,30 @@ def _percentile(values: list[float], p: int) -> float:
     return sorted_vals[idx]
 
 
+def _labels_str(labels_key: tuple) -> str:
+    if not labels_key:
+        return ""
+    return ",".join(f"{k}={v}" for k, v in labels_key)
+
+
 def get_stats() -> dict:
-    """Snapshot of all metrics. Safe to call from any thread."""
+    """Snapshot of all metrics. Safe to call from any thread.
+
+    Inner-dict keys are stringified labels (e.g. "provider=binance"; "" when no
+    labels) so the whole payload is JSON-serializable by FastAPI.
+    """
     with _lock:
         counters_snapshot = {
-            name: dict(vals) for name, vals in _counters.items()
+            name: {_labels_str(k): v for k, v in vals.items()}
+            for name, vals in _counters.items()
         }
-        latencies_p50 = {
-            key: _percentile(list(samples), 50)
-            for key, samples in _latencies.items()
-        }
-        latencies_p95 = {
-            key: _percentile(list(samples), 95)
-            for key, samples in _latencies.items()
-        }
+        latencies_p50: dict[str, dict[str, float]] = {}
+        latencies_p95: dict[str, dict[str, float]] = {}
+        for (name, labels_key), samples in _latencies.items():
+            samples_list = list(samples)
+            label_str = _labels_str(labels_key)
+            latencies_p50.setdefault(name, {})[label_str] = _percentile(samples_list, 50)
+            latencies_p95.setdefault(name, {})[label_str] = _percentile(samples_list, 95)
     return {
         "counters": counters_snapshot,
         "latency_p50_ms": latencies_p50,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,4 @@
+import json
 import threading
 import pytest
 from data import metrics
@@ -17,15 +18,15 @@ class TestCounters:
         metrics.inc("fetches_total")
         metrics.inc("fetches_total", n=3)
         stats = metrics.get_stats()
-        assert stats["counters"]["fetches_total"] == {(): 4}
+        assert stats["counters"]["fetches_total"] == {"": 4}
 
     def test_inc_with_labels(self):
         metrics.inc("fetches_total", labels={"provider": "binance"})
         metrics.inc("fetches_total", labels={"provider": "binance"})
         metrics.inc("fetches_total", labels={"provider": "bybit"})
         stats = metrics.get_stats()
-        assert stats["counters"]["fetches_total"][(("provider", "binance"),)] == 2
-        assert stats["counters"]["fetches_total"][(("provider", "bybit"),)] == 1
+        assert stats["counters"]["fetches_total"]["provider=binance"] == 2
+        assert stats["counters"]["fetches_total"]["provider=bybit"] == 1
 
     def test_inc_thread_safety(self):
         def worker():
@@ -35,7 +36,7 @@ class TestCounters:
         for t in threads: t.start()
         for t in threads: t.join()
         stats = metrics.get_stats()
-        assert stats["counters"]["race_counter"][()] == 8000
+        assert stats["counters"]["race_counter"][""] == 8000
 
 
 class TestLatencyHistogram:
@@ -43,11 +44,10 @@ class TestLatencyHistogram:
         for v in [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]:
             metrics.observe("fetch_latency_ms", v)
         stats = metrics.get_stats()
-        p50_key = ("fetch_latency_ms", ())
-        assert p50_key in stats["latency_p50_ms"]
+        assert "fetch_latency_ms" in stats["latency_p50_ms"]
         # p50 of 1..10 scaled to 10..100: median is 50 or 60 depending on interpolation
-        assert 40 <= stats["latency_p50_ms"][p50_key] <= 70
-        assert 85 <= stats["latency_p95_ms"][p50_key] <= 100
+        assert 40 <= stats["latency_p50_ms"]["fetch_latency_ms"][""] <= 70
+        assert 85 <= stats["latency_p95_ms"]["fetch_latency_ms"][""] <= 100
 
     def test_observe_bounded_deque(self):
         # maxlen=100; adding 250 values should retain only the last 100
@@ -55,7 +55,15 @@ class TestLatencyHistogram:
             metrics.observe("bounded", v)
         stats = metrics.get_stats()
         # Median of last 100 values (150..249) is ~199
-        assert 190 <= stats["latency_p50_ms"][("bounded", ())] <= 210
+        assert 190 <= stats["latency_p50_ms"]["bounded"][""] <= 210
+
+    def test_observe_with_labels_nests_by_name(self):
+        metrics.observe("fetch_ms", 100.0, labels={"provider": "binance"})
+        metrics.observe("fetch_ms", 200.0, labels={"provider": "bybit"})
+        stats = metrics.get_stats()
+        assert set(stats["latency_p50_ms"]["fetch_ms"].keys()) == {
+            "provider=binance", "provider=bybit"
+        }
 
 
 class TestGetStats:
@@ -67,3 +75,13 @@ class TestGetStats:
         assert isinstance(stats, dict)
         assert isinstance(stats["counters"], dict)
         assert isinstance(stats["latency_p50_ms"], dict)
+
+    def test_snapshot_is_json_serializable(self):
+        # Regression for #153: FastAPI cannot serialize tuple dict keys.
+        metrics.inc("fetches_total", labels={"provider": "binance", "tf": "1h"})
+        metrics.inc("fetches_total")
+        metrics.observe("fetch_ms", 12.5, labels={"symbol": "BTC"})
+        metrics.observe("fetch_ms", 7.5)
+        stats = metrics.get_stats()
+        # Would raise TypeError on any non-string dict key
+        json.dumps(stats)


### PR DESCRIPTION
## Summary
- `data/metrics.py::get_stats()` returned dicts with `tuple` keys (inner counters dict + outer latency key), which FastAPI cannot JSON-encode → `GET /status` → 500.
- Label keys are now stringified as `"k=v,k2=v2"` (empty string for no labels), and latency percentiles are nested under the metric name to mirror the counters layout.
- Added `test_snapshot_is_json_serializable` as a regression guard (`json.dumps(stats)` would previously raise `TypeError`).

Fixes #153.

## Test plan
- [x] `python -m pytest tests/test_metrics.py -v` → 8/8 passed
- [x] `python -m pytest tests/ -q` → 364/364 passed
- [ ] Post-merge: `REINICIAR_SERVICIOS.ps1`, then `GET /status` returns 200 with stats payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)