### PR TITLE
fix(backtest): SHORT direction at final-bar close (#156, #157)

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -245,6 +245,40 @@ def _regime_at_time(
     )
 
 
+def _close_position(position: dict, exit_price: float, exit_time, exit_reason: str,
+                    capital: float) -> dict:
+    """Compute P&L + trade dict for closing `position` at exit_price.
+
+    Handles LONG and SHORT symmetrically: SHORT gains when exit_price < entry_price,
+    SHORT stop-loss distance uses |entry − sl_orig| so pnl_usd never short-circuits
+    to 0 for a valid SHORT setup (fix for #156, #157).
+    """
+    entry_price = position["entry_price"]
+    if position.get("direction") == "SHORT":
+        pnl_pct = (entry_price - exit_price) / entry_price * 100
+    else:
+        pnl_pct = (exit_price - entry_price) / entry_price * 100
+    risk_amount = capital * RISK_PER_TRADE * position["size_mult"]
+    sl_pct_actual = abs(entry_price - position["sl_orig"]) / entry_price * 100
+    pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0
+    return {
+        "entry_time": position["entry_time"],
+        "exit_time": exit_time,
+        "entry_price": entry_price,
+        "exit_price": exit_price,
+        "exit_reason": exit_reason,
+        "direction": position.get("direction", "LONG"),
+        "pnl_pct": round(pnl_pct, 4),
+        "pnl_usd": round(pnl_usd, 2),
+        "score": position["score"],
+        "size_mult": position["size_mult"],
+        "duration_hours": (exit_time - position["entry_time"]).total_seconds() / 3600,
+        "atr_sl_mult_used": position.get("atr_sl_mult_used"),
+        "atr_tp_mult_used": position.get("atr_tp_mult_used"),
+        "atr_be_mult_used": position.get("atr_be_mult_used"),
+    }
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  SIMULATION
 # ─────────────────────────────────────────────────────────────────────────────
@@ -324,32 +358,12 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                 exit_reason = None
 
             if exit_price is not None:
-                if pos_dir == "SHORT":
-                    pnl_pct = (position["entry_price"] - exit_price) / position["entry_price"] * 100
-                else:
-                    pnl_pct = (exit_price - position["entry_price"]) / position["entry_price"] * 100
-                risk_amount = capital * RISK_PER_TRADE * position["size_mult"]
-                sl_pct_actual = abs(position["entry_price"] - position["sl_orig"]) / position["entry_price"] * 100
-                pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0
-
-                trade = {
-                    "entry_time": position["entry_time"],
-                    "exit_time": bar_time,
-                    "entry_price": position["entry_price"],
-                    "exit_price": exit_price,
-                    "exit_reason": exit_reason,
-                    "direction": pos_dir,
-                    "pnl_pct": round(pnl_pct, 4),
-                    "pnl_usd": round(pnl_usd, 2),
-                    "score": position["score"],
-                    "size_mult": position["size_mult"],
-                    "duration_hours": (bar_time - position["entry_time"]).total_seconds() / 3600,
-                    "atr_sl_mult_used": position.get("atr_sl_mult_used"),
-                    "atr_tp_mult_used": position.get("atr_tp_mult_used"),
-                    "atr_be_mult_used": position.get("atr_be_mult_used"),
-                }
+                trade = _close_position(
+                    position, exit_price=exit_price, exit_time=bar_time,
+                    exit_reason=exit_reason, capital=capital,
+                )
                 trades.append(trade)
-                capital += pnl_usd
+                capital += trade["pnl_usd"]
                 position = None
                 last_exit_time = bar_time
 
@@ -537,26 +551,12 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
     if position is not None:
         last_bar = df1h.iloc[-1]
         exit_price = float(last_bar["close"])
-        pnl_pct = (exit_price - position["entry_price"]) / position["entry_price"] * 100
-        risk_amount = capital * RISK_PER_TRADE * position["size_mult"]
-        sl_pct_actual = (position["entry_price"] - position["sl_orig"]) / position["entry_price"] * 100
-        pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0
-        trades.append({
-            "entry_time": position["entry_time"],
-            "exit_time": df1h.index[-1],
-            "entry_price": position["entry_price"],
-            "exit_price": exit_price,
-            "exit_reason": "OPEN",
-            "pnl_pct": round(pnl_pct, 4),
-            "pnl_usd": round(pnl_usd, 2),
-            "score": position["score"],
-            "size_mult": position["size_mult"],
-            "duration_hours": (df1h.index[-1] - position["entry_time"]).total_seconds() / 3600,
-            "atr_sl_mult_used": position.get("atr_sl_mult_used"),
-            "atr_tp_mult_used": position.get("atr_tp_mult_used"),
-            "atr_be_mult_used": position.get("atr_be_mult_used"),
-        })
-        capital += pnl_usd
+        trade = _close_position(
+            position, exit_price=exit_price, exit_time=df1h.index[-1],
+            exit_reason="OPEN", capital=capital,
+        )
+        trades.append(trade)
+        capital += trade["pnl_usd"]
 
     return trades, equity_curve
 

--- a/tests/test_backtest_close_position.py
+++ b/tests/test_backtest_close_position.py
@@ -1,0 +1,148 @@
+"""Regression tests for backtest._close_position helper (#156, #157).
+
+The final-bar close path in simulate_strategy used to:
+  - #156: compute pnl_pct with LONG formula unconditionally (SHORT got sign-flipped P&L)
+  - #157: omit abs() in sl_pct_actual (SHORT got pnl_usd=0 due to the short-circuit)
+
+Both sites now delegate to _close_position, which handles direction correctly.
+"""
+import pytest
+from datetime import datetime, timezone, timedelta
+
+from backtest import _close_position, RISK_PER_TRADE
+
+
+ENTRY_TS = datetime(2026, 1, 1, tzinfo=timezone.utc)
+EXIT_TS = ENTRY_TS + timedelta(hours=24)
+
+
+def _make_short_position(entry=50_000.0, sl=55_000.0, tp=40_000.0):
+    """SHORT position: sl above entry, tp below entry."""
+    return {
+        "entry_time": ENTRY_TS,
+        "entry_price": entry,
+        "direction": "SHORT",
+        "sl": sl,
+        "sl_orig": sl,
+        "tp": tp,
+        "size_mult": 1.0,
+        "score": 5,
+        "be_threshold": entry - 1000,
+        "atr_sl_mult_used": 1.0,
+        "atr_tp_mult_used": 2.0,
+        "atr_be_mult_used": 1.5,
+    }
+
+
+def _make_long_position(entry=50_000.0, sl=45_000.0, tp=60_000.0):
+    """LONG position: sl below entry, tp above entry."""
+    return {
+        "entry_time": ENTRY_TS,
+        "entry_price": entry,
+        "direction": "LONG",
+        "sl": sl,
+        "sl_orig": sl,
+        "tp": tp,
+        "size_mult": 1.0,
+        "score": 5,
+        "be_threshold": entry + 1000,
+        "atr_sl_mult_used": 1.0,
+        "atr_tp_mult_used": 2.0,
+        "atr_be_mult_used": 1.5,
+    }
+
+
+class TestCloseShortPosition:
+    """#156 + #157: SHORT closes must invert the P&L sign and use abs(sl distance)."""
+
+    def test_short_with_price_below_entry_is_profitable(self):
+        """SHORT entered at 50k, close at 45k ⇒ +10% profit (was -10% under #156)."""
+        trade = _close_position(
+            _make_short_position(entry=50_000.0, sl=55_000.0),
+            exit_price=45_000.0,
+            exit_time=EXIT_TS,
+            exit_reason="OPEN",
+            capital=10_000.0,
+        )
+        assert trade["pnl_pct"] == pytest.approx(10.0)
+        assert trade["pnl_usd"] > 0, "SHORT winning trade must report positive pnl_usd"
+
+    def test_short_with_price_above_entry_is_loss(self):
+        """SHORT entered at 50k, close at 52.5k ⇒ -5% loss."""
+        trade = _close_position(
+            _make_short_position(entry=50_000.0, sl=55_000.0),
+            exit_price=52_500.0,
+            exit_time=EXIT_TS,
+            exit_reason="OPEN",
+            capital=10_000.0,
+        )
+        assert trade["pnl_pct"] == pytest.approx(-5.0)
+        assert trade["pnl_usd"] < 0
+
+    def test_short_pnl_usd_is_nonzero_when_winning(self):
+        """#157: sl_pct_actual must use abs() so SHORT winners don't short-circuit to 0."""
+        trade = _close_position(
+            _make_short_position(entry=50_000.0, sl=55_000.0),
+            exit_price=45_000.0,
+            exit_time=EXIT_TS,
+            exit_reason="OPEN",
+            capital=10_000.0,
+        )
+        expected_sl_pct = abs(50_000.0 - 55_000.0) / 50_000.0 * 100
+        expected_pnl_usd = 10_000.0 * RISK_PER_TRADE * 1.0 * (10.0 / expected_sl_pct)
+        assert trade["pnl_usd"] == pytest.approx(expected_pnl_usd, rel=1e-3)
+
+
+class TestCloseLongPosition:
+    """Regression: LONG continues to work as before."""
+
+    def test_long_with_price_above_entry_is_profitable(self):
+        """LONG entered at 50k, close at 55k ⇒ +10%."""
+        trade = _close_position(
+            _make_long_position(entry=50_000.0, sl=45_000.0),
+            exit_price=55_000.0,
+            exit_time=EXIT_TS,
+            exit_reason="OPEN",
+            capital=10_000.0,
+        )
+        assert trade["pnl_pct"] == pytest.approx(10.0)
+        assert trade["pnl_usd"] > 0
+
+    def test_long_with_price_below_entry_is_loss(self):
+        """LONG entered at 50k, close at 47.5k ⇒ -5%."""
+        trade = _close_position(
+            _make_long_position(entry=50_000.0, sl=45_000.0),
+            exit_price=47_500.0,
+            exit_time=EXIT_TS,
+            exit_reason="OPEN",
+            capital=10_000.0,
+        )
+        assert trade["pnl_pct"] == pytest.approx(-5.0)
+        assert trade["pnl_usd"] < 0
+
+
+class TestCloseTradeShape:
+    """Helper must emit the full trade dict shape (keys + types) the rest of the
+    pipeline expects. Guard against accidental field drops during refactor."""
+
+    def test_trade_dict_has_expected_keys(self):
+        trade = _close_position(
+            _make_short_position(),
+            exit_price=45_000.0,
+            exit_time=EXIT_TS,
+            exit_reason="OPEN",
+            capital=10_000.0,
+        )
+        expected_keys = {
+            "entry_time", "exit_time", "entry_price", "exit_price", "exit_reason",
+            "direction", "pnl_pct", "pnl_usd", "score", "size_mult",
+            "duration_hours", "atr_sl_mult_used", "atr_tp_mult_used", "atr_be_mult_used",
+        }
+        assert expected_keys.issubset(trade.keys()), (
+            f"Missing: {expected_keys - trade.keys()}")
+
+    def test_direction_preserved(self):
+        t_short = _close_position(_make_short_position(), 45_000.0, EXIT_TS, "OPEN", 10_000.0)
+        t_long = _close_position(_make_long_position(), 55_000.0, EXIT_TS, "OPEN", 10_000.0)
+        assert t_short["direction"] == "SHORT"
+        assert t_long["direction"] == "LONG"


### PR DESCRIPTION
## Summary

Two silent bugs in the final-bar close path of `simulate_strategy`:

### #156 — sign-flipped `pnl_pct` for SHORT
```python
pnl_pct = (exit_price - position["entry_price"]) / position["entry_price"] * 100
```
LONG formula applied unconditionally. A winning SHORT (entry 50k → exit 45k, +10%) was reported as -10%.

### #157 — missing `abs()` in `sl_pct_actual` for SHORT
```python
sl_pct_actual = (position["entry_price"] - position["sl_orig"]) / position["entry_price"] * 100
```
For SHORT, `sl_orig` is above `entry_price`, so the value goes negative and the subsequent short-circuit
`pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0` sets `pnl_usd = 0`.

Both originated in commit 81fce06 (revert of dual strategy). The sister bar-by-bar exit path was updated
when SHORT came back; this specific final-bar site wasn't.

## Fix

Extract `_close_position(position, exit_price, exit_time, exit_reason, capital) → trade_dict` as a pure
helper. Route BOTH exit paths through it. Single source of truth, single test surface, no more drift.

## Tests

7 new tests in `tests/test_backtest_close_position.py`:
- [x] SHORT profitable: exit below entry → positive `pnl_pct`, non-zero `pnl_usd`
- [x] SHORT losing: exit above entry → negative `pnl_pct`, negative `pnl_usd`
- [x] SHORT `pnl_usd` matches expected (abs-based sl_pct_actual) — #157
- [x] LONG profitable (regression guard)
- [x] LONG losing (regression guard)
- [x] Trade dict shape preserved
- [x] Direction field preserved

Full suite: **463 passed** (was 456; +7), 0 failed.

## Impact on recent analyses

Any backtest that left a SHORT open at sim_end had that trade miscounted: `pnl_pct` sign-flipped AND
`pnl_usd = 0`. Typically 1 trade per backtest per symbol, but systematic across all recent hunger-games
runs (`scripts/gate_regime_modes`, `scripts/gate_per_direction`). Magnitude is small but directional:
SHORT contribution was under-counted. The "NO WINNER" verdicts from 2026-04-21 remain directionally
correct but the full-window numbers should be re-verified if precision matters for next iteration.

Closes #156, Closes #157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)