### PR TITLE
feat(health): kill switch Alert tier (#138 PR 2 of 4)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -1193,14 +1193,25 @@ def push_telegram_direct(rep: dict, cfg: dict, max_retries: int = 3):
 
     DEPRECATED (#162): delegates to notifier.notify(SignalEvent(...)).
     """
+    # Kill switch #138 PR 2: stamp symbol health state so ALERT symbols get
+    # a warning prefix in the Telegram message.
+    symbol = rep.get("symbol", "")
+    try:
+        from health import get_symbol_state
+        health_state = get_symbol_state(symbol) if symbol else "NORMAL"
+    except Exception as e:
+        log.warning("push_telegram_direct: health lookup failed for %s: %s", symbol, e)
+        health_state = "NORMAL"
+
     receipts = notify(
         SignalEvent(
-            symbol=rep.get("symbol", ""),
+            symbol=symbol,
             score=int(rep.get("score", 0) or 0),
             direction=rep.get("direction", "LONG"),
             entry=float(rep.get("price") or 0.0),
             sl=float((rep.get("sizing_1h") or {}).get("sl_precio") or 0.0),
             tp=float((rep.get("sizing_1h") or {}).get("tp_precio") or 0.0),
+            health_state=health_state,
         ),
         cfg=cfg,
     )

--- a/health.py
+++ b/health.py
@@ -10,6 +10,15 @@ import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+# Lazy re-export so tests can patch health.notify without reaching into notifier.
+# Using a try/except because notifier is a sibling package (not a stdlib) and
+# we want health.py to remain importable even if notifier fails to import.
+try:
+    from notifier import notify, HealthEvent  # noqa: F401
+except ImportError:
+    notify = None  # type: ignore
+    HealthEvent = None  # type: ignore
+
 
 def _month_key(dt: datetime) -> str:
     """YYYY-MM string from a datetime (used as pnl_by_month key)."""
@@ -301,6 +310,17 @@ def evaluate_and_record(symbol: str, cfg: dict[str, Any], now: datetime | None =
     if new_state != current:
         apply_transition(symbol, new_state=new_state, reason=reason,
                          metrics=metrics, from_state=current)
+        # PR 2 (#138): one-shot notify only on transitions into ALERT.
+        # PRs 3/4 will extend this to REDUCED and PAUSED.
+        if new_state == "ALERT" and notify is not None and HealthEvent is not None:
+            try:
+                notify(
+                    HealthEvent(symbol=symbol, from_state=current,
+                                to_state=new_state, reason=reason, metrics=metrics),
+                    cfg=cfg,
+                )
+            except Exception as e:  # noqa: BLE001
+                log.warning("health: ALERT notify failed for %s: %s", symbol, e)
     else:
         _record_evaluation(symbol, metrics, new_state)
     return new_state

--- a/health.py
+++ b/health.py
@@ -7,8 +7,13 @@ lands in PRs 2-4.
 from __future__ import annotations
 
 import json
+import logging
+import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any
+
+
+log = logging.getLogger("health")
 
 # Lazy re-export so tests can patch health.notify without reaching into notifier.
 # Using a try/except because notifier is a sibling package (not a stdlib) and
@@ -347,11 +352,6 @@ def evaluate_all_symbols(cfg: dict[str, Any], now: datetime | None = None) -> di
 #  TRIGGER + DAILY LOOP
 # ─────────────────────────────────────────────────────────────────────────────
 
-import logging as _logging
-import threading as _threading
-
-log = _logging.getLogger("health")
-
 
 def trigger_health_evaluation(symbol: str, cfg: dict[str, Any]) -> None:
     """Fire-and-forget health evaluation for a single symbol.
@@ -380,7 +380,7 @@ def health_monitor_loop(cfg_fn, stop_event=None) -> None:
     threading.Event for graceful shutdown; if None, loops until killed.
     """
     if stop_event is None:
-        stop_event = _threading.Event()
+        stop_event = threading.Event()
     while not stop_event.is_set():
         sleep_s = _seconds_until_next_midnight_utc(datetime.now(timezone.utc))
         if stop_event.wait(timeout=sleep_s):

--- a/notifier/events.py
+++ b/notifier/events.py
@@ -41,6 +41,9 @@ class SignalEvent(_BaseEvent):
     entry: float = 0.0
     sl: float = 0.0
     tp: float = 0.0
+    # Kill-switch context (#138): "NORMAL" | "ALERT" | "REDUCED" | "PAUSED".
+    # Determines whether the template prepends a warning prefix.
+    health_state: str = "NORMAL"
 
     def __post_init__(self):
         self.event_type = "signal"

--- a/notifier/templates/signal.telegram.j2
+++ b/notifier/templates/signal.telegram.j2
@@ -1,3 +1,6 @@
+{%- if health_state and health_state != "NORMAL" -%}
+⚠️ *{{ health_state }}* 
+{% endif -%}
 *Signal* `{{ symbol }}`
 Score: *{{ score }}* ({{ direction }})
 Entry: `{{ "%.2f"|format(entry) }}` | SL: `{{ "%.2f"|format(sl) }}` | TP: `{{ "%.2f"|format(tp) }}`

--- a/notifier/templates/signal.telegram.j2
+++ b/notifier/templates/signal.telegram.j2
@@ -1,5 +1,5 @@
 {%- if health_state and health_state != "NORMAL" -%}
-⚠️ *{{ health_state }}* 
+⚠️ *{{ health_state }}*
 {% endif -%}
 *Signal* `{{ symbol }}`
 Score: *{{ score }}* ({{ direction }})

--- a/tests/test_health_alert_notify.py
+++ b/tests/test_health_alert_notify.py
@@ -1,0 +1,108 @@
+"""evaluate_and_record must fire notify(HealthEvent) once when a symbol
+transitions to ALERT, and must NOT re-fire on subsequent evaluations where
+the state stays ALERT."""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    from notifier import ratelimit
+    ratelimit.reset_all_for_tests()
+    yield db_path
+
+
+def _insert_closed(conn, symbol, pnl, exit_ts):
+    conn.execute(
+        """INSERT INTO positions
+           (symbol, direction, status, entry_price, entry_ts,
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?)""",
+        (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
+    )
+    conn.commit()
+
+
+CFG = {"kill_switch": {
+    "enabled": True, "min_trades_for_eval": 20,
+    "alert_win_rate_threshold": 0.15,
+    "reduce_pnl_window_days": 30, "reduce_size_factor": 0.5,
+    "pause_months_consecutive": 3, "auto_recovery_enabled": True,
+}}
+NOW = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def _seed_for_alert(conn):
+    """25 closed trades: 24 tiny losses, 1 big win → wr=1/25=0.04 (< 0.15) but
+    aggregate pnl positive (so REDUCED rule doesn't fire first)."""
+    for i in range(25):
+        pnl = 1000.0 if i == 24 else -1.0  # single big winner dominates → agg positive
+        _insert_closed(conn, "BTC", pnl, (NOW - timedelta(days=25 - i)).isoformat())
+
+
+def test_transition_to_alert_fires_notify(tmp_db):
+    from health import evaluate_and_record
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        _seed_for_alert(conn)
+    finally:
+        conn.close()
+
+    with patch("health.notify") as mock_notify:
+        state = evaluate_and_record("BTC", CFG, now=NOW)
+
+    assert state == "ALERT", f"expected ALERT, got {state}"
+    assert mock_notify.call_count == 1
+    event_arg = mock_notify.call_args.args[0]
+    # Arg is a HealthEvent — check its fields
+    assert event_arg.symbol == "BTC"
+    assert event_arg.to_state == "ALERT"
+    assert event_arg.from_state == "NORMAL"
+
+
+def test_alert_no_renotify_when_state_unchanged(tmp_db):
+    """After the first ALERT transition, a second evaluate_and_record with the
+    same data must NOT fire notify again (state stays ALERT)."""
+    from health import evaluate_and_record
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        _seed_for_alert(conn)
+    finally:
+        conn.close()
+
+    with patch("health.notify") as mock_notify:
+        evaluate_and_record("BTC", CFG, now=NOW)
+        evaluate_and_record("BTC", CFG, now=NOW)
+
+    assert mock_notify.call_count == 1  # not 2
+
+
+def test_non_alert_transitions_do_not_fire_in_pr2(tmp_db):
+    """PR 2 only emits for ALERT. REDUCED/PAUSED transitions stay silent (for now)."""
+    from health import evaluate_and_record
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        for i in range(25):
+            _insert_closed(conn, "DOGE", -100.0, (NOW - timedelta(days=25 - i)).isoformat())
+    finally:
+        conn.close()
+
+    with patch("health.notify") as mock_notify:
+        state = evaluate_and_record("DOGE", CFG, now=NOW)
+
+    assert state == "REDUCED"
+    assert mock_notify.call_count == 0

--- a/tests/test_health_alert_notify.py
+++ b/tests/test_health_alert_notify.py
@@ -41,8 +41,10 @@ NOW = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
 
 
 def _seed_for_alert(conn):
-    """25 closed trades: 24 tiny losses, 1 big win → wr=1/25=0.04 (< 0.15) but
-    aggregate pnl positive (so REDUCED rule doesn't fire first)."""
+    """25 closed trades: 24 tiny losses, 1 big win.
+    compute_rolling_metrics uses LIMIT 20 for win_rate, so only the most recent
+    20 trades (i=5..24) count → wr = 1/20 = 0.05 (< 0.15 threshold).
+    Aggregate pnl over 30d is positive (≈$976) so REDUCED doesn't fire first."""
     for i in range(25):
         pnl = 1000.0 if i == 24 else -1.0  # single big winner dominates → agg positive
         _insert_closed(conn, "BTC", pnl, (NOW - timedelta(days=25 - i)).isoformat())

--- a/tests/test_health_shim_integration.py
+++ b/tests/test_health_shim_integration.py
@@ -1,0 +1,73 @@
+"""push_telegram_direct (the notifier shim) must stamp the symbol's current
+health_state into the SignalEvent so ALERT symbols get the warning prefix."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    # Reset ratelimit between tests
+    from notifier import ratelimit
+    ratelimit.reset_all_for_tests()
+    yield db_path
+
+
+def _cfg():
+    return {
+        "notifier": {"enabled": True, "test_mode": False},
+        "telegram_bot_token": "t", "telegram_chat_id": "1",
+    }
+
+
+def test_shim_sends_signal_with_health_state_from_db(tmp_db):
+    """If get_symbol_state(sym) == 'ALERT', the SignalEvent carries health_state='ALERT'."""
+    from health import apply_transition
+    import btc_api
+
+    apply_transition(
+        "BTC", new_state="ALERT", reason="wr_below_threshold",
+        metrics={"trades_count_total": 50, "win_rate_20_trades": 0.1,
+                 "pnl_30d": 0.0, "pnl_by_month": {}, "months_negative_consecutive": 0},
+        from_state="NORMAL",
+    )
+
+    rep = {"symbol": "BTC", "score": 6, "direction": "LONG",
+           "price": 50_000.0, "sizing_1h": {"sl_precio": 49_000.0, "tp_precio": 55_000.0}}
+
+    fake_resp = MagicMock()
+    fake_resp.ok = True
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {"ok": True}
+
+    with patch("notifier.channels.telegram.requests.post", return_value=fake_resp) as mock_post:
+        result = btc_api.push_telegram_direct(rep, _cfg())
+
+    assert result is True
+    assert mock_post.call_count == 1
+    sent_text = mock_post.call_args.kwargs["json"]["text"]
+    assert sent_text.startswith("⚠️ *ALERT*\n"), f"no prefix on shim-routed signal: {sent_text!r}"
+    assert "BTC" in sent_text
+
+
+def test_shim_unknown_symbol_defaults_to_normal(tmp_db):
+    """If no row exists in symbol_health, health_state defaults to NORMAL → no prefix."""
+    import btc_api
+
+    rep = {"symbol": "UNSEEN", "score": 3, "direction": "LONG",
+           "price": 1.0, "sizing_1h": {"sl_precio": 0.9, "tp_precio": 1.2}}
+
+    fake_resp = MagicMock()
+    fake_resp.ok = True
+
+    with patch("notifier.channels.telegram.requests.post", return_value=fake_resp) as mock_post:
+        btc_api.push_telegram_direct(rep, _cfg())
+
+    sent_text = mock_post.call_args.kwargs["json"]["text"]
+    assert not sent_text.startswith("⚠️"), f"unexpected prefix: {sent_text!r}"

--- a/tests/test_health_shim_integration.py
+++ b/tests/test_health_shim_integration.py
@@ -69,5 +69,6 @@ def test_shim_unknown_symbol_defaults_to_normal(tmp_db):
     with patch("notifier.channels.telegram.requests.post", return_value=fake_resp) as mock_post:
         btc_api.push_telegram_direct(rep, _cfg())
 
+    assert mock_post.call_count == 1, "no signal sent — later assertion would be misleading"
     sent_text = mock_post.call_args.kwargs["json"]["text"]
     assert not sent_text.startswith("⚠️"), f"unexpected prefix: {sent_text!r}"

--- a/tests/test_notifier_events.py
+++ b/tests/test_notifier_events.py
@@ -57,3 +57,18 @@ def test_event_to_dict_serializable():
     json.dumps(d)  # must not raise
     assert d["symbol"] == "BTCUSDT"
     assert d["event_type"] == "signal"
+
+
+def test_signal_event_health_state_default():
+    """Default health_state is 'NORMAL' so existing callers stay backward-compat."""
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTC", score=5, direction="LONG",
+                     entry=1.0, sl=1.0, tp=1.0)
+    assert ev.health_state == "NORMAL"
+
+
+def test_signal_event_health_state_set_to_alert():
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTC", score=5, direction="LONG",
+                     entry=1.0, sl=1.0, tp=1.0, health_state="ALERT")
+    assert ev.health_state == "ALERT"

--- a/tests/test_notifier_templates.py
+++ b/tests/test_notifier_templates.py
@@ -80,3 +80,25 @@ def test_health_metrics_backtick_in_value_does_not_break_span():
     # metrics_line should look like: Metrics: `{"note": "watch 'DOGE' next"}`
     # i.e. exactly 2 backticks (the outer code-span delimiters)
     assert metrics_line.count("`") == 2, f"expected 2 backticks, got: {metrics_line!r}"
+
+
+def test_signal_telegram_prepends_alert_warning():
+    """ALERT symbols get a '⚠️ ALERT' prefix on the first line."""
+    from notifier._templates import render
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                     entry=50_000.0, sl=49_000.0, tp=55_000.0,
+                     health_state="ALERT")
+    msg = render(ev, channel="telegram")
+    assert msg.startswith("⚠️ *ALERT* "), f"unexpected prefix: {msg!r}"
+    assert "BTCUSDT" in msg
+
+
+def test_signal_telegram_no_prefix_for_normal():
+    """NORMAL symbols render identically to pre-PR — no prefix."""
+    from notifier._templates import render
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                     entry=50_000.0, sl=49_000.0, tp=55_000.0)
+    msg = render(ev, channel="telegram")
+    assert not msg.startswith("⚠️")

--- a/tests/test_notifier_templates.py
+++ b/tests/test_notifier_templates.py
@@ -83,22 +83,28 @@ def test_health_metrics_backtick_in_value_does_not_break_span():
 
 
 def test_signal_telegram_prepends_alert_warning():
-    """ALERT symbols get a '⚠️ ALERT' prefix on the first line."""
+    """ALERT symbols get a '⚠️ *ALERT*' prefix on its own line before *Signal*."""
     from notifier._templates import render
     from notifier import SignalEvent
     ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
                      entry=50_000.0, sl=49_000.0, tp=55_000.0,
                      health_state="ALERT")
     msg = render(ev, channel="telegram")
-    assert msg.startswith("⚠️ *ALERT* "), f"unexpected prefix: {msg!r}"
+    # Exact prefix: emoji, space, *ALERT*, newline (no trailing space before the newline).
+    assert msg.startswith("⚠️ *ALERT*\n"), f"unexpected prefix: {msg!r}"
     assert "BTCUSDT" in msg
 
 
 def test_signal_telegram_no_prefix_for_normal():
-    """NORMAL symbols render identically to pre-PR — no prefix."""
+    """NORMAL symbols render byte-identical to pre-PR (no prefix, no extra newlines)."""
     from notifier._templates import render
     from notifier import SignalEvent
     ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
                      entry=50_000.0, sl=49_000.0, tp=55_000.0)
     msg = render(ev, channel="telegram")
-    assert not msg.startswith("⚠️")
+    expected = (
+        "*Signal* `BTCUSDT`\n"
+        "Score: *6* (LONG)\n"
+        "Entry: `50000.00` | SL: `49000.00` | TP: `55000.00`"
+    )
+    assert msg == expected, f"parity broken: {msg!r}"


### PR DESCRIPTION
## Summary

Second PR in the #138 series. Wires the **ALERT tier** into the Foundation from PR #165:

1. **SignalEvent.health_state** field (default `NORMAL`) + conditional `⚠️ *ALERT*` prefix in `signal.telegram.j2`. NORMAL case is byte-identical to pre-PR (parity test pinned).
2. **push_telegram_direct shim** looks up `get_symbol_state(symbol)` before building the `SignalEvent`, so every outbound signal carries the correct state. DB lookup failure → falls back to `NORMAL`, signal still sends.
3. **health.evaluate_and_record** emits a one-shot `notify(HealthEvent)` on any transition *into* `ALERT`. Idempotent: subsequent evaluations while state stays ALERT do NOT re-fire. Exception-swallowed so a broken notifier can't crash health eval.

REDUCED / PAUSED transitions remain silent — PRs 3 and 4 extend the notify logic.

## Does NOT change
- Trading behavior: ALERT symbols are still operated on normally. PR 2 only adds a visual prefix + a single warning notification on the state change.
- NORMAL rendering is byte-identical (`test_notifier_signal_parity` still passes).
- `push_telegram_direct` signature + return type preserved.

## Unblocks
- PRs 3 (REDUCED) and 4 (PAUSED) — same pattern, extended to additional states + tier-specific actions.

## Test plan

- [x] **9 new tests** across 4 files:
  - `test_notifier_events.py`: +2 (health_state default, set)
  - `test_notifier_templates.py`: +2 (ALERT prefix, NORMAL byte-identical)
  - `test_health_shim_integration.py` (new): +2 (ALERT → prefix, NORMAL → no prefix)
  - `test_health_alert_notify.py` (new): +3 (notify fires on transition, no re-fire, REDUCED silent)
- [x] Full suite: **556 passed**, 0 failed (up from 547 after PR #165)

## Review-driven improvements during implementation

Per-task two-stage review caught:
- Trailing space on ALERT prefix that would have broken downstream `msg.startswith("⚠️ *ALERT*")` matches
- Weak parity assertion (replaced `not msg.startswith("⚠️")` with byte-for-byte expected string match)
- Weak test assertion missing `mock_post.call_count == 1` guard
- Log import placement (hoisted from mid-file to top per PEP 8)
- Incorrect docstring on `_seed_for_alert` (said wr=1/25 but rolling window is LIMIT 20 → actual wr=1/20)
- Confirmed (pre-existing, not touched here): `max_retries` parameter drop in `push_telegram_direct` shim — shim-wide concern, out of scope for PR 2

Closes partial: #138 (PR 2 of 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)