### PR TITLE
feat(notifier): Webhook channel + PositionExitEvent — #162 PR B (parcial)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -624,31 +624,29 @@ def check_position_stops(symbol: str, price: float):
             log.info(f"POSICION #{pos['id']} {symbol} {reason} @ ${exit_price}")
             _write_position_event_log(pos, reason, exit_price)
 
-            # Send Telegram notification
+            # Send exit notification via the centralized notifier (#162 PR B).
             entry = pos.get("entry_price", 0)
             qty = pos.get("qty", 0)
             pnl_usd, pnl_pct = _calc_pnl(pos["direction"], entry, exit_price, qty)
-            pnl_str = f"${pnl_usd:+.2f}" if qty else "N/A"
-            pnl_pct_str = f"{pnl_pct:+.2f}%" if qty else "N/A"
-
-            if reason == "SL_HIT":
-                emoji, label = "\U0001f534", "STOP LOSS"
-            else:
-                emoji, label = "\U0001f7e2", "TAKE PROFIT"
-
-            msg = (
-                f"{emoji} *{label} HIT*\n"
-                f"*{symbol}* ({pos['direction']})\n"
-                f"Entry: `${entry:.2f}` -> Exit: `${exit_price:.2f}`\n"
-                f"P&L: `{pnl_str}` ({pnl_pct_str})\n"
-                f"Reason: `{reason}`"
-            )
 
             try:
-                # TODO (#162 PR B): migrate to notifier.notify(InfraEvent(...)) once a
-                # PositionExitEvent type exists. The pre-formatted TP/SL message has no
-                # suitable SignalEvent mapping; leaving on _send_telegram_raw for now.
-                _send_telegram_raw(msg, cfg)
+                from notifier import notify, PositionExitEvent
+                # Map legacy reason strings ("SL_HIT"/"TP_HIT") to tier codes.
+                exit_reason_code = "SL" if reason == "SL_HIT" else (
+                    "TP" if reason == "TP_HIT" else reason
+                )
+                notify(
+                    PositionExitEvent(
+                        symbol=symbol,
+                        direction=pos.get("direction", "LONG"),
+                        exit_reason=exit_reason_code,
+                        entry_price=float(entry or 0.0),
+                        exit_price=float(exit_price or 0.0),
+                        pnl_usd=float(pnl_usd or 0.0),
+                        pnl_pct=float(pnl_pct or 0.0),
+                    ),
+                    cfg=cfg,
+                )
             except Exception as e:
                 log.warning(f"Failed to notify {reason} for {symbol}: {e}")
 

--- a/notifier/__init__.py
+++ b/notifier/__init__.py
@@ -9,6 +9,7 @@ from notifier._storage import record_delivery
 from notifier._templates import render
 from notifier.channels.base import DeliveryReceipt
 from notifier.channels.telegram import TelegramChannel
+from notifier.channels.webhook import WebhookChannel
 from notifier.events import (
     SignalEvent, HealthEvent, InfraEvent, SystemEvent, PositionExitEvent,
     Event,
@@ -26,17 +27,19 @@ log = logging.getLogger("notifier")
 
 
 _DEFAULT_CHANNELS_BY_EVENT_TYPE: dict[str, list[str]] = {
-    "signal": ["telegram"],
-    "health": ["telegram"],
-    "infra":  ["telegram"],
-    "system": ["telegram"],
+    "signal":        ["telegram"],
+    "health":        ["telegram"],
+    "infra":         ["telegram"],
+    "system":        ["telegram"],
+    "position_exit": ["telegram"],
 }
 
 _DEFAULT_DEDUPE_SECONDS_BY_EVENT_TYPE: dict[str, int] = {
-    "signal": 0,      # no dedupe — signals are rare and each matters
-    "health": 1800,   # 30 min
-    "infra":  300,    # 5 min
-    "system": 0,
+    "signal":        0,      # no dedupe — signals are rare and each matters
+    "health":        1800,   # 30 min
+    "infra":         300,    # 5 min
+    "system":        0,
+    "position_exit": 0,      # each exit is a discrete event; no dedupe
 }
 
 
@@ -89,8 +92,10 @@ def notify(event: Event, cfg: dict) -> list[DeliveryReceipt]:
         # a channel we cannot dispatch to.
         if channel_name == "telegram":
             channel = TelegramChannel(cfg)
+        elif channel_name == "webhook":
+            channel = WebhookChannel(cfg)
         else:
-            log.warning("notify: unsupported channel %r (not yet wired — see PR B of #162)",
+            log.warning("notify: unsupported channel %r (email lands in a future PR)",
                          channel_name)
             receipts.append(DeliveryReceipt(channel=channel_name, status="failed",
                                               error=f"unsupported channel: {channel_name}"))
@@ -117,7 +122,12 @@ def notify(event: Event, cfg: dict) -> list[DeliveryReceipt]:
             channels_sent.append(channel_name)
             continue
 
-        receipt = channel.send(message)
+        # WebhookChannel takes event_type as an extra arg so it can route to
+        # endpoint subscribers. Other channels ignore the kwarg.
+        if channel_name == "webhook":
+            receipt = channel.send(message, event_type=event.event_type)
+        else:
+            receipt = channel.send(message)
         receipts.append(receipt)
         if receipt.status == "ok":
             channels_sent.append(channel_name)

--- a/notifier/__init__.py
+++ b/notifier/__init__.py
@@ -10,15 +10,15 @@ from notifier._templates import render
 from notifier.channels.base import DeliveryReceipt
 from notifier.channels.telegram import TelegramChannel
 from notifier.events import (
-    SignalEvent, HealthEvent, InfraEvent, SystemEvent,
+    SignalEvent, HealthEvent, InfraEvent, SystemEvent, PositionExitEvent,
     Event,
 )
 
 
 __all__ = [
     "notify",
-    "SignalEvent", "HealthEvent", "InfraEvent", "SystemEvent", "Event",
-    "DeliveryReceipt",
+    "SignalEvent", "HealthEvent", "InfraEvent", "SystemEvent", "PositionExitEvent",
+    "Event", "DeliveryReceipt",
 ]
 
 

--- a/notifier/channels/webhook.py
+++ b/notifier/channels/webhook.py
@@ -1,0 +1,117 @@
+"""Generic webhook channel — POST JSON to one or more configured URLs.
+
+Compatible with n8n, Discord webhooks, Slack incoming webhooks, and any
+generic JSON-receiver. Multi-endpoint support per event type via config:
+
+    "notifier": {
+        "channels": {
+            "webhook": {
+                "enabled": true,
+                "endpoints": [
+                    {"url": "http://localhost:5678/webhook/trading",
+                     "types": ["signal", "health"]},
+                    {"url": "https://discord.com/api/webhooks/...",
+                     "types": ["position_exit"]}
+                ]
+            }
+        }
+    }
+
+Each endpoint opts into the event types it wants. An endpoint with no `types`
+entry receives all events. Transport: `requests.post` with 4xx fail-fast,
+429 Retry-After honored, exponential backoff on 5xx (1s, 2s, 4s).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import requests
+
+from notifier.channels.base import Channel, DeliveryReceipt
+
+
+log = logging.getLogger("notifier.webhook")
+
+
+class WebhookChannel(Channel):
+    name = "webhook"
+
+    def __init__(self, cfg: dict[str, Any]):
+        """cfg is the full app config; we read notifier.channels.webhook.endpoints."""
+        notif_cfg = (cfg.get("notifier") or {})
+        ch_cfg = ((notif_cfg.get("channels") or {}).get("webhook") or {})
+        self._enabled = bool(ch_cfg.get("enabled", False))
+        self._endpoints: list[dict[str, Any]] = list(ch_cfg.get("endpoints") or [])
+
+    def _filter_endpoints_for(self, event_type: str) -> list[dict[str, Any]]:
+        matched: list[dict[str, Any]] = []
+        for ep in self._endpoints:
+            types = ep.get("types")
+            if not types or event_type in types:
+                matched.append(ep)
+        return matched
+
+    def send(self, message: str, event_type: str = "", max_retries: int = 3) -> DeliveryReceipt:
+        """`message` is the rendered JSON string from the <event>.webhook.j2 template."""
+        if not self._enabled:
+            return DeliveryReceipt(channel=self.name, status="failed",
+                                    error="webhook channel disabled in config")
+        endpoints = self._filter_endpoints_for(event_type)
+        if not endpoints:
+            return DeliveryReceipt(channel=self.name, status="failed",
+                                    error=f"no webhook endpoint subscribes to event_type={event_type!r}")
+
+        # If any endpoint succeeds, the overall result is ok. Aggregate errors otherwise.
+        any_ok = False
+        errors: list[str] = []
+        for ep in endpoints:
+            url = ep.get("url", "").strip()
+            if not url:
+                errors.append("endpoint has empty url")
+                continue
+            ok, err = self._post_with_retry(url, message, max_retries=max_retries)
+            if ok:
+                any_ok = True
+            else:
+                errors.append(f"{url}: {err}")
+        if any_ok:
+            return DeliveryReceipt(
+                channel=self.name, status="ok",
+                error=(None if not errors else " | ".join(errors)),
+            )
+        return DeliveryReceipt(channel=self.name, status="failed",
+                                error=" | ".join(errors) or "all endpoints failed")
+
+    def _post_with_retry(self, url: str, body: str, max_retries: int) -> tuple[bool, str | None]:
+        last_error: str | None = None
+        for attempt in range(1, max_retries + 1):
+            try:
+                r = requests.post(url, data=body,
+                                   headers={"Content-Type": "application/json"},
+                                   timeout=10)
+                if r.ok:
+                    return True, None
+                if 400 <= r.status_code < 500 and r.status_code != 429:
+                    err = f"HTTP {r.status_code}: {r.text[:200]}"
+                    log.error("webhook permanent error, not retrying: %s", err)
+                    return False, err
+                last_error = f"HTTP {r.status_code}: {r.text[:200]}"
+                log.warning("webhook attempt %d/%d failed: %s",
+                             attempt, max_retries, last_error)
+                if r.status_code == 429 and attempt < max_retries:
+                    try:
+                        retry_after = int(r.headers.get("Retry-After", "0"))
+                    except (TypeError, ValueError):
+                        retry_after = 0
+                    if retry_after > 0:
+                        time.sleep(retry_after)
+                        continue
+            except requests.RequestException as e:
+                last_error = f"{type(e).__name__}: {e}"
+                log.warning("webhook attempt %d/%d exception: %s",
+                             attempt, max_retries, last_error)
+            if attempt < max_retries:
+                time.sleep(2 ** (attempt - 1))  # 1s, 2s, 4s
+        return False, last_error

--- a/notifier/events.py
+++ b/notifier/events.py
@@ -100,4 +100,28 @@ class SystemEvent(_BaseEvent):
         return f"system:{self.kind}"
 
 
-Event = SignalEvent | HealthEvent | InfraEvent | SystemEvent
+@dataclass
+class PositionExitEvent(_BaseEvent):
+    """Emitted when a position closes (TP/SL/manual). Replaces the legacy
+    _send_telegram_raw TP/SL notification in btc_api.py (#138 PR 4 TODO, #162 PR B)."""
+    symbol: str = ""
+    direction: str = "LONG"
+    exit_reason: str = ""     # 'TP' | 'SL' | 'BE' | 'MANUAL'
+    entry_price: float = 0.0
+    exit_price: float = 0.0
+    pnl_usd: float = 0.0
+    pnl_pct: float = 0.0
+
+    def __post_init__(self):
+        self.event_type = "position_exit"
+        # Losers are warning; winners are info. Operator can tune via config later.
+        self.priority = "info" if self.pnl_usd >= 0 else "warning"
+
+    @property
+    def dedupe_key(self) -> str:
+        # Include exit_price + reason so two consecutive closures of the same
+        # symbol don't collide in the dedupe window.
+        return f"position_exit:{self.symbol}:{self.exit_reason}:{self.exit_price}"
+
+
+Event = SignalEvent | HealthEvent | InfraEvent | SystemEvent | PositionExitEvent

--- a/notifier/templates/health.webhook.j2
+++ b/notifier/templates/health.webhook.j2
@@ -1,0 +1,8 @@
+{
+  "type": "health",
+  "symbol": "{{ symbol }}",
+  "from_state": "{{ from_state }}",
+  "to_state": "{{ to_state }}",
+  "reason": "{{ reason }}",
+  "metrics": {{ metrics|tojson }}
+}

--- a/notifier/templates/infra.webhook.j2
+++ b/notifier/templates/infra.webhook.j2
@@ -1,0 +1,6 @@
+{
+  "type": "infra",
+  "component": "{{ component }}",
+  "severity": "{{ severity }}",
+  "message": {{ message|tojson }}
+}

--- a/notifier/templates/position_exit.telegram.j2
+++ b/notifier/templates/position_exit.telegram.j2
@@ -1,0 +1,3 @@
+{%- if exit_reason == "TP" %}🎯 *TP hit*{% elif exit_reason == "SL" %}🛑 *SL hit*{% elif exit_reason == "BE" %}⚖️ *Break-even*{% else %}📕 *Position closed*{% endif %} `{{ symbol }}` ({{ direction }})
+Entry: `{{ "%.2f"|format(entry_price) }}` → Exit: `{{ "%.2f"|format(exit_price) }}`
+P&L: `{{ "%+.2f"|format(pnl_usd) }}` USD ({{ "%+.2f"|format(pnl_pct) }}%)

--- a/notifier/templates/position_exit.webhook.j2
+++ b/notifier/templates/position_exit.webhook.j2
@@ -1,0 +1,10 @@
+{
+  "type": "position_exit",
+  "symbol": "{{ symbol }}",
+  "direction": "{{ direction }}",
+  "exit_reason": "{{ exit_reason }}",
+  "entry_price": {{ "%.2f"|format(entry_price) }},
+  "exit_price": {{ "%.2f"|format(exit_price) }},
+  "pnl_usd": {{ "%.2f"|format(pnl_usd) }},
+  "pnl_pct": {{ "%.2f"|format(pnl_pct) }}
+}

--- a/notifier/templates/signal.webhook.j2
+++ b/notifier/templates/signal.webhook.j2
@@ -1,0 +1,10 @@
+{
+  "type": "signal",
+  "symbol": "{{ symbol }}",
+  "score": {{ score }},
+  "direction": "{{ direction }}",
+  "entry": {{ "%.2f"|format(entry) }},
+  "sl": {{ "%.2f"|format(sl) }},
+  "tp": {{ "%.2f"|format(tp) }},
+  "health_state": "{{ health_state }}"
+}

--- a/notifier/templates/system.webhook.j2
+++ b/notifier/templates/system.webhook.j2
@@ -1,0 +1,5 @@
+{
+  "type": "system",
+  "kind": "{{ kind }}",
+  "message": {{ message|tojson }}
+}

--- a/tests/test_notifier_integration.py
+++ b/tests/test_notifier_integration.py
@@ -119,12 +119,13 @@ def test_notify_render_failure_produces_failed_receipt(tmp_db_and_reset):
 
 
 def test_notify_unsupported_channel_logs_warning(tmp_db_and_reset, caplog):
-    """Unknown channel name must log a warning (so operator notices config drift)."""
+    """Unknown channel name must log a warning (so operator notices config drift).
+    Uses 'email' since webhook is now a supported channel in #162 PR B."""
     import logging
     from notifier import notify, SignalEvent
 
     cfg = _cfg()
-    cfg["notifier"]["channels_by_event_type"] = {"signal": ["webhook"]}
+    cfg["notifier"]["channels_by_event_type"] = {"signal": ["email"]}
 
     ev = SignalEvent(symbol="BTC", score=5, direction="LONG",
                      entry=1, sl=1, tp=1)

--- a/tests/test_notifier_position_exit.py
+++ b/tests/test_notifier_position_exit.py
@@ -1,0 +1,57 @@
+"""PositionExitEvent + position_exit.telegram.j2 template tests (#162 PR B)."""
+
+
+def test_position_exit_event_required_fields():
+    from notifier import PositionExitEvent
+    ev = PositionExitEvent(symbol="BTC", direction="LONG", exit_reason="TP",
+                            entry_price=50_000, exit_price=55_000,
+                            pnl_usd=100.0, pnl_pct=10.0)
+    assert ev.event_type == "position_exit"
+    assert ev.priority == "info"  # winner
+    assert "BTC" in ev.dedupe_key
+    assert "TP" in ev.dedupe_key
+
+
+def test_position_exit_loser_has_warning_priority():
+    from notifier import PositionExitEvent
+    ev = PositionExitEvent(symbol="DOGE", direction="SHORT", exit_reason="SL",
+                            entry_price=1.0, exit_price=1.2,
+                            pnl_usd=-50.0, pnl_pct=-5.0)
+    assert ev.priority == "warning"
+
+
+def test_position_exit_telegram_template_tp_winner():
+    from notifier._templates import render
+    from notifier import PositionExitEvent
+    ev = PositionExitEvent(symbol="BTC", direction="LONG", exit_reason="TP",
+                            entry_price=50_000, exit_price=55_000,
+                            pnl_usd=500.0, pnl_pct=10.0)
+    msg = render(ev, channel="telegram")
+    assert "🎯" in msg
+    assert "BTC" in msg
+    assert "LONG" in msg
+    assert "TP hit" in msg
+    assert "+500.00" in msg
+
+
+def test_position_exit_telegram_template_sl_loser():
+    from notifier._templates import render
+    from notifier import PositionExitEvent
+    ev = PositionExitEvent(symbol="DOGE", direction="SHORT", exit_reason="SL",
+                            entry_price=1.0, exit_price=1.2,
+                            pnl_usd=-50.0, pnl_pct=-20.0)
+    msg = render(ev, channel="telegram")
+    assert "🛑" in msg
+    assert "SL hit" in msg
+    assert "-50.00" in msg
+
+
+def test_position_exit_dedupe_key_includes_exit_price():
+    """Two closures on the same symbol with different exit prices must dedupe
+    independently (otherwise a second close after re-entry would be suppressed)."""
+    from notifier import PositionExitEvent
+    e1 = PositionExitEvent(symbol="BTC", direction="LONG", exit_reason="TP",
+                            exit_price=55_000, pnl_usd=100, pnl_pct=10)
+    e2 = PositionExitEvent(symbol="BTC", direction="LONG", exit_reason="TP",
+                            exit_price=56_000, pnl_usd=120, pnl_pct=12)
+    assert e1.dedupe_key != e2.dedupe_key

--- a/tests/test_notifier_webhook_channel.py
+++ b/tests/test_notifier_webhook_channel.py
@@ -1,0 +1,134 @@
+"""WebhookChannel tests — POST JSON to configured endpoints."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def _cfg(endpoints=None, enabled=True):
+    return {
+        "notifier": {
+            "channels": {
+                "webhook": {
+                    "enabled": enabled,
+                    "endpoints": endpoints or [],
+                },
+            },
+        },
+    }
+
+
+def test_webhook_disabled_by_default():
+    """cfg without webhook.enabled → channel returns failed without HTTP."""
+    from notifier.channels.webhook import WebhookChannel
+    channel = WebhookChannel(_cfg(enabled=False))
+    receipt = channel.send('{"foo":"bar"}', event_type="signal")
+    assert receipt.status == "failed"
+    assert "disabled" in receipt.error.lower()
+
+
+def test_webhook_no_matching_endpoint():
+    """An endpoint with types=['signal'] does NOT receive health events."""
+    from notifier.channels.webhook import WebhookChannel
+    cfg = _cfg([{"url": "http://x", "types": ["signal"]}])
+    channel = WebhookChannel(cfg)
+    receipt = channel.send('{"ok": true}', event_type="health")
+    assert receipt.status == "failed"
+    assert "no webhook endpoint subscribes" in receipt.error
+
+
+def test_webhook_success_posts_json():
+    """Single endpoint, event type matches → POST is made once with correct body."""
+    from notifier.channels.webhook import WebhookChannel
+    cfg = _cfg([{"url": "http://n8n.local/hook", "types": ["signal"]}])
+    channel = WebhookChannel(cfg)
+
+    ok = MagicMock()
+    ok.ok = True
+    ok.status_code = 200
+
+    with patch("notifier.channels.webhook.requests.post", return_value=ok) as mock_post:
+        receipt = channel.send('{"symbol":"BTC"}', event_type="signal")
+
+    assert receipt.status == "ok"
+    assert mock_post.call_count == 1
+    call = mock_post.call_args
+    assert call.args[0] == "http://n8n.local/hook"
+    assert call.kwargs["data"] == '{"symbol":"BTC"}'
+    assert call.kwargs["headers"]["Content-Type"] == "application/json"
+
+
+def test_webhook_endpoint_without_types_receives_all():
+    """An endpoint without 'types' filter accepts every event_type."""
+    from notifier.channels.webhook import WebhookChannel
+    cfg = _cfg([{"url": "http://catchall"}])  # no 'types' key
+    channel = WebhookChannel(cfg)
+
+    ok = MagicMock()
+    ok.ok = True
+    with patch("notifier.channels.webhook.requests.post", return_value=ok) as mock_post:
+        channel.send('{"x":1}', event_type="infra")
+        channel.send('{"x":2}', event_type="signal")
+    assert mock_post.call_count == 2
+
+
+def test_webhook_4xx_fail_fast():
+    """401/400/403 etc. are permanent — no retry."""
+    from notifier.channels.webhook import WebhookChannel
+    cfg = _cfg([{"url": "http://bad"}])
+    channel = WebhookChannel(cfg)
+
+    fail = MagicMock()
+    fail.ok = False
+    fail.status_code = 401
+    fail.text = "Unauthorized"
+
+    with patch("notifier.channels.webhook.requests.post", return_value=fail) as mock_post:
+        with patch("notifier.channels.webhook.time.sleep") as mock_sleep:
+            receipt = channel.send('{}', event_type="signal")
+    assert receipt.status == "failed"
+    assert "401" in receipt.error
+    assert mock_post.call_count == 1
+    assert mock_sleep.call_count == 0
+
+
+def test_webhook_5xx_retries_with_backoff():
+    from notifier.channels.webhook import WebhookChannel
+    cfg = _cfg([{"url": "http://flaky"}])
+    channel = WebhookChannel(cfg)
+
+    fail = MagicMock()
+    fail.ok = False
+    fail.status_code = 500
+    fail.text = "server err"
+    ok = MagicMock()
+    ok.ok = True
+    ok.status_code = 200
+
+    with patch("notifier.channels.webhook.requests.post",
+                side_effect=[fail, fail, ok]):
+        with patch("notifier.channels.webhook.time.sleep") as mock_sleep:
+            receipt = channel.send('{}', event_type="signal")
+    assert receipt.status == "ok"
+    # Backoff after attempts 1 and 2 (not after the successful attempt 3)
+    assert mock_sleep.call_count == 2
+    assert mock_sleep.call_args_list[0].args[0] == 1
+    assert mock_sleep.call_args_list[1].args[0] == 2
+
+
+def test_webhook_multiple_endpoints_partial_success():
+    """If one endpoint succeeds and another fails, overall status is ok + error recorded."""
+    from notifier.channels.webhook import WebhookChannel
+    cfg = _cfg([
+        {"url": "http://good"},
+        {"url": "http://bad"},
+    ])
+    channel = WebhookChannel(cfg)
+
+    ok = MagicMock(); ok.ok = True; ok.status_code = 200
+    bad = MagicMock(); bad.ok = False; bad.status_code = 400; bad.text = "bad req"
+
+    with patch("notifier.channels.webhook.requests.post",
+                side_effect=[ok, bad]):
+        receipt = channel.send('{}', event_type="signal")
+    assert receipt.status == "ok"
+    assert "http://bad" in receipt.error

--- a/tests/test_notifier_webhook_integration.py
+++ b/tests/test_notifier_webhook_integration.py
@@ -1,0 +1,145 @@
+"""End-to-end: notify(event) with webhook channel configured → POST JSON to URL."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db_and_reset(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    from notifier import ratelimit
+    ratelimit.reset_all_for_tests()
+    yield db_path
+
+
+def _cfg_with_webhook(url="http://n8n.local/hook", types=None, telegram_enabled=False):
+    cfg = {
+        "notifier": {
+            "enabled": True,
+            "channels_by_event_type": {
+                "signal": (["telegram", "webhook"] if telegram_enabled else ["webhook"]),
+                "position_exit": ["webhook"],
+                "health": ["webhook"],
+            },
+            "channels": {
+                "webhook": {
+                    "enabled": True,
+                    "endpoints": [{"url": url, "types": types}] if types else [{"url": url}],
+                },
+            },
+        },
+    }
+    if telegram_enabled:
+        cfg["telegram_bot_token"] = "t"
+        cfg["telegram_chat_id"] = "1"
+    return cfg
+
+
+def test_notify_signal_via_webhook_posts_json(tmp_db_and_reset):
+    from notifier import notify, SignalEvent
+
+    ok = MagicMock()
+    ok.ok = True
+    ok.status_code = 200
+
+    with patch("notifier.channels.webhook.requests.post", return_value=ok) as mock_post:
+        receipts = notify(
+            SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                         entry=50_000, sl=49_000, tp=55_000),
+            cfg=_cfg_with_webhook(types=["signal"]),
+        )
+
+    assert len(receipts) == 1
+    assert receipts[0].status == "ok"
+    assert mock_post.call_count == 1
+    body = mock_post.call_args.kwargs["data"]
+    # The body is a rendered JSON template — check it contains the expected fields.
+    assert '"type": "signal"' in body
+    assert '"symbol": "BTCUSDT"' in body
+
+
+def test_notify_position_exit_via_webhook(tmp_db_and_reset):
+    from notifier import notify, PositionExitEvent
+
+    ok = MagicMock()
+    ok.ok = True
+
+    with patch("notifier.channels.webhook.requests.post", return_value=ok) as mock_post:
+        receipts = notify(
+            PositionExitEvent(symbol="BTC", direction="LONG", exit_reason="TP",
+                               entry_price=50_000, exit_price=55_000,
+                               pnl_usd=100, pnl_pct=10),
+            cfg=_cfg_with_webhook(types=["position_exit"]),
+        )
+
+    assert receipts[0].status == "ok"
+    body = mock_post.call_args.kwargs["data"]
+    assert '"type": "position_exit"' in body
+    assert '"exit_reason": "TP"' in body
+
+
+def _ok_response():
+    m = MagicMock()
+    m.ok = True
+    m.status_code = 200
+    return m
+
+
+def test_notify_routes_to_both_telegram_and_webhook(tmp_db_and_reset):
+    """Both telegram and webhook channels route via requests.post — use a single
+    patch that dispatches by URL (they share the same module-level requests.post
+    reference so two patches would collide)."""
+    from notifier import notify, SignalEvent
+
+    calls = {"telegram": 0, "webhook": 0}
+
+    def _dispatcher(url, *a, **kw):
+        if "api.telegram.org" in url:
+            calls["telegram"] += 1
+        else:
+            calls["webhook"] += 1
+        return _ok_response()
+
+    with patch("requests.post", side_effect=_dispatcher):
+        receipts = notify(
+            SignalEvent(symbol="BTC", score=5, direction="LONG",
+                         entry=1, sl=1, tp=1),
+            cfg=_cfg_with_webhook(telegram_enabled=True),
+        )
+
+    assert calls["telegram"] == 1
+    assert calls["webhook"] == 1
+    statuses = {r.channel: r.status for r in receipts}
+    assert statuses["telegram"] == "ok"
+    assert statuses["webhook"] == "ok"
+
+
+def test_notify_webhook_failure_does_not_block_telegram(tmp_db_and_reset):
+    """Partial delivery: webhook 500s but telegram succeeds → both tier receipts recorded."""
+    from notifier import notify, SignalEvent
+
+    def _dispatcher(url, *a, **kw):
+        if "api.telegram.org" in url:
+            return _ok_response()
+        fail = MagicMock()
+        fail.ok = False
+        fail.status_code = 500
+        fail.text = "server err"
+        return fail
+
+    with patch("requests.post", side_effect=_dispatcher), \
+         patch("notifier.channels.webhook.time.sleep"):
+        receipts = notify(
+            SignalEvent(symbol="BTC", score=5, direction="LONG",
+                         entry=1, sl=1, tp=1),
+            cfg=_cfg_with_webhook(telegram_enabled=True),
+        )
+
+    statuses = {r.channel: r.status for r in receipts}
+    assert statuses["telegram"] == "ok"
+    assert statuses["webhook"] == "failed"


### PR DESCRIPTION
## Summary

Partial PR B of #162 — ships the high-ROI parts of the multi-channel work without the SMTP Email channel. Two deliverables:

1. **PositionExitEvent** + telegram template — closes the `TODO (#162 PR B)` left in `btc_api.py:622` since PR #164. Migrates TP/SL exit notifications from the legacy `_send_telegram_raw` path to `notify(PositionExitEvent(...))`.
2. **WebhookChannel** — generic POST-JSON channel compatible with n8n, Discord, Slack incoming webhooks, or any JSON-receiver. Endpoint subscriptions per event type. 4xx fail-fast, 429 Retry-After, exponential backoff on 5xx.

## What's included
- `notifier/events.py`: `PositionExitEvent` dataclass with dedupe key `(symbol, reason, exit_price)` so successive closes on the same symbol don't collide.
- `notifier/templates/position_exit.telegram.j2`: 🎯/🛑/⚖️/📕 prefix by exit reason; P&L formatting with sign.
- `notifier/channels/webhook.py`: `WebhookChannel` with multi-endpoint config, per-event-type subscription via `endpoints[i].types`, and structured retry logic mirroring `TelegramChannel`.
- `notifier/templates/{signal,health,infra,system,position_exit}.webhook.j2`: JSON payload per event type. Consumers get typed, stable payloads.
- `notifier/__init__.py`: factory dispatches `webhook` → `WebhookChannel`, passes `event_type` kwarg. Defaults added for `position_exit`.
- `btc_api.py:622`: TP/SL send migrated to `notify(PositionExitEvent(...))`.

## Config example

```json
"notifier": {
  "enabled": true,
  "channels_by_event_type": {
    "signal":        ["telegram", "webhook"],
    "health":        ["telegram", "webhook"],
    "position_exit": ["telegram", "webhook"]
  },
  "channels": {
    "webhook": {
      "enabled": true,
      "endpoints": [
        {"url": "http://localhost:5678/webhook/trading", "types": ["signal", "health"]},
        {"url": "https://discord.com/api/webhooks/...",  "types": ["position_exit"]}
      ]
    }
  }
}
```

An endpoint without `types` receives all events.

## Does NOT include
- **Email (SMTP) channel** — pushed to a later PR. Low ROI for now; all current consumers (Telegram, n8n, Discord) work over webhook.
- **Frontend notification center (PR C)** — still pending. Dashboard-side UX for Simon.

## Test plan
- [x] **16 new tests** across 3 files:
  - `test_notifier_position_exit.py` (5): event fields, winner/loser priority, TP/SL templates, dedupe key
  - `test_notifier_webhook_channel.py` (7): disabled/no-endpoint/success/catchall, 4xx fail-fast, 5xx retry with backoff, partial multi-endpoint success
  - `test_notifier_webhook_integration.py` (4): end-to-end via notify() for signal + position_exit + multi-channel fanout + partial failure
- [x] 1 existing test updated: `test_notify_unsupported_channel_logs_warning` now uses `email` as the unknown channel (webhook is supported now)
- [x] Full suite: **589 passed**, 0 failed (up from 573 after #168)

## Notes
- Testing gotcha: `TelegramChannel` and `WebhookChannel` both import the same `requests` module, so two `patch()` contexts targeting `requests.post` collide. Integration tests use a single patch with URL-based dispatch.
- PR C (frontend notification center) and Email channel can land after this without touching any of the core wiring.

Closes partial: #162 (PR B — webhook + position_exit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)