### PR TITLE
feat(notifier): frontend notification center (#162 PR C)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -2043,6 +2043,56 @@ def get_health_events(
     return {"events": [dict(zip(cols, r)) for r in rows]}
 
 
+# ── Notification center endpoints (#162 PR C) ────────────────────────
+@app.get("/notifications", dependencies=[Depends(verify_api_key)])
+def get_notifications(
+    unread: bool = True,
+    limit: int = Query(50, ge=1, le=200,
+                        description="Max rows returned (capped to prevent unbounded scans)"),
+):
+    """List notifications recorded by the notifier.
+
+    By default returns only unread entries; pass ?unread=false to include
+    read ones too. Sorted most-recent-first.
+    """
+    from notifier._storage import list_unread
+    if not unread:
+        # Full list (both read + unread) — use a direct query since list_unread
+        # filters on read_at IS NULL.
+        con = get_db()
+        try:
+            rows = con.execute(
+                """SELECT id, event_type, event_key, priority, payload_json,
+                          channels_sent, delivery_status, sent_at, read_at, error_log
+                   FROM notifications_sent
+                   ORDER BY sent_at DESC
+                   LIMIT ?""",
+                (limit,),
+            ).fetchall()
+        finally:
+            con.close()
+        cols = ("id", "event_type", "event_key", "priority", "payload_json",
+                "channels_sent", "delivery_status", "sent_at", "read_at", "error_log")
+        return {"notifications": [dict(zip(cols, r)) for r in rows]}
+    return {"notifications": list_unread(limit=limit)}
+
+
+@app.post("/notifications/{notif_id}/read", dependencies=[Depends(verify_api_key)])
+def post_notification_read(notif_id: int):
+    """Mark a single notification as read."""
+    from notifier._storage import mark_read
+    mark_read(notif_id)
+    return {"ok": True, "id": notif_id}
+
+
+@app.post("/notifications/read-all", dependencies=[Depends(verify_api_key)])
+def post_notifications_read_all():
+    """Mark all currently-unread notifications as read. Returns how many were updated."""
+    from notifier._storage import mark_all_read
+    n = mark_all_read()
+    return {"ok": True, "marked": n}
+
+
 @app.post("/health/reactivate/{symbol}", dependencies=[Depends(verify_api_key)])
 def post_health_reactivate(symbol: str, body: ReactivateRequest):
     """Manually reset a symbol to NORMAL with manual_override=1."""

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2465,3 +2465,152 @@ button:focus-visible {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.5; transform: scale(1.3); }
 }
+
+/* ============================================================
+   NotificationBell (#162 PR C)
+   ============================================================ */
+.notification-bell {
+  position: relative;
+  display: inline-block;
+}
+
+.notification-bell-btn {
+  position: relative;
+  font-size: 1.1rem;
+}
+
+.notification-bell-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  background: #e03131;
+  color: #fff;
+  border-radius: 9px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 18px;
+  text-align: center;
+  pointer-events: none;
+}
+
+.notification-dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 360px;
+  max-height: 460px;
+  overflow-y: auto;
+  background: var(--bg-secondary, #1c1d25);
+  border: 1px solid var(--border, #2b2d38);
+  border-radius: 8px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+}
+
+.notification-dropdown-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border, #2b2d38);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.notification-dropdown-clear {
+  background: transparent;
+  border: 1px solid var(--border, #2b2d38);
+  color: var(--text-secondary, #a8aab7);
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.notification-dropdown-clear:hover {
+  color: var(--text-primary, #fff);
+  border-color: var(--accent, #4c6ef5);
+}
+
+.notification-dropdown-empty {
+  padding: 22px;
+  text-align: center;
+  color: var(--text-secondary, #a8aab7);
+  font-size: 0.9rem;
+}
+
+.notification-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.notification-item {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border, #2b2d38);
+}
+
+.notification-item:last-child {
+  border-bottom: none;
+}
+
+.notification-item--critical {
+  background: rgba(224, 49, 49, 0.08);
+}
+
+.notification-item--warning {
+  background: rgba(224, 169, 49, 0.05);
+}
+
+.notification-icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.notification-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.notification-summary {
+  font-size: 0.88rem;
+  color: var(--text-primary, #fff);
+  word-break: break-word;
+}
+
+.notification-meta {
+  display: flex;
+  gap: 10px;
+  margin-top: 3px;
+  font-size: 0.72rem;
+  color: var(--text-secondary, #a8aab7);
+}
+
+.notification-type {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.notification-read-btn {
+  background: transparent;
+  border: 1px solid var(--border, #2b2d38);
+  color: var(--text-secondary, #a8aab7);
+  font-size: 0.8rem;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.notification-read-btn:hover {
+  color: var(--accent, #4c6ef5);
+  border-color: var(--accent, #4c6ef5);
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -20,6 +20,7 @@ import type {
   PositionClosePayload,
   Position,
   TuneResult,
+  NotificationsResponse,
 } from './types';
 
 const BASE_URL = '/api';
@@ -178,5 +179,30 @@ export async function updateConfigFull(
   return request<ConfigUpdateResponse>('/config', {
     method: 'POST',
     body: JSON.stringify(body),
+  });
+}
+
+// ---- Notifications (#162 PR C) ---------------------------------------
+
+// GET /notifications?unread=true&limit=50 — defaults to unread only
+export async function getNotifications(opts: { unread?: boolean; limit?: number } = {}): Promise<NotificationsResponse> {
+  const params = new URLSearchParams();
+  if (opts.unread !== undefined) params.set('unread', String(opts.unread));
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  const qs = params.toString();
+  return request<NotificationsResponse>(`/notifications${qs ? `?${qs}` : ''}`);
+}
+
+// POST /notifications/{id}/read
+export async function markNotificationRead(id: number): Promise<{ ok: boolean; id: number }> {
+  return request<{ ok: boolean; id: number }>(`/notifications/${id}/read`, {
+    method: 'POST',
+  });
+}
+
+// POST /notifications/read-all
+export async function markAllNotificationsRead(): Promise<{ ok: boolean; marked: number }> {
+  return request<{ ok: boolean; marked: number }>(`/notifications/read-all`, {
+    method: 'POST',
   });
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@
 // ============================================================
 
 import React from 'react';
+import NotificationBell from './NotificationBell';
 
 interface HeaderProps {
   scannerRunning: boolean;
@@ -98,6 +99,7 @@ const Header: React.FC<HeaderProps> = ({
             <span className="tune-badge-dot" />
           </button>
         )}
+        <NotificationBell />
         <button
           className="btn btn-icon"
           onClick={onConfigOpen}

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,0 +1,206 @@
+// ============================================================
+// NotificationBell.tsx — bell icon + badge + dropdown (#162 PR C)
+//
+// Polls /notifications every 30s. Badge shows count of unread.
+// Click opens a dropdown listing the N most recent unread events.
+// Each row has a "mark read" button; header has "mark all read".
+//
+// Event realtime push is tracked in issue #62 (WebSocket/SSE). Until
+// that lands, polling is the mechanism.
+// ============================================================
+
+import React, { useEffect, useState, useCallback, useRef } from 'react';
+import {
+  getNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+} from '../api';
+import type { Notification } from '../types';
+
+const POLL_INTERVAL_MS = 30_000;
+
+function eventIcon(ev: Notification): string {
+  if (ev.event_type === 'position_exit') return '📕';
+  if (ev.event_type === 'health') {
+    try {
+      const payload = JSON.parse(ev.payload_json);
+      if (payload.to_state === 'PAUSED') return '🛑';
+      if (payload.to_state === 'REDUCED') return '⚠️';
+      if (payload.to_state === 'ALERT') return '⚠️';
+    } catch {
+      /* fall through */
+    }
+    return 'ℹ️';
+  }
+  if (ev.event_type === 'infra') {
+    if (ev.priority === 'critical') return '🚨';
+    if (ev.priority === 'warning') return '⚠️';
+    return 'ℹ️';
+  }
+  if (ev.event_type === 'signal') return '📈';
+  return 'ℹ️';
+}
+
+function summary(ev: Notification): string {
+  try {
+    const p = JSON.parse(ev.payload_json);
+    if (ev.event_type === 'signal') {
+      return `${p.symbol ?? '?'} · score ${p.score ?? '?'} (${p.direction ?? ''})`;
+    }
+    if (ev.event_type === 'health') {
+      return `${p.symbol ?? '?'} ${p.from_state ?? ''} → ${p.to_state ?? ''} (${p.reason ?? ''})`;
+    }
+    if (ev.event_type === 'position_exit') {
+      const pnl = typeof p.pnl_usd === 'number' ? p.pnl_usd.toFixed(2) : '?';
+      return `${p.symbol ?? '?'} ${p.exit_reason ?? ''} · P&L ${pnl}`;
+    }
+    if (ev.event_type === 'infra') {
+      return `${p.component ?? '?'}: ${p.message ?? ''}`;
+    }
+    if (ev.event_type === 'system') {
+      return `${p.kind ?? '?'}: ${p.message ?? ''}`;
+    }
+  } catch {
+    /* fall through */
+  }
+  return ev.event_key;
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' });
+}
+
+const NotificationBell: React.FC = () => {
+  const [items, setItems] = useState<Notification[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const resp = await getNotifications({ unread: true, limit: 50 });
+      setItems(resp.notifications ?? []);
+    } catch (err) {
+      // Silent: the bell should never crash the header.
+      console.warn('NotificationBell refresh failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Initial + periodic polling
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  const handleRead = async (id: number) => {
+    try {
+      await markNotificationRead(id);
+      setItems((prev) => prev.filter((n) => n.id !== id));
+    } catch (err) {
+      console.warn('markNotificationRead failed', err);
+    }
+  };
+
+  const handleReadAll = async () => {
+    try {
+      await markAllNotificationsRead();
+      setItems([]);
+    } catch (err) {
+      console.warn('markAllNotificationsRead failed', err);
+    }
+  };
+
+  const unreadCount = items.length;
+  const hasUnread = unreadCount > 0;
+
+  return (
+    <div className="notification-bell" ref={dropdownRef}>
+      <button
+        className="btn btn-icon notification-bell-btn"
+        onClick={() => setOpen((v) => !v)}
+        title={hasUnread ? `${unreadCount} notificaciones sin leer` : 'Sin notificaciones nuevas'}
+        aria-label="Notificaciones"
+      >
+        🔔
+        {hasUnread && (
+          <span className="notification-bell-badge" aria-hidden="true">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="notification-dropdown" role="menu">
+          <div className="notification-dropdown-header">
+            <span>Notificaciones {hasUnread ? `(${unreadCount})` : ''}</span>
+            {hasUnread && (
+              <button
+                className="notification-dropdown-clear"
+                onClick={handleReadAll}
+                title="Marcar todas como leídas"
+              >
+                Marcar todas leídas
+              </button>
+            )}
+          </div>
+
+          {loading && items.length === 0 && (
+            <div className="notification-dropdown-empty">Cargando…</div>
+          )}
+
+          {!loading && items.length === 0 && (
+            <div className="notification-dropdown-empty">Sin notificaciones nuevas.</div>
+          )}
+
+          {items.length > 0 && (
+            <ul className="notification-list">
+              {items.map((ev) => (
+                <li
+                  key={ev.id}
+                  className={`notification-item notification-item--${ev.priority}`}
+                >
+                  <span className="notification-icon">{eventIcon(ev)}</span>
+                  <div className="notification-body">
+                    <div className="notification-summary">{summary(ev)}</div>
+                    <div className="notification-meta">
+                      <span className="notification-type">{ev.event_type}</span>
+                      <span className="notification-time">{formatTime(ev.sent_at)}</span>
+                    </div>
+                  </div>
+                  <button
+                    className="notification-read-btn"
+                    onClick={() => handleRead(ev.id)}
+                    title="Marcar como leída"
+                    aria-label="Marcar como leída"
+                  >
+                    ✓
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationBell;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -234,3 +234,22 @@ export interface TuneResult {
   applied_ts?: string | null;
   changes_count: number;
 }
+
+// ---- Notifications (#162 PR C) ----------------------------------------
+
+export interface Notification {
+  id: number;
+  event_type: 'signal' | 'health' | 'infra' | 'system' | 'position_exit' | string;
+  event_key: string;
+  priority: 'info' | 'warning' | 'critical' | string;
+  payload_json: string;
+  channels_sent: string;
+  delivery_status: 'ok' | 'partial' | 'failed' | 'rate_limited' | string;
+  sent_at: string;
+  read_at: string | null;
+  error_log: string | null;
+}
+
+export interface NotificationsResponse {
+  notifications: Notification[];
+}

--- a/tests/test_notifications_endpoints.py
+++ b/tests/test_notifications_endpoints.py
@@ -1,0 +1,103 @@
+"""GET /notifications, POST /notifications/{id}/read, POST /notifications/read-all."""
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    return TestClient(btc_api.app)
+
+
+def _seed(n_unread=3, n_read=2):
+    """Insert notifications directly via the storage helper."""
+    from notifier._storage import record_delivery, mark_read
+    ids = []
+    for i in range(n_unread):
+        ids.append(record_delivery(
+            event_type="signal", event_key=f"signal:SYM{i}", priority="info",
+            payload={"symbol": f"SYM{i}"}, channels_sent=["telegram"],
+            delivery_status="ok",
+        ))
+    for i in range(n_read):
+        nid = record_delivery(
+            event_type="health", event_key=f"health:R{i}", priority="warning",
+            payload={"symbol": f"R{i}"}, channels_sent=["telegram"],
+            delivery_status="ok",
+        )
+        mark_read(nid)
+    return ids
+
+
+def test_get_notifications_empty(client):
+    resp = client.get("/notifications")
+    assert resp.status_code == 200
+    assert resp.json() == {"notifications": []}
+
+
+def test_get_notifications_only_unread_by_default(client):
+    _seed(n_unread=3, n_read=2)
+    resp = client.get("/notifications")
+    assert resp.status_code == 200
+    rows = resp.json()["notifications"]
+    assert len(rows) == 3
+    assert all(r["read_at"] is None for r in rows)
+
+
+def test_get_notifications_include_read_when_unread_false(client):
+    _seed(n_unread=2, n_read=2)
+    resp = client.get("/notifications?unread=false")
+    assert resp.status_code == 200
+    rows = resp.json()["notifications"]
+    assert len(rows) == 4
+
+
+def test_get_notifications_respects_limit(client):
+    _seed(n_unread=10, n_read=0)
+    resp = client.get("/notifications?limit=5")
+    assert resp.status_code == 200
+    rows = resp.json()["notifications"]
+    assert len(rows) == 5
+
+
+def test_get_notifications_limit_bounded_below_1_rejected(client):
+    resp = client.get("/notifications?limit=0")
+    assert resp.status_code == 422  # pydantic/fastapi validation
+
+
+def test_get_notifications_limit_bounded_above_200_rejected(client):
+    resp = client.get("/notifications?limit=999")
+    assert resp.status_code == 422
+
+
+def test_post_notification_read_marks_single(client):
+    ids = _seed(n_unread=3, n_read=0)
+    resp = client.post(f"/notifications/{ids[0]}/read")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "id": ids[0]}
+
+    # The marked row is no longer in unread list
+    unread = client.get("/notifications").json()["notifications"]
+    assert len(unread) == 2
+    assert ids[0] not in [r["id"] for r in unread]
+
+
+def test_post_notifications_read_all(client):
+    _seed(n_unread=4, n_read=1)
+    resp = client.post("/notifications/read-all")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "marked": 4}
+
+    unread = client.get("/notifications").json()["notifications"]
+    assert unread == []
+
+
+def test_post_notifications_read_all_when_none_unread(client):
+    _seed(n_unread=0, n_read=3)
+    resp = client.post("/notifications/read-all")
+    assert resp.json() == {"ok": True, "marked": 0}


### PR DESCRIPTION
## Summary

Final PR of #162 — closes the notifier epic with a dashboard-facing UX:

1. **Backend endpoints** (gated by `verify_api_key`, matching the rest of the API):
   - `GET /notifications?unread=true&limit=50` — paginated feed of unread events (or all with `?unread=false`)
   - `POST /notifications/{id}/read` — mark a single notification as read
   - `POST /notifications/read-all` — mark all currently-unread as read, returns the number updated
   - `limit` capped at 200 (pydantic `Query(ge=1, le=200)`)

2. **Frontend `NotificationBell.tsx`**:
   - Bell icon 🔔 in the header with an unread-count badge (shows `99+` above 99)
   - Click opens a 360px dropdown with up to 50 unread events, each with an event-type icon, summary, type/time meta, and per-event "mark read" button
   - Header includes total count + a "Marcar todas leídas" action
   - Polls every 30s (same cadence as the rest of the dashboard)
   - Dropdown closes on outside-click
   - API calls wrapped in try/catch — the bell never crashes the header

3. **Visual treatment**:
   - Event-type + state-aware icons: 📈 signal, 🛑 PAUSED, ⚠️ REDUCED/ALERT/infra-warning, 🚨 infra-critical, 📕 position_exit
   - Priority-based row tint: critical rows get a faint red background, warning rows faint amber
   - Design inherits existing CSS variables (`--bg-secondary`, `--border`, `--accent`, etc.)

## Notes for future work

- Currently poll-based (30s). Issue **#62** tracks a WebSocket/SSE upgrade; when it lands, only `NotificationBell.tsx` needs to switch from `setInterval(refresh, 30_000)` to a subscription — the API shape stays the same.
- No toast-on-load in this PR (the spec mentioned it as future UX). The bell badge covers the core "you have unread events" signal.
- Email channel still deferred (low priority).

## Test plan

- [x] **9 new backend tests** in `tests/test_notifications_endpoints.py`:
  empty response, unread-only by default, include read via query param, limit respect, limit validation (< 1 and > 200 rejected), mark single read, mark all read (including no-op when already clear).
- [x] Full backend suite: **598 passed**, 0 failed (up from 589 after #169).
- [x] Frontend TypeScript typecheck: clean (no errors).
- [ ] Manual smoke: loading the dashboard, opening the bell, and marking read — **deferred to reviewer** (no Vitest infra yet; tracked in #34).

## #162 Notifier epic summary

With this PR, #162 ships:
- ✅ PR A (#164): core + Telegram + dedupe + ratelimit + Jinja templates
- ✅ PR B (#169, partial): WebhookChannel + PositionExitEvent
- ✅ PR C (this PR): frontend notification center + endpoints

**Deferred, low priority:** SMTP EmailChannel (no active consumer needs it).

Closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)