### PR TITLE
feat(notifier): SMTP email channel (#162 — closes the epic)

### DIFF
--- a/notifier/__init__.py
+++ b/notifier/__init__.py
@@ -10,6 +10,7 @@ from notifier._templates import render
 from notifier.channels.base import DeliveryReceipt
 from notifier.channels.telegram import TelegramChannel
 from notifier.channels.webhook import WebhookChannel
+from notifier.channels.email import EmailChannel
 from notifier.events import (
     SignalEvent, HealthEvent, InfraEvent, SystemEvent, PositionExitEvent,
     Event,
@@ -94,9 +95,10 @@ def notify(event: Event, cfg: dict) -> list[DeliveryReceipt]:
             channel = TelegramChannel(cfg)
         elif channel_name == "webhook":
             channel = WebhookChannel(cfg)
+        elif channel_name == "email":
+            channel = EmailChannel(cfg)
         else:
-            log.warning("notify: unsupported channel %r (email lands in a future PR)",
-                         channel_name)
+            log.warning("notify: unsupported channel %r", channel_name)
             receipts.append(DeliveryReceipt(channel=channel_name, status="failed",
                                               error=f"unsupported channel: {channel_name}"))
             continue
@@ -122,10 +124,14 @@ def notify(event: Event, cfg: dict) -> list[DeliveryReceipt]:
             channels_sent.append(channel_name)
             continue
 
-        # WebhookChannel takes event_type as an extra arg so it can route to
-        # endpoint subscribers. Other channels ignore the kwarg.
+        # WebhookChannel + EmailChannel take extra kwargs for routing / subject.
+        # Telegram ignores them.
         if channel_name == "webhook":
             receipt = channel.send(message, event_type=event.event_type)
+        elif channel_name == "email":
+            receipt = channel.send(message,
+                                    event_type=event.event_type,
+                                    event_key=event.dedupe_key)
         else:
             receipt = channel.send(message)
         receipts.append(receipt)

--- a/notifier/channels/email.py
+++ b/notifier/channels/email.py
@@ -1,0 +1,92 @@
+"""SMTP email channel — send notification emails via a configured SMTP server.
+
+Config shape (cfg["notifier"]["channels"]["email"]):
+    {
+        "enabled": true,
+        "smtp_host": "smtp.gmail.com",
+        "smtp_port": 587,
+        "use_tls": true,
+        "username": "alerts@example.com",
+        "password": "app-password",
+        "from_addr": "alerts@example.com",
+        "to_addrs": ["operator@example.com"]
+    }
+
+The rendered template for <event>.email.j2 is treated as the message body.
+Subject is derived from the event type + key (e.g. "[health] BTC PAUSED").
+"""
+from __future__ import annotations
+
+import logging
+import smtplib
+import ssl
+from email.mime.text import MIMEText
+from typing import Any
+
+from notifier.channels.base import Channel, DeliveryReceipt
+
+
+log = logging.getLogger("notifier.email")
+
+
+def _subject_for(event_type: str, event_key: str) -> str:
+    return f"[{event_type}] {event_key}"
+
+
+class EmailChannel(Channel):
+    name = "email"
+
+    def __init__(self, cfg: dict[str, Any]):
+        notif_cfg = (cfg.get("notifier") or {})
+        ch_cfg = ((notif_cfg.get("channels") or {}).get("email") or {})
+        self._enabled: bool = bool(ch_cfg.get("enabled", False))
+        self._host: str = (ch_cfg.get("smtp_host") or "").strip()
+        self._port: int = int(ch_cfg.get("smtp_port") or 587)
+        self._use_tls: bool = bool(ch_cfg.get("use_tls", True))
+        self._username: str = (ch_cfg.get("username") or "").strip()
+        self._password: str = ch_cfg.get("password") or ""
+        self._from_addr: str = (ch_cfg.get("from_addr") or self._username).strip()
+        to = ch_cfg.get("to_addrs") or []
+        if isinstance(to, str):
+            to = [to]
+        self._to_addrs: list[str] = [str(a).strip() for a in to if str(a).strip()]
+
+    def send(self, message: str, event_type: str = "", event_key: str = "") -> DeliveryReceipt:
+        if not self._enabled:
+            return DeliveryReceipt(channel=self.name, status="failed",
+                                    error="email channel disabled in config")
+        if not self._host or not self._from_addr or not self._to_addrs:
+            return DeliveryReceipt(
+                channel=self.name, status="failed",
+                error="email not configured (missing smtp_host, from_addr, or to_addrs)",
+            )
+
+        msg = MIMEText(message, "plain", "utf-8")
+        msg["Subject"] = _subject_for(event_type or "notification", event_key or "")
+        msg["From"] = self._from_addr
+        msg["To"] = ", ".join(self._to_addrs)
+
+        try:
+            context = ssl.create_default_context() if self._use_tls else None
+            with smtplib.SMTP(self._host, self._port, timeout=15) as server:
+                server.ehlo()
+                if self._use_tls:
+                    server.starttls(context=context)
+                    server.ehlo()
+                if self._username and self._password:
+                    server.login(self._username, self._password)
+                server.sendmail(self._from_addr, self._to_addrs, msg.as_string())
+        except smtplib.SMTPAuthenticationError as e:
+            err = f"SMTP auth failed: {e}"
+            log.error("email send failed (auth): %s", err)
+            return DeliveryReceipt(channel=self.name, status="failed", error=err)
+        except smtplib.SMTPException as e:
+            err = f"SMTP error: {type(e).__name__}: {e}"
+            log.warning("email send failed: %s", err)
+            return DeliveryReceipt(channel=self.name, status="failed", error=err)
+        except OSError as e:
+            err = f"SMTP connection error: {e}"
+            log.warning("email send failed (network): %s", err)
+            return DeliveryReceipt(channel=self.name, status="failed", error=err)
+
+        return DeliveryReceipt(channel=self.name, status="ok")

--- a/notifier/templates/health.email.j2
+++ b/notifier/templates/health.email.j2
@@ -1,0 +1,11 @@
+Health transition: {{ symbol }}
+
+{{ from_state }} -> {{ to_state }}
+Reason: {{ reason }}
+
+{% if metrics -%}
+Metrics:
+{% for key, value in metrics.items() -%}
+  {{ key }}: {{ value }}
+{% endfor %}
+{%- endif %}

--- a/notifier/templates/infra.email.j2
+++ b/notifier/templates/infra.email.j2
@@ -1,0 +1,3 @@
+Infra ({{ severity }}): {{ component }}
+
+{{ message }}

--- a/notifier/templates/position_exit.email.j2
+++ b/notifier/templates/position_exit.email.j2
@@ -1,0 +1,7 @@
+Position closed: {{ symbol }} ({{ direction }})
+
+Exit reason: {{ exit_reason }}
+Entry: {{ "%.2f"|format(entry_price) }}
+Exit:  {{ "%.2f"|format(exit_price) }}
+
+P&L: {{ "%+.2f"|format(pnl_usd) }} USD ({{ "%+.2f"|format(pnl_pct) }}%)

--- a/notifier/templates/signal.email.j2
+++ b/notifier/templates/signal.email.j2
@@ -1,0 +1,7 @@
+Signal: {{ symbol }} (score {{ score }} {{ direction }})
+
+Entry: {{ "%.2f"|format(entry) }}
+SL:    {{ "%.2f"|format(sl) }}
+TP:    {{ "%.2f"|format(tp) }}
+
+Health state: {{ health_state }}

--- a/notifier/templates/system.email.j2
+++ b/notifier/templates/system.email.j2
@@ -1,0 +1,3 @@
+System: {{ kind }}
+
+{{ message }}

--- a/tests/test_notifier_email_channel.py
+++ b/tests/test_notifier_email_channel.py
@@ -1,0 +1,135 @@
+"""EmailChannel tests — SMTP send via smtplib, with TLS + auth + error handling."""
+import smtplib
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def _cfg(**overrides):
+    base = {
+        "notifier": {
+            "channels": {
+                "email": {
+                    "enabled": True,
+                    "smtp_host": "smtp.example.com",
+                    "smtp_port": 587,
+                    "use_tls": True,
+                    "username": "alerts@example.com",
+                    "password": "pw",
+                    "from_addr": "alerts@example.com",
+                    "to_addrs": ["operator@example.com"],
+                },
+            },
+        },
+    }
+    base["notifier"]["channels"]["email"].update(overrides)
+    return base
+
+
+def test_email_disabled_returns_failed():
+    from notifier.channels.email import EmailChannel
+    ch = EmailChannel(_cfg(enabled=False))
+    receipt = ch.send("body", event_type="signal", event_key="sig:BTC")
+    assert receipt.status == "failed"
+    assert "disabled" in receipt.error.lower()
+
+
+def test_email_missing_host_returns_failed():
+    from notifier.channels.email import EmailChannel
+    ch = EmailChannel(_cfg(smtp_host=""))
+    receipt = ch.send("body")
+    assert receipt.status == "failed"
+    assert "not configured" in receipt.error.lower()
+
+
+def test_email_missing_to_addrs_returns_failed():
+    from notifier.channels.email import EmailChannel
+    ch = EmailChannel(_cfg(to_addrs=[]))
+    receipt = ch.send("body")
+    assert receipt.status == "failed"
+    assert "not configured" in receipt.error.lower()
+
+
+def test_email_send_success():
+    from notifier.channels.email import EmailChannel
+    ch = EmailChannel(_cfg())
+
+    fake_smtp = MagicMock()
+    fake_smtp.__enter__ = MagicMock(return_value=fake_smtp)
+    fake_smtp.__exit__ = MagicMock(return_value=False)
+
+    with patch("notifier.channels.email.smtplib.SMTP", return_value=fake_smtp) as ctor, \
+         patch("notifier.channels.email.ssl.create_default_context"):
+        receipt = ch.send("Hello world", event_type="signal", event_key="sig:BTC")
+
+    assert receipt.status == "ok"
+    ctor.assert_called_once_with("smtp.example.com", 587, timeout=15)
+    fake_smtp.starttls.assert_called_once()
+    fake_smtp.login.assert_called_once_with("alerts@example.com", "pw")
+    fake_smtp.sendmail.assert_called_once()
+    args, _ = fake_smtp.sendmail.call_args
+    # from_addr, [to_addrs], message_body (MIME-encoded, may base64 the body)
+    assert args[0] == "alerts@example.com"
+    assert args[1] == ["operator@example.com"]
+    assert "[signal] sig:BTC" in args[2]  # Subject is not encoded
+    # Body is base64 on MIMEText text/plain in some versions — decode to check.
+    import base64
+    body_line = args[2].split("\n\n", 1)[-1].strip()
+    try:
+        decoded = base64.b64decode(body_line).decode("utf-8")
+    except Exception:
+        decoded = body_line
+    assert "Hello world" in decoded
+
+
+def test_email_auth_failure_returns_failed():
+    from notifier.channels.email import EmailChannel
+    ch = EmailChannel(_cfg())
+
+    fake_smtp = MagicMock()
+    fake_smtp.__enter__ = MagicMock(return_value=fake_smtp)
+    fake_smtp.__exit__ = MagicMock(return_value=False)
+    fake_smtp.login.side_effect = smtplib.SMTPAuthenticationError(535, b"auth failed")
+
+    with patch("notifier.channels.email.smtplib.SMTP", return_value=fake_smtp), \
+         patch("notifier.channels.email.ssl.create_default_context"):
+        receipt = ch.send("body", event_type="signal")
+
+    assert receipt.status == "failed"
+    assert "auth" in receipt.error.lower()
+
+
+def test_email_network_failure_returns_failed():
+    from notifier.channels.email import EmailChannel
+    ch = EmailChannel(_cfg())
+
+    with patch("notifier.channels.email.smtplib.SMTP",
+                side_effect=OSError("connection refused")):
+        receipt = ch.send("body")
+
+    assert receipt.status == "failed"
+    assert "connection" in receipt.error.lower()
+
+
+def test_email_to_addrs_accepts_single_string():
+    """If to_addrs is a bare string in config, it should be wrapped into a list."""
+    from notifier.channels.email import EmailChannel
+    cfg = _cfg()
+    cfg["notifier"]["channels"]["email"]["to_addrs"] = "only@example.com"
+    ch = EmailChannel(cfg)
+    assert ch._to_addrs == ["only@example.com"]
+
+
+def test_email_use_tls_false_skips_starttls():
+    from notifier.channels.email import EmailChannel
+    ch = EmailChannel(_cfg(use_tls=False))
+
+    fake_smtp = MagicMock()
+    fake_smtp.__enter__ = MagicMock(return_value=fake_smtp)
+    fake_smtp.__exit__ = MagicMock(return_value=False)
+
+    with patch("notifier.channels.email.smtplib.SMTP", return_value=fake_smtp):
+        receipt = ch.send("body")
+
+    assert receipt.status == "ok"
+    fake_smtp.starttls.assert_not_called()

--- a/tests/test_notifier_integration.py
+++ b/tests/test_notifier_integration.py
@@ -120,12 +120,12 @@ def test_notify_render_failure_produces_failed_receipt(tmp_db_and_reset):
 
 def test_notify_unsupported_channel_logs_warning(tmp_db_and_reset, caplog):
     """Unknown channel name must log a warning (so operator notices config drift).
-    Uses 'email' since webhook is now a supported channel in #162 PR B."""
+    telegram/webhook/email are all supported now; pick an unused name like 'sms'."""
     import logging
     from notifier import notify, SignalEvent
 
     cfg = _cfg()
-    cfg["notifier"]["channels_by_event_type"] = {"signal": ["email"]}
+    cfg["notifier"]["channels_by_event_type"] = {"signal": ["sms"]}
 
     ev = SignalEvent(symbol="BTC", score=5, direction="LONG",
                      entry=1, sl=1, tp=1)


### PR DESCRIPTION
## Summary

Closes the last loose end of the #162 notifier epic: a full SMTP `EmailChannel` alongside Telegram (#164) and Webhook (#169).

## Ships

- `notifier/channels/email.py`: `EmailChannel` using `smtplib` with configurable STARTTLS, optional auth, single-or-list `to_addrs`. Safe failure modes (auth error, SMTP error, network error all return failed receipts — never raise).
- Per-event `*.email.j2` templates: `signal`, `health`, `infra`, `system`, `position_exit`. Subject derived from `[event_type] dedupe_key`.
- `notify()` orchestrator dispatches `email` → `EmailChannel`, passes `event_type` + `event_key` so the channel can build the subject line.

## Config example

```json
"notifier": {
  "enabled": true,
  "channels_by_event_type": {
    "system":        ["email"],
    "infra":         ["telegram", "email"],
    "position_exit": ["telegram"]
  },
  "channels": {
    "email": {
      "enabled": true,
      "smtp_host": "smtp.gmail.com",
      "smtp_port": 587,
      "use_tls": true,
      "username": "alerts@example.com",
      "password": "app-password",
      "from_addr": "alerts@example.com",
      "to_addrs": ["operator@example.com"]
    }
  }
}
```

## Test plan

- [x] **8 new tests** in `tests/test_notifier_email_channel.py`:
  - disabled/misconfigured returns failed
  - happy path with MIME payload base64-decode verification
  - `SMTPAuthenticationError` → failed (captured in error)
  - `OSError` (network) → failed
  - single-string `to_addrs` coerced to list
  - `use_tls=False` skips STARTTLS
- [x] Existing `test_notify_unsupported_channel_logs_warning` updated to use `sms` (email is now supported)
- [x] Full suite: **607 passed**, 0 failed (up from 598 after #170)

## #162 epic state — now complete

- ✅ PR A (#164) — core + Telegram
- ✅ PR B (#169) — Webhook + PositionExitEvent
- ✅ PR C (#170) — frontend notification center
- ✅ This PR — Email channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)