### PR TITLE
docs(plans): archive implementation plans for shipped epics

### DIFF
--- a/docs/superpowers/plans/2026-04-21-notifier-core-pr-a.md
+++ b/docs/superpowers/plans/2026-04-21-notifier-core-pr-a.md
@@ -1,0 +1,1667 @@
+# Notifier core (#162 PR A) implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace ad-hoc Telegram notification code (`push_telegram_direct`, `build_telegram_message`, `_send_telegram_raw` in `btc_api.py`) with a centralized `notifier/` module exposing a typed `notify(event)` API backed by Jinja2 templates, DB-backed dedupe, token-bucket ratelimit, and an extensible `Channel` ABC. Only `TelegramChannel` ships in this PR.
+
+**Architecture:** `notifier.notify(event)` pipeline: `dedupe.should_send` → `ratelimit.acquire` → template render → `channel.send` → record to `notifications_sent`. Events are `@dataclass` (SignalEvent, HealthEvent, InfraEvent, SystemEvent). Templates are Jinja2 files in `notifier/templates/`. Current ~10 call sites in `btc_api.py` are redirected to `notifier.notify(SignalEvent(...))` with a snapshot test guaranteeing byte-identical output.
+
+**Tech Stack:** Python 3.12, SQLite (existing `signals.db`), Jinja2 (already transitive via FastAPI/Starlette, added explicitly to requirements), pytest, requests (existing).
+
+---
+
+## File structure
+
+```
+notifier/                                 (new package)
+├── __init__.py                           (public API: notify(), event exports)
+├── events.py                             (@dataclass types)
+├── _storage.py                           (notifications_sent table + helpers)
+├── dedupe.py                             (DB-backed sliding window)
+├── ratelimit.py                          (token bucket per channel)
+├── _templates.py                         (Jinja2 loader + render helper)
+├── channels/
+│   ├── __init__.py
+│   ├── base.py                           (Channel ABC, DeliveryReceipt)
+│   └── telegram.py                       (TelegramChannel — wraps HTTP call)
+└── templates/
+    ├── signal.telegram.j2
+    ├── health.telegram.j2
+    ├── infra.telegram.j2
+    └── system.telegram.j2
+
+tests/
+├── test_notifier_events.py               (dataclass sanity)
+├── test_notifier_storage.py              (insert / query / mark-read)
+├── test_notifier_dedupe.py               (sliding window)
+├── test_notifier_ratelimit.py            (token bucket)
+├── test_notifier_templates.py            (render per event type)
+├── test_notifier_telegram_channel.py     (send + retry behavior)
+├── test_notifier_integration.py          (end-to-end notify() flow)
+└── test_notifier_signal_parity.py        (snapshot: pre-refactor byte-equals post-refactor)
+
+btc_api.py                                (modified: ~10 call sites redirected)
+requirements.txt                          (modified: add jinja2>=3.1)
+```
+
+**Modifications to `btc_api.py`:**
+- Line 622, 1086, 1094, 1124, 1151, 1254, 1569, 1588, 1605, 1757 — replace direct calls with `notifier.notify(SignalEvent(...))`.
+- Deprecate `push_telegram_direct` (line 1086), `build_telegram_message` (line 1010), `_send_telegram_raw` (line 1124) via module-level comment `# DEPRECATED: use notifier.notify. Kept for backwards compat through this refactor.` Do not delete yet — `trading_webhook.py` still uses the `telegram_message` payload key emitted by scanner.
+
+---
+
+## Task 1: Add jinja2 to requirements + create notifier package skeleton
+
+**Files:**
+- Modify: `requirements.txt`
+- Create: `notifier/__init__.py`
+- Create: `notifier/channels/__init__.py`
+- Create: `tests/test_notifier_events.py`
+
+- [ ] **Step 1: Confirm Jinja2 availability**
+
+Run: `python -c "import jinja2; print(jinja2.__version__)"`
+Expected: `3.1.6` (or newer). It's already installed transitively via FastAPI/Starlette.
+
+- [ ] **Step 2: Add jinja2 to requirements.txt**
+
+Read `requirements.txt` and append:
+```
+jinja2>=3.1
+```
+
+- [ ] **Step 3: Write failing test for notifier package import**
+
+Create `tests/test_notifier_events.py`:
+```python
+"""Sanity tests for notifier package. Proves the package imports and exposes
+the dataclass event types the rest of the system will use."""
+from datetime import datetime, timezone
+
+
+def test_notifier_package_imports():
+    import notifier  # noqa: F401
+
+
+def test_event_types_exported():
+    from notifier import SignalEvent, HealthEvent, InfraEvent, SystemEvent  # noqa: F401
+```
+
+- [ ] **Step 4: Run test to verify failure**
+
+Run: `python -m pytest tests/test_notifier_events.py -v`
+Expected: `ModuleNotFoundError: No module named 'notifier'`.
+
+- [ ] **Step 5: Create empty package files**
+
+Create `notifier/__init__.py` with just:
+```python
+"""Centralized notifier (#162). Public API: notify, event types."""
+```
+
+Create `notifier/channels/__init__.py`:
+```python
+"""Channel implementations."""
+```
+
+- [ ] **Step 6: Re-run and verify partial pass**
+
+Run: `python -m pytest tests/test_notifier_events.py::test_notifier_package_imports -v`
+Expected: PASS. The second test still fails (types not exported yet) — next task fixes it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add requirements.txt notifier/__init__.py notifier/channels/__init__.py tests/test_notifier_events.py
+git commit -m "feat(notifier): package skeleton + jinja2 dep (#162)"
+```
+
+---
+
+## Task 2: Event dataclasses
+
+**Files:**
+- Create: `notifier/events.py`
+- Modify: `notifier/__init__.py`
+- Modify: `tests/test_notifier_events.py`
+
+- [ ] **Step 1: Expand failing test with event shape assertions**
+
+Append to `tests/test_notifier_events.py`:
+```python
+def test_signal_event_required_fields():
+    from notifier import SignalEvent
+    ev = SignalEvent(
+        symbol="BTCUSDT", score=6, direction="LONG",
+        entry=50_000.0, sl=49_000.0, tp=55_000.0,
+    )
+    assert ev.event_type == "signal"
+    assert ev.priority == "info"  # default
+    assert ev.dedupe_key == "signal:BTCUSDT"
+
+
+def test_health_event_required_fields():
+    from notifier import HealthEvent
+    ev = HealthEvent(
+        symbol="JUPUSDT", from_state="REDUCED", to_state="PAUSED",
+        reason="3mo_consec_neg", metrics={"pnl_30d": -500},
+    )
+    assert ev.event_type == "health"
+    assert ev.priority == "warning"  # default
+    assert ev.dedupe_key == "health:JUPUSDT:PAUSED"
+
+
+def test_infra_event_severity_maps_to_priority():
+    from notifier import InfraEvent
+    ev = InfraEvent(component="scanner", severity="critical", message="died")
+    assert ev.priority == "critical"
+    crit = InfraEvent(component="x", severity="info", message="ok")
+    assert crit.priority == "info"
+
+
+def test_system_event_defaults():
+    from notifier import SystemEvent
+    ev = SystemEvent(kind="startup", message="API online")
+    assert ev.event_type == "system"
+    assert ev.priority == "info"
+
+
+def test_event_to_dict_serializable():
+    """to_dict() must produce a JSON-serializable dict (used by _storage)."""
+    import json
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                      entry=50_000.0, sl=49_000.0, tp=55_000.0)
+    d = ev.to_dict()
+    json.dumps(d)  # must not raise
+    assert d["symbol"] == "BTCUSDT"
+    assert d["event_type"] == "signal"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_notifier_events.py -v`
+Expected: FAIL with `ImportError: cannot import name 'SignalEvent'`.
+
+- [ ] **Step 3: Create events.py**
+
+Create `notifier/events.py`:
+```python
+"""Typed events consumed by notifier.notify().
+
+All events share: event_type, priority, dedupe_key, to_dict().
+Specific events add their own fields.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Any
+
+
+Priority = str  # 'info' | 'warning' | 'critical'
+
+
+@dataclass
+class _BaseEvent:
+    """Shared behavior. Do not instantiate directly."""
+    event_type: str = field(init=False)
+    priority: Priority = field(init=False, default="info")
+
+    @property
+    def dedupe_key(self) -> str:
+        return self.event_type
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["dedupe_key"] = self.dedupe_key
+        return d
+
+
+@dataclass
+class SignalEvent(_BaseEvent):
+    symbol: str = ""
+    score: int = 0
+    direction: str = "LONG"
+    entry: float = 0.0
+    sl: float = 0.0
+    tp: float = 0.0
+
+    def __post_init__(self):
+        self.event_type = "signal"
+        self.priority = "info"
+
+    @property
+    def dedupe_key(self) -> str:
+        return f"signal:{self.symbol}"
+
+
+@dataclass
+class HealthEvent(_BaseEvent):
+    symbol: str = ""
+    from_state: str = "NORMAL"
+    to_state: str = "NORMAL"
+    reason: str = ""
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        self.event_type = "health"
+        self.priority = "warning"
+
+    @property
+    def dedupe_key(self) -> str:
+        return f"health:{self.symbol}:{self.to_state}"
+
+
+@dataclass
+class InfraEvent(_BaseEvent):
+    component: str = ""
+    severity: str = "info"  # 'info' | 'warning' | 'critical'
+    message: str = ""
+
+    def __post_init__(self):
+        self.event_type = "infra"
+        # severity drives priority directly
+        self.priority = self.severity if self.severity in {"info", "warning", "critical"} else "warning"
+
+    @property
+    def dedupe_key(self) -> str:
+        return f"infra:{self.component}"
+
+
+@dataclass
+class SystemEvent(_BaseEvent):
+    kind: str = ""
+    message: str = ""
+
+    def __post_init__(self):
+        self.event_type = "system"
+        self.priority = "info"
+
+    @property
+    def dedupe_key(self) -> str:
+        return f"system:{self.kind}"
+
+
+Event = SignalEvent | HealthEvent | InfraEvent | SystemEvent
+```
+
+- [ ] **Step 4: Re-export from package __init__.py**
+
+Replace contents of `notifier/__init__.py`:
+```python
+"""Centralized notifier (#162). Public API: notify, event types."""
+from notifier.events import (
+    SignalEvent, HealthEvent, InfraEvent, SystemEvent,
+    Event,
+)
+
+__all__ = ["SignalEvent", "HealthEvent", "InfraEvent", "SystemEvent", "Event"]
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `python -m pytest tests/test_notifier_events.py -v`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add notifier/events.py notifier/__init__.py tests/test_notifier_events.py
+git commit -m "feat(notifier): typed event dataclasses (#162)"
+```
+
+---
+
+## Task 3: Storage helpers for `notifications_sent`
+
+**Files:**
+- Create: `notifier/_storage.py`
+- Create: `tests/test_notifier_storage.py`
+- Modify: `btc_api.py` (add table to `init_db()` — insert after existing tables around line 865)
+
+- [ ] **Step 1: Write failing storage tests**
+
+Create `tests/test_notifier_storage.py`:
+```python
+"""Storage of outbound notifications — insert, list unread, mark-read."""
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Isolated signals.db pointing at tmp path."""
+    import btc_api
+    from notifier import _storage as notif_storage
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    # reset any thread-local connection if present
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    # create all tables on fresh db
+    btc_api.init_db()
+    yield db_path
+
+
+def test_record_delivery_inserts_row(tmp_db):
+    from notifier._storage import record_delivery
+    record_delivery(
+        event_type="signal", event_key="signal:BTCUSDT",
+        priority="info",
+        payload={"symbol": "BTCUSDT", "score": 6},
+        channels_sent=["telegram"],
+        delivery_status="ok",
+    )
+    from notifier._storage import list_unread
+    rows = list_unread(limit=10)
+    assert len(rows) == 1
+    assert rows[0]["event_type"] == "signal"
+    assert rows[0]["delivery_status"] == "ok"
+
+
+def test_list_unread_filters_read(tmp_db):
+    from notifier._storage import record_delivery, list_unread, mark_read
+    record_delivery("signal", "signal:BTCUSDT", "info",
+                    {"symbol": "BTCUSDT"}, ["telegram"], "ok")
+    (row_id,) = (r["id"] for r in list_unread(limit=10))
+    mark_read(row_id)
+    assert list_unread(limit=10) == []
+
+
+def test_list_unread_ordered_by_sent_at_desc(tmp_db):
+    from notifier._storage import record_delivery, list_unread
+    record_delivery("signal", "signal:A", "info", {"s": "A"}, ["telegram"], "ok")
+    record_delivery("signal", "signal:B", "info", {"s": "B"}, ["telegram"], "ok")
+    rows = list_unread(limit=10)
+    assert rows[0]["event_key"] == "signal:B"
+    assert rows[1]["event_key"] == "signal:A"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_notifier_storage.py -v`
+Expected: all FAIL — `_storage.py` doesn't exist.
+
+- [ ] **Step 3: Add `notifications_sent` table to `btc_api.init_db()`**
+
+Open `btc_api.py`, find `init_db()` (around line 780). After the existing `tune_results` table creation (around line 865), add before the closing of the function:
+
+```python
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS notifications_sent (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type      TEXT    NOT NULL,
+            event_key       TEXT    NOT NULL,
+            priority        TEXT    NOT NULL DEFAULT 'info',
+            payload_json    TEXT    NOT NULL,
+            channels_sent   TEXT    NOT NULL,
+            delivery_status TEXT    NOT NULL DEFAULT 'ok',
+            sent_at         TEXT    NOT NULL,
+            read_at         TEXT,
+            error_log       TEXT
+        )
+    """)
+    con.execute("""
+        CREATE INDEX IF NOT EXISTS idx_notif_sent_unread
+            ON notifications_sent(read_at, sent_at DESC) WHERE read_at IS NULL
+    """)
+```
+
+- [ ] **Step 4: Implement `notifier/_storage.py`**
+
+Create `notifier/_storage.py`:
+```python
+"""Thin wrapper around signals.db for notification records.
+
+Uses btc_api.get_db() so tests monkeypatching DB_FILE work transparently.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _conn() -> sqlite3.Connection:
+    import btc_api
+    return btc_api.get_db()
+
+
+def record_delivery(
+    event_type: str,
+    event_key: str,
+    priority: str,
+    payload: dict[str, Any],
+    channels_sent: list[str],
+    delivery_status: str,
+    error_log: str | None = None,
+) -> int:
+    conn = _conn()
+    cur = conn.execute(
+        """INSERT INTO notifications_sent
+           (event_type, event_key, priority, payload_json,
+            channels_sent, delivery_status, sent_at, error_log)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            event_type, event_key, priority,
+            json.dumps(payload, default=str),
+            ",".join(channels_sent), delivery_status,
+            _now_iso(), error_log,
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def list_unread(limit: int = 50) -> list[dict[str, Any]]:
+    conn = _conn()
+    rows = conn.execute(
+        """SELECT id, event_type, event_key, priority, payload_json,
+                  channels_sent, delivery_status, sent_at, read_at, error_log
+           FROM notifications_sent
+           WHERE read_at IS NULL
+           ORDER BY sent_at DESC
+           LIMIT ?""",
+        (limit,),
+    ).fetchall()
+    cols = ["id", "event_type", "event_key", "priority", "payload_json",
+            "channels_sent", "delivery_status", "sent_at", "read_at", "error_log"]
+    return [dict(zip(cols, r)) for r in rows]
+
+
+def mark_read(notification_id: int) -> None:
+    conn = _conn()
+    conn.execute(
+        "UPDATE notifications_sent SET read_at = ? WHERE id = ?",
+        (_now_iso(), notification_id),
+    )
+    conn.commit()
+
+
+def mark_all_read() -> int:
+    conn = _conn()
+    cur = conn.execute(
+        "UPDATE notifications_sent SET read_at = ? WHERE read_at IS NULL",
+        (_now_iso(),),
+    )
+    conn.commit()
+    return cur.rowcount
+```
+
+- [ ] **Step 5: Run storage tests**
+
+Run: `python -m pytest tests/test_notifier_storage.py -v`
+Expected: 3 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add notifier/_storage.py tests/test_notifier_storage.py btc_api.py
+git commit -m "feat(notifier): notifications_sent table + storage helpers (#162)"
+```
+
+---
+
+## Task 4: Dedupe
+
+**Files:**
+- Create: `notifier/dedupe.py`
+- Create: `tests/test_notifier_dedupe.py`
+
+- [ ] **Step 1: Write failing dedupe tests**
+
+Create `tests/test_notifier_dedupe.py`:
+```python
+"""Dedupe is a DB-backed sliding window over notifications_sent.
+Same (event_type, event_key) within window_seconds returns False (don't send).
+Outside window or first occurrence returns True (send)."""
+from datetime import timedelta
+import time
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def test_first_send_always_allowed(tmp_db):
+    from notifier.dedupe import should_send
+    assert should_send("health", "health:BTC:PAUSED", window_seconds=60) is True
+
+
+def test_repeat_within_window_blocked(tmp_db):
+    from notifier.dedupe import should_send
+    from notifier._storage import record_delivery
+
+    record_delivery("health", "health:BTC:PAUSED", "warning",
+                    {"symbol": "BTC"}, ["telegram"], "ok")
+    assert should_send("health", "health:BTC:PAUSED", window_seconds=60) is False
+
+
+def test_zero_window_never_dedupes(tmp_db):
+    from notifier.dedupe import should_send
+    from notifier._storage import record_delivery
+
+    record_delivery("signal", "signal:BTC", "info",
+                    {"symbol": "BTC"}, ["telegram"], "ok")
+    assert should_send("signal", "signal:BTC", window_seconds=0) is True
+
+
+def test_critical_priority_bypasses_dedupe(tmp_db):
+    """Critical events always send, regardless of recent history."""
+    from notifier.dedupe import should_send
+    from notifier._storage import record_delivery
+
+    record_delivery("infra", "infra:scanner", "critical",
+                    {"component": "scanner"}, ["telegram"], "ok")
+    assert should_send("infra", "infra:scanner", window_seconds=60,
+                        priority="critical") is True
+    assert should_send("infra", "infra:scanner", window_seconds=60,
+                        priority="warning") is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_notifier_dedupe.py -v`
+Expected: FAIL — `notifier.dedupe` doesn't exist.
+
+- [ ] **Step 3: Implement dedupe.py**
+
+Create `notifier/dedupe.py`:
+```python
+"""DB-backed sliding-window deduplication for notifier.notify().
+
+Query shape:
+  SELECT 1 FROM notifications_sent
+  WHERE event_type=? AND event_key=?
+        AND sent_at >= (now - window_seconds)
+  LIMIT 1
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+
+def should_send(
+    event_type: str,
+    event_key: str,
+    window_seconds: int,
+    priority: str = "info",
+) -> bool:
+    """Return True if this event should be sent (no recent duplicate found).
+
+    Critical-priority events always pass. Window of 0 disables dedupe.
+    """
+    if priority == "critical":
+        return True
+    if window_seconds <= 0:
+        return True
+
+    import btc_api
+    conn = btc_api.get_db()
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=window_seconds)
+    row = conn.execute(
+        """SELECT 1 FROM notifications_sent
+           WHERE event_type = ? AND event_key = ? AND sent_at >= ?
+           LIMIT 1""",
+        (event_type, event_key, cutoff.isoformat()),
+    ).fetchone()
+    return row is None
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `python -m pytest tests/test_notifier_dedupe.py -v`
+Expected: all 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add notifier/dedupe.py tests/test_notifier_dedupe.py
+git commit -m "feat(notifier): DB-backed sliding-window dedupe (#162)"
+```
+
+---
+
+## Task 5: Rate limit (token bucket)
+
+**Files:**
+- Create: `notifier/ratelimit.py`
+- Create: `tests/test_notifier_ratelimit.py`
+
+- [ ] **Step 1: Write failing ratelimit tests**
+
+Create `tests/test_notifier_ratelimit.py`:
+```python
+"""Token-bucket per channel. Default capacity=20, refill_per_sec=20/60 = 0.333."""
+import time
+
+
+def test_fresh_bucket_allows_up_to_capacity():
+    from notifier.ratelimit import TokenBucket
+    b = TokenBucket(capacity=20, refill_per_sec=1.0)
+    # Fresh bucket starts full; can consume 20 without waiting
+    for _ in range(20):
+        assert b.acquire() is True
+    # 21st must fail (bucket empty, no time passed)
+    assert b.acquire() is False
+
+
+def test_refill_over_time():
+    from notifier.ratelimit import TokenBucket
+    b = TokenBucket(capacity=10, refill_per_sec=10.0)
+    # Drain
+    for _ in range(10):
+        assert b.acquire() is True
+    assert b.acquire() is False
+    time.sleep(0.5)  # refill 5 tokens
+    # Now ~5 should be available
+    acquired = sum(1 for _ in range(10) if b.acquire())
+    assert 4 <= acquired <= 6, f"expected ~5 refilled tokens, got {acquired}"
+
+
+def test_bucket_never_exceeds_capacity():
+    from notifier.ratelimit import TokenBucket
+    b = TokenBucket(capacity=5, refill_per_sec=100.0)
+    time.sleep(0.5)  # should refill way past capacity
+    # Can only drain up to capacity even though many tokens were "refilled"
+    for _ in range(5):
+        assert b.acquire() is True
+    assert b.acquire() is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_notifier_ratelimit.py -v`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement ratelimit.py**
+
+Create `notifier/ratelimit.py`:
+```python
+"""Thread-safe in-memory token bucket.
+
+Shared across the process. For multi-process workers a DB-backed
+alternative would be needed, but the scanner runs single-process today."""
+from __future__ import annotations
+
+import threading
+import time
+
+
+class TokenBucket:
+    def __init__(self, capacity: int, refill_per_sec: float):
+        self.capacity = float(capacity)
+        self.refill_per_sec = float(refill_per_sec)
+        self._tokens = float(capacity)
+        self._last_refill = time.monotonic()
+        self._lock = threading.Lock()
+
+    def acquire(self, n: float = 1.0) -> bool:
+        """Try to acquire n tokens. Returns True if granted, False if not."""
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_refill
+            self._tokens = min(self.capacity, self._tokens + elapsed * self.refill_per_sec)
+            self._last_refill = now
+            if self._tokens >= n:
+                self._tokens -= n
+                return True
+            return False
+
+
+# Module-level registry: one bucket per channel name.
+_buckets: dict[str, TokenBucket] = {}
+_registry_lock = threading.Lock()
+
+
+def bucket_for(channel_name: str, capacity: int = 20, refill_per_sec: float | None = None) -> TokenBucket:
+    """Get-or-create the token bucket for a channel.
+
+    Default: capacity=20, refill_per_sec=capacity/60 (i.e. 20 req/min steady state)."""
+    refill = refill_per_sec if refill_per_sec is not None else capacity / 60.0
+    with _registry_lock:
+        if channel_name not in _buckets:
+            _buckets[channel_name] = TokenBucket(capacity, refill)
+        return _buckets[channel_name]
+
+
+def reset_all_for_tests() -> None:
+    """Test helper. Clears the registry so each test starts fresh."""
+    with _registry_lock:
+        _buckets.clear()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_notifier_ratelimit.py -v`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add notifier/ratelimit.py tests/test_notifier_ratelimit.py
+git commit -m "feat(notifier): token-bucket rate limiter (#162)"
+```
+
+---
+
+## Task 6: Templates + template loader
+
+**Files:**
+- Create: `notifier/_templates.py`
+- Create: `notifier/templates/signal.telegram.j2`
+- Create: `notifier/templates/health.telegram.j2`
+- Create: `notifier/templates/infra.telegram.j2`
+- Create: `notifier/templates/system.telegram.j2`
+- Create: `tests/test_notifier_templates.py`
+
+- [ ] **Step 1: Write failing template tests**
+
+Create `tests/test_notifier_templates.py`:
+```python
+"""Template loader renders per (event_type, channel) combination.
+Renders must match the current Telegram message format for backward compat
+(the snapshot test in Task 9 will enforce byte-level parity for signals)."""
+
+
+def test_render_signal_telegram_includes_symbol_score_direction():
+    from notifier._templates import render
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                      entry=50_000.0, sl=49_000.0, tp=55_000.0)
+    msg = render(ev, channel="telegram")
+    assert "BTCUSDT" in msg
+    assert "6" in msg
+    assert "LONG" in msg
+
+
+def test_render_health_telegram_flags_transition():
+    from notifier._templates import render
+    from notifier import HealthEvent
+    ev = HealthEvent(symbol="JUPUSDT", from_state="REDUCED", to_state="PAUSED",
+                      reason="3mo_consec_neg", metrics={"pnl_30d": -500})
+    msg = render(ev, channel="telegram")
+    assert "JUPUSDT" in msg
+    assert "PAUSED" in msg
+    assert "3mo_consec_neg" in msg
+
+
+def test_render_infra_telegram_critical():
+    from notifier._templates import render
+    from notifier import InfraEvent
+    ev = InfraEvent(component="scanner", severity="critical", message="died")
+    msg = render(ev, channel="telegram")
+    assert "scanner" in msg
+    assert "critical" in msg.lower()
+    assert "died" in msg
+
+
+def test_render_system_telegram():
+    from notifier._templates import render
+    from notifier import SystemEvent
+    ev = SystemEvent(kind="startup", message="API online")
+    msg = render(ev, channel="telegram")
+    assert "startup" in msg
+    assert "API online" in msg
+
+
+def test_unknown_template_raises():
+    import pytest
+    from notifier._templates import render
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="X", score=1, direction="LONG",
+                     entry=1.0, sl=1.0, tp=1.0)
+    with pytest.raises(FileNotFoundError):
+        render(ev, channel="sms")  # no template for sms
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_notifier_templates.py -v`
+Expected: FAIL — `_templates.py` doesn't exist.
+
+- [ ] **Step 3: Create template files**
+
+Create `notifier/templates/signal.telegram.j2`:
+```jinja
+*Signal* `{{ symbol }}`
+Score: *{{ score }}* ({{ direction }})
+Entry: `{{ "%.2f"|format(entry) }}` | SL: `{{ "%.2f"|format(sl) }}` | TP: `{{ "%.2f"|format(tp) }}`
+```
+
+Create `notifier/templates/health.telegram.j2`:
+```jinja
+{%- if to_state == "PAUSED" %}🛑{% elif to_state == "REDUCED" %}⚠️{% elif to_state == "ALERT" %}⚠️{% else %}ℹ️{% endif %} *Health transition*
+`{{ symbol }}` {{ from_state }} → *{{ to_state }}*
+Reason: `{{ reason }}`
+{%- if metrics %}
+Metrics: `{{ metrics|tojson }}`
+{%- endif %}
+```
+
+Create `notifier/templates/infra.telegram.j2`:
+```jinja
+{%- if severity == "critical" %}🚨{% elif severity == "warning" %}⚠️{% else %}ℹ️{% endif %} *Infra ({{ severity }})*
+Component: `{{ component }}`
+{{ message }}
+```
+
+Create `notifier/templates/system.telegram.j2`:
+```jinja
+ℹ️ *System: {{ kind }}*
+{{ message }}
+```
+
+- [ ] **Step 4: Implement template loader**
+
+Create `notifier/_templates.py`:
+```python
+"""Jinja2 template loader + render helper.
+
+Templates are named '<event_type>.<channel>.j2' under notifier/templates/.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from notifier.events import _BaseEvent
+
+
+_TEMPLATE_DIR = Path(__file__).parent / "templates"
+_env = Environment(
+    loader=FileSystemLoader(str(_TEMPLATE_DIR)),
+    undefined=StrictUndefined,
+    autoescape=False,
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+def render(event: _BaseEvent, channel: str) -> str:
+    """Render an event through the appropriate <event_type>.<channel>.j2 template."""
+    template_name = f"{event.event_type}.{channel}.j2"
+    template_path = _TEMPLATE_DIR / template_name
+    if not template_path.exists():
+        raise FileNotFoundError(
+            f"No template for event_type={event.event_type!r} channel={channel!r} "
+            f"(looked for {template_name})"
+        )
+    template = _env.get_template(template_name)
+    return template.render(**event.to_dict()).strip()
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest tests/test_notifier_templates.py -v`
+Expected: all 5 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add notifier/_templates.py notifier/templates/ tests/test_notifier_templates.py
+git commit -m "feat(notifier): Jinja2 template loader + telegram templates (#162)"
+```
+
+---
+
+## Task 7: Channel ABC + TelegramChannel
+
+**Files:**
+- Create: `notifier/channels/base.py`
+- Create: `notifier/channels/telegram.py`
+- Create: `tests/test_notifier_telegram_channel.py`
+
+- [ ] **Step 1: Write failing channel tests**
+
+Create `tests/test_notifier_telegram_channel.py`:
+```python
+"""TelegramChannel refactors push_telegram_direct behind a Channel ABC.
+Uses requests mocking to avoid real HTTP."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def telegram_cfg():
+    return {"telegram_bot_token": "test-token", "telegram_chat_id": "12345"}
+
+
+def test_telegram_send_success(telegram_cfg):
+    from notifier.channels.telegram import TelegramChannel
+    channel = TelegramChannel(telegram_cfg)
+
+    fake_response = MagicMock()
+    fake_response.ok = True
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"ok": True, "result": {"message_id": 42}}
+
+    with patch("notifier.channels.telegram.requests.post", return_value=fake_response) as mock_post:
+        receipt = channel.send("hello")
+
+    assert receipt.status == "ok"
+    assert mock_post.call_count == 1
+    args, kwargs = mock_post.call_args
+    assert "test-token" in args[0]
+    assert kwargs["json"]["chat_id"] == "12345"
+    assert kwargs["json"]["text"] == "hello"
+
+
+def test_telegram_send_retries_on_transient_failure(telegram_cfg):
+    from notifier.channels.telegram import TelegramChannel
+    channel = TelegramChannel(telegram_cfg)
+
+    fail_resp = MagicMock()
+    fail_resp.ok = False
+    fail_resp.status_code = 500
+    fail_resp.text = "server error"
+    ok_resp = MagicMock()
+    ok_resp.ok = True
+    ok_resp.status_code = 200
+    ok_resp.json.return_value = {"ok": True}
+
+    with patch("notifier.channels.telegram.requests.post",
+                side_effect=[fail_resp, fail_resp, ok_resp]) as mock_post:
+        with patch("notifier.channels.telegram.time.sleep"):
+            receipt = channel.send("hello")
+
+    assert receipt.status == "ok"
+    assert mock_post.call_count == 3
+
+
+def test_telegram_send_gives_up_after_max_retries(telegram_cfg):
+    from notifier.channels.telegram import TelegramChannel
+    channel = TelegramChannel(telegram_cfg)
+
+    fail_resp = MagicMock()
+    fail_resp.ok = False
+    fail_resp.status_code = 500
+    fail_resp.text = "server error"
+
+    with patch("notifier.channels.telegram.requests.post", return_value=fail_resp):
+        with patch("notifier.channels.telegram.time.sleep"):
+            receipt = channel.send("hello", max_retries=2)
+
+    assert receipt.status == "failed"
+    assert "server error" in (receipt.error or "")
+
+
+def test_telegram_send_noop_when_not_configured():
+    from notifier.channels.telegram import TelegramChannel
+    # No token/chat_id — channel reports failed without attempting HTTP
+    channel = TelegramChannel({})
+    receipt = channel.send("hello")
+    assert receipt.status == "failed"
+    assert "not configured" in receipt.error.lower()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_notifier_telegram_channel.py -v`
+Expected: FAIL — modules don't exist.
+
+- [ ] **Step 3: Implement Channel ABC**
+
+Create `notifier/channels/base.py`:
+```python
+"""Channel ABC + DeliveryReceipt."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass
+class DeliveryReceipt:
+    channel: str
+    status: str       # 'ok' | 'failed'
+    error: str | None = None
+
+
+class Channel(ABC):
+    """A destination (Telegram, Webhook, Email). Concrete impls implement send."""
+
+    name: str = "base"
+
+    @abstractmethod
+    def send(self, message: str, **kwargs) -> DeliveryReceipt:
+        raise NotImplementedError
+```
+
+- [ ] **Step 4: Implement TelegramChannel**
+
+Create `notifier/channels/telegram.py`:
+```python
+"""Telegram channel. Wraps the direct sendMessage API.
+
+Replaces btc_api.push_telegram_direct / _send_telegram_raw while preserving
+the same retry behavior (up to 3 attempts with backoff)."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import requests
+
+from notifier.channels.base import Channel, DeliveryReceipt
+
+
+log = logging.getLogger("notifier.telegram")
+
+_TELEGRAM_API = "https://api.telegram.org/bot{token}/sendMessage"
+
+
+class TelegramChannel(Channel):
+    name = "telegram"
+
+    def __init__(self, cfg: dict[str, Any]):
+        self._token = (cfg.get("telegram_bot_token") or "").strip()
+        self._chat_id = (cfg.get("telegram_chat_id") or "").strip()
+
+    def send(self, message: str, max_retries: int = 3) -> DeliveryReceipt:
+        if not self._token or not self._chat_id:
+            return DeliveryReceipt(channel=self.name, status="failed",
+                                    error="telegram not configured (missing token or chat_id)")
+
+        url = _TELEGRAM_API.format(token=self._token)
+        payload = {
+            "chat_id": self._chat_id,
+            "text": message,
+            "parse_mode": "Markdown",
+            "disable_web_page_preview": True,
+        }
+
+        last_error: str | None = None
+        for attempt in range(1, max_retries + 1):
+            try:
+                r = requests.post(url, json=payload, timeout=10)
+                if r.ok:
+                    return DeliveryReceipt(channel=self.name, status="ok")
+                last_error = f"HTTP {r.status_code}: {r.text[:200]}"
+                log.warning("telegram attempt %d/%d failed: %s", attempt, max_retries, last_error)
+            except requests.RequestException as e:
+                last_error = f"{type(e).__name__}: {e}"
+                log.warning("telegram attempt %d/%d exception: %s", attempt, max_retries, last_error)
+
+            if attempt < max_retries:
+                time.sleep(2 ** (attempt - 1))  # 1s, 2s, 4s backoff
+
+        return DeliveryReceipt(channel=self.name, status="failed", error=last_error)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest tests/test_notifier_telegram_channel.py -v`
+Expected: 4 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add notifier/channels/base.py notifier/channels/telegram.py tests/test_notifier_telegram_channel.py
+git commit -m "feat(notifier): Channel ABC + TelegramChannel (#162)"
+```
+
+---
+
+## Task 8: Main `notify()` orchestrator
+
+**Files:**
+- Modify: `notifier/__init__.py`
+- Create: `tests/test_notifier_integration.py`
+
+- [ ] **Step 1: Write failing integration test**
+
+Create `tests/test_notifier_integration.py`:
+```python
+"""End-to-end notify() flow: dedupe → ratelimit → render → send → record."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db_and_reset(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Reset ratelimit singletons between tests
+    from notifier import ratelimit
+    ratelimit.reset_all_for_tests()
+    yield db_path
+
+
+@pytest.fixture
+def ok_telegram():
+    fake = MagicMock()
+    fake.ok = True
+    fake.status_code = 200
+    fake.json.return_value = {"ok": True}
+    return fake
+
+
+def _cfg():
+    return {
+        "notifier": {"enabled": True, "test_mode": False,
+                      "dedupe": {"default_window_minutes": 30}},
+        "telegram_bot_token": "t", "telegram_chat_id": "1",
+    }
+
+
+def test_notify_signal_sends_to_telegram_and_records(tmp_db_and_reset, ok_telegram):
+    from notifier import notify, SignalEvent
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                      entry=50_000, sl=49_000, tp=55_000)
+
+    with patch("notifier.channels.telegram.requests.post", return_value=ok_telegram) as mock_post:
+        receipts = notify(ev, cfg=_cfg())
+
+    assert len(receipts) == 1
+    assert receipts[0].status == "ok"
+    assert mock_post.call_count == 1
+
+    from notifier._storage import list_unread
+    rows = list_unread(limit=5)
+    assert len(rows) == 1
+    assert rows[0]["event_type"] == "signal"
+
+
+def test_notify_blocks_duplicate_within_dedupe_window(tmp_db_and_reset, ok_telegram):
+    from notifier import notify, HealthEvent
+    ev = HealthEvent(symbol="JUP", from_state="REDUCED", to_state="PAUSED",
+                     reason="3mo_consec_neg")
+
+    with patch("notifier.channels.telegram.requests.post", return_value=ok_telegram) as mock_post:
+        r1 = notify(ev, cfg=_cfg())
+        r2 = notify(ev, cfg=_cfg())
+
+    assert len(r1) == 1 and r1[0].status == "ok"
+    assert r2 == []  # deduped
+    assert mock_post.call_count == 1
+
+
+def test_notify_test_mode_skips_http(tmp_db_and_reset):
+    from notifier import notify, SignalEvent
+    cfg = _cfg()
+    cfg["notifier"]["test_mode"] = True
+
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                     entry=50_000, sl=49_000, tp=55_000)
+    with patch("notifier.channels.telegram.requests.post") as mock_post:
+        receipts = notify(ev, cfg=cfg)
+
+    assert mock_post.call_count == 0
+    assert len(receipts) == 1
+    assert receipts[0].status == "ok"  # treated as "simulated ok"
+
+
+def test_notify_disabled_config_returns_empty(tmp_db_and_reset):
+    from notifier import notify, SignalEvent
+    cfg = _cfg()
+    cfg["notifier"]["enabled"] = False
+
+    ev = SignalEvent(symbol="X", score=1, direction="LONG",
+                     entry=1, sl=1, tp=1)
+    with patch("notifier.channels.telegram.requests.post") as mock_post:
+        receipts = notify(ev, cfg=cfg)
+
+    assert receipts == []
+    assert mock_post.call_count == 0
+
+
+def test_notify_rate_limit_queues_overflow(tmp_db_and_reset, ok_telegram):
+    """21st call in a burst hits the rate limiter (default capacity=20)."""
+    from notifier import notify, SignalEvent, ratelimit
+
+    cfg = _cfg()
+
+    with patch("notifier.channels.telegram.requests.post", return_value=ok_telegram):
+        receipts_batch = []
+        for i in range(25):
+            ev = SignalEvent(symbol=f"SYM{i}", score=1, direction="LONG",
+                              entry=1, sl=1, tp=1)
+            receipts_batch.append(notify(ev, cfg=cfg))
+
+    sent_count = sum(1 for r in receipts_batch if r and r[0].status == "ok")
+    limited_count = sum(1 for r in receipts_batch if r and r[0].status == "rate_limited")
+    # At most 20 go through; the rest are rate_limited
+    assert sent_count <= 20
+    assert sent_count + limited_count == 25
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_notifier_integration.py -v`
+Expected: FAIL — `notify()` not implemented.
+
+- [ ] **Step 3: Implement notify() orchestrator**
+
+Replace `notifier/__init__.py` with:
+```python
+"""Centralized notifier (#162). Public API: notify, event types."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from notifier import dedupe, ratelimit
+from notifier._storage import record_delivery
+from notifier._templates import render
+from notifier.channels.base import DeliveryReceipt
+from notifier.channels.telegram import TelegramChannel
+from notifier.events import (
+    SignalEvent, HealthEvent, InfraEvent, SystemEvent,
+    Event,
+)
+
+
+__all__ = [
+    "notify",
+    "SignalEvent", "HealthEvent", "InfraEvent", "SystemEvent", "Event",
+    "DeliveryReceipt",
+]
+
+
+log = logging.getLogger("notifier")
+
+
+_DEFAULT_CHANNELS_BY_EVENT_TYPE: dict[str, list[str]] = {
+    "signal": ["telegram"],
+    "health": ["telegram"],
+    "infra":  ["telegram"],
+    "system": ["telegram"],
+}
+
+_DEFAULT_DEDUPE_SECONDS_BY_EVENT_TYPE: dict[str, int] = {
+    "signal": 0,      # no dedupe — signals are rare and each matters
+    "health": 1800,   # 30 min
+    "infra":  300,    # 5 min
+    "system": 0,
+}
+
+
+def _resolve_channels(event: Event, cfg: dict) -> list[str]:
+    notif_cfg = cfg.get("notifier", {}) or {}
+    overrides = (notif_cfg.get("channels_by_event_type") or {})
+    return overrides.get(event.event_type,
+                          _DEFAULT_CHANNELS_BY_EVENT_TYPE.get(event.event_type, ["telegram"]))
+
+
+def _resolve_dedupe_window(event: Event, cfg: dict) -> int:
+    notif_cfg = cfg.get("notifier", {}) or {}
+    dedupe_cfg = notif_cfg.get("dedupe", {}) or {}
+    per_type = dedupe_cfg.get("by_event_type", {}) or {}
+    if event.event_type in per_type:
+        return int(per_type[event.event_type])
+    default_min = dedupe_cfg.get("default_window_minutes")
+    if default_min is not None:
+        return int(default_min) * 60
+    return _DEFAULT_DEDUPE_SECONDS_BY_EVENT_TYPE.get(event.event_type, 0)
+
+
+def notify(event: Event, cfg: dict) -> list[DeliveryReceipt]:
+    """Send an event through configured channels with dedupe + ratelimit.
+
+    Returns [] if: notifier disabled, or the event was deduped, or no channels configured.
+    Returns list of DeliveryReceipt (one per channel attempted) otherwise.
+    """
+    notif_cfg = cfg.get("notifier", {}) or {}
+    if not notif_cfg.get("enabled", True):
+        return []
+
+    window_seconds = _resolve_dedupe_window(event, cfg)
+    if not dedupe.should_send(event.event_type, event.dedupe_key,
+                                window_seconds=window_seconds,
+                                priority=event.priority):
+        log.debug("notify deduped: %s %s", event.event_type, event.dedupe_key)
+        return []
+
+    test_mode = notif_cfg.get("test_mode", False)
+    channels = _resolve_channels(event, cfg)
+    receipts: list[DeliveryReceipt] = []
+    channels_sent: list[str] = []
+    any_error: str | None = None
+
+    for channel_name in channels:
+        bucket = ratelimit.bucket_for(channel_name)
+        if not bucket.acquire():
+            receipts.append(DeliveryReceipt(channel=channel_name, status="rate_limited",
+                                              error="bucket empty"))
+            continue
+
+        # Render through template
+        try:
+            message = render(event, channel=channel_name)
+        except Exception as e:
+            receipts.append(DeliveryReceipt(channel=channel_name, status="failed",
+                                              error=f"render failed: {e}"))
+            any_error = any_error or str(e)
+            continue
+
+        if test_mode:
+            receipts.append(DeliveryReceipt(channel=channel_name, status="ok",
+                                              error="test_mode"))
+            channels_sent.append(channel_name)
+            continue
+
+        if channel_name == "telegram":
+            channel = TelegramChannel(cfg)
+        else:
+            receipts.append(DeliveryReceipt(channel=channel_name, status="failed",
+                                              error="unsupported channel in PR A"))
+            continue
+
+        receipt = channel.send(message)
+        receipts.append(receipt)
+        if receipt.status == "ok":
+            channels_sent.append(channel_name)
+        else:
+            any_error = any_error or receipt.error
+
+    delivery_status = "ok" if channels_sent else "failed"
+    if channels_sent and any_error:
+        delivery_status = "partial"
+
+    try:
+        record_delivery(
+            event_type=event.event_type,
+            event_key=event.dedupe_key,
+            priority=event.priority,
+            payload=event.to_dict(),
+            channels_sent=channels_sent or ["none"],
+            delivery_status=delivery_status,
+            error_log=any_error,
+        )
+    except Exception as e:
+        log.exception("notifier failed to persist delivery record: %s", e)
+
+    return receipts
+```
+
+- [ ] **Step 4: Run integration tests**
+
+Run: `python -m pytest tests/test_notifier_integration.py -v`
+Expected: 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add notifier/__init__.py tests/test_notifier_integration.py
+git commit -m "feat(notifier): notify() orchestrator — dedupe + ratelimit + render + send (#162)"
+```
+
+---
+
+## Task 9: Snapshot parity test (pre-refactor == post-refactor for SignalEvent)
+
+**Files:**
+- Create: `tests/test_notifier_signal_parity.py`
+
+**Goal:** Lock down the exact string that used to be emitted by `build_telegram_message` for signals, so migrating callers can't regress the user-visible message format.
+
+- [ ] **Step 1: Extract current format into a fixture**
+
+Read `btc_api.py` `build_telegram_message` (around line 1010). Inspect the exact string shape for a representative input: a scan report dict with `symbol`, `score`, `direction`, `entry_price`, `sl_price`, `tp_price`, etc.
+
+- [ ] **Step 2: Write snapshot test**
+
+Create `tests/test_notifier_signal_parity.py`:
+```python
+"""Lock the current Telegram signal message format.
+
+When we migrate btc_api call sites to notifier.notify(SignalEvent(...)),
+the rendered message must match what build_telegram_message used to produce.
+If this test fails, either:
+  (a) the SignalEvent→telegram template drifted — fix the template, or
+  (b) the legacy build_telegram_message evolved — sync the template.
+"""
+from notifier import SignalEvent
+from notifier._templates import render
+
+
+def _sample_scan_report():
+    # Minimal report mirroring what scan() builds pre-refactor.
+    return {
+        "symbol": "BTCUSDT", "score": 6, "direction": "LONG",
+        "price": 50_000.0,
+        "sl": 49_000.0,
+        "tp": 55_000.0,
+    }
+
+
+def test_signal_telegram_message_contains_required_tokens():
+    """Loose contract: the message must mention symbol, score, direction, entry, sl, tp.
+    Exact byte-level parity will be verified by the btc_api migration task against a
+    fixture produced from build_telegram_message."""
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                      entry=50_000.0, sl=49_000.0, tp=55_000.0)
+    msg = render(ev, channel="telegram")
+    assert "BTCUSDT" in msg
+    assert "6" in msg
+    assert "LONG" in msg
+    assert "50000" in msg or "50,000" in msg or "50000.00" in msg
+    assert "49000" in msg or "49,000" in msg or "49000.00" in msg
+    assert "55000" in msg or "55,000" in msg or "55000.00" in msg
+
+
+def test_signal_template_stable_for_fixed_input():
+    """Guard against accidental template edits that change the output.
+    If you intentionally change the format, update EXPECTED below."""
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                      entry=50_000.0, sl=49_000.0, tp=55_000.0)
+    got = render(ev, channel="telegram")
+    expected = (
+        "*Signal* `BTCUSDT`\n"
+        "Score: *6* (LONG)\n"
+        "Entry: `50000.00` | SL: `49000.00` | TP: `55000.00`"
+    )
+    assert got == expected, f"template drift detected:\nexpected:\n{expected!r}\ngot:\n{got!r}"
+```
+
+- [ ] **Step 3: Run test**
+
+Run: `python -m pytest tests/test_notifier_signal_parity.py -v`
+Expected: 2 PASS (assuming the template in Task 6 produces exactly this string — verify). If the template differs, either update the template in `notifier/templates/signal.telegram.j2` or update `expected` in the test, **but NOT both silently**. Document the decision in the commit.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_notifier_signal_parity.py
+git commit -m "test(notifier): snapshot test for signal telegram template (#162)"
+```
+
+---
+
+## Task 10: Migrate btc_api.py call sites + deprecation markers
+
+**Files:**
+- Modify: `btc_api.py` (~10 call sites)
+
+**Goal:** Replace direct `push_telegram_direct` / `_send_telegram_raw` / `build_telegram_message` usage with `notifier.notify(SignalEvent(...))`. Leave the legacy functions in place with deprecation comments — `trading_webhook.py` and other external consumers still rely on the `telegram_message` payload key.
+
+- [ ] **Step 1: Add module-level deprecation banners**
+
+Open `btc_api.py`. Above the definition of each legacy function, add comments:
+
+At line ~1010 (before `def build_telegram_message`):
+```python
+# DEPRECATED (#162): for new callers use notifier.notify(SignalEvent(...)).
+# Kept because trading_webhook.py and a few legacy paths still consume the
+# 'telegram_message' payload key emitted by scan results. Remove after those are migrated.
+```
+
+Same above `def push_telegram_direct` (line ~1086) and `def _send_telegram_raw` (line ~1124).
+
+- [ ] **Step 2: Inventory every call site**
+
+Run: `grep -n "push_telegram_direct\|_send_telegram_raw\|build_telegram_message" btc_api.py`
+
+Expected output (from pre-refactor inventory): lines 622, 1010, 1086, 1094, 1124, 1151, 1254, 1569, 1588, 1605, 1757.
+
+For each line, classify:
+- **Direct send call** (needs migration): e.g. `push_telegram_direct(rep, cfg)` at line 1254 — replace with `notifier.notify(SignalEvent(...), cfg)`.
+- **Payload-emitting**: e.g. lines 1171, 1569, 1588, 1605 that stuff `telegram_message` into a dict — keep for now, these serve `trading_webhook.py`.
+
+- [ ] **Step 3: Migrate line 1254 (and any other direct call to `push_telegram_direct`)**
+
+Open the context around that line and find the scan-report dict being passed to `push_telegram_direct`. Example rewrite:
+
+```python
+# Before
+push_telegram_direct(rep, cfg)
+
+# After
+from notifier import notify, SignalEvent
+notify(
+    SignalEvent(
+        symbol=rep["symbol"],
+        score=int(rep.get("score", 0) or 0),
+        direction=rep.get("direction", "LONG"),
+        entry=float(rep.get("price") or 0.0),
+        sl=float(rep.get("sl") or 0.0),
+        tp=float(rep.get("tp") or 0.0),
+    ),
+    cfg=cfg,
+)
+```
+
+The `from notifier import notify, SignalEvent` should be at module top of `btc_api.py`, not inline.
+
+- [ ] **Step 4: Migrate line 622**
+
+Read the 40 lines around line 622. It's inside a scanner loop path. Determine whether the call is a signal notification or something else, and migrate to the appropriate event type (`SignalEvent`, `InfraEvent`, etc.).
+
+- [ ] **Step 5: Run full regression**
+
+Run: `python -m pytest tests/ -q -m "not network"`
+Expected: all pass (was 463 pre-refactor; now 463 + new notifier tests ~27 = ~490). No test suite regressions.
+
+- [ ] **Step 6: Manual smoke**
+
+Start the API locally (if safe in the dev env) and trigger a scan. Verify the Telegram message still lands correctly (or the `test_mode=true` equivalent produces a record in `notifications_sent`).
+
+If manual smoke isn't safe/possible in this env, skip with a note and rely on the test suite. State clearly in the commit that manual verification is deferred to the reviewer.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add btc_api.py
+git commit -m "refactor(api): migrate telegram call sites to notifier.notify (#162)
+
+Routes direct push_telegram_direct callers through notifier.notify(SignalEvent(...)).
+Legacy build_telegram_message / push_telegram_direct / _send_telegram_raw
+kept with deprecation banners — trading_webhook.py still consumes their
+output via scan payload."
+```
+
+---
+
+## Task 11: Full regression + open PR
+
+**Files:** none changed; verification only.
+
+- [ ] **Step 1: Full test suite**
+
+Run: `python -m pytest tests/ -q -m "not network"`
+Expected: all PASS; test count 463 (prior baseline) + ~27 new notifier tests = ~490. If any regression, stop and debug.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin feat/notifier-core
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base main --head feat/notifier-core \
+  --title "feat(notifier): centralized typed notifier — PR A of #162" \
+  --body "$(cat <<'BODY'
+## Summary
+First of 3 PRs for #162. Ships the notifier package skeleton + typed events + Jinja2 templates + DB-backed dedupe + token-bucket ratelimit + TelegramChannel (refactor of push_telegram_direct). Migrates btc_api direct call sites. Does NOT yet ship Webhook or Email channels (PR B) or the frontend notification center (PR C).
+
+## Unblocks
+- #138 Foundation can now use notifier.notify(HealthEvent(...)) directly.
+
+## Test plan
+- [x] 27 new notifier tests, 463 existing tests, all green (~490 total).
+- [x] Snapshot test for signal telegram template stability.
+- [x] Manual smoke (if feasible) — noted in commit message if deferred.
+
+## Backward compatibility
+- Legacy build_telegram_message / push_telegram_direct / _send_telegram_raw left in place with deprecation banners.
+- config.json keys (telegram_bot_token, telegram_chat_id) read unchanged.
+- trading_webhook.py path unaffected.
+
+Closes partial: #162 (PR A). PRs B (multi-channel) and C (frontend) land separately.
+BODY
+)"
+```
+
+- [ ] **Step 4: Watch CI**
+
+```bash
+sleep 12 && gh pr checks --watch --interval 15
+```
+Expected: backend-tests + frontend-typecheck PASS.
+
+- [ ] **Step 5: Report**
+
+If CI green, report PR URL and verdict to the user. Do NOT merge automatically — wait for user's explicit approval.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- §3 "Incluido" PR A scope — all ships in this plan.
+- §4 arquitectura — file structure matches the diagram.
+- §5 API pública — notify() signature in Task 8, event exports in Task 2.
+- §6 config — consumed in Task 8 (notifier.enabled, test_mode, dedupe); config schema itself is informational (no migration, just reads existing or defaults).
+- §7 PR A scope — all items land (skeleton, events, storage, dedupe, ratelimit, templates, channel, orchestrator, snapshot, migration). ✓
+- §8 testing — per-module tests in Tasks 2-7, integration in Task 8, snapshot in Task 9, regression in Task 11.
+- §9 backward-compat — deprecation banners in Task 10; legacy functions not deleted. ✓
+- §10 riesgos — snapshot test mitigates format drift; critical-priority dedupe bypass in dedupe.py; queue-via-rate_limited receipt in notify(); Jinja2 added to requirements; test coverage pre-refactor is the 463 baseline.
+- §11 métricas de éxito — 1 entry point (notify()); 0 direct push_telegram_direct callers outside notifier (Task 10); notifier.notify(HealthEvent) unblocks #138 (stated in PR description); dedupe functional (test); snapshot parity test.
+
+**Placeholder scan:** no "TBD", no "similar to Task N", no "add error handling as needed". Every code step shows concrete code. One hedge in Task 10 Step 6 about manual smoke — the escape hatch is explicit ("state clearly in the commit"), acceptable.
+
+**Type consistency:**
+- `DeliveryReceipt(channel, status, error)` defined in Task 7 base.py; used in Task 7 telegram.py, Task 8 orchestrator, Task 8 integration tests. Field `status` values: `"ok" | "failed" | "rate_limited"` — used consistently.
+- `Event = SignalEvent | HealthEvent | InfraEvent | SystemEvent` defined in Task 2 events.py; imported and used in Task 8 orchestrator.
+- `render(event, channel)` defined in Task 6 _templates.py; called in Task 8 orchestrator.
+- `record_delivery(...)` 7 args defined in Task 3 _storage.py; called in Task 8 orchestrator with all 7.
+- `should_send(event_type, event_key, window_seconds, priority)` in Task 4; called with all 4 kwargs in Task 8 orchestrator.
+- `bucket_for(channel_name)` in Task 5; called with just `channel_name` in Task 8 (refill uses default = capacity/60).
+- `notify(event, cfg)` — signature in Task 8; called from Task 10 with `(SignalEvent(...), cfg=cfg)`. ✓
+
+All consistent.
+
+**Scope:** single PR A of #162. Does not try to include Webhook/Email (PR B) or frontend (PR C). Does not try to include #138 content.
+
+Plan looks good.

--- a/docs/superpowers/plans/2026-04-22-kill-switch-alert-tier-pr2.md
+++ b/docs/superpowers/plans/2026-04-22-kill-switch-alert-tier-pr2.md
@@ -1,0 +1,607 @@
+# Kill switch Alert tier (#138 PR 2 of 4) implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the ALERT tier into the already-shipped Foundation (#138 PR 1). Two integration points: (1) prepend `⚠️ ALERT` to the signal Telegram message for any symbol whose current state is `ALERT`; (2) fire a one-shot `notify(HealthEvent)` when a symbol transitions *to* `ALERT`.
+
+**Architecture:** Extend `SignalEvent` with an optional `health_state` field rendered by `signal.telegram.j2`. Teach the `push_telegram_direct` shim (in `btc_api.py`) to look up `get_symbol_state(symbol)` and stamp it into the `SignalEvent`. Extend `health.evaluate_and_record` to emit `notify(HealthEvent)` on any transition that ends in `ALERT`. No change to trading behavior — the symbol is still operated on normally; we just add a visibility prefix and a one-shot warning.
+
+**Tech Stack:** Python 3.12, notifier module (PR #164), health module (PR #165), pytest.
+
+---
+
+## File structure
+
+```
+notifier/events.py                               (modified: +1 field on SignalEvent)
+notifier/templates/signal.telegram.j2            (modified: conditional prefix)
+tests/test_notifier_events.py                    (modified: +1 test for field)
+tests/test_notifier_templates.py                 (modified: +1 test for prefix)
+tests/test_notifier_signal_parity.py             (modified: update expected string)
+
+btc_api.py                                       (modified: push_telegram_direct shim)
+tests/test_health_shim_integration.py            (new: shim + get_symbol_state wiring)
+
+health.py                                        (modified: notify on ALERT transitions)
+tests/test_health_alert_notify.py                (new: notify fires on transition only)
+```
+
+Task count: 4 tasks — small, tightly scoped.
+
+---
+
+## Task 1: SignalEvent health_state field + template prefix
+
+**Files:**
+- Modify: `notifier/events.py`
+- Modify: `notifier/templates/signal.telegram.j2`
+- Modify: `tests/test_notifier_events.py`
+- Modify: `tests/test_notifier_templates.py`
+- Modify: `tests/test_notifier_signal_parity.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/test_notifier_events.py`:
+```python
+def test_signal_event_health_state_default():
+    """Default health_state is 'NORMAL' so existing callers stay backward-compat."""
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTC", score=5, direction="LONG",
+                     entry=1.0, sl=1.0, tp=1.0)
+    assert ev.health_state == "NORMAL"
+
+
+def test_signal_event_health_state_set_to_alert():
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTC", score=5, direction="LONG",
+                     entry=1.0, sl=1.0, tp=1.0, health_state="ALERT")
+    assert ev.health_state == "ALERT"
+```
+
+Append to `tests/test_notifier_templates.py`:
+```python
+def test_signal_telegram_prepends_alert_warning():
+    """ALERT symbols get a '⚠️ ALERT' prefix on the first line."""
+    from notifier._templates import render
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                     entry=50_000.0, sl=49_000.0, tp=55_000.0,
+                     health_state="ALERT")
+    msg = render(ev, channel="telegram")
+    assert msg.startswith("⚠️ *ALERT* "), f"unexpected prefix: {msg!r}"
+    assert "BTCUSDT" in msg
+
+
+def test_signal_telegram_no_prefix_for_normal():
+    """NORMAL symbols render identically to pre-PR — no prefix."""
+    from notifier._templates import render
+    from notifier import SignalEvent
+    ev = SignalEvent(symbol="BTCUSDT", score=6, direction="LONG",
+                     entry=50_000.0, sl=49_000.0, tp=55_000.0)
+    msg = render(ev, channel="telegram")
+    assert not msg.startswith("⚠️")
+```
+
+Update `tests/test_notifier_signal_parity.py::test_signal_template_stable_for_fixed_input` expected value. The NORMAL-case output should be UNCHANGED — so the template must only emit the prefix when `health_state != "NORMAL"`.
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+python -m pytest tests/test_notifier_events.py tests/test_notifier_templates.py tests/test_notifier_signal_parity.py -v
+```
+Expected: 2 new events tests FAIL (unexpected kwarg `health_state`), 2 new template tests FAIL (no prefix), parity test still passes for now (template unchanged).
+
+- [ ] **Step 3: Add the field to SignalEvent**
+
+In `notifier/events.py`, modify `SignalEvent` to add the field. Find:
+```python
+@dataclass
+class SignalEvent(_BaseEvent):
+    symbol: str = ""
+    score: int = 0
+    direction: str = "LONG"
+    entry: float = 0.0
+    sl: float = 0.0
+    tp: float = 0.0
+```
+
+Replace with:
+```python
+@dataclass
+class SignalEvent(_BaseEvent):
+    symbol: str = ""
+    score: int = 0
+    direction: str = "LONG"
+    entry: float = 0.0
+    sl: float = 0.0
+    tp: float = 0.0
+    # Kill-switch context (#138): "NORMAL" | "ALERT" | "REDUCED" | "PAUSED".
+    # Determines whether the template prepends a warning prefix.
+    health_state: str = "NORMAL"
+```
+
+- [ ] **Step 4: Update signal.telegram.j2**
+
+Replace the contents of `notifier/templates/signal.telegram.j2` with:
+```jinja
+{%- if health_state and health_state != "NORMAL" -%}
+⚠️ *{{ health_state }}* 
+{% endif -%}
+*Signal* `{{ symbol }}`
+Score: *{{ score }}* ({{ direction }})
+Entry: `{{ "%.2f"|format(entry) }}` | SL: `{{ "%.2f"|format(sl) }}` | TP: `{{ "%.2f"|format(tp) }}`
+```
+
+Note: the trailing space after `{{ health_state }}` is intentional (so the prefix reads `⚠️ *ALERT* *Signal*` on one line in the final rendered message). Test the parity case to confirm NORMAL output is unchanged.
+
+- [ ] **Step 5: Run events + template tests**
+
+```bash
+python -m pytest tests/test_notifier_events.py tests/test_notifier_templates.py -v
+```
+Expected: all PASS.
+
+- [ ] **Step 6: Run + fix the parity test**
+
+```bash
+python -m pytest tests/test_notifier_signal_parity.py -v
+```
+If the NORMAL case now renders with a leading newline from the `{%- if ... -%}` block, adjust the template's whitespace control. The goal is: **for NORMAL, the output string is IDENTICAL to pre-PR** — no new newline at the start.
+
+The template above uses `{%- if health_state and health_state != "NORMAL" -%}` (strips whitespace before the if) and `{% endif -%}` (strips after endif) so the NORMAL branch produces nothing at all — the `*Signal*` line stays the first byte.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add notifier/events.py notifier/templates/signal.telegram.j2 \
+        tests/test_notifier_events.py tests/test_notifier_templates.py \
+        tests/test_notifier_signal_parity.py
+git commit -m "feat(notifier): SignalEvent.health_state + ALERT prefix in template (#138)"
+```
+
+---
+
+## Task 2: push_telegram_direct shim looks up symbol health state
+
+**Files:**
+- Modify: `btc_api.py` (push_telegram_direct shim body)
+- Create: `tests/test_health_shim_integration.py`
+
+- [ ] **Step 1: Write failing integration test**
+
+Create `tests/test_health_shim_integration.py`:
+```python
+"""push_telegram_direct (the notifier shim) must stamp the symbol's current
+health_state into the SignalEvent so ALERT symbols get the warning prefix."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    # Reset ratelimit between tests
+    from notifier import ratelimit
+    ratelimit.reset_all_for_tests()
+    yield db_path
+
+
+def _cfg():
+    return {
+        "notifier": {"enabled": True, "test_mode": False},
+        "telegram_bot_token": "t", "telegram_chat_id": "1",
+    }
+
+
+def test_shim_sends_signal_with_health_state_from_db(tmp_db):
+    """If get_symbol_state(sym) == 'ALERT', the SignalEvent carries health_state='ALERT'."""
+    from health import apply_transition
+    import btc_api
+
+    # Seed BTC in ALERT
+    apply_transition(
+        "BTC", new_state="ALERT", reason="wr_below_threshold",
+        metrics={"trades_count_total": 50, "win_rate_20_trades": 0.1,
+                 "pnl_30d": 0.0, "pnl_by_month": {}, "months_negative_consecutive": 0},
+        from_state="NORMAL",
+    )
+
+    rep = {"symbol": "BTC", "score": 6, "direction": "LONG",
+           "price": 50_000.0, "sizing_1h": {"sl_precio": 49_000.0, "tp_precio": 55_000.0}}
+
+    fake_resp = MagicMock()
+    fake_resp.ok = True
+    fake_resp.status_code = 200
+    fake_resp.json.return_value = {"ok": True}
+
+    with patch("notifier.channels.telegram.requests.post", return_value=fake_resp) as mock_post:
+        result = btc_api.push_telegram_direct(rep, _cfg())
+
+    assert result is True
+    assert mock_post.call_count == 1
+    # The rendered text sent to Telegram must contain the ALERT prefix.
+    sent_text = mock_post.call_args.kwargs["json"]["text"]
+    assert sent_text.startswith("⚠️ *ALERT*"), f"no prefix on shim-routed signal: {sent_text!r}"
+    assert "BTC" in sent_text
+
+
+def test_shim_unknown_symbol_defaults_to_normal(tmp_db):
+    """If no row exists in symbol_health, health_state defaults to NORMAL → no prefix."""
+    import btc_api
+
+    rep = {"symbol": "UNSEEN", "score": 3, "direction": "LONG",
+           "price": 1.0, "sizing_1h": {"sl_precio": 0.9, "tp_precio": 1.2}}
+
+    fake_resp = MagicMock()
+    fake_resp.ok = True
+
+    with patch("notifier.channels.telegram.requests.post", return_value=fake_resp) as mock_post:
+        btc_api.push_telegram_direct(rep, _cfg())
+
+    sent_text = mock_post.call_args.kwargs["json"]["text"]
+    assert not sent_text.startswith("⚠️"), f"unexpected prefix: {sent_text!r}"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+python -m pytest tests/test_health_shim_integration.py -v
+```
+Expected: 2 FAIL — shim doesn't look up health state yet.
+
+- [ ] **Step 3: Update push_telegram_direct shim**
+
+Locate `def push_telegram_direct(rep: dict, cfg: dict, max_retries: int = 3):` in `btc_api.py` (around line 1111). Modify the SignalEvent construction to include `health_state`:
+
+Find the `notify(SignalEvent(...))` call inside the function body. Currently:
+```python
+    receipts = notify(
+        SignalEvent(
+            symbol=rep.get("symbol", ""),
+            score=int(rep.get("score", 0) or 0),
+            direction=rep.get("direction", "LONG"),
+            entry=float(rep.get("price") or 0.0),
+            sl=float((rep.get("sizing_1h") or {}).get("sl_precio") or 0.0),
+            tp=float((rep.get("sizing_1h") or {}).get("tp_precio") or 0.0),
+        ),
+        cfg=cfg,
+    )
+    return bool(receipts and receipts[0].status == "ok")
+```
+
+Replace with:
+```python
+    # Kill switch #138 PR 2: stamp symbol health state so ALERT symbols get
+    # a warning prefix in the Telegram message.
+    symbol = rep.get("symbol", "")
+    try:
+        from health import get_symbol_state
+        health_state = get_symbol_state(symbol) if symbol else "NORMAL"
+    except Exception as e:
+        log.warning("push_telegram_direct: health lookup failed for %s: %s", symbol, e)
+        health_state = "NORMAL"
+
+    receipts = notify(
+        SignalEvent(
+            symbol=symbol,
+            score=int(rep.get("score", 0) or 0),
+            direction=rep.get("direction", "LONG"),
+            entry=float(rep.get("price") or 0.0),
+            sl=float((rep.get("sizing_1h") or {}).get("sl_precio") or 0.0),
+            tp=float((rep.get("sizing_1h") or {}).get("tp_precio") or 0.0),
+            health_state=health_state,
+        ),
+        cfg=cfg,
+    )
+    return bool(receipts and receipts[0].status == "ok")
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+python -m pytest tests/test_health_shim_integration.py -v
+```
+Expected: 2 PASS.
+
+- [ ] **Step 5: Full regression**
+
+```bash
+python -m pytest tests/ -q -m "not network"
+```
+Expected: all PASS (no regressions on existing test_notifier_signal_parity — the NORMAL case must be byte-identical to pre-PR).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add btc_api.py tests/test_health_shim_integration.py
+git commit -m "feat(health): push_telegram_direct stamps health_state on SignalEvent (#138)"
+```
+
+---
+
+## Task 3: evaluate_and_record emits notify(HealthEvent) on ALERT transitions
+
+**Files:**
+- Modify: `health.py`
+- Create: `tests/test_health_alert_notify.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_health_alert_notify.py`:
+```python
+"""evaluate_and_record must fire notify(HealthEvent) once when a symbol
+transitions to ALERT, and must NOT re-fire on subsequent evaluations where
+the state stays ALERT."""
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    from notifier import ratelimit
+    ratelimit.reset_all_for_tests()
+    yield db_path
+
+
+def _insert_closed(conn, symbol, pnl, exit_ts):
+    conn.execute(
+        """INSERT INTO positions
+           (symbol, direction, status, entry_price, entry_ts,
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?)""",
+        (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
+    )
+    conn.commit()
+
+
+CFG = {"kill_switch": {
+    "enabled": True, "min_trades_for_eval": 20,
+    "alert_win_rate_threshold": 0.15,
+    "reduce_pnl_window_days": 30, "reduce_size_factor": 0.5,
+    "pause_months_consecutive": 3, "auto_recovery_enabled": True,
+}}
+NOW = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def _seed_for_alert(conn):
+    """25 trades: 1 win, 24 losses (positive pnl, so no REDUCED) — wr=0.04 → ALERT."""
+    for i in range(25):
+        pnl = 10.0 if i == 0 else 5.0  # all winners by value, but…
+        # Actually: we need the WIN RATE low but the aggregate P&L POSITIVE (else
+        # REDUCED/PAUSED would fire first). Trick: small wins, but count few of them.
+        pass
+    # Correct scenario: 25 closed trades, last 20 have 1 winner (wr=0.05),
+    # but the pnl sum over 30d is positive.
+    for i in range(25):
+        pnl = 100.0 if i == 24 else -1.0  # one big winner beats 24 tiny losers → agg positive
+        _insert_closed(conn, "BTC", pnl, (NOW - timedelta(days=25 - i)).isoformat())
+
+
+def test_transition_to_alert_fires_notify(tmp_db):
+    from health import evaluate_and_record
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        _seed_for_alert(conn)
+    finally:
+        conn.close()
+
+    with patch("health.notify") as mock_notify:
+        state = evaluate_and_record("BTC", CFG, now=NOW)
+
+    assert state == "ALERT"
+    assert mock_notify.call_count == 1
+    event_arg = mock_notify.call_args.args[0]
+    # Arg is a HealthEvent — check its fields
+    assert event_arg.symbol == "BTC"
+    assert event_arg.to_state == "ALERT"
+    assert event_arg.from_state == "NORMAL"
+
+
+def test_alert_no_renotify_when_state_unchanged(tmp_db):
+    """After the first ALERT transition, a second evaluate_and_record with the
+    same data must NOT fire notify again (state stays ALERT)."""
+    from health import evaluate_and_record
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        _seed_for_alert(conn)
+    finally:
+        conn.close()
+
+    with patch("health.notify") as mock_notify:
+        evaluate_and_record("BTC", CFG, now=NOW)
+        evaluate_and_record("BTC", CFG, now=NOW)
+
+    assert mock_notify.call_count == 1  # not 2
+
+
+def test_non_alert_transitions_do_not_fire_in_pr2(tmp_db):
+    """PR 2 only emits for ALERT. REDUCED/PAUSED transitions stay silent (for now)."""
+    from health import evaluate_and_record
+    import btc_api
+
+    # 25 trades all negative → REDUCED (not ALERT)
+    conn = btc_api.get_db()
+    try:
+        for i in range(25):
+            _insert_closed(conn, "DOGE", -100.0, (NOW - timedelta(days=25 - i)).isoformat())
+    finally:
+        conn.close()
+
+    with patch("health.notify") as mock_notify:
+        state = evaluate_and_record("DOGE", CFG, now=NOW)
+
+    assert state == "REDUCED"
+    assert mock_notify.call_count == 0
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+python -m pytest tests/test_health_alert_notify.py -v
+```
+Expected: 3 FAIL — `health.notify` doesn't exist yet (health.py doesn't import notifier).
+
+- [ ] **Step 3: Modify health.evaluate_and_record**
+
+In `health.py`, add the import at the top (after the existing `from typing import Any`):
+```python
+# Lazy re-export so tests can patch health.notify without reaching into notifier.
+try:
+    from notifier import notify, HealthEvent  # noqa: F401
+except ImportError:
+    notify = None  # type: ignore
+    HealthEvent = None  # type: ignore
+```
+
+Then locate `evaluate_and_record` and modify the transition path. Current tail:
+```python
+    if new_state != current:
+        apply_transition(symbol, new_state=new_state, reason=reason,
+                         metrics=metrics, from_state=current)
+    else:
+        _record_evaluation(symbol, metrics, new_state)
+    return new_state
+```
+
+Replace with:
+```python
+    if new_state != current:
+        apply_transition(symbol, new_state=new_state, reason=reason,
+                         metrics=metrics, from_state=current)
+        # PR 2 (#138): one-shot notify only on transitions into ALERT.
+        # PRs 3/4 will extend this to REDUCED and PAUSED.
+        if new_state == "ALERT" and notify is not None and HealthEvent is not None:
+            try:
+                # Config for notifier is the same dict passed in (contains telegram_bot_token etc.)
+                notify(
+                    HealthEvent(symbol=symbol, from_state=current,
+                                to_state=new_state, reason=reason, metrics=metrics),
+                    cfg=cfg,
+                )
+            except Exception as e:  # noqa: BLE001
+                log.warning("health: ALERT notify failed for %s: %s", symbol, e)
+    else:
+        _record_evaluation(symbol, metrics, new_state)
+    return new_state
+```
+
+Note: the test patches `health.notify`, which works because of the `from notifier import notify` re-export at the top of `health.py`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+python -m pytest tests/test_health_alert_notify.py -v
+```
+Expected: 3 PASS.
+
+- [ ] **Step 5: Full regression**
+
+```bash
+python -m pytest tests/ -q -m "not network"
+```
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add health.py tests/test_health_alert_notify.py
+git commit -m "feat(health): one-shot notify(HealthEvent) on ALERT transitions (#138)"
+```
+
+---
+
+## Task 4: Full regression + push + PR
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+python -m pytest tests/ -q -m "not network"
+```
+Expected: all PASS. Prior baseline was 547 (end of PR #165); PR 2 adds ~7 tests (2 events + 2 template + 2 shim + 3 alert-notify − 1 parity update = 7 net). Target ≈ **554 passed**, 0 failed.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin feat/kill-switch-alert
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base main --head feat/kill-switch-alert \
+  --title "feat(health): kill switch Alert tier (#138 PR 2 of 4)" \
+  --body "$(cat <<'BODY'
+## Summary
+Second PR in the #138 series. Wires the ALERT tier into the Foundation from PR #165:
+
+1. `SignalEvent` gets an optional `health_state` field (default `NORMAL`).
+   `signal.telegram.j2` prepends `⚠️ *ALERT*` when `health_state != NORMAL`.
+2. `push_telegram_direct` shim in `btc_api.py` looks up `get_symbol_state(symbol)`
+   before building the `SignalEvent`, so every outbound signal Telegram message
+   carries the correct state.
+3. `health.evaluate_and_record` emits a one-shot `notify(HealthEvent)` when a
+   symbol transitions to `ALERT` (any state → ALERT). Subsequent evaluations
+   while the symbol stays in ALERT do NOT re-fire.
+
+REDUCED / PAUSED transitions remain silent — PRs 3 and 4 extend the notify logic.
+
+## Does NOT change
+- Trading behavior: ALERT symbols are still operated on normally. This PR only
+  adds a visual prefix + a single warning notification on the state change.
+- The byte-identical NORMAL case — `test_notifier_signal_parity` still passes.
+
+## Tests
+- [x] ~7 new tests across 5 files
+- [x] Full suite: ~554 passed, 0 failed
+
+Closes partial: #138 (PR 2 of 4).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+- [ ] **Step 4: Watch CI**
+
+```bash
+sleep 12 && gh pr checks --watch --interval 15
+```
+Expected: backend-tests + frontend-typecheck PASS.
+
+---
+
+## Self-review
+
+**Spec coverage** (against `docs/superpowers/specs/es/2026-04-21-kill-switch-design.md` §9 PR 2):
+- scan/scanner → prefix `⚠️ ALERT` when state == ALERT: Task 1+2 (field + template + shim wiring). ✓
+- one-shot notify(HealthEvent) on NORMAL→ALERT: Task 3. Note: also covers REDUCED→ALERT and PAUSED→ALERT (possible via auto-recovery paths), which is a reasonable superset. ✓
+- NOT firing on subsequent same-state evaluations: Task 3 test `test_alert_no_renotify_when_state_unchanged`. ✓
+
+**Placeholder scan:** no TBDs. Template whitespace handling is explicit. The `health.notify` re-export pattern is shown with its rationale (tests can patch `health.notify`).
+
+**Type consistency:**
+- `SignalEvent.health_state: str = "NORMAL"` — Task 1 defines; Task 2 shim sets it.
+- `get_symbol_state(symbol) -> str` — already exists in health.py (PR #165); Task 2 imports lazily.
+- `notify(event, cfg)` — already exists in notifier (PR #164); Task 3 imports via health re-export.
+
+All consistent.
+
+**Scope:** PR 2 of 4 in #138 series. Does not include REDUCED/PAUSED tier actions (PRs 3/4).

--- a/docs/superpowers/plans/2026-04-22-kill-switch-foundation-pr1.md
+++ b/docs/superpowers/plans/2026-04-22-kill-switch-foundation-pr1.md
@@ -1,0 +1,1586 @@
+# Kill switch Foundation (#138 PR 1) implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the observer-only infrastructure for per-symbol health monitoring — rolling metrics, state machine (NORMAL/ALERT/REDUCED/PAUSED), persistence, API endpoints, and a daily cron + on-position-close evaluation loop — without changing any trading behavior. Downstream PRs 2-4 will add the tier actions (alert message, size reduction, skip signals).
+
+**Architecture:** New `health.py` module with pure functions for metrics + state evaluation, thin persistence wrappers over two new `signals.db` tables (`symbol_health`, `symbol_health_events`). Evaluation runs from a thread inside `btc_api.py` that fires on a daily cron at 00:00 UTC and after every position close. API exposes read endpoints and a manual-reactivate POST. No consumer reads `get_symbol_state()` yet — that's PRs 2-4.
+
+**Tech Stack:** Python 3.12, SQLite (existing `signals.db`), FastAPI (existing), pytest, freezegun (already in deps via pytest ecosystem — verify in Task 1). Uses `notifier.notify(HealthEvent(...))` from PR #164 for state-transition Telegram messages.
+
+---
+
+## File structure
+
+```
+health.py                                (new module, ~250 LOC)
+
+tests/
+├── test_health_rolling_metrics.py       (compute_rolling_metrics)
+├── test_health_state_machine.py         (evaluate_state transitions)
+├── test_health_persistence.py           (apply_transition, get_symbol_state)
+├── test_health_integration.py           (end-to-end: positions → evaluate → events)
+└── test_health_endpoints.py             (GET /health/symbols, GET /health/events, POST /reactivate)
+
+btc_api.py                               (modified)
+  - init_db()              — +symbol_health + symbol_health_events tables
+  - scanner_loop area      — spawn health_monitor_loop thread alongside
+  - NEW endpoints          — GET /health/symbols, GET /health/events, POST /health/reactivate/{symbol}
+  - db_close_position()    — trigger health evaluation after status=closed
+
+config-defaults              — add kill_switch block (in CFG_DEFAULTS)
+```
+
+**health.py responsibilities (by function):**
+
+| Function | Kind | Purpose |
+|---|---|---|
+| `compute_rolling_metrics(symbol, conn, now)` | pure | Read positions table, return dict of metrics |
+| `_months_negative_consecutive(pnl_by_month, now)` | pure | Count trailing full calendar months with pnl<0 |
+| `evaluate_state(metrics, current_state, manual_override, config)` | pure | Returns (new_state, reason) |
+| `apply_transition(symbol, new_state, reason, metrics, conn)` | persist | Writes symbol_health + symbol_health_events |
+| `get_symbol_state(symbol)` | read | Fast lookup — returns "NORMAL" if no row |
+| `evaluate_and_record(symbol, cfg, conn, now)` | orchestrator | The composite used by the monitor loop |
+| `evaluate_all_symbols(cfg, now)` | orchestrator | Calls evaluate_and_record for every curated symbol |
+| `health_monitor_loop(...)` | thread | Daily cron @ 00:00 UTC; separate fn for on-position-close trigger |
+
+**Task 10 will wire the on-position-close trigger into `db_close_position` in `btc_api.py`.**
+
+---
+
+## Task 1: Dependency check + schema migration + config defaults
+
+**Files:**
+- Modify: `btc_api.py` (init_db + CFG_DEFAULTS)
+- Create: `tests/test_health_persistence.py` (initial file with just schema test)
+
+- [ ] **Step 1: Confirm freezegun is importable**
+
+Run: `python -c "import freezegun; print(freezegun.__version__)"`
+Expected: version string. If ImportError, add `freezegun>=1.4` to `requirements.txt` and `pip install freezegun`. (freezegun is widely available; btc_scanner tests use it already — verify with `grep -l freezegun tests/`.)
+
+- [ ] **Step 2: Write failing schema test**
+
+Create `tests/test_health_persistence.py`:
+```python
+"""Schema + persistence tests for health module."""
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def test_schema_has_symbol_health_tables(tmp_db):
+    """init_db() must create the two health tables."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('symbol_health', 'symbol_health_events')"
+        ).fetchall()
+    finally:
+        conn.close()
+    names = {r[0] for r in rows}
+    assert "symbol_health" in names
+    assert "symbol_health_events" in names
+
+
+def test_symbol_health_columns(tmp_db):
+    """symbol_health must have the specified columns."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        cols = conn.execute("PRAGMA table_info(symbol_health)").fetchall()
+    finally:
+        conn.close()
+    col_names = {c[1] for c in cols}
+    for required in ("symbol", "state", "state_since",
+                      "last_evaluated_at", "last_metrics_json", "manual_override"):
+        assert required in col_names, f"missing column: {required}"
+
+
+def test_symbol_health_events_columns(tmp_db):
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        cols = conn.execute("PRAGMA table_info(symbol_health_events)").fetchall()
+    finally:
+        conn.close()
+    col_names = {c[1] for c in cols}
+    for required in ("id", "symbol", "from_state", "to_state",
+                      "trigger_reason", "metrics_json", "ts"):
+        assert required in col_names, f"missing column: {required}"
+```
+
+- [ ] **Step 3: Run test to verify fail**
+
+Run: `python -m pytest tests/test_health_persistence.py -v`
+Expected: 3 tests FAIL (tables don't exist).
+
+- [ ] **Step 4: Add tables to btc_api.init_db()**
+
+Open `btc_api.py`, locate `init_db()` (around line 780). After the existing `notifications_sent` table + index (added in PR #164), add before the closing of the function:
+
+```python
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS symbol_health (
+            symbol              TEXT PRIMARY KEY,
+            state               TEXT NOT NULL DEFAULT 'NORMAL',
+            state_since         TEXT NOT NULL,
+            last_evaluated_at   TEXT NOT NULL,
+            last_metrics_json   TEXT,
+            manual_override     INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS symbol_health_events (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            symbol          TEXT NOT NULL,
+            from_state      TEXT NOT NULL,
+            to_state        TEXT NOT NULL,
+            trigger_reason  TEXT NOT NULL,
+            metrics_json    TEXT NOT NULL,
+            ts              TEXT NOT NULL
+        )
+    """)
+    con.execute("""
+        CREATE INDEX IF NOT EXISTS idx_health_events_symbol
+            ON symbol_health_events(symbol, ts DESC)
+    """)
+```
+
+- [ ] **Step 5: Add kill_switch block to CFG_DEFAULTS**
+
+Locate `CFG_DEFAULTS` in `btc_api.py` (around line 160). Add the `kill_switch` block among other defaults:
+
+```python
+        "kill_switch": {
+            "enabled": True,
+            "min_trades_for_eval": 20,
+            "alert_win_rate_threshold": 0.15,
+            "reduce_pnl_window_days": 30,
+            "reduce_size_factor": 0.5,
+            "pause_months_consecutive": 3,
+            "auto_recovery_enabled": True,
+        },
+```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+Run: `python -m pytest tests/test_health_persistence.py -v`
+Expected: 3 PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add btc_api.py tests/test_health_persistence.py
+git commit -m "feat(health): add symbol_health + symbol_health_events tables + config (#138)"
+```
+
+---
+
+## Task 2: compute_rolling_metrics (pure function)
+
+**Files:**
+- Create: `health.py`
+- Create: `tests/test_health_rolling_metrics.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_health_rolling_metrics.py`:
+```python
+"""Rolling metrics computed from positions table (closed positions only)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from freezegun import freeze_time
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def _insert_closed_position(conn, symbol, pnl_usd, exit_ts):
+    """Insert a closed position directly. exit_ts is an ISO datetime string."""
+    conn.execute(
+        """INSERT INTO positions
+           (symbol, direction, status, entry_price, entry_ts,
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?)""",
+        (symbol, exit_ts, exit_ts, pnl_usd, pnl_usd / 100.0),
+    )
+    conn.commit()
+
+
+NOW = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def test_empty_db_returns_zero_trades(tmp_db):
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        metrics = compute_rolling_metrics("BTCUSDT", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["trades_count_total"] == 0
+    assert metrics["win_rate_20_trades"] == 0.0
+    assert metrics["pnl_30d"] == 0.0
+    assert metrics["months_negative_consecutive"] == 0
+
+
+def test_open_positions_are_excluded(tmp_db):
+    """Only closed positions count."""
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO positions
+               (symbol, direction, status, entry_price, entry_ts, pnl_usd, pnl_pct)
+               VALUES ('BTCUSDT', 'LONG', 'open', 100.0, ?, NULL, NULL)""",
+            (NOW.isoformat(),),
+        )
+        conn.commit()
+        metrics = compute_rolling_metrics("BTCUSDT", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["trades_count_total"] == 0
+
+
+def test_win_rate_last_20_trades(tmp_db):
+    """win_rate_20_trades = (winners in last 20 closed) / 20."""
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        # 25 closed positions: first 5 wins, then 15 losses, then 5 wins → last 20 = 15 L + 5 W
+        for i in range(25):
+            pnl = 100.0 if (i < 5 or i >= 20) else -50.0
+            ts = (NOW - timedelta(days=25 - i)).isoformat()
+            _insert_closed_position(conn, "BTCUSDT", pnl, ts)
+        metrics = compute_rolling_metrics("BTCUSDT", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["trades_count_total"] == 25
+    # Last 20 sorted desc by exit_ts: the 20 most recent → i=5..24 → 15 losses (i=5..19) + 5 wins (i=20..24) = 5/20 = 0.25
+    assert metrics["win_rate_20_trades"] == 0.25
+
+
+def test_win_rate_falls_back_to_available_when_under_20(tmp_db):
+    """If only 10 trades exist, win_rate uses those 10 (caller handles cold-start via trades_count_total)."""
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        for i in range(10):
+            pnl = 100.0 if i < 3 else -50.0
+            ts = (NOW - timedelta(days=10 - i)).isoformat()
+            _insert_closed_position(conn, "BTCUSDT", pnl, ts)
+        metrics = compute_rolling_metrics("BTCUSDT", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["trades_count_total"] == 10
+    assert metrics["win_rate_20_trades"] == 0.3  # 3/10
+
+
+def test_pnl_30d_window(tmp_db):
+    """Only positions with exit_ts >= now - 30d contribute to pnl_30d."""
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        # 1 trade 40 days ago (excluded), 3 trades in the last 30 days
+        _insert_closed_position(conn, "BTC", 999.0, (NOW - timedelta(days=40)).isoformat())
+        _insert_closed_position(conn, "BTC", 100.0, (NOW - timedelta(days=10)).isoformat())
+        _insert_closed_position(conn, "BTC", -50.0, (NOW - timedelta(days=5)).isoformat())
+        _insert_closed_position(conn, "BTC", 30.0, (NOW - timedelta(days=1)).isoformat())
+        metrics = compute_rolling_metrics("BTC", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["pnl_30d"] == 80.0  # 100 - 50 + 30
+
+
+def test_months_negative_consecutive_3_months(tmp_db):
+    """3 full calendar months all with sum(pnl)<0 → months_negative_consecutive=3."""
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        # NOW = 2026-06-15; previous 3 full calendar months are 2026-05, 2026-04, 2026-03.
+        # Seed each with a loss.
+        _insert_closed_position(conn, "BTC", -100.0, "2026-05-10T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", -50.0,  "2026-04-15T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", -75.0,  "2026-03-20T12:00:00+00:00")
+        # Positive in 2026-02 — breaks the streak after 3
+        _insert_closed_position(conn, "BTC", +200.0, "2026-02-05T12:00:00+00:00")
+        metrics = compute_rolling_metrics("BTC", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["months_negative_consecutive"] == 3
+
+
+def test_months_negative_consecutive_broken_by_positive(tmp_db):
+    """A positive month in the trailing window caps the streak."""
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        # 2026-05 positive → streak is 0 from this moment
+        _insert_closed_position(conn, "BTC", +500.0, "2026-05-10T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", -50.0,  "2026-04-15T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", -75.0,  "2026-03-20T12:00:00+00:00")
+        metrics = compute_rolling_metrics("BTC", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["months_negative_consecutive"] == 0
+
+
+def test_months_negative_consecutive_partial_streak(tmp_db):
+    """Most recent 2 months negative, 3rd back positive → streak=2."""
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        _insert_closed_position(conn, "BTC", -100.0, "2026-05-10T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", -50.0,  "2026-04-15T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", +200.0, "2026-03-20T12:00:00+00:00")
+        metrics = compute_rolling_metrics("BTC", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["months_negative_consecutive"] == 2
+
+
+def test_current_month_in_progress_is_excluded_from_streak(tmp_db):
+    """The month containing NOW does NOT count toward consecutive_negative
+    (it's partial). Only FULL prior calendar months do."""
+    from health import compute_rolling_metrics
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        # 2026-06 is partial (NOW = 2026-06-15). Put a loss here — should not matter.
+        _insert_closed_position(conn, "BTC", -999.0, "2026-06-10T12:00:00+00:00")
+        # 2026-05, 04, 03 negative → streak=3
+        _insert_closed_position(conn, "BTC", -100.0, "2026-05-10T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", -50.0,  "2026-04-15T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", -75.0,  "2026-03-20T12:00:00+00:00")
+        metrics = compute_rolling_metrics("BTC", conn, now=NOW)
+    finally:
+        conn.close()
+    assert metrics["months_negative_consecutive"] == 3  # not 4
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `python -m pytest tests/test_health_rolling_metrics.py -v`
+Expected: 9 FAIL (module `health` doesn't exist).
+
+- [ ] **Step 3: Create `health.py` with compute_rolling_metrics**
+
+Create `health.py`:
+```python
+"""Per-symbol health monitor (#138) — observer-only in PR 1.
+
+Pure functions for computing rolling metrics + deciding state transitions,
+plus thin persistence wrappers. Does NOT change trading behavior here; that
+lands in PRs 2-4.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+def _month_key(dt: datetime) -> str:
+    """YYYY-MM string from a datetime (used as pnl_by_month key)."""
+    return dt.strftime("%Y-%m")
+
+
+def _previous_full_month_keys(now: datetime, n: int) -> list[str]:
+    """Return the last n full calendar months BEFORE the month containing `now`,
+    ordered from most recent to oldest. Example: now=2026-06-15, n=3 → ['2026-05', '2026-04', '2026-03']."""
+    keys: list[str] = []
+    # Step to the first day of `now`'s month, then step back one month at a time.
+    first_of_now = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    current = first_of_now
+    for _ in range(n):
+        # Step back one month
+        if current.month == 1:
+            current = current.replace(year=current.year - 1, month=12)
+        else:
+            current = current.replace(month=current.month - 1)
+        keys.append(_month_key(current))
+    return keys
+
+
+def _months_negative_consecutive(pnl_by_month: dict[str, float], now: datetime) -> int:
+    """Count trailing consecutive FULL calendar months (starting from the month
+    before `now`'s month) with sum(pnl) < 0. Stops at the first non-negative month."""
+    streak = 0
+    # Check up to 12 months backward — enough for any realistic threshold
+    for key in _previous_full_month_keys(now, 12):
+        pnl = pnl_by_month.get(key, 0.0)
+        if pnl < 0:
+            streak += 1
+        else:
+            break
+    return streak
+
+
+def compute_rolling_metrics(symbol: str, conn, now: datetime | None = None) -> dict[str, Any]:
+    """Compute health metrics for `symbol` from the positions table.
+
+    Only closed positions (`status='closed'`) are counted. `now` defaults to
+    `datetime.now(timezone.utc)` but is injectable for tests.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    cutoff_30d = (now - timedelta(days=30)).isoformat()
+
+    total = conn.execute(
+        "SELECT COUNT(*) FROM positions WHERE symbol=? AND status='closed'",
+        (symbol,),
+    ).fetchone()[0]
+
+    last20 = conn.execute(
+        """SELECT pnl_usd FROM positions
+           WHERE symbol=? AND status='closed'
+           ORDER BY exit_ts DESC
+           LIMIT 20""",
+        (symbol,),
+    ).fetchall()
+    if last20:
+        winners = sum(1 for (pnl,) in last20 if (pnl or 0) > 0)
+        win_rate_20_trades = winners / len(last20)
+    else:
+        win_rate_20_trades = 0.0
+
+    pnl_30d_row = conn.execute(
+        """SELECT COALESCE(SUM(pnl_usd), 0) FROM positions
+           WHERE symbol=? AND status='closed' AND exit_ts >= ?""",
+        (symbol, cutoff_30d),
+    ).fetchone()
+    pnl_30d = float(pnl_30d_row[0]) if pnl_30d_row else 0.0
+
+    by_month_rows = conn.execute(
+        """SELECT substr(exit_ts, 1, 7) AS ym, SUM(pnl_usd) AS pnl
+           FROM positions
+           WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL
+           GROUP BY ym""",
+        (symbol,),
+    ).fetchall()
+    pnl_by_month = {row[0]: float(row[1] or 0.0) for row in by_month_rows}
+
+    return {
+        "trades_count_total": int(total),
+        "win_rate_20_trades": float(win_rate_20_trades),
+        "pnl_30d": pnl_30d,
+        "pnl_by_month": pnl_by_month,
+        "months_negative_consecutive": _months_negative_consecutive(pnl_by_month, now),
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_health_rolling_metrics.py -v`
+Expected: 9 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add health.py tests/test_health_rolling_metrics.py
+git commit -m "feat(health): compute_rolling_metrics pure function (#138)"
+```
+
+---
+
+## Task 3: evaluate_state (state machine, pure)
+
+**Files:**
+- Modify: `health.py`
+- Create: `tests/test_health_state_machine.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_health_state_machine.py`:
+```python
+"""State machine: NORMAL → ALERT → REDUCED → PAUSED + manual override.
+
+evaluate_state is pure: given metrics + current state + manual_override flag +
+config, returns (new_state, reason)."""
+
+
+CFG = {
+    "min_trades_for_eval": 20,
+    "alert_win_rate_threshold": 0.15,
+    "reduce_pnl_window_days": 30,  # resolved elsewhere — evaluate_state just uses pnl_30d
+    "reduce_size_factor": 0.5,     # unused by evaluate_state
+    "pause_months_consecutive": 3,
+    "auto_recovery_enabled": True,
+}
+
+
+def _metrics(total=50, wr=0.5, pnl_30d=500.0, months_neg=0):
+    return {
+        "trades_count_total": total,
+        "win_rate_20_trades": wr,
+        "pnl_30d": pnl_30d,
+        "pnl_by_month": {},
+        "months_negative_consecutive": months_neg,
+    }
+
+
+def test_healthy_symbol_stays_normal():
+    from health import evaluate_state
+    new, reason = evaluate_state(_metrics(), "NORMAL", False, CFG)
+    assert new == "NORMAL"
+    assert reason == "healthy"
+
+
+def test_low_win_rate_transitions_to_alert():
+    from health import evaluate_state
+    new, reason = evaluate_state(_metrics(wr=0.10), "NORMAL", False, CFG)
+    assert new == "ALERT"
+    assert reason == "wr_below_threshold"
+
+
+def test_negative_pnl_30d_transitions_to_reduced():
+    from health import evaluate_state
+    new, reason = evaluate_state(_metrics(wr=0.5, pnl_30d=-100.0), "ALERT", False, CFG)
+    assert new == "REDUCED"
+    assert reason == "pnl_neg_30d"
+
+
+def test_three_months_negative_transitions_to_paused():
+    from health import evaluate_state
+    new, reason = evaluate_state(_metrics(months_neg=3), "REDUCED", False, CFG)
+    assert new == "PAUSED"
+    assert reason == "3mo_consec_neg"
+
+
+def test_rule_order_paused_beats_reduced_beats_alert():
+    """When multiple rules fire, the most severe wins."""
+    from health import evaluate_state
+    new, reason = evaluate_state(
+        _metrics(wr=0.05, pnl_30d=-500, months_neg=3), "NORMAL", False, CFG,
+    )
+    assert new == "PAUSED"
+
+
+def test_cold_start_holds_state_unchanged():
+    """If trades_count_total < min_trades, state is locked to its current value."""
+    from health import evaluate_state
+    new, reason = evaluate_state(
+        _metrics(total=10, wr=0.0, pnl_30d=-1000, months_neg=3), "NORMAL", False, CFG,
+    )
+    assert new == "NORMAL"
+    assert reason == "insufficient_data"
+
+
+def test_auto_recovery_from_alert_to_normal():
+    """Once metrics are healthy again, ALERT → NORMAL automatically."""
+    from health import evaluate_state
+    new, reason = evaluate_state(_metrics(wr=0.5), "ALERT", False, CFG)
+    assert new == "NORMAL"
+    assert reason == "auto_recovery"
+
+
+def test_auto_recovery_disabled_by_config():
+    """If auto_recovery_enabled=False, non-healthy states hold until manual intervention."""
+    from health import evaluate_state
+    cfg = dict(CFG, auto_recovery_enabled=False)
+    new, reason = evaluate_state(_metrics(wr=0.5), "ALERT", False, cfg)
+    assert new == "ALERT"
+    assert reason == "auto_recovery_disabled"
+
+
+def test_manual_override_respected_on_normal_with_good_metrics():
+    """A reactivated (manual_override=1) symbol with healthy metrics stays NORMAL
+    (auto-recovery path but also fine; override is informational here)."""
+    from health import evaluate_state
+    new, reason = evaluate_state(_metrics(wr=0.5), "NORMAL", True, CFG)
+    assert new == "NORMAL"
+
+
+def test_manual_override_expires_if_a_severe_rule_fires():
+    """Manual override survives minor dips but NOT a fresh PAUSED-triggering condition."""
+    from health import evaluate_state
+    new, reason = evaluate_state(
+        _metrics(months_neg=3), "NORMAL", True, CFG,
+    )
+    assert new == "PAUSED"
+    assert reason == "3mo_consec_neg"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `python -m pytest tests/test_health_state_machine.py -v`
+Expected: 10 FAIL (`evaluate_state` doesn't exist).
+
+- [ ] **Step 3: Implement evaluate_state**
+
+Append to `health.py`:
+```python
+# ─────────────────────────────────────────────────────────────────────────────
+#  STATE MACHINE (pure)
+# ─────────────────────────────────────────────────────────────────────────────
+
+VALID_STATES = ("NORMAL", "ALERT", "REDUCED", "PAUSED")
+
+
+def evaluate_state(
+    metrics: dict[str, Any],
+    current_state: str,
+    manual_override: bool,
+    config: dict[str, Any],
+) -> tuple[str, str]:
+    """Return (new_state, reason) given metrics + current state + manual override.
+
+    Rule precedence (most severe wins):
+      1. insufficient_data → hold current state
+      2. months_negative_consecutive >= pause_months_consecutive → PAUSED
+      3. pnl_30d < 0 → REDUCED
+      4. win_rate_20_trades < alert_win_rate_threshold → ALERT
+      5. else → NORMAL (auto-recovery; if auto_recovery_enabled=False and
+         current != NORMAL, hold current state with reason='auto_recovery_disabled')
+
+    manual_override is informational: a PAUSED→NORMAL reactivation sets override=True,
+    but a SUBSEQUENT severe rule (rule 2) still transitions to PAUSED.
+    """
+    min_trades = int(config.get("min_trades_for_eval", 20))
+    if metrics.get("trades_count_total", 0) < min_trades:
+        return current_state, "insufficient_data"
+
+    # Most severe first
+    pause_threshold = int(config.get("pause_months_consecutive", 3))
+    if metrics.get("months_negative_consecutive", 0) >= pause_threshold:
+        return "PAUSED", "3mo_consec_neg"
+
+    if metrics.get("pnl_30d", 0.0) < 0:
+        return "REDUCED", "pnl_neg_30d"
+
+    wr_threshold = float(config.get("alert_win_rate_threshold", 0.15))
+    if metrics.get("win_rate_20_trades", 0.0) < wr_threshold:
+        return "ALERT", "wr_below_threshold"
+
+    # Healthy path
+    if current_state == "NORMAL":
+        return "NORMAL", "healthy"
+
+    if config.get("auto_recovery_enabled", True):
+        return "NORMAL", "auto_recovery"
+    return current_state, "auto_recovery_disabled"
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_health_state_machine.py -v`
+Expected: 10 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add health.py tests/test_health_state_machine.py
+git commit -m "feat(health): evaluate_state pure function (#138)"
+```
+
+---
+
+## Task 4: apply_transition + get_symbol_state (persistence)
+
+**Files:**
+- Modify: `health.py`
+- Modify: `tests/test_health_persistence.py`
+
+- [ ] **Step 1: Extend failing tests**
+
+Append to `tests/test_health_persistence.py`:
+```python
+from datetime import datetime, timezone
+
+
+def test_apply_transition_writes_row_and_event(tmp_db):
+    from health import apply_transition
+    import btc_api
+    metrics = {
+        "trades_count_total": 50, "win_rate_20_trades": 0.5,
+        "pnl_30d": 100.0, "pnl_by_month": {},
+        "months_negative_consecutive": 0,
+    }
+    apply_transition("BTCUSDT", new_state="ALERT", reason="wr_below_threshold",
+                     metrics=metrics, from_state="NORMAL")
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            "SELECT state, state_since, manual_override FROM symbol_health WHERE symbol=?",
+            ("BTCUSDT",),
+        ).fetchone()
+        event = conn.execute(
+            """SELECT from_state, to_state, trigger_reason FROM symbol_health_events
+               WHERE symbol=? ORDER BY ts DESC LIMIT 1""",
+            ("BTCUSDT",),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "ALERT"
+    assert row[2] == 0  # manual_override default 0
+    assert event == ("NORMAL", "ALERT", "wr_below_threshold")
+
+
+def test_get_symbol_state_returns_normal_for_unknown(tmp_db):
+    """A symbol with no row is treated as NORMAL by default."""
+    from health import get_symbol_state
+    assert get_symbol_state("UNSEEN") == "NORMAL"
+
+
+def test_get_symbol_state_returns_persisted(tmp_db):
+    from health import apply_transition, get_symbol_state
+    metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
+                "pnl_30d": 0.0, "pnl_by_month": {},
+                "months_negative_consecutive": 0}
+    apply_transition("JUPUSDT", new_state="PAUSED", reason="3mo_consec_neg",
+                      metrics=metrics, from_state="REDUCED")
+    assert get_symbol_state("JUPUSDT") == "PAUSED"
+
+
+def test_apply_transition_same_state_is_idempotent(tmp_db):
+    """If new_state == current, update last_evaluated_at but do NOT insert event row."""
+    from health import apply_transition, _record_evaluation
+    import btc_api
+    metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
+                "pnl_30d": 0.0, "pnl_by_month": {},
+                "months_negative_consecutive": 0}
+    apply_transition("BTC", new_state="ALERT", reason="wr_below_threshold",
+                      metrics=metrics, from_state="NORMAL")
+    _record_evaluation("BTC", metrics, new_state="ALERT")  # idempotent no-op transition
+    conn = btc_api.get_db()
+    try:
+        event_count = conn.execute(
+            "SELECT COUNT(*) FROM symbol_health_events WHERE symbol='BTC'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert event_count == 1  # initial transition, not a second event
+
+
+def test_reactivate_sets_manual_override(tmp_db):
+    """reactivate_symbol flips manual_override to 1 and emits event."""
+    from health import apply_transition, reactivate_symbol
+    metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
+                "pnl_30d": 0.0, "pnl_by_month": {},
+                "months_negative_consecutive": 0}
+    apply_transition("DOGE", new_state="PAUSED", reason="3mo_consec_neg",
+                      metrics=metrics, from_state="REDUCED")
+    reactivate_symbol("DOGE", reason="backtest_validated")
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            "SELECT state, manual_override FROM symbol_health WHERE symbol='DOGE'"
+        ).fetchone()
+        last_event = conn.execute(
+            "SELECT trigger_reason FROM symbol_health_events WHERE symbol='DOGE' "
+            "ORDER BY ts DESC LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row == ("NORMAL", 1)
+    assert last_event[0] == "manual_override"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `python -m pytest tests/test_health_persistence.py -v`
+Expected: 3 existing PASS + 5 new FAIL.
+
+- [ ] **Step 3: Implement the persistence helpers in health.py**
+
+Append to `health.py`:
+```python
+# ─────────────────────────────────────────────────────────────────────────────
+#  PERSISTENCE
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _conn():
+    import btc_api
+    return btc_api.get_db()
+
+
+def get_symbol_state(symbol: str) -> str:
+    """Return the current state of a symbol, or 'NORMAL' if it has no row."""
+    conn = _conn()
+    try:
+        row = conn.execute(
+            "SELECT state FROM symbol_health WHERE symbol=?",
+            (symbol,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return row[0] if row else "NORMAL"
+
+
+def _record_evaluation(symbol: str, metrics: dict[str, Any], new_state: str) -> None:
+    """Update last_evaluated_at + last_metrics_json without changing state.
+    Creates the row if it doesn't exist. No event is emitted."""
+    conn = _conn()
+    now = _now_iso()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health (symbol, state, state_since, last_evaluated_at, last_metrics_json)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(symbol) DO UPDATE SET
+                 last_evaluated_at = excluded.last_evaluated_at,
+                 last_metrics_json = excluded.last_metrics_json""",
+            (symbol, new_state, now, now, json.dumps(metrics, default=str)),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def apply_transition(
+    symbol: str,
+    new_state: str,
+    reason: str,
+    metrics: dict[str, Any],
+    from_state: str,
+    manual_override: int | None = None,
+) -> None:
+    """Write the new state to symbol_health AND append a row to symbol_health_events.
+
+    If new_state == from_state this is a bug — callers should prefer `_record_evaluation`
+    for same-state updates. We still handle it gracefully by skipping the event insert.
+    """
+    if new_state not in VALID_STATES:
+        raise ValueError(f"invalid state: {new_state!r}")
+    now = _now_iso()
+    metrics_json = json.dumps(metrics, default=str)
+
+    conn = _conn()
+    try:
+        # Update symbol_health (upsert).
+        extra_sets = ""
+        extra_params: tuple = ()
+        if manual_override is not None:
+            extra_sets = ", manual_override = excluded.manual_override"
+        conn.execute(
+            f"""INSERT INTO symbol_health
+                (symbol, state, state_since, last_evaluated_at, last_metrics_json, manual_override)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(symbol) DO UPDATE SET
+                  state = excluded.state,
+                  state_since = excluded.state_since,
+                  last_evaluated_at = excluded.last_evaluated_at,
+                  last_metrics_json = excluded.last_metrics_json
+                  {extra_sets}""",
+            (symbol, new_state, now, now, metrics_json,
+             int(manual_override) if manual_override is not None else 0),
+        )
+
+        # Emit event only if state actually changed.
+        if from_state != new_state:
+            conn.execute(
+                """INSERT INTO symbol_health_events
+                   (symbol, from_state, to_state, trigger_reason, metrics_json, ts)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (symbol, from_state, new_state, reason, metrics_json, now),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def reactivate_symbol(symbol: str, reason: str = "manual") -> None:
+    """Manually reset a symbol to NORMAL with manual_override=1. Used by the
+    reactivate endpoint and CLI."""
+    current = get_symbol_state(symbol)
+    metrics = {"reactivation_reason": reason}
+    apply_transition(
+        symbol, new_state="NORMAL", reason="manual_override",
+        metrics=metrics, from_state=current, manual_override=1,
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_health_persistence.py -v`
+Expected: 8 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add health.py tests/test_health_persistence.py
+git commit -m "feat(health): apply_transition + get_symbol_state + reactivate_symbol (#138)"
+```
+
+---
+
+## Task 5: evaluate_and_record + evaluate_all_symbols orchestrators
+
+**Files:**
+- Modify: `health.py`
+- Create: `tests/test_health_integration.py`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Create `tests/test_health_integration.py`:
+```python
+"""End-to-end: insert positions → run evaluate_and_record → verify state + events."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def _insert_closed(conn, symbol, pnl, exit_ts):
+    conn.execute(
+        """INSERT INTO positions
+           (symbol, direction, status, entry_price, entry_ts,
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?)""",
+        (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
+    )
+    conn.commit()
+
+
+CFG = {"kill_switch": {
+    "enabled": True,
+    "min_trades_for_eval": 20,
+    "alert_win_rate_threshold": 0.15,
+    "reduce_pnl_window_days": 30,
+    "reduce_size_factor": 0.5,
+    "pause_months_consecutive": 3,
+    "auto_recovery_enabled": True,
+}}
+NOW = datetime(2026, 6, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def test_evaluate_and_record_healthy_leaves_normal_no_event(tmp_db):
+    from health import evaluate_and_record
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        # 25 winning trades → healthy
+        for i in range(25):
+            _insert_closed(conn, "BTC", 100.0, (NOW - timedelta(days=25 - i)).isoformat())
+        evaluate_and_record("BTC", CFG, now=NOW)
+        state = conn.execute(
+            "SELECT state FROM symbol_health WHERE symbol='BTC'"
+        ).fetchone()
+        events = conn.execute(
+            "SELECT COUNT(*) FROM symbol_health_events WHERE symbol='BTC'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert state[0] == "NORMAL"
+    assert events[0] == 0  # no state transition
+
+
+def test_evaluate_and_record_transitions_emit_event(tmp_db):
+    from health import evaluate_and_record
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        # 25 losing trades in last 3 months → PAUSED
+        _insert_closed(conn, "DOGE", -100.0, "2026-05-10T12:00:00+00:00")
+        _insert_closed(conn, "DOGE", -100.0, "2026-04-15T12:00:00+00:00")
+        _insert_closed(conn, "DOGE", -100.0, "2026-03-20T12:00:00+00:00")
+        for i in range(22):
+            _insert_closed(conn, "DOGE", -10.0, (NOW - timedelta(days=40 + i)).isoformat())
+        evaluate_and_record("DOGE", CFG, now=NOW)
+        state_row = conn.execute(
+            "SELECT state FROM symbol_health WHERE symbol='DOGE'"
+        ).fetchone()
+        events = conn.execute(
+            "SELECT to_state, trigger_reason FROM symbol_health_events WHERE symbol='DOGE'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert state_row[0] == "PAUSED"
+    assert len(events) == 1
+    assert events[0] == ("PAUSED", "3mo_consec_neg")
+
+
+def test_evaluate_all_symbols_iterates_default_list(tmp_db, monkeypatch):
+    from health import evaluate_all_symbols
+    import btc_api
+    # Patch DEFAULT_SYMBOLS to a small deterministic set
+    monkeypatch.setattr("btc_scanner.DEFAULT_SYMBOLS", ["ALPHA", "BETA"])
+    conn = btc_api.get_db()
+    try:
+        # Seed ALPHA healthy; leave BETA without trades
+        for i in range(25):
+            _insert_closed(conn, "ALPHA", 100.0, (NOW - timedelta(days=25 - i)).isoformat())
+        evaluate_all_symbols(CFG, now=NOW)
+        rows = conn.execute(
+            "SELECT symbol, state FROM symbol_health"
+        ).fetchall()
+    finally:
+        conn.close()
+    rows_dict = dict(rows)
+    assert rows_dict.get("ALPHA") == "NORMAL"
+    # BETA has 0 trades → insufficient_data → state stays at default NORMAL
+    assert rows_dict.get("BETA") == "NORMAL"
+
+
+def test_kill_switch_disabled_in_config_skips_evaluation(tmp_db, monkeypatch):
+    from health import evaluate_all_symbols
+    import btc_api
+    monkeypatch.setattr("btc_scanner.DEFAULT_SYMBOLS", ["X"])
+    cfg = {"kill_switch": {"enabled": False}}
+    conn = btc_api.get_db()
+    try:
+        for i in range(25):
+            _insert_closed(conn, "X", -100.0, (NOW - timedelta(days=25 - i)).isoformat())
+        evaluate_all_symbols(cfg, now=NOW)
+        rows = conn.execute("SELECT COUNT(*) FROM symbol_health").fetchone()
+    finally:
+        conn.close()
+    assert rows[0] == 0  # no row created
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `python -m pytest tests/test_health_integration.py -v`
+Expected: 4 FAIL (orchestrators don't exist).
+
+- [ ] **Step 3: Implement orchestrators**
+
+Append to `health.py`:
+```python
+# ─────────────────────────────────────────────────────────────────────────────
+#  ORCHESTRATION
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _get_manual_override(symbol: str) -> bool:
+    conn = _conn()
+    try:
+        row = conn.execute(
+            "SELECT manual_override FROM symbol_health WHERE symbol=?",
+            (symbol,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return bool(row[0]) if row else False
+
+
+def evaluate_and_record(symbol: str, cfg: dict[str, Any], now: datetime | None = None) -> str:
+    """Compute metrics + evaluate state + persist. Returns the resulting state."""
+    ks_cfg = (cfg.get("kill_switch") or {})
+    if not ks_cfg.get("enabled", True):
+        return "NORMAL"
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    conn = _conn()
+    try:
+        metrics = compute_rolling_metrics(symbol, conn, now=now)
+    finally:
+        conn.close()
+
+    current = get_symbol_state(symbol)
+    override = _get_manual_override(symbol)
+    new_state, reason = evaluate_state(metrics, current, override, ks_cfg)
+
+    if new_state != current:
+        apply_transition(symbol, new_state=new_state, reason=reason,
+                         metrics=metrics, from_state=current)
+    else:
+        _record_evaluation(symbol, metrics, new_state)
+    return new_state
+
+
+def evaluate_all_symbols(cfg: dict[str, Any], now: datetime | None = None) -> dict[str, str]:
+    """Evaluate every symbol in btc_scanner.DEFAULT_SYMBOLS. Returns {symbol: state}.
+
+    If kill_switch.enabled is False, returns {} without touching the DB.
+    """
+    ks_cfg = (cfg.get("kill_switch") or {})
+    if not ks_cfg.get("enabled", True):
+        return {}
+    from btc_scanner import DEFAULT_SYMBOLS
+    return {sym: evaluate_and_record(sym, cfg, now=now) for sym in DEFAULT_SYMBOLS}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_health_integration.py -v`
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add health.py tests/test_health_integration.py
+git commit -m "feat(health): evaluate_and_record + evaluate_all_symbols orchestrators (#138)"
+```
+
+---
+
+## Task 6: Daily cron + on-position-close trigger (health_monitor_loop)
+
+**Files:**
+- Modify: `health.py` (add health_monitor_loop + trigger_health_evaluation)
+- Modify: `btc_api.py` (spawn thread in main startup; call trigger on close)
+- Create: `tests/test_health_trigger.py` (focused test — the full loop is not unit-tested)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/test_health_trigger.py`:
+```python
+"""Position-close trigger: closing a position must invoke evaluate_and_record
+for that symbol."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def test_trigger_health_evaluation_calls_evaluate_and_record(tmp_db):
+    """The trigger wraps evaluate_and_record in error-suppression so DB errors
+    don't crash the position-close path."""
+    from health import trigger_health_evaluation
+    with patch("health.evaluate_and_record") as mock_eval:
+        trigger_health_evaluation("BTCUSDT", {"kill_switch": {"enabled": True}})
+    mock_eval.assert_called_once_with("BTCUSDT", {"kill_switch": {"enabled": True}})
+
+
+def test_trigger_swallows_exceptions(tmp_db, caplog):
+    """If evaluate_and_record raises, the trigger logs and returns None."""
+    import logging
+    from health import trigger_health_evaluation
+    with patch("health.evaluate_and_record", side_effect=RuntimeError("boom")):
+        with caplog.at_level(logging.ERROR, logger="health"):
+            result = trigger_health_evaluation("BTC", {"kill_switch": {"enabled": True}})
+    assert result is None
+    assert any("boom" in r.message for r in caplog.records)
+
+
+def test_trigger_respects_disabled_kill_switch(tmp_db):
+    """If kill_switch.enabled=False, trigger is a no-op (does not call evaluate)."""
+    from health import trigger_health_evaluation
+    with patch("health.evaluate_and_record") as mock_eval:
+        trigger_health_evaluation("BTC", {"kill_switch": {"enabled": False}})
+    assert mock_eval.call_count == 0
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `python -m pytest tests/test_health_trigger.py -v`
+Expected: 3 FAIL.
+
+- [ ] **Step 3: Implement trigger and loop**
+
+Append to `health.py`:
+```python
+# ─────────────────────────────────────────────────────────────────────────────
+#  TRIGGER + DAILY LOOP
+# ─────────────────────────────────────────────────────────────────────────────
+
+import logging as _logging
+import threading as _threading
+import time as _time
+
+log = _logging.getLogger("health")
+
+
+def trigger_health_evaluation(symbol: str, cfg: dict[str, Any]) -> None:
+    """Fire-and-forget health evaluation for a single symbol.
+    Swallows exceptions so callers (e.g. db_close_position) never crash."""
+    ks_cfg = (cfg.get("kill_switch") or {})
+    if not ks_cfg.get("enabled", True):
+        return
+    try:
+        evaluate_and_record(symbol, cfg)
+    except Exception as e:  # noqa: BLE001
+        log.error("health trigger failed for %s: %s", symbol, e, exc_info=True)
+
+
+def _seconds_until_next_midnight_utc(now: datetime) -> float:
+    tomorrow = (now + timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0,
+    )
+    return (tomorrow - now).total_seconds()
+
+
+def health_monitor_loop(cfg_fn, stop_event=None) -> None:
+    """Daily cron @ 00:00 UTC: run evaluate_all_symbols with fresh cfg.
+
+    `cfg_fn` is a callable returning the current config dict (re-read each
+    day in case user edits config.json). `stop_event` is an optional
+    threading.Event for graceful shutdown; if None, loops until killed.
+    """
+    if stop_event is None:
+        stop_event = _threading.Event()
+    while not stop_event.is_set():
+        sleep_s = _seconds_until_next_midnight_utc(datetime.now(timezone.utc))
+        # Wake slightly before midnight in case of drift, but the loop body rechecks time
+        if stop_event.wait(timeout=sleep_s):
+            return
+        try:
+            cfg = cfg_fn()
+            evaluate_all_symbols(cfg)
+            log.info("health_monitor_loop: daily sweep complete")
+        except Exception as e:  # noqa: BLE001
+            log.error("health_monitor_loop sweep failed: %s", e, exc_info=True)
+```
+
+- [ ] **Step 4: Wire the trigger into db_close_position**
+
+In `btc_api.py`, find `db_close_position` (around line 510-520). After the successful UPDATE, just before `return`, add:
+
+```python
+    # Kill switch #138: trigger health evaluation for this symbol.
+    try:
+        from health import trigger_health_evaluation
+        trigger_health_evaluation(pos["symbol"], CFG)
+    except Exception as e:
+        log.warning("health trigger skipped for position close: %s", e)
+```
+
+Adjust variable names to match the actual function (it may be `pos["symbol"]` or similar — read the function body and use the real variable holding the symbol).
+
+- [ ] **Step 5: Spawn the daily thread in the API startup**
+
+In `btc_api.py`, locate where `scanner_loop` is started (look for `threading.Thread(target=scanner_loop...)`). After that thread starts, add:
+
+```python
+    # Kill switch daily sweep (#138)
+    from health import health_monitor_loop
+    health_thread = threading.Thread(
+        target=health_monitor_loop,
+        args=(lambda: CFG,),  # fresh CFG lookup each day
+        daemon=True,
+        name="health-monitor",
+    )
+    health_thread.start()
+    log.info("Health monitor thread started (daily @ 00:00 UTC)")
+```
+
+- [ ] **Step 6: Run trigger tests**
+
+Run: `python -m pytest tests/test_health_trigger.py -v`
+Expected: 3 PASS.
+
+- [ ] **Step 7: Run full health test set**
+
+Run: `python -m pytest tests/test_health_*.py -v`
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add health.py btc_api.py tests/test_health_trigger.py
+git commit -m "feat(health): trigger + health_monitor_loop (daily cron + on-close) (#138)"
+```
+
+---
+
+## Task 7: API endpoints
+
+**Files:**
+- Modify: `btc_api.py` (add three endpoints)
+- Create: `tests/test_health_endpoints.py`
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+Create `tests/test_health_endpoints.py`:
+```python
+"""GET /health/symbols, GET /health/events, POST /health/reactivate/{symbol}."""
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    return TestClient(btc_api.app)
+
+
+def test_get_health_symbols_empty(client):
+    resp = client.get("/health/symbols")
+    assert resp.status_code == 200
+    assert resp.json() == {"symbols": []}
+
+
+def test_get_health_symbols_returns_rows(client):
+    from health import apply_transition
+    apply_transition(
+        "BTC", new_state="ALERT", reason="wr_below_threshold",
+        metrics={"trades_count_total": 50, "win_rate_20_trades": 0.1,
+                  "pnl_30d": 0.0, "pnl_by_month": {},
+                  "months_negative_consecutive": 0},
+        from_state="NORMAL",
+    )
+    resp = client.get("/health/symbols")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert len(payload["symbols"]) == 1
+    assert payload["symbols"][0]["symbol"] == "BTC"
+    assert payload["symbols"][0]["state"] == "ALERT"
+
+
+def test_get_health_events_returns_history(client):
+    from health import apply_transition
+    metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
+                "pnl_30d": 0.0, "pnl_by_month": {},
+                "months_negative_consecutive": 0}
+    apply_transition("BTC", "ALERT", "wr_below_threshold", metrics, "NORMAL")
+    apply_transition("BTC", "REDUCED", "pnl_neg_30d", metrics, "ALERT")
+    resp = client.get("/health/events?symbol=BTC")
+    assert resp.status_code == 200
+    events = resp.json()["events"]
+    assert len(events) == 2
+    # Most recent first
+    assert events[0]["to_state"] == "REDUCED"
+    assert events[1]["to_state"] == "ALERT"
+
+
+def test_post_health_reactivate_sets_manual_override(client):
+    from health import apply_transition
+    metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
+                "pnl_30d": 0.0, "pnl_by_month": {},
+                "months_negative_consecutive": 0}
+    apply_transition("JUP", "PAUSED", "3mo_consec_neg", metrics, "REDUCED")
+
+    resp = client.post("/health/reactivate/JUP", json={"reason": "backtest_ok"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ok"] is True
+    assert data["state"] == "NORMAL"
+
+    # GET again and verify
+    resp = client.get("/health/symbols")
+    rows = {r["symbol"]: r for r in resp.json()["symbols"]}
+    assert rows["JUP"]["state"] == "NORMAL"
+    assert rows["JUP"]["manual_override"] == 1
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `python -m pytest tests/test_health_endpoints.py -v`
+Expected: 4 FAIL (endpoints don't exist).
+
+- [ ] **Step 3: Add endpoints to btc_api.py**
+
+Find a convenient location near other endpoints in `btc_api.py` (e.g., after `/positions` endpoints). Add:
+
+```python
+# ── Kill switch / health endpoints (#138) ─────────────────────────────
+from pydantic import BaseModel
+
+
+class ReactivateRequest(BaseModel):
+    reason: str = "manual"
+
+
+@app.get("/health/symbols")
+def get_health_symbols():
+    """List current health state per symbol."""
+    con = get_db()
+    try:
+        rows = con.execute(
+            """SELECT symbol, state, state_since, last_evaluated_at,
+                      last_metrics_json, manual_override
+               FROM symbol_health
+               ORDER BY symbol"""
+        ).fetchall()
+    finally:
+        con.close()
+    cols = ("symbol", "state", "state_since", "last_evaluated_at",
+            "last_metrics_json", "manual_override")
+    return {"symbols": [dict(zip(cols, r)) for r in rows]}
+
+
+@app.get("/health/events")
+def get_health_events(symbol: Optional[str] = None, limit: int = 50):
+    """Transition history. Optionally filter by symbol."""
+    con = get_db()
+    try:
+        if symbol:
+            rows = con.execute(
+                """SELECT id, symbol, from_state, to_state, trigger_reason,
+                          metrics_json, ts
+                   FROM symbol_health_events WHERE symbol=?
+                   ORDER BY ts DESC LIMIT ?""",
+                (symbol, limit),
+            ).fetchall()
+        else:
+            rows = con.execute(
+                """SELECT id, symbol, from_state, to_state, trigger_reason,
+                          metrics_json, ts
+                   FROM symbol_health_events ORDER BY ts DESC LIMIT ?""",
+                (limit,),
+            ).fetchall()
+    finally:
+        con.close()
+    cols = ("id", "symbol", "from_state", "to_state", "trigger_reason",
+            "metrics_json", "ts")
+    return {"events": [dict(zip(cols, r)) for r in rows]}
+
+
+@app.post("/health/reactivate/{symbol}")
+def post_health_reactivate(symbol: str, body: ReactivateRequest):
+    """Manually reset a symbol to NORMAL with manual_override=1."""
+    from health import reactivate_symbol, get_symbol_state
+    reactivate_symbol(symbol.upper(), reason=body.reason)
+    return {"ok": True, "symbol": symbol.upper(), "state": get_symbol_state(symbol.upper())}
+```
+
+- [ ] **Step 4: Run endpoint tests**
+
+Run: `python -m pytest tests/test_health_endpoints.py -v`
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add btc_api.py tests/test_health_endpoints.py
+git commit -m "feat(health): GET /health/symbols, GET /health/events, POST /health/reactivate (#138)"
+```
+
+---
+
+## Task 8: Full regression + push + PR
+
+**Files:** none changed; verification only.
+
+- [ ] **Step 1: Full test suite**
+
+Run: `python -m pytest tests/ -q -m "not network"`
+Expected: all PASS. Prior baseline was 504 (after PR #164); this PR adds ~35 tests (9 + 10 + 8 + 4 + 3 + 4 = 38), so target is **~542 passed, 0 failed**. If different, investigate before pushing.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin feat/kill-switch-foundation
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base main --head feat/kill-switch-foundation \
+  --title "feat(health): kill switch Foundation — observer-only (#138 PR 1)" \
+  --body "$(cat <<'BODY'
+## Summary
+First of 4 PRs for #138 (see [spec](docs/superpowers/specs/es/2026-04-21-kill-switch-design.md)). Ships the health-monitor infrastructure as an **observer only** — state machine, rolling metrics, persistence, API endpoints, daily cron + on-position-close trigger — without changing any trading behavior. Downstream PRs 2-4 will add the tier actions.
+
+## What ships
+- New tables `symbol_health` + `symbol_health_events` (via `btc_api.init_db()`)
+- New module `health.py`:
+  - `compute_rolling_metrics` (pure)
+  - `evaluate_state` (pure state machine)
+  - `apply_transition` / `get_symbol_state` / `reactivate_symbol` (persistence)
+  - `evaluate_and_record` / `evaluate_all_symbols` (orchestrators)
+  - `trigger_health_evaluation` + `health_monitor_loop` (daily cron + on-close)
+- New endpoints: `GET /health/symbols`, `GET /health/events`, `POST /health/reactivate/{symbol}`
+- Config: `kill_switch` block added to `CFG_DEFAULTS` in `btc_api.py`
+- `db_close_position` now triggers `trigger_health_evaluation` after a successful close (fire-and-forget, errors logged)
+
+## Unblocks
+- PRs 2 (Alert), 3 (Reduce), 4 (Pause) can now wire their hooks into `scan()` via `get_symbol_state()`.
+
+## Does NOT change
+- Trading behavior: PR 1 is observer-only. No signals are skipped, no sizing is adjusted.
+- No Telegram notifications yet (wired in PR 2 via `notifier.notify(HealthEvent)`).
+
+## Test plan
+- [x] ~38 new tests across 6 files (rolling metrics, state machine, persistence, integration, trigger, endpoints)
+- [x] Full suite: ~542 passed, 0 failed
+- [x] Schema migration verified (symbol_health + symbol_health_events exist after init_db)
+
+Closes partial: #138 (PR 1 of 4).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+- [ ] **Step 4: Watch CI**
+
+```bash
+sleep 12 && gh pr checks --watch --interval 15
+```
+Expected: backend-tests + frontend-typecheck PASS.
+
+---
+
+## Self-review
+
+**Spec coverage (against `docs/superpowers/specs/es/2026-04-21-kill-switch-design.md` §9 PR 1):**
+- §5 Arquitectura — `health.py` module + thread in `btc_api.py` + endpoints ✓ (Tasks 2-7)
+- §6 Schema DB — `symbol_health` + `symbol_health_events` + index ✓ (Task 1)
+- §7 State machine — all 5 transition rules, cold start, auto-recovery, manual_override ✓ (Task 3, 4)
+- §8 Config block — kill_switch defaults ✓ (Task 1)
+- §9 PR 1 list items:
+  - Schema migration ✓ (Task 1)
+  - `compute_rolling_metrics` ✓ (Task 2)
+  - `evaluate_state` ✓ (Task 3)
+  - `apply_transition` ✓ (Task 4)
+  - `get_symbol_state` ✓ (Task 4)
+  - `health_monitor_loop` daily cron ✓ (Task 6)
+  - Triggered on position close ✓ (Task 6)
+  - 3 API endpoints ✓ (Task 7)
+  - Tests for state machine, rolling metrics, cold start, idempotence, migration ✓ (Tasks 1-7)
+  - Trading behavior unchanged ✓ (no modifications to `btc_scanner.scan`, `simulate_strategy`, or Telegram emission paths aside from the notifier refactor already in PR #164)
+- §11 Riesgos — `try/except` around trigger swallows failures so position close doesn't crash ✓ (Task 6, step 3)
+
+**Placeholder scan:** no "TBD", no "similar to Task N", no "add error handling as needed". Every code step shows concrete code. Task 6 step 4 has one hedge ("adjust variable names to match") — acceptable because the implementer must read the actual function body.
+
+**Type consistency:**
+- `metrics` dict shape defined once in Task 2 (`trades_count_total`, `win_rate_20_trades`, `pnl_30d`, `pnl_by_month`, `months_negative_consecutive`) — used consistently in Tasks 3, 4, 5, 7.
+- `apply_transition(symbol, new_state, reason, metrics, from_state, manual_override=None)` — Task 4 defines; Task 5 calls with 5 positional args (from_state=current) + no manual_override; `reactivate_symbol` in Task 4 calls with manual_override=1.
+- `evaluate_state(metrics, current_state, manual_override, config) -> (new_state, reason)` — Task 3 signature used in Task 5 orchestrator.
+- `trigger_health_evaluation(symbol, cfg)` — Task 6 defines; Task 6 step 4 calls from btc_api.
+- `health_monitor_loop(cfg_fn, stop_event=None)` — Task 6 defines; step 5 spawns thread with `args=(lambda: CFG,)`.
+
+All consistent.
+
+**Scope:** observer-only PR 1 of #138 series. Does not include Alert/Reduce/Pause tier actions (PRs 2-4) or weekly report (separate feature, explicitly out of scope).


### PR DESCRIPTION
## Summary

Archives three implementation plans that guided already-merged epics. Docs-only; zero code change.

| Plan file | Describes PR | State |
|---|---|---|
| `2026-04-21-notifier-core-pr-a.md` | #164 notifier core + Telegram | ✅ merged |
| `2026-04-22-kill-switch-foundation-pr1.md` | #165 kill-switch foundation | ✅ merged |
| `2026-04-22-kill-switch-alert-tier-pr2.md` | #166 kill-switch ALERT tier | ✅ merged |

## Why

These plans were left untracked on the working tree. Committing them makes the task-by-task execution record auditable next to the commits that realized them — useful when revisiting decision history.

## Test plan

- [x] Docs-only — no code, no tests affected.
- [ ] CI still runs (expect both jobs green — backend doesn't exercise the new path; frontend-typecheck is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)