### PR TITLE
test(frontend): api client + SymbolCard — closes #34

### DIFF
--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getSymbols, getStatus } from './api';
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(impl: (url: string, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = vi.fn(impl as typeof fetch);
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('api client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('getSymbols', () => {
+    it('returns typed response with symbols array on 200', async () => {
+      const payload = {
+        total: 2,
+        symbols: [
+          { symbol: 'BTCUSDT', estado: 'ok', price: 50_000, lrc_pct: 20, score: 6, señal: true, gatillo: true, ts: '2026-04-22T12:00:00Z' },
+          { symbol: 'ETHUSDT', estado: 'ok', price: 3_000, lrc_pct: 30, score: 4, señal: false, gatillo: true, ts: '2026-04-22T12:00:00Z' },
+        ],
+      };
+      mockFetch(async () => jsonResponse(payload));
+
+      const resp = await getSymbols();
+
+      expect(resp.total).toBe(2);
+      expect(resp.symbols).toHaveLength(2);
+      expect(resp.symbols[0].symbol).toBe('BTCUSDT');
+      expect(resp.symbols[1].score).toBe(4);
+    });
+
+    it('hits /api/symbols', async () => {
+      const spy = vi.fn<typeof fetch>(async () => jsonResponse({ total: 0, symbols: [] }));
+      globalThis.fetch = spy;
+
+      await getSymbols();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(String(spy.mock.calls[0][0])).toBe('/api/symbols');
+    });
+  });
+
+  describe('request error handling', () => {
+    it('throws when fetch rejects (network error)', async () => {
+      mockFetch(async () => { throw new TypeError('Failed to fetch'); });
+
+      await expect(getStatus()).rejects.toThrow(/Failed to fetch/);
+    });
+
+    it('throws on non-2xx response with status and body text', async () => {
+      mockFetch(async () => new Response('internal server error', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      }));
+
+      await expect(getStatus()).rejects.toThrow(/API error 500: internal server error/);
+    });
+
+    it('throws on 404 with response body in message', async () => {
+      mockFetch(async () => new Response('not found', { status: 404 }));
+
+      await expect(getStatus()).rejects.toThrow(/API error 404: not found/);
+    });
+  });
+});

--- a/frontend/src/components/SymbolCard.test.tsx
+++ b/frontend/src/components/SymbolCard.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SymbolCard from './SymbolCard';
+import type { SymbolStatus } from '../types';
+
+function makeSymbol(overrides: Partial<SymbolStatus> = {}): SymbolStatus {
+  return {
+    symbol: 'BTCUSDT',
+    estado: 'ok',
+    price: 50_000,
+    lrc_pct: 20,
+    score: 6,
+    señal: false,
+    gatillo: true,
+    ts: '2026-04-22T12:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SymbolCard', () => {
+  it('renders the base/quote symbol split', () => {
+    render(<SymbolCard symbol={makeSymbol()} />);
+    expect(screen.getByText('BTC')).toBeInTheDocument();
+    expect(screen.getByText('/USDT')).toBeInTheDocument();
+  });
+
+  it('renders numeric score and LRC%', () => {
+    render(<SymbolCard symbol={makeSymbol({ score: 7, lrc_pct: 15 })} />);
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('15.0%')).toBeInTheDocument();
+  });
+
+  it('shows LONG badge when señal is true and direction is LONG', () => {
+    render(<SymbolCard symbol={makeSymbol({ señal: true, direction: 'LONG' })} />);
+    expect(screen.getByText('LONG')).toBeInTheDocument();
+  });
+
+  it('shows SHORT badge when señal is true and direction is SHORT', () => {
+    render(<SymbolCard symbol={makeSymbol({ señal: true, direction: 'SHORT' })} />);
+    expect(screen.getByText('SHORT')).toBeInTheDocument();
+  });
+
+  it('shows SETUP badge when not a signal but gatillo is true', () => {
+    render(<SymbolCard symbol={makeSymbol({ señal: false, gatillo: true })} />);
+    expect(screen.getByText('SETUP')).toBeInTheDocument();
+  });
+
+  it('shows em-dash placeholders for null price/score/lrc', () => {
+    render(<SymbolCard symbol={makeSymbol({ price: null, score: null, lrc_pct: null })} />);
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('invokes onClick when the card is clicked', () => {
+    const onClick = vi.fn();
+    render(<SymbolCard symbol={makeSymbol()} onClick={onClick} />);
+    fireEvent.click(screen.getByTitle('Ver gráfico'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the remaining scope of #34 with the two test files the issue originally prioritized. Builds on the Vitest infra landed in #177.

## Ships

- **`src/api.test.ts`**: `getSymbols` happy path (typed return + URL assertion) plus the fetch wrapper's error handling — network error (fetch rejects) and non-2xx response (status + body text in thrown message).
- **`src/components/SymbolCard.test.tsx`**: 7 tests covering base/quote symbol split, score + LRC% rendering, LONG/SHORT/SETUP badge selection, em-dash placeholders for null fields, and the onClick handler firing.

## Verification

- `npm test` → 17/17 passing (5 NotificationToast + 5 api + 7 SymbolCard)
- `npx tsc --noEmit` → clean

Closes #34, closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)