### PR TITLE
refactor(notifier): drop dead max_retries kwarg + migrate tests — closes #174, #175

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -1186,10 +1186,13 @@ _TELEGRAM_API = "https://api.telegram.org/bot{token}/sendMessage"
 # transition. Once all callers patch notifier.notify instead, delete this function.
 # trading_webhook.py and legacy paths that consume 'telegram_message' payload key are
 # unaffected — they use build_telegram_message() which is unchanged.
-def push_telegram_direct(rep: dict, cfg: dict, max_retries: int = 3):
+def push_telegram_direct(rep: dict, cfg: dict):
     """Envía señal directo a Telegram con retry y backoff exponencial.
 
     DEPRECATED (#162): delegates to notifier.notify(SignalEvent(...)).
+    Retry count is controlled by TelegramChannel (default 3). The previous
+    `max_retries` kwarg on this shim was dead — it was never forwarded to
+    notify() and no caller passed a non-default value. Dropped in #175.
     """
     # Kill switch #138 PR 2: stamp symbol health state so ALERT symbols get
     # a warning prefix in the Telegram message.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -638,7 +638,7 @@ class TestExecuteScanForSymbol:
             "confirmations": {},
         }
         monkeypatch.setattr(btc_api, "scan", lambda sym: fake_report)
-        monkeypatch.setattr(btc_api, "push_telegram_direct", lambda r, c: None)
+        monkeypatch.setattr(btc_api, "notify", lambda event, cfg: [])
 
         cfg = btc_api.load_config()
         result = btc_api.execute_scan_for_symbol("BTCUSDT", cfg)
@@ -655,7 +655,7 @@ class TestExecuteScanForSymbol:
             "macro_4h": {}, "lrc_1h": {}, "sizing_1h": {}, "confirmations": {},
         }
         monkeypatch.setattr(btc_api, "scan", lambda sym: fake_report)
-        monkeypatch.setattr(btc_api, "push_telegram_direct", lambda r, c: None)
+        monkeypatch.setattr(btc_api, "notify", lambda event, cfg: [])
 
         cfg = btc_api.load_config()
         btc_api.execute_scan_for_symbol("ETHUSDT", cfg)
@@ -673,7 +673,7 @@ class TestExecuteScanForSymbol:
             "macro_4h": {}, "lrc_1h": {}, "sizing_1h": {}, "confirmations": {},
         }
         monkeypatch.setattr(btc_api, "scan", lambda sym: fake_report)
-        monkeypatch.setattr(btc_api, "push_telegram_direct", lambda r, c: None)
+        monkeypatch.setattr(btc_api, "notify", lambda event, cfg: [])
         initial_count = btc_api._scanner_state["scans_total"]
 
         cfg = btc_api.load_config()
@@ -694,8 +694,8 @@ class TestExecuteScanForSymbol:
             "confirmations": {},
         }
         monkeypatch.setattr(btc_api, "scan", lambda sym: fake_report)
-        monkeypatch.setattr(btc_api, "push_telegram_direct",
-                            lambda r, c: notified.append(r["symbol"]))
+        monkeypatch.setattr(btc_api, "notify",
+                            lambda event, cfg: notified.append(event.symbol) or [])
 
         cfg = btc_api.load_config()
         cfg["signal_filters"]["min_score"] = 4
@@ -714,8 +714,8 @@ class TestExecuteScanForSymbol:
             "confirmations": {},
         }
         monkeypatch.setattr(btc_api, "scan", lambda sym: fake_report)
-        monkeypatch.setattr(btc_api, "push_telegram_direct",
-                            lambda r, c: notified.append(True))
+        monkeypatch.setattr(btc_api, "notify",
+                            lambda event, cfg: notified.append(True) or [])
 
         cfg = btc_api.load_config()
         cfg["signal_filters"]["min_score"] = 4
@@ -745,7 +745,7 @@ class TestExecuteScanForSymbol:
             "macro_4h": {}, "lrc_1h": {}, "sizing_1h": {}, "confirmations": {},
         }
         monkeypatch.setattr(btc_api, "scan", lambda sym: fake_report)
-        monkeypatch.setattr(btc_api, "push_telegram_direct", lambda r, c: None)
+        monkeypatch.setattr(btc_api, "notify", lambda event, cfg: [])
 
         initial = btc_api._scanner_state["signals_total"]
         cfg = btc_api.load_config()


### PR DESCRIPTION
## Summary

Two related cleanups on the `push_telegram_direct` shim introduced by the #162 notifier refactor. Single PR because both touch the same lines.

### #175 — drop the dead `max_retries` kwarg

`push_telegram_direct(rep, cfg, max_retries=3)` was defined with a `max_retries` parameter that:
- was never forwarded to `notify()`,
- was never forwarded to `TelegramChannel.send()` (which has its own default of 3),
- was never passed a non-default value by any caller anywhere in the repo.

Dead kwarg. Signature dropped to `push_telegram_direct(rep, cfg)`. Retry behavior remains identical — `TelegramChannel` keeps its default `max_retries=3`.

### #174 — migrate `test_api.py` patches to target `notifier.notify`

Six tests in `test_api.py` patched `btc_api.push_telegram_direct` (the shim) to no-op notifications during `execute_scan_for_symbol` exercises. Migrated to patch `btc_api.notify` (the real collaborator) so the tests:
- survive an eventual shim deletion,
- actually exercise the new code path.

Left `tests/test_health_shim_integration.py` untouched — those tests validate the shim itself (health-state stamping), so the shim IS the system under test there.

## Test plan

- [x] `python -m pytest tests/ -q -m "not network"` → **607 passed**, 0 failed (unchanged baseline).
- [x] Signature change doesn't break any call site — only production caller is `btc_api.py:1352` which passes `(rep, cfg)` without max_retries.

## References

- PR #164 body — original shim deprecation banner + PR C promise to migrate the tests.
- PR #166 body — the `max_retries` parameter drop was flagged out-of-scope there.

Closes #174, closes #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)