### PR TITLE
fix(config): split defaults (committed) from secrets (gitignored) — unblock backtests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@
 # ══════════════════════════════════════════════════════════════
 
 # ── Configuración sensible ────────────────────────────────────
-# Contiene bot token de Telegram y chat_id — NUNCA commitear
+# Contiene bot token de Telegram, chat_id, webhook_url — NUNCA commitear
 config.json
+config.secrets.json
 
 # ── Datos de backtesting (descargados de Binance) ────────────
 data/backtest/

--- a/auto_tune.py
+++ b/auto_tune.py
@@ -125,12 +125,11 @@ def should_recommend(current_pnl: float, proposed_pnl: float, total_trades: int,
 
 
 def load_config() -> dict:
-    """Read config.json from SCRIPT_DIR. Return {} if not found."""
-    config_path = os.path.join(SCRIPT_DIR, "config.json")
-    if not os.path.exists(config_path):
-        return {}
-    with open(config_path, "r", encoding="utf-8") as f:
-        return json.load(f)
+    """Delegate to btc_api.load_config() so we pick up config.defaults.json
+    (symbol_overrides) + config.secrets.json + legacy config.json layering.
+    """
+    import btc_api
+    return btc_api.load_config()
 
 
 def get_current_params(symbol: str, config: dict) -> dict:

--- a/btc_api.py
+++ b/btc_api.py
@@ -132,7 +132,9 @@ def check_pending_signal_outcomes(current_prices: dict[str, float]):
 
 #  CONFIGURACIÓN
 # ─────────────────────────────────────────────────────────────────────────────
-CONFIG_FILE       = os.path.join(SCRIPT_DIR, "config.json")
+CONFIG_FILE       = os.path.join(SCRIPT_DIR, "config.json")           # legacy, secret + overrides (Simon prod)
+DEFAULTS_FILE     = os.path.join(SCRIPT_DIR, "config.defaults.json")  # committed, symbol_overrides + non-secret defaults
+SECRETS_FILE      = os.path.join(SCRIPT_DIR, "config.secrets.json")   # gitignored, telegram/webhook creds only
 DB_FILE           = os.path.join(SCRIPT_DIR, "signals.db")
 DATA_DIR          = os.path.join(SCRIPT_DIR, "data")
 LOGS_DIR          = os.path.join(SCRIPT_DIR, "logs")
@@ -159,47 +161,73 @@ logging.basicConfig(
 log = logging.getLogger("btc_api")
 
 
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursive merge: dicts merge, other types replace. Used to layer config files."""
+    result = dict(base)
+    for k, v in override.items():
+        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+            result[k] = _deep_merge(result[k], v)
+        else:
+            result[k] = v
+    return result
+
+
+def _load_json_file(path: str) -> dict:
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
 def load_config() -> dict:
-    defaults = {
-        "webhook_url":       "",
-        "webhook_secret":    "",
-        "notify_setup_only": False,
-        "scan_interval_sec": SCAN_INTERVAL_SEC,
-        "num_symbols":       20,
-        "telegram_chat_id":  "",   # chat_id de Telegram donde llegan las alertas
-        "telegram_bot_token": "",  # token del bot (envío directo, sin n8n)
+    """Load configuration as a layered merge.
+
+    Precedence (lowest → highest, later wins):
+      1. Hardcoded safety net (this function)
+      2. config.defaults.json (committed — symbol_overrides + tuned defaults)
+      3. config.secrets.json (gitignored — telegram/webhook creds)
+      4. config.json (legacy single-file; backward-compat for Simon prod)
+      5. TRADING_* environment variables
+    """
+    # 1. Hardcoded safety net — used if defaults file is missing. Keeps the system
+    # functional but WITHOUT symbol_overrides, which means backtests and the scanner
+    # fall back to generic ATR multipliers. This is the state the repo was in when
+    # config.json had always been gitignored — see drawer "config-json-gitignored-elephant".
+    hardcoded = {
+        "webhook_url":        "",
+        "webhook_secret":     "",
+        "notify_setup_only":  False,
+        "scan_interval_sec":  SCAN_INTERVAL_SEC,
+        "num_symbols":        10,
+        "telegram_chat_id":   "",
+        "telegram_bot_token": "",
         "signal_filters": {
-            "min_score":       0,      # score mínimo para enviar (0 = sin filtro)
-            "require_macro_ok": False, # exigir macro 4H alcista
-            "notify_setup":    False,  # enviar también setups sin gatillo
-            "dedup_window_minutes": 30, # ventana de deduplicación (minutos)
+            "min_score":            0,
+            "require_macro_ok":     False,
+            "notify_setup":         False,
+            "dedup_window_minutes": 30,
         },
         "kill_switch": {
-            "enabled": True,
-            "min_trades_for_eval": 20,
-            "alert_win_rate_threshold": 0.15,
-            "reduce_pnl_window_days": 30,
-            "reduce_size_factor": 0.5,
-            "pause_months_consecutive": 3,
-            "auto_recovery_enabled": True,
+            "enabled":                   True,
+            "min_trades_for_eval":       20,
+            "alert_win_rate_threshold":  0.15,
+            "reduce_pnl_window_days":    30,
+            "reduce_size_factor":        0.5,
+            "pause_months_consecutive":  3,
+            "auto_recovery_enabled":     True,
         },
     }
-    if os.path.exists(CONFIG_FILE):
-        with open(CONFIG_FILE, encoding="utf-8") as f:
-            stored = json.load(f)
-        # merge signal_filters en lugar de reemplazarlo
-        sf_defaults = defaults["signal_filters"].copy()
-        ks_defaults = defaults["kill_switch"].copy()
-        defaults.update(stored)
-        if "signal_filters" in stored:
-            sf_defaults.update(stored["signal_filters"])
-        defaults["signal_filters"] = sf_defaults
-        if "kill_switch" in stored:
-            ks_defaults.update(stored["kill_switch"])
-        defaults["kill_switch"] = ks_defaults
 
-    # ENV var overrides (for Docker/container deployments)
-    cfg = defaults
+    cfg = hardcoded
+    if os.path.exists(DEFAULTS_FILE):
+        cfg = _deep_merge(cfg, _load_json_file(DEFAULTS_FILE))
+    else:
+        log.warning("config.defaults.json missing — backtests will run without symbol_overrides")
+    if os.path.exists(SECRETS_FILE):
+        cfg = _deep_merge(cfg, _load_json_file(SECRETS_FILE))
+    if os.path.exists(CONFIG_FILE):
+        cfg = _deep_merge(cfg, _load_json_file(CONFIG_FILE))
+
     _env_map = {
         "TRADING_WEBHOOK_URL":       "webhook_url",
         "TRADING_TELEGRAM_CHAT_ID":  "telegram_chat_id",

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -1,0 +1,32 @@
+{
+  "scan_interval_sec": 300,
+  "num_symbols": 10,
+  "notify_setup_only": false,
+  "signal_filters": {
+    "min_score": 4,
+    "require_macro_ok": false,
+    "notify_setup": false,
+    "dedup_window_minutes": 30
+  },
+  "kill_switch": {
+    "enabled": true,
+    "min_trades_for_eval": 20,
+    "alert_win_rate_threshold": 0.15,
+    "reduce_pnl_window_days": 30,
+    "reduce_size_factor": 0.5,
+    "pause_months_consecutive": 3,
+    "auto_recovery_enabled": true
+  },
+  "symbol_overrides": {
+    "BTCUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5 },
+    "ETHUSDT":    { "atr_sl_mult": 1.2, "atr_tp_mult": 4.0, "atr_be_mult": 1.5 },
+    "ADAUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5 },
+    "AVAXUSDT":   { "atr_sl_mult": 1.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5 },
+    "DOGEUSDT":   { "atr_sl_mult": 0.7, "atr_tp_mult": 4.0, "atr_be_mult": 1.5 },
+    "UNIUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 3.0, "atr_be_mult": 1.5 },
+    "XLMUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5 },
+    "PENDLEUSDT": { "atr_sl_mult": 0.5, "atr_tp_mult": 3.0, "atr_be_mult": 2.0 },
+    "JUPUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 2.5 },
+    "RUNEUSDT":   { "atr_sl_mult": 0.7, "atr_tp_mult": 6.0, "atr_be_mult": 2.5 }
+  }
+}

--- a/scripts/gate_regime_modes.py
+++ b/scripts/gate_regime_modes.py
@@ -117,13 +117,25 @@ def rank_winners(passing_contenders: dict) -> str | None:
 
 
 def run_portfolio(config_path: str, start, end, symbols, regime_mode: str, df1d_btc):
-    """Run portfolio backtest with regime_mode. Returns aggregate dict."""
+    """Run portfolio backtest with regime_mode. Returns aggregate dict.
+
+    Config loading uses btc_api.load_config() so the layered defaults +
+    secrets + legacy config.json precedence applies. The `config_path`
+    argument is kept for CLI back-compat but not used directly.
+    """
     import backtest
+    import btc_api
     from backtest import get_cached_data, simulate_strategy, calculate_metrics
 
     data_start = datetime(start.year - 1, 1, 1, tzinfo=timezone.utc)
-    cfg = json.loads(Path(config_path).read_text()) if Path(config_path).exists() else {}
+    cfg = btc_api.load_config()
     overrides = cfg.get("symbol_overrides", {})
+    if not overrides:
+        raise RuntimeError(
+            "No symbol_overrides loaded. Check config.defaults.json exists and "
+            "contains the tuned per-symbol ATR multipliers. Running the gate "
+            "without overrides produces ~40% of the documented alpha."
+        )
 
     df_fng = backtest.get_historical_fear_greed()
     df_funding = backtest.get_historical_funding_rate()


### PR DESCRIPTION
## TL;DR

`config.json` being 100% gitignored meant every fresh repo checkout ran backtests and hunger-games with `overrides={}`. That's ~40% of the documented FORMULA GANADORA alpha ($+68k/4yr instead of $+168k/4yr). All hunger-games verdicts in this repo on 2026-04-21 and 2026-04-22 were taken on a crippled pipeline. This PR fixes the pipeline.

## The bug

`scripts/gate_regime_modes.py:125`:

```python
cfg = json.loads(Path(config_path).read_text()) if Path(config_path).exists() else {}
overrides = cfg.get("symbol_overrides", {})
```

Silent fallback to empty dict → generic ATR multipliers (1.0/2.0/1.0) instead of the per-symbol tuned values (PENDLE 0.5/3.0/2.0, DOGE 0.7/4.0/1.5, ADA 0.5/4.0/1.5, RUNE 0.7/6.0/2.5, etc.) from 735+ simulations.

`config.json` has been on line 7 of `.gitignore` since it contained `telegram_bot_token`. The non-secret tuning lived in the same file, so it was gitignored too.

## The fix

Layered config with clear ownership:

| File | State | Holds |
|---|---|---|
| `config.defaults.json` | **committed (new)** | symbol_overrides + tuned non-secret defaults |
| `config.secrets.json` | gitignored (new) | telegram_bot_token, telegram_chat_id, webhook_url |
| `config.json` | gitignored (legacy) | backward-compat for Simon's production |

`load_config()` in `btc_api.py` merges in order: hardcoded < defaults.json < secrets.json < legacy config.json < TRADING_* env vars. Deep-merge so nested blocks (signal_filters, kill_switch) merge correctly.

Canonical `symbol_overrides` extracted from:
- `docs/superpowers/specs/es/2026-04-17-formula-ganadora-resultados-finales.md` (BTC/ETH/ADA/AVAX/DOGE/UNI/XLM)
- `data/backtest/new_tokens_optimized.json` (PENDLE/JUP/RUNE)

`scripts/gate_regime_modes.py` and `auto_tune.py` migrated to call `btc_api.load_config()`. The gate now **raises RuntimeError** if `symbol_overrides` is empty, so we never silently run with a crippled pipeline again.

## Intentionally NOT migrated

- `btc_scanner._load_proxy()` and `scan()` still read `config.json` directly — production scanner has a local config.json (not affected by repo gitignore). Tests for these use tmp_path + `scanner.SCRIPT_DIR` monkeypatching that would be hostile to convert.
- `trading_webhook.py` same reason.

The targeted victim is backtest/tuning scripts, where the gitignore actually bites. Production behavior unchanged.

## Verification

- Full suite: **607 passed, 0 failed** (unchanged baseline).
- `python -c "import btc_api; print(len(btc_api.load_config()['symbol_overrides']))"` → `10`.
- Hunger-games re-run with valid config in progress as of this PR opening; report will be posted separately once the verdict lands.

## Follow-ups expected

1. A separate PR after the hunger-games re-run completes — either a `regime_mode=<winner>` config change or a closure comment on #173 depending on the real verdict.
2. Migration of `grid_search_tf.py` and `scripts/apply_tune_to_config.py` to `load_config()` — independent of the blocker this PR resolves; tracked as follow-up issue if not done here.
3. Documentation of the config.defaults / config.secrets pattern in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)