### PR TITLE
feat(kill-switch): tighten v1 thresholds — closes #201

### DIFF
--- a/config.defaults.json
+++ b/config.defaults.json
@@ -11,11 +11,11 @@
   },
   "kill_switch": {
     "enabled": true,
-    "min_trades_for_eval": 20,
-    "alert_win_rate_threshold": 0.15,
-    "reduce_pnl_window_days": 30,
+    "min_trades_for_eval": 10,
+    "alert_win_rate_threshold": 0.30,
+    "reduce_pnl_window_days": 14,
     "reduce_size_factor": 0.5,
-    "pause_months_consecutive": 3,
+    "pause_months_consecutive": 2,
     "auto_recovery_enabled": true
   },
   "symbol_overrides": {

--- a/tests/test_health_persistence.py
+++ b/tests/test_health_persistence.py
@@ -76,7 +76,8 @@ def test_kill_switch_config_partial_override_preserves_defaults(tmp_path, monkey
                       "reduce_pnl_window_days", "reduce_size_factor",
                       "pause_months_consecutive", "auto_recovery_enabled"):
         assert required in ks, f"deep-merge dropped kill_switch.{required}"
-    assert ks["min_trades_for_eval"] == 20  # default preserved
+    # default preserved — value sourced from config.defaults.json (canonical)
+    assert ks["min_trades_for_eval"] == 10
 
 
 from datetime import datetime, timezone


### PR DESCRIPTION
## Summary

Apretar los thresholds del kill switch v1 (config-only change) como **mitigación puente** mientras epic #187 (kill switch v2 smart/predictive) se construye.

## Change

`config.defaults.json` → `kill_switch`:

| Key | Antes | Ahora | Efecto |
|---|---|---|---|
| `min_trades_for_eval` | 20 | **10** | Evalúa al doble de velocidad |
| `alert_win_rate_threshold` | 0.15 | **0.30** | ALERT con WR < 30% (era 15%) |
| `reduce_pnl_window_days` | 30 | **14** | REDUCED si pnl 14d < 0 |
| `pause_months_consecutive` | 3 | **2** | PAUSED tras 2 meses negativos |

## Por qué

Con los thresholds actuales, ETH llegó a -55.8% individual en el backtest antes de que el switch lo pausara. Para el target de negocio de DD agregado ≤10%, los thresholds son demasiado permisivos. Este tighten corrige la exposición inmediata sin esperar el trabajo grande (refactor #186 + features v2 #187).

## Trade-off

- **Más Telegrams de ALERT** (algunos falsos positivos en correcciones normales).
- **Menos tolerancia a rachas perdedoras cortas** (corrección de 1-2 semanas puede disparar REDUCED temporal).
- Aceptable porque el beneficio (corte temprano de símbolos problemáticos) supera el costo (ruido operativo manejable).

## No cambios estructurales

No implementa features nuevas. No toca el scanner ni el backtest. Solo ajusta 4 números en el config canónico. Reversible con otro PR de 4 números.

## Test plan

- [x] `python -m pytest tests/ -q -m "not network"` → **607 passed** (baseline unchanged, con 1 assert actualizado por el cambio de valor canónico).
- [x] `python -c "import btc_api; print(btc_api.load_config()['kill_switch'])"` → nuevos valores confirmados.
- [ ] Monitor 2 semanas post-merge: cuántos ALERT dispara, qué símbolos entran en REDUCED, si PAUSED se activa.

## Relación con epics

- **Cierra #201** (tracked as a sub-issue of epic #187, bridge-category).
- No bloquea ni depende de #186 (refactor) ni #187 (v2 features). Puede convivir con cualquier orden de ejecución de esos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)