### PR TITLE
feat(observability): kill switch decision log + MVP dashboard (#187 phase 1)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -2148,6 +2148,25 @@ def post_notifications_read_all():
     return {"ok": True, "marked": n}
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+#  KILL SWITCH OBSERVABILITY ENDPOINTS (#187 phase 1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@app.get("/kill_switch/decisions", dependencies=[Depends(verify_api_key)])
+def get_kill_switch_decisions(
+    symbol: Optional[str] = None,
+    engine: Optional[str] = None,
+    since: Optional[str] = None,
+    limit: int = Query(50, ge=1, le=200),
+):
+    """Kill switch decision log (#187 phase 1). Filter by symbol/engine/since ts."""
+    import observability
+    rows = observability.query_decisions(
+        symbol=symbol, engine=engine, since=since, limit=limit,
+    )
+    return {"decisions": rows}
+
+
 @app.post("/health/reactivate/{symbol}", dependencies=[Depends(verify_api_key)])
 def post_health_reactivate(symbol: str, body: ReactivateRequest):
     """Manually reset a symbol to NORMAL with manual_override=1."""

--- a/btc_api.py
+++ b/btc_api.py
@@ -2167,6 +2167,13 @@ def get_kill_switch_decisions(
     return {"decisions": rows}
 
 
+@app.get("/kill_switch/current_state", dependencies=[Depends(verify_api_key)])
+def get_kill_switch_current_state(engine: str = "v1"):
+    """Current tier state per symbol + portfolio aggregate (#187 phase 1)."""
+    import observability
+    return observability.get_current_state(engine=engine)
+
+
 @app.post("/health/reactivate/{symbol}", dependencies=[Depends(verify_api_key)])
 def post_health_reactivate(symbol: str, body: ReactivateRequest):
     """Manually reset a symbol to NORMAL with manual_override=1."""

--- a/btc_api.py
+++ b/btc_api.py
@@ -994,6 +994,30 @@ def init_db():
         CREATE INDEX IF NOT EXISTS idx_health_events_symbol
             ON symbol_health_events(symbol, ts DESC)
     """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS kill_switch_decisions (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts              TEXT NOT NULL,
+            scan_id         INTEGER,
+            symbol          TEXT NOT NULL,
+            engine          TEXT NOT NULL,
+            per_symbol_tier TEXT NOT NULL,
+            portfolio_tier  TEXT NOT NULL,
+            velocity_active INTEGER DEFAULT 0,
+            size_factor     REAL NOT NULL,
+            skip            INTEGER NOT NULL,
+            reasons_json    TEXT,
+            slider_value    REAL
+        )
+    """)
+    con.execute("""
+        CREATE INDEX IF NOT EXISTS idx_ks_decisions_ts
+            ON kill_switch_decisions(ts)
+    """)
+    con.execute("""
+        CREATE INDEX IF NOT EXISTS idx_ks_decisions_symbol_ts
+            ON kill_switch_decisions(symbol, ts)
+    """)
     con.commit()
     con.close()
     log.info(f"DB inicializada: {DB_FILE}")

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -1032,6 +1032,32 @@ def scan(symbol: str = None):
     except Exception as e:
         log.warning("scan: health state lookup failed for %s: %s", symbol, e)
         _health_state = "NORMAL"
+
+    # Observability (#187 phase 1): log the v1 decision so the dashboard
+    # can visualize + so future shadow mode can compare v2 vs v1 side-by-side.
+    # Fail-open: never break the scanner on observability errors.
+    try:
+        import observability
+        _v1_size_factor = {
+            "NORMAL": 1.0, "ALERT": 1.0, "REDUCED": 0.5,
+            "PAUSED": 0.0, "PROBATION": 0.5,
+        }.get(_health_state, 1.0)
+        _v1_skip = (_health_state == "PAUSED")
+        observability.record_decision(
+            symbol=symbol,
+            engine="v1",
+            per_symbol_tier=_health_state,
+            portfolio_tier="NORMAL",          # phase 1: hardcoded; B2 computes real aggregate
+            size_factor=_v1_size_factor,
+            skip=_v1_skip,
+            reasons={"health_state": _health_state},
+            scan_id=None,
+            slider_value=None,
+            velocity_active=False,
+        )
+    except Exception as _obs_err:
+        log.warning("observability.record_decision failed for %s: %s", symbol, _obs_err)
+
     if _health_state == "PAUSED":
         rep.update({
             "estado": f"🛑 {symbol} PAUSED por kill switch (#138) — reactivar manualmente",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2696,3 +2696,88 @@ button:focus-visible {
   from { transform: translateX(20px); opacity: 0; }
   to { transform: translateX(0); opacity: 1; }
 }
+
+/* KillSwitchDashboard (#187 phase 1) */
+.ks-dashboard {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ks-portfolio-card {
+  background: var(--bg-secondary, #1c1d25);
+  border: 1px solid var(--border, #2b2d38);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ks-portfolio-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary, #a8aab7);
+}
+
+.ks-portfolio-tier {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.ks-portfolio-meta {
+  font-size: 0.85rem;
+  color: var(--text-secondary, #a8aab7);
+}
+
+.ks-symbol-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.ks-symbol-card {
+  background: var(--bg-secondary, #1c1d25);
+  border: 1px solid var(--border, #2b2d38);
+  border-radius: 6px;
+  padding: 12px;
+}
+
+.ks-symbol-name {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.ks-symbol-tier {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.ks-symbol-meta {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #a8aab7);
+}
+
+.ks-symbol-ts {
+  font-size: 0.7rem;
+  color: var(--text-secondary, #a8aab7);
+  margin-top: 4px;
+}
+
+.ks-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 32px;
+  color: var(--text-secondary, #a8aab7);
+}
+
+.ks-error {
+  padding: 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 4px;
+  color: #ef4444;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,9 +15,10 @@ import ConfigPanel from './components/ConfigPanel';
 import PositionsPanel from './components/PositionsPanel';
 import TuneReportModal from './components/TuneReportModal';
 import NotificationToast from './components/NotificationToast';
+import KillSwitchDashboard from './components/KillSwitchDashboard';
 
 type FilterType = 'all' | 'signals';
-type MainTab    = 'mercado' | 'posiciones';
+type MainTab    = 'mercado' | 'posiciones' | 'kill-switch';
 
 const REFRESH_INTERVAL_MS = 30_000;
 
@@ -160,6 +161,12 @@ const App: React.FC = () => {
           >
             Posiciones
           </button>
+          <button
+            className={`main-tab${mainTab === 'kill-switch' ? ' main-tab--active' : ''}`}
+            onClick={() => setMainTab('kill-switch')}
+          >
+            Kill Switch
+          </button>
         </div>
 
         {/* ── Mercado tab ──────────────────────────────────── */}
@@ -192,6 +199,13 @@ const App: React.FC = () => {
               onOpenFromSignal={signalForPos}
               onSignalConsumed={() => setSignalForPos(null)}
             />
+          </ErrorBoundary>
+        )}
+
+        {/* ── Kill Switch tab ─────────────────────────────────── */}
+        {mainTab === 'kill-switch' && (
+          <ErrorBoundary fallbackLabel="Error en dashboard de kill switch">
+            <KillSwitchDashboard />
           </ErrorBoundary>
         )}
       </main>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -21,6 +21,9 @@ import type {
   Position,
   TuneResult,
   NotificationsResponse,
+  KillSwitchDecisionsResponse,
+  KillSwitchCurrentStateResponse,
+  KillSwitchEngine,
 } from './types';
 
 const BASE_URL = '/api';
@@ -205,4 +208,33 @@ export async function markAllNotificationsRead(): Promise<{ ok: boolean; marked:
   return request<{ ok: boolean; marked: number }>(`/notifications/read-all`, {
     method: 'POST',
   });
+}
+
+// ---- Kill switch observability (#187 phase 1) ---------------------------
+
+export async function getKillSwitchDecisions(
+  opts: {
+    symbol?: string;
+    engine?: KillSwitchEngine;
+    since?: string;
+    limit?: number;
+  } = {},
+): Promise<KillSwitchDecisionsResponse> {
+  const params = new URLSearchParams();
+  if (opts.symbol) params.set('symbol', opts.symbol);
+  if (opts.engine) params.set('engine', opts.engine);
+  if (opts.since) params.set('since', opts.since);
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  const qs = params.toString();
+  return request<KillSwitchDecisionsResponse>(
+    `/kill_switch/decisions${qs ? `?${qs}` : ''}`,
+  );
+}
+
+export async function getKillSwitchCurrentState(
+  engine: KillSwitchEngine = 'v1',
+): Promise<KillSwitchCurrentStateResponse> {
+  return request<KillSwitchCurrentStateResponse>(
+    `/kill_switch/current_state?engine=${engine}`,
+  );
 }

--- a/frontend/src/components/KillSwitchDashboard.test.tsx
+++ b/frontend/src/components/KillSwitchDashboard.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import KillSwitchDashboard from './KillSwitchDashboard';
+
+vi.mock('../api', () => ({
+  getKillSwitchCurrentState: vi.fn(),
+}));
+
+import { getKillSwitchCurrentState } from '../api';
+
+describe('KillSwitchDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows portfolio tier NORMAL when no symbols reported', async () => {
+    (getKillSwitchCurrentState as ReturnType<typeof vi.fn>).mockResolvedValue({
+      symbols: {},
+      portfolio: { tier: 'NORMAL', concurrent_failures: 0 },
+    });
+    render(<KillSwitchDashboard />);
+    await waitFor(() => {
+      expect(getKillSwitchCurrentState).toHaveBeenCalled();
+    });
+    expect(screen.getByText(/Portfolio/i)).toBeInTheDocument();
+    expect(screen.getByText('NORMAL')).toBeInTheDocument();
+  });
+
+  it('renders per-symbol tier cards for each symbol', async () => {
+    (getKillSwitchCurrentState as ReturnType<typeof vi.fn>).mockResolvedValue({
+      symbols: {
+        BTCUSDT: {
+          symbol: 'BTCUSDT', per_symbol_tier: 'NORMAL', portfolio_tier: 'NORMAL',
+          size_factor: 1.0, skip: false, velocity_active: false,
+          ts: '2026-04-23T12:00:00Z', reasons_json: '{}',
+        },
+        ETHUSDT: {
+          symbol: 'ETHUSDT', per_symbol_tier: 'ALERT', portfolio_tier: 'NORMAL',
+          size_factor: 1.0, skip: false, velocity_active: false,
+          ts: '2026-04-23T12:00:00Z', reasons_json: '{}',
+        },
+      },
+      portfolio: { tier: 'NORMAL', concurrent_failures: 1 },
+    });
+    render(<KillSwitchDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('BTCUSDT')).toBeInTheDocument();
+      expect(screen.getByText('ETHUSDT')).toBeInTheDocument();
+    });
+  });
+
+  it('shows portfolio WARNED when threshold reached', async () => {
+    (getKillSwitchCurrentState as ReturnType<typeof vi.fn>).mockResolvedValue({
+      symbols: {},
+      portfolio: { tier: 'WARNED', concurrent_failures: 3 },
+    });
+    render(<KillSwitchDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('WARNED')).toBeInTheDocument();
+    });
+  });
+
+  it('survives API failure without crashing', async () => {
+    (getKillSwitchCurrentState as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('network'),
+    );
+    const { container } = render(<KillSwitchDashboard />);
+    await waitFor(() => {
+      expect(getKillSwitchCurrentState).toHaveBeenCalled();
+    });
+    expect(container.querySelector('.ks-dashboard')).not.toBeNull();
+  });
+});

--- a/frontend/src/components/KillSwitchDashboard.tsx
+++ b/frontend/src/components/KillSwitchDashboard.tsx
@@ -1,0 +1,105 @@
+// ============================================================
+// KillSwitchDashboard.tsx — Phase 1 MVP of kill switch v2 (#187)
+// Shows per-symbol tier grid + portfolio aggregate state.
+// Polls /kill_switch/current_state every 30s.
+// ============================================================
+
+import React, { useEffect, useState } from 'react';
+import { getKillSwitchCurrentState } from '../api';
+import type {
+  KillSwitchCurrentStateResponse,
+  KillSwitchPerSymbolTier,
+  KillSwitchPortfolioTier,
+} from '../types';
+
+const POLL_INTERVAL_MS = 30_000;
+
+const TIER_COLORS_PER_SYMBOL: Record<KillSwitchPerSymbolTier, string> = {
+  NORMAL: '#22c55e',
+  ALERT: '#f59e0b',
+  REDUCED: '#fb923c',
+  PAUSED: '#ef4444',
+  PROBATION: '#a78bfa',
+};
+
+const TIER_COLORS_PORTFOLIO: Record<KillSwitchPortfolioTier, string> = {
+  NORMAL: '#22c55e',
+  WARNED: '#f59e0b',
+  REDUCED: '#fb923c',
+  FROZEN: '#ef4444',
+};
+
+const KillSwitchDashboard: React.FC = () => {
+  const [state, setState] = useState<KillSwitchCurrentStateResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const fetchState = async () => {
+      try {
+        const resp = await getKillSwitchCurrentState('v1');
+        if (!alive) return;
+        setState(resp);
+        setError(null);
+      } catch (err) {
+        if (!alive) return;
+        setError(err instanceof Error ? err.message : 'Error');
+      }
+    };
+    fetchState();
+    const id = setInterval(fetchState, POLL_INTERVAL_MS);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  const symbols = state ? Object.values(state.symbols) : [];
+  const portfolio = state?.portfolio ?? { tier: 'NORMAL' as const, concurrent_failures: 0 };
+
+  return (
+    <div className="ks-dashboard">
+      {error && (
+        <div className="ks-error">Error cargando kill switch: {error}</div>
+      )}
+
+      <div className="ks-portfolio-card">
+        <div className="ks-portfolio-label">Portfolio</div>
+        <div
+          className="ks-portfolio-tier"
+          style={{ color: TIER_COLORS_PORTFOLIO[portfolio.tier] }}
+        >
+          {portfolio.tier}
+        </div>
+        <div className="ks-portfolio-meta">
+          {portfolio.concurrent_failures} símbolo(s) en ALERT/REDUCED/PAUSED
+        </div>
+      </div>
+
+      <div className="ks-symbol-grid">
+        {symbols.map((s) => (
+          <div key={s.symbol} className="ks-symbol-card">
+            <div className="ks-symbol-name">{s.symbol}</div>
+            <div
+              className="ks-symbol-tier"
+              style={{ color: TIER_COLORS_PER_SYMBOL[s.per_symbol_tier] }}
+            >
+              {s.per_symbol_tier}
+            </div>
+            <div className="ks-symbol-meta">
+              size × {s.size_factor.toFixed(2)} · {s.skip ? 'skip' : 'operating'}
+            </div>
+            <div className="ks-symbol-ts">
+              {new Date(s.ts).toLocaleString('es-ES')}
+            </div>
+          </div>
+        ))}
+        {symbols.length === 0 && (
+          <div className="ks-empty">Sin datos aún — esperando scans.</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default KillSwitchDashboard;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -253,3 +253,51 @@ export interface Notification {
 export interface NotificationsResponse {
   notifications: Notification[];
 }
+
+// ─── Kill switch observability (#187 phase 1) ────────────────────────
+
+export type KillSwitchEngine = 'v1' | 'v2_shadow' | 'v2_live';
+export type KillSwitchPerSymbolTier =
+  | 'NORMAL' | 'ALERT' | 'REDUCED' | 'PAUSED' | 'PROBATION';
+export type KillSwitchPortfolioTier =
+  | 'NORMAL' | 'WARNED' | 'REDUCED' | 'FROZEN';
+
+export interface KillSwitchDecision {
+  id: number;
+  ts: string;
+  scan_id: number | null;
+  symbol: string;
+  engine: KillSwitchEngine;
+  per_symbol_tier: KillSwitchPerSymbolTier;
+  portfolio_tier: KillSwitchPortfolioTier;
+  velocity_active: boolean;
+  size_factor: number;
+  skip: boolean;
+  reasons_json: string;
+  slider_value: number | null;
+}
+
+export interface KillSwitchDecisionsResponse {
+  decisions: KillSwitchDecision[];
+}
+
+export interface KillSwitchSymbolState {
+  symbol: string;
+  per_symbol_tier: KillSwitchPerSymbolTier;
+  portfolio_tier: KillSwitchPortfolioTier;
+  size_factor: number;
+  skip: boolean;
+  velocity_active: boolean;
+  ts: string;
+  reasons_json: string;
+}
+
+export interface KillSwitchPortfolioState {
+  tier: KillSwitchPortfolioTier;
+  concurrent_failures: number;
+}
+
+export interface KillSwitchCurrentStateResponse {
+  symbols: { [symbol: string]: KillSwitchSymbolState };
+  portfolio: KillSwitchPortfolioState;
+}

--- a/observability.py
+++ b/observability.py
@@ -37,19 +37,22 @@ def record_decision(
 ) -> int:
     """Insert a decision row. Returns the row id."""
     conn = _conn()
-    cur = conn.execute(
-        """INSERT INTO kill_switch_decisions
-           (ts, scan_id, symbol, engine, per_symbol_tier, portfolio_tier,
-            velocity_active, size_factor, skip, reasons_json, slider_value)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (
-            _now_iso(), scan_id, symbol, engine, per_symbol_tier, portfolio_tier,
-            int(velocity_active), size_factor, int(skip),
-            json.dumps(reasons, default=str), slider_value,
-        ),
-    )
-    conn.commit()
-    return cur.lastrowid
+    try:
+        cur = conn.execute(
+            """INSERT INTO kill_switch_decisions
+               (ts, scan_id, symbol, engine, per_symbol_tier, portfolio_tier,
+                velocity_active, size_factor, skip, reasons_json, slider_value)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                _now_iso(), scan_id, symbol, engine, per_symbol_tier, portfolio_tier,
+                int(velocity_active), size_factor, int(skip),
+                json.dumps(reasons, default=str), slider_value,
+            ),
+        )
+        conn.commit()
+        return cur.lastrowid
+    finally:
+        conn.close()
 
 
 def query_decisions(
@@ -60,34 +63,37 @@ def query_decisions(
 ) -> list[dict[str, Any]]:
     """Query decisions, newest first. Optional filters by symbol, engine, time."""
     conn = _conn()
-    where: list[str] = []
-    params: list[Any] = []
-    if symbol:
-        where.append("symbol = ?")
-        params.append(symbol)
-    if engine:
-        where.append("engine = ?")
-        params.append(engine)
-    if since:
-        where.append("ts >= ?")
-        params.append(since)
-    where_sql = f"WHERE {' AND '.join(where)}" if where else ""
+    try:
+        where: list[str] = []
+        params: list[Any] = []
+        if symbol:
+            where.append("symbol = ?")
+            params.append(symbol)
+        if engine:
+            where.append("engine = ?")
+            params.append(engine)
+        if since:
+            where.append("ts >= ?")
+            params.append(since)
+        where_sql = f"WHERE {' AND '.join(where)}" if where else ""
 
-    cols = ["id", "ts", "scan_id", "symbol", "engine", "per_symbol_tier",
-            "portfolio_tier", "velocity_active", "size_factor", "skip",
-            "reasons_json", "slider_value"]
-    rows = conn.execute(
-        f"""SELECT {', '.join(cols)} FROM kill_switch_decisions
-           {where_sql}
-           ORDER BY ts DESC
-           LIMIT ?""",
-        (*params, limit),
-    ).fetchall()
+        cols = ["id", "ts", "scan_id", "symbol", "engine", "per_symbol_tier",
+                "portfolio_tier", "velocity_active", "size_factor", "skip",
+                "reasons_json", "slider_value"]
+        rows = conn.execute(
+            f"""SELECT {', '.join(cols)} FROM kill_switch_decisions
+               {where_sql}
+               ORDER BY ts DESC, id DESC
+               LIMIT ?""",
+            (*params, limit),
+        ).fetchall()
 
-    result = []
-    for r in rows:
-        d = dict(zip(cols, r))
-        d["skip"] = bool(d["skip"])
-        d["velocity_active"] = bool(d["velocity_active"])
-        result.append(d)
-    return result
+        result = []
+        for r in rows:
+            d = dict(zip(cols, r))
+            d["skip"] = bool(d["skip"])
+            d["velocity_active"] = bool(d["velocity_active"])
+            result.append(d)
+        return result
+    finally:
+        conn.close()

--- a/observability.py
+++ b/observability.py
@@ -14,6 +14,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 
+PORTFOLIO_FAILURE_TIERS = {"ALERT", "REDUCED", "PAUSED", "PROBATION"}
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -97,3 +100,22 @@ def query_decisions(
         return result
     finally:
         conn.close()
+
+
+def compute_portfolio_aggregate(
+    per_symbol_tiers: dict[str, str],
+    concurrent_alert_threshold: int = 3,
+) -> dict[str, Any]:
+    """Compute the portfolio-level aggregate state from per-symbol tiers.
+
+    Phase 1 scope: concurrent-failure-count only. Real aggregate DD
+    computation (REDUCED/FROZEN thresholds) lands with B2 (portfolio
+    circuit breaker) in epic #187.
+
+    Returns {"tier": "NORMAL" | "WARNED", "concurrent_failures": int}.
+    """
+    failures = sum(
+        1 for t in per_symbol_tiers.values() if t in PORTFOLIO_FAILURE_TIERS
+    )
+    tier = "WARNED" if failures >= concurrent_alert_threshold else "NORMAL"
+    return {"tier": tier, "concurrent_failures": failures}

--- a/observability.py
+++ b/observability.py
@@ -119,3 +119,49 @@ def compute_portfolio_aggregate(
     )
     tier = "WARNED" if failures >= concurrent_alert_threshold else "NORMAL"
     return {"tier": tier, "concurrent_failures": failures}
+
+
+def get_current_state(
+    engine: str = "v1",
+    concurrent_alert_threshold: int = 3,
+) -> dict[str, Any]:
+    """Return current per-symbol state + portfolio aggregate.
+
+    Takes the latest decision per symbol from the log (filtered to the
+    given engine) and computes portfolio aggregate.
+    """
+    conn = _conn()
+    try:
+        rows = conn.execute(
+            """SELECT d.symbol, d.per_symbol_tier, d.portfolio_tier, d.size_factor,
+                      d.skip, d.velocity_active, d.ts, d.reasons_json
+               FROM kill_switch_decisions d
+               INNER JOIN (
+                   SELECT symbol, MAX(ts) AS max_ts
+                   FROM kill_switch_decisions
+                   WHERE engine = ?
+                   GROUP BY symbol
+               ) latest
+                 ON d.symbol = latest.symbol AND d.ts = latest.max_ts
+               WHERE d.engine = ?""",
+            (engine, engine),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    cols = ["symbol", "per_symbol_tier", "portfolio_tier", "size_factor",
+            "skip", "velocity_active", "ts", "reasons_json"]
+    symbols: dict[str, dict[str, Any]] = {}
+    per_symbol_tiers: dict[str, str] = {}
+    for r in rows:
+        d = dict(zip(cols, r))
+        d["skip"] = bool(d["skip"])
+        d["velocity_active"] = bool(d["velocity_active"])
+        symbols[d["symbol"]] = d
+        per_symbol_tiers[d["symbol"]] = d["per_symbol_tier"]
+
+    portfolio = compute_portfolio_aggregate(
+        per_symbol_tiers,
+        concurrent_alert_threshold=concurrent_alert_threshold,
+    )
+    return {"symbols": symbols, "portfolio": portfolio}

--- a/observability.py
+++ b/observability.py
@@ -1,0 +1,93 @@
+"""Observability layer for the kill switch (Phase 1 of #187).
+
+Tracks every decision taken by v1/v2 engines in the kill_switch_decisions
+table. Used by the frontend dashboard, shadow-mode validation (future
+phases), and audit trails.
+
+Append-only. Queries read by symbol/engine/time window.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _conn() -> sqlite3.Connection:
+    import btc_api
+    return btc_api.get_db()
+
+
+def record_decision(
+    symbol: str,
+    engine: str,
+    per_symbol_tier: str,
+    portfolio_tier: str,
+    size_factor: float,
+    skip: bool,
+    reasons: dict[str, Any],
+    scan_id: int | None = None,
+    slider_value: float | None = None,
+    velocity_active: bool = False,
+) -> int:
+    """Insert a decision row. Returns the row id."""
+    conn = _conn()
+    cur = conn.execute(
+        """INSERT INTO kill_switch_decisions
+           (ts, scan_id, symbol, engine, per_symbol_tier, portfolio_tier,
+            velocity_active, size_factor, skip, reasons_json, slider_value)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            _now_iso(), scan_id, symbol, engine, per_symbol_tier, portfolio_tier,
+            int(velocity_active), size_factor, int(skip),
+            json.dumps(reasons, default=str), slider_value,
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def query_decisions(
+    symbol: str | None = None,
+    engine: str | None = None,
+    since: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """Query decisions, newest first. Optional filters by symbol, engine, time."""
+    conn = _conn()
+    where: list[str] = []
+    params: list[Any] = []
+    if symbol:
+        where.append("symbol = ?")
+        params.append(symbol)
+    if engine:
+        where.append("engine = ?")
+        params.append(engine)
+    if since:
+        where.append("ts >= ?")
+        params.append(since)
+    where_sql = f"WHERE {' AND '.join(where)}" if where else ""
+
+    cols = ["id", "ts", "scan_id", "symbol", "engine", "per_symbol_tier",
+            "portfolio_tier", "velocity_active", "size_factor", "skip",
+            "reasons_json", "slider_value"]
+    rows = conn.execute(
+        f"""SELECT {', '.join(cols)} FROM kill_switch_decisions
+           {where_sql}
+           ORDER BY ts DESC
+           LIMIT ?""",
+        (*params, limit),
+    ).fetchall()
+
+    result = []
+    for r in rows:
+        d = dict(zip(cols, r))
+        d["skip"] = bool(d["skip"])
+        d["velocity_active"] = bool(d["velocity_active"])
+        result.append(d)
+    return result

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1705,3 +1705,76 @@ class TestSignalPerformance:
         assert by_score[0]["win_rate"] == 1.0
         assert by_score[1]["score"] == 4
         assert by_score[1]["win_rate"] == 0.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  TESTS — Kill Switch Observability Endpoints (#187 phase 1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestKillSwitchDecisionsEndpoint:
+    @pytest.fixture(autouse=True)
+    def setup_db(self, tmp_db, monkeypatch):
+        import btc_api
+        monkeypatch.setattr(btc_api, "DB_FILE", tmp_db)
+        btc_api.init_db()
+        yield
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        import btc_api
+        return TestClient(btc_api.app)
+
+    def test_returns_empty_when_no_decisions(self, client, tmp_db):
+        """GET /kill_switch/decisions returns [] when no decisions recorded."""
+        r = client.get("/kill_switch/decisions")
+        assert r.status_code == 200
+        assert r.json()["decisions"] == []
+
+    def test_returns_recorded_decisions(self, client, tmp_db):
+        """GET /kill_switch/decisions returns what was recorded."""
+        import observability
+        observability.record_decision(
+            symbol="BTCUSDT", engine="v1", per_symbol_tier="NORMAL",
+            portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+            reasons={"x": 1}, scan_id=None, slider_value=None,
+            velocity_active=False,
+        )
+        r = client.get("/kill_switch/decisions")
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["decisions"]) == 1
+        assert body["decisions"][0]["symbol"] == "BTCUSDT"
+        assert body["decisions"][0]["engine"] == "v1"
+
+    def test_filters_by_symbol(self, client, tmp_db):
+        import observability
+        observability.record_decision(symbol="BTCUSDT", engine="v1",
+                                      per_symbol_tier="NORMAL", portfolio_tier="NORMAL",
+                                      size_factor=1.0, skip=False, reasons={},
+                                      scan_id=None, slider_value=None, velocity_active=False)
+        observability.record_decision(symbol="ETHUSDT", engine="v1",
+                                      per_symbol_tier="ALERT", portfolio_tier="NORMAL",
+                                      size_factor=1.0, skip=False, reasons={},
+                                      scan_id=None, slider_value=None, velocity_active=False)
+        r = client.get("/kill_switch/decisions?symbol=ETHUSDT")
+        assert r.status_code == 200
+        assert len(r.json()["decisions"]) == 1
+        assert r.json()["decisions"][0]["symbol"] == "ETHUSDT"
+
+    def test_respects_limit_query(self, client, tmp_db):
+        import observability
+        for i in range(5):
+            observability.record_decision(
+                symbol=f"S{i}", engine="v1",
+                per_symbol_tier="NORMAL", portfolio_tier="NORMAL",
+                size_factor=1.0, skip=False, reasons={},
+                scan_id=None, slider_value=None, velocity_active=False,
+            )
+        r = client.get("/kill_switch/decisions?limit=2")
+        assert r.status_code == 200
+        assert len(r.json()["decisions"]) == 2
+
+    def test_rejects_limit_over_max(self, client, tmp_db):
+        r = client.get("/kill_switch/decisions?limit=500")
+        assert r.status_code == 422  # pydantic Query validation

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1778,3 +1778,39 @@ class TestKillSwitchDecisionsEndpoint:
     def test_rejects_limit_over_max(self, client, tmp_db):
         r = client.get("/kill_switch/decisions?limit=500")
         assert r.status_code == 422  # pydantic Query validation
+
+
+class TestKillSwitchCurrentStateEndpoint:
+    @pytest.fixture(autouse=True)
+    def setup_db(self, tmp_db, monkeypatch):
+        import btc_api
+        monkeypatch.setattr(btc_api, "DB_FILE", tmp_db)
+        btc_api.init_db()
+        yield
+
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+        import btc_api
+        return TestClient(btc_api.app)
+
+    def test_returns_empty_state(self, client, tmp_db):
+        r = client.get("/kill_switch/current_state")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["symbols"] == {}
+        assert body["portfolio"]["tier"] == "NORMAL"
+        assert body["portfolio"]["concurrent_failures"] == 0
+
+    def test_returns_latest_per_symbol(self, client, tmp_db):
+        import observability
+        observability.record_decision(
+            symbol="BTCUSDT", engine="v1",
+            per_symbol_tier="ALERT", portfolio_tier="NORMAL",
+            size_factor=1.0, skip=False, reasons={},
+            scan_id=None, slider_value=None, velocity_active=False,
+        )
+        r = client.get("/kill_switch/current_state")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["symbols"]["BTCUSDT"]["per_symbol_tier"] == "ALERT"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -9,8 +9,6 @@ def tmp_db(tmp_path, monkeypatch):
     import btc_api
     db_path = str(tmp_path / "signals.db")
     monkeypatch.setattr(btc_api, "DB_FILE", db_path)
-    if hasattr(btc_api, "_db_conn"):
-        delattr(btc_api, "_db_conn")
     btc_api.init_db()
     yield db_path
 
@@ -86,3 +84,22 @@ def test_query_respects_limit(tmp_db):
                         reasons={}, scan_id=None, slider_value=None, velocity_active=False)
     rows = query_decisions(limit=3)
     assert len(rows) == 3
+
+
+def test_query_filters_by_since(tmp_db):
+    from observability import record_decision, query_decisions
+    import time
+    record_decision(symbol="OLD", engine="v1", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    # Capture a cutoff between the two inserts
+    time.sleep(0.01)  # ensure different ISO timestamps
+    from datetime import datetime, timezone
+    cutoff = datetime.now(timezone.utc).isoformat()
+    time.sleep(0.01)
+    record_decision(symbol="NEW", engine="v1", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    rows = query_decisions(since=cutoff)
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "NEW"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,88 @@
+"""Tests for the kill switch decision log (Phase 1 of #187)."""
+import json
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def test_record_decision_inserts_row(tmp_db):
+    from observability import record_decision, query_decisions
+    record_decision(
+        symbol="BTCUSDT",
+        engine="v1",
+        per_symbol_tier="NORMAL",
+        portfolio_tier="NORMAL",
+        size_factor=1.0,
+        skip=False,
+        reasons={"wr_rolling_20": 0.35},
+        scan_id=None,
+        slider_value=None,
+        velocity_active=False,
+    )
+    rows = query_decisions()
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "BTCUSDT"
+    assert rows[0]["engine"] == "v1"
+    assert rows[0]["per_symbol_tier"] == "NORMAL"
+    assert rows[0]["size_factor"] == 1.0
+    assert rows[0]["skip"] is False
+    assert json.loads(rows[0]["reasons_json"]) == {"wr_rolling_20": 0.35}
+
+
+def test_query_filters_by_symbol(tmp_db):
+    from observability import record_decision, query_decisions
+    record_decision(symbol="BTCUSDT", engine="v1", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    record_decision(symbol="ETHUSDT", engine="v1", per_symbol_tier="ALERT",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    rows = query_decisions(symbol="ETHUSDT")
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "ETHUSDT"
+
+
+def test_query_filters_by_engine(tmp_db):
+    from observability import record_decision, query_decisions
+    record_decision(symbol="BTCUSDT", engine="v1", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    record_decision(symbol="BTCUSDT", engine="v2_shadow", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    rows = query_decisions(engine="v1")
+    assert len(rows) == 1
+    assert rows[0]["engine"] == "v1"
+
+
+def test_query_ordered_by_ts_desc(tmp_db):
+    from observability import record_decision, query_decisions
+    record_decision(symbol="A", engine="v1", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    record_decision(symbol="B", engine="v1", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    rows = query_decisions()
+    assert rows[0]["symbol"] == "B"
+    assert rows[1]["symbol"] == "A"
+
+
+def test_query_respects_limit(tmp_db):
+    from observability import record_decision, query_decisions
+    for i in range(5):
+        record_decision(symbol=f"SYM{i}", engine="v1", per_symbol_tier="NORMAL",
+                        portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                        reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    rows = query_decisions(limit=3)
+    assert len(rows) == 3

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -103,3 +103,37 @@ def test_query_filters_by_since(tmp_db):
     rows = query_decisions(since=cutoff)
     assert len(rows) == 1
     assert rows[0]["symbol"] == "NEW"
+
+
+def test_compute_portfolio_aggregate_all_normal():
+    from observability import compute_portfolio_aggregate
+    per_symbol_tiers = {"BTCUSDT": "NORMAL", "ETHUSDT": "NORMAL", "ADAUSDT": "NORMAL"}
+    result = compute_portfolio_aggregate(per_symbol_tiers, concurrent_alert_threshold=3)
+    assert result["tier"] == "NORMAL"
+    assert result["concurrent_failures"] == 0
+
+
+def test_compute_portfolio_aggregate_warned_at_threshold():
+    from observability import compute_portfolio_aggregate
+    per_symbol_tiers = {
+        "BTCUSDT": "ALERT", "ETHUSDT": "REDUCED",
+        "ADAUSDT": "PAUSED", "XLMUSDT": "NORMAL",
+    }
+    result = compute_portfolio_aggregate(per_symbol_tiers, concurrent_alert_threshold=3)
+    assert result["tier"] == "WARNED"
+    assert result["concurrent_failures"] == 3
+
+
+def test_compute_portfolio_aggregate_below_threshold():
+    from observability import compute_portfolio_aggregate
+    per_symbol_tiers = {"BTCUSDT": "ALERT", "ETHUSDT": "NORMAL", "ADAUSDT": "NORMAL"}
+    result = compute_portfolio_aggregate(per_symbol_tiers, concurrent_alert_threshold=3)
+    assert result["tier"] == "NORMAL"
+    assert result["concurrent_failures"] == 1
+
+
+def test_compute_portfolio_aggregate_empty_input():
+    from observability import compute_portfolio_aggregate
+    result = compute_portfolio_aggregate({}, concurrent_alert_threshold=3)
+    assert result["tier"] == "NORMAL"
+    assert result["concurrent_failures"] == 0

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -137,3 +137,47 @@ def test_compute_portfolio_aggregate_empty_input():
     result = compute_portfolio_aggregate({}, concurrent_alert_threshold=3)
     assert result["tier"] == "NORMAL"
     assert result["concurrent_failures"] == 0
+
+
+def test_get_current_state_returns_latest_per_symbol(tmp_db):
+    from observability import record_decision, get_current_state
+    # Record two decisions for the same symbol; newer should win
+    record_decision(symbol="BTCUSDT", engine="v1", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    record_decision(symbol="BTCUSDT", engine="v1", per_symbol_tier="ALERT",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    record_decision(symbol="ETHUSDT", engine="v1", per_symbol_tier="REDUCED",
+                    portfolio_tier="NORMAL", size_factor=0.5, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+
+    state = get_current_state()
+    assert state["symbols"]["BTCUSDT"]["per_symbol_tier"] == "ALERT"
+    assert state["symbols"]["ETHUSDT"]["per_symbol_tier"] == "REDUCED"
+    assert state["portfolio"]["tier"] == "NORMAL"
+    # ALERT + REDUCED = 2 concurrent failures (< default threshold of 3)
+    assert state["portfolio"]["concurrent_failures"] == 2
+
+
+def test_get_current_state_empty_db(tmp_db):
+    from observability import get_current_state
+    state = get_current_state()
+    assert state["symbols"] == {}
+    assert state["portfolio"]["tier"] == "NORMAL"
+    assert state["portfolio"]["concurrent_failures"] == 0
+
+
+def test_get_current_state_filters_by_engine(tmp_db):
+    from observability import record_decision, get_current_state
+    record_decision(symbol="BTCUSDT", engine="v1", per_symbol_tier="NORMAL",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+    record_decision(symbol="BTCUSDT", engine="v2_shadow", per_symbol_tier="ALERT",
+                    portfolio_tier="NORMAL", size_factor=1.0, skip=False,
+                    reasons={}, scan_id=None, slider_value=None, velocity_active=False)
+
+    state_v1 = get_current_state(engine="v1")
+    state_v2 = get_current_state(engine="v2_shadow")
+    assert state_v1["symbols"]["BTCUSDT"]["per_symbol_tier"] == "NORMAL"
+    assert state_v2["symbols"]["BTCUSDT"]["per_symbol_tier"] == "ALERT"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1265,3 +1265,50 @@ class TestScanRegimeModeDispatch:
         rep = scanner.scan("BTCUSDT")
         assert rep is not None
         assert isinstance(rep, dict)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  TESTS — scan() writes v1 decision to the observability log (#187 phase 1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestScanWritesToDecisionLog:
+    def test_scan_records_v1_decision(self, tmp_path, monkeypatch):
+        """scan() writes a row to kill_switch_decisions with engine='v1'."""
+        import btc_api, btc_scanner, observability
+        db_path = str(tmp_path / "signals.db")
+        monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+        if hasattr(btc_api, "_db_conn"):
+            delattr(btc_api, "_db_conn")
+        btc_api.init_db()
+
+        # Minimal DataFrame with a "close" column so scan() can read
+        # `df1h["close"].iloc[-1]` without crashing before reaching the
+        # health-state lookup + observability log write. Indicator
+        # computation downstream will blow up on a 1-row frame, but the
+        # test's try/except intentionally swallows that — we only need
+        # record_decision() to be called once.
+        tiny_df = pd.DataFrame({
+            "open": [100.0], "high": [101.0], "low": [99.0],
+            "close": [100.0], "volume": [10.0],
+            "taker_buy_base": [5.0], "taker_buy_quote": [500.0],
+        })
+        monkeypatch.setattr(btc_scanner.md, "get_klines",
+                            lambda *a, **k: tiny_df.copy())
+        # Avoid HTTP during regime detection (scan's path after PAUSED check).
+        monkeypatch.setattr(btc_scanner, "get_cached_regime",
+                            lambda: {"regime": "BULL", "score": 80.0})
+
+        try:
+            btc_scanner.scan("BTCUSDT")
+        except Exception:
+            # Scan may throw on the 1-row dataframe — fine for this test.
+            # We assert the side effect of the decision log write that
+            # happens after the health-state lookup.
+            pass
+
+        rows = observability.query_decisions(symbol="BTCUSDT")
+        assert len(rows) >= 1
+        assert rows[0]["engine"] == "v1"
+        assert rows[0]["per_symbol_tier"] in (
+            "NORMAL", "ALERT", "REDUCED", "PAUSED", "PROBATION",
+        )


### PR DESCRIPTION
## Summary

Phase 1 of the kill switch v2 (epic #187) — the observability foundation. Delivers decision log infrastructure, 2 read-only API endpoints, and an MVP frontend dashboard. Ships operational value for v1 immediately (Simon sees tier per symbol + portfolio summary in real time) and unlocks v2 shadow mode in future phases (the \`engine\` column accepts \`v1\` | \`v2_shadow\` | \`v2_live\`).

Ejecutado con subagent-driven-development sobre el plan \`docs/superpowers/plans/2026-04-23-kill-switch-v2-phase1-observability.md\`. 9 tasks, TDD estricto, cada task con spec + code quality review.

## Ships

- \`observability.py\` (new) — record_decision, query_decisions, get_current_state, compute_portfolio_aggregate. Try/finally conn.close() pattern.
- \`kill_switch_decisions\` table in signals.db (append-only, indexed on ts + (symbol, ts)).
- \`btc_scanner.scan()\` logs every v1 decision with fail-open try/except.
- \`GET /kill_switch/decisions?symbol=&engine=&since=&limit=\` — filtered + paginated log. Auth-gated.
- \`GET /kill_switch/current_state?engine=v1\` — latest per-symbol + portfolio aggregate.
- Frontend \`KillSwitchDashboard.tsx\` — polling 30s, portfolio card + per-symbol grid, tier-colored.
- \`Kill Switch\` tab en App.tsx.

## Intentionally NOT shipped (deferred)

- Real portfolio aggregate DD — lands con B2 (portfolio circuit breaker, #196).
- v2 decision engine (shadow or live) — features posteriores.
- Slider / advanced config panel — con auto-calibrator.
- \`GET /kill_switch/recommendations\` — con auto-calibrator daemon.

## Test plan

- [x] Python suite: **628 passed**, 0 failed (15 new observability + scanner + api tests added).
- [x] Frontend suite: **21 passed**, 0 failed (4 new KillSwitchDashboard tests + 17 baseline).
- [x] Frontend \`tsc --noEmit\` clean.
- [x] Frontend \`npm run build\` clean (362KB gzip 112KB JS).
- [ ] Manual smoke: cargar el tab Kill Switch, disparar \`/scan?symbol=BTCUSDT\`, confirmar row aparece en dashboard dentro de 30s.

## Commits

1. \`1b8ac62\` — observability module + DB table + record/query
2. \`61cd2c4\` — conn.close() + ordering tiebreak + since filter test (code review fixes)
3. \`e3c7762\` — compute_portfolio_aggregate
4. \`f4e4bab\` — scanner logs v1 decisions
5. \`c41f70b\` — GET /kill_switch/decisions endpoint
6. \`b84efa7\` — get_current_state + endpoint
7. \`5728050\` — frontend API client + types
8. \`91cce89\` — KillSwitchDashboard component MVP
9. \`f61174f\` — Kill Switch tab wired into App.tsx

## Addresses

Partial de #200 (B6 dashboard — MVP; dashboard con slider + recommendations llega cuando v2 features existan).

## Referencias

- Epic: #187
- Design spec: \`docs/superpowers/specs/es/2026-04-23-kill-switch-v2-design.md\` §6.1
- Plan: \`docs/superpowers/plans/2026-04-23-kill-switch-v2-phase1-observability.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)