### PR TITLE
refactor: extract trading logic to strategy/ module (#186 epic — PARTIAL)

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -245,6 +245,24 @@ def _regime_at_time(
     )
 
 
+def _ensure_tz_aware(ts) -> datetime:
+    """Return a tz-aware UTC datetime from a pandas Timestamp / datetime.
+
+    `compute_rolling_metrics_from_trades` (via `health._months_negative_consecutive`
+    and `cutoff_30d`) compares `now` to dates parsed from ISO strings — mixing
+    tz-naive and tz-aware raises. The backtest's bar_time is tz-naive (the
+    cache strips tz), so we normalize to tz-aware here.
+    """
+    if ts is None:
+        return datetime.now(timezone.utc)
+    if hasattr(ts, "tz_localize"):
+        # pandas Timestamp
+        return (ts.tz_localize("UTC") if ts.tzinfo is None else ts.tz_convert("UTC")).to_pydatetime()
+    if getattr(ts, "tzinfo", None) is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts
+
+
 def _close_position(position: dict, exit_price: float, exit_time, exit_reason: str,
                     capital: float) -> dict:
     """Compute P&L + trade dict for closing `position` at exit_price.
@@ -296,13 +314,30 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                       df1d_btc: pd.DataFrame = None,     # NEW (#152)
                       apply_kill_switch: bool = False,   # NEW (#138 PR 3)
                       kill_switch_cfg: dict | None = None,  # NEW (#138 PR 3)
+                      shared_simulator=None,             # NEW (#186 A6)
+                      cfg: dict | None = None,           # NEW (#186 A6)
                       ) -> list[dict]:
     """Run bar-by-bar simulation of the Spot V6 strategy.
 
     Kill switch (#138): disabled by default to preserve backtest reproducibility.
     Pass apply_kill_switch=True + kill_switch_cfg to simulate production behavior
     where REDUCED symbols use size_mult × reduce_size_factor.
+
+    #186 A6 — when apply_kill_switch=True, prefer `shared_simulator` (a
+    `KillSwitchSimulator` instance) for in-memory tier tracking that updates
+    bar-by-bar from the trades generated in THIS run. If no simulator is
+    passed, one is created internally. Falls back to `health.apply_reduce_factor`
+    (DB-backed, static during a backtest) only when `shared_simulator is None`
+    AND caller explicitly passes `kill_switch_cfg` without opting into the
+    simulator — legacy path preserved for callers that rely on it.
+
+    `cfg` is the merged config dict (`btc_api.load_config()` shape); used for
+    the KillSwitchSimulator bootstrap when `shared_simulator` is not supplied.
     """
+    # #186 A6: lazy imports keep backtest.py importable even when `strategy/`
+    # or `backtest_kill_switch` has its own transient import issues.
+    from backtest_kill_switch import KillSwitchSimulator
+
     trades = []
     position = None  # {entry_price, entry_time, score, sl, tp, size_mult}
     last_exit_time = None
@@ -313,6 +348,31 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
     _sl_m = atr_sl_mult if atr_sl_mult is not None else ATR_SL_MULT
     _tp_m = atr_tp_mult if atr_tp_mult is not None else ATR_TP_MULT
     _be_m = atr_be_mult if atr_be_mult is not None else ATR_BE_MULT
+
+    # ─────────────────────────────────────────────────────────────────────
+    # #186 A6 — KillSwitchSimulator wiring.
+    #
+    # When apply_kill_switch=True:
+    #   - If shared_simulator is passed, use it (lets caller share state across
+    #     multiple simulate_strategy calls — e.g., a portfolio-level driver).
+    #   - Else, auto-construct one. This replaces the static DB lookup
+    #     `health.apply_reduce_factor` used for tier detection below.
+    #
+    # When apply_kill_switch=False: no simulator is active; behavior is
+    # byte-identical to the pre-A6 version.
+    # ─────────────────────────────────────────────────────────────────────
+    _simulator: "KillSwitchSimulator | None" = None
+    if apply_kill_switch:
+        if shared_simulator is not None:
+            _simulator = shared_simulator
+        else:
+            _ks_cfg_payload: dict = {}
+            if cfg is not None:
+                _ks_cfg_payload = cfg
+            elif kill_switch_cfg is not None:
+                # kill_switch_cfg is the INNER dict; wrap for KillSwitchSimulator
+                _ks_cfg_payload = {"kill_switch": kill_switch_cfg}
+            _simulator = KillSwitchSimulator(_ks_cfg_payload)
 
     # Need at least LRC_PERIOD bars of warmup
     warmup = max(LRC_PERIOD, 100) + 10
@@ -373,6 +433,25 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                 capital += trade["pnl_usd"]
                 position = None
                 last_exit_time = bar_time
+                # #186 A6: feed the simulator so tier can evolve mid-backtest.
+                # Safe: _simulator is only non-None when apply_kill_switch=True.
+                if _simulator is not None:
+                    try:
+                        # Always produce a tz-aware ISO string — health.py's pure
+                        # metrics function compares parsed timestamps to a tz-aware
+                        # `now`, and mixing naive/aware raises TypeError inside the
+                        # loop (the except guards only ValueError/AttributeError).
+                        _bt_aware = _ensure_tz_aware(bar_time)
+                        _simulator.on_trade_close(
+                            symbol, _bt_aware.isoformat(),
+                            float(trade["pnl_usd"]),
+                            _bt_aware,
+                        )
+                    except Exception as e:  # noqa: BLE001
+                        log.warning(
+                            "simulate_strategy: simulator.on_trade_close failed for "
+                            "%s @ %s: %s", symbol, bar_time, e,
+                        )
 
         # Record equity
         equity_curve.append({"time": bar_time, "equity": capital})
@@ -499,13 +578,29 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         # Kill switch #138 PR 3: optionally halve size for REDUCED symbols.
         # Gated behind apply_kill_switch flag — defaults off in backtests
         # to preserve reproducibility; enable when simulating production.
-        if apply_kill_switch and kill_switch_cfg is not None:
+        #
+        # #186 A6: the in-memory `_simulator` replaces the DB-backed
+        # `health.apply_reduce_factor` used in PR 3. The simulator's tier
+        # evolves as the backtest generates trades, giving faithful
+        # kill-switch behavior instead of reading the static prod DB.
+        if apply_kill_switch and _simulator is not None:
             try:
-                from health import apply_reduce_factor
-                size_mult = apply_reduce_factor(size_mult, symbol,
-                                                {"kill_switch": kill_switch_cfg})
-            except Exception:
-                pass  # fail-open; trading decision proceeds at full size
+                tier = _simulator.get_tier(symbol)
+                if tier == "PAUSED":
+                    continue  # skip opening; matches compute_size → 0 semantics
+                if tier in ("REDUCED", "PROBATION"):
+                    ks_block = (
+                        (cfg or {}).get("kill_switch", {})
+                        if cfg is not None
+                        else (kill_switch_cfg or {})
+                    )
+                    factor = float(ks_block.get("reduce_size_factor", 0.5))
+                    size_mult *= factor
+            except Exception as e:  # noqa: BLE001
+                log.warning(
+                    "simulate_strategy: simulator.get_tier failed for %s: %s",
+                    symbol, e,
+                )
 
         # ── Open position ─────────────────────────────────────────────────
         if sl_mode == "atr":

--- a/backtest_kill_switch.py
+++ b/backtest_kill_switch.py
@@ -1,0 +1,73 @@
+"""In-memory kill switch simulator for backtests (#186 A6).
+
+Mimics health.py's state machine using the now-pure functions:
+    evaluate_state + compute_rolling_metrics_from_trades.
+
+This lets backtest.simulate_strategy() drive a per-symbol tier (NORMAL / ALERT
+/ REDUCED / PAUSED) without touching the production SQLite DB, so a historical
+run can replay the exact behavior the live system would have taken at each bar.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from health import compute_rolling_metrics_from_trades, evaluate_state
+
+
+@dataclass
+class SymbolState:
+    """Per-symbol simulator state: current tier + accumulated closed trades."""
+
+    tier: str = "NORMAL"
+    closed_trades: list[dict[str, Any]] = field(default_factory=list)
+
+
+class KillSwitchSimulator:
+    """Per-symbol health tier tracking, driven by the pure logic prod uses.
+
+    Usage:
+        sim = KillSwitchSimulator(cfg)
+        # ... during backtest, read tier before opening a position:
+        tier = sim.get_tier("BTCUSDT")
+        # ... after a position closes, feed the trade back in:
+        new_tier = sim.on_trade_close("BTCUSDT", exit_ts_iso, pnl_usd, now)
+
+    `cfg` is the full config dict (with a top-level `kill_switch` block). The
+    simulator passes `cfg["kill_switch"]` into `evaluate_state` — matching how
+    health.evaluate_and_record drives the production state machine.
+    """
+
+    def __init__(self, cfg: dict[str, Any]):
+        self.cfg = cfg
+        self.states: dict[str, SymbolState] = {}
+
+    def _state_for(self, symbol: str) -> SymbolState:
+        if symbol not in self.states:
+            self.states[symbol] = SymbolState()
+        return self.states[symbol]
+
+    def get_tier(self, symbol: str) -> str:
+        """Return the current tier for `symbol` (defaulting to NORMAL)."""
+        return self._state_for(symbol).tier
+
+    def on_trade_close(
+        self,
+        symbol: str,
+        exit_ts_iso: str,
+        pnl_usd: float,
+        now: datetime,
+    ) -> str:
+        """Record a closed trade, recompute metrics, transition tier if needed.
+
+        Returns the (possibly new) tier after the transition.
+        """
+        state = self._state_for(symbol)
+        state.closed_trades.append({"exit_ts": exit_ts_iso, "pnl_usd": pnl_usd})
+        metrics = compute_rolling_metrics_from_trades(state.closed_trades, now=now)
+        ks_cfg = (self.cfg or {}).get("kill_switch", {}) or {}
+        # evaluate_state signature: (metrics, current_state, manual_override, config)
+        new_tier, _reason = evaluate_state(metrics, state.tier, False, ks_cfg)
+        state.tier = new_tier
+        return new_tier

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -949,51 +949,59 @@ def scan(symbol: str = None):
     else:
         regime_data = detect_regime_for_symbol(symbol, _regime_mode)
 
-    regime = regime_data.get("regime", "BULL")
-    regime = "LONG" if regime == "BULL" else "SHORT" if regime == "BEAR" else "LONG"
+    # ── PURE DECISION KERNEL (#186 A5) ────────────────────────────────────────
+    # Delegate the indicators → direction → score → SL/TP → classification chain
+    # to strategy.core.evaluate_signal. This function is a pure mirror of the
+    # block we used to have inline; it returns a SignalDecision whose fields we
+    # map onto the legacy report shape below. Heavy I/O (data fetch, config,
+    # regime detect, observability, health-state lookup) stays in scan().
+    from strategy.core import evaluate_signal
+    from strategy.sizing import compute_size  # wired per A5 spec; not yet
+                                              # mapped onto riesgo_usd (see note below).
 
-    # ── Indicadores 1H (señal) ────────────────────────────────────────────────
-    lrc_pct, lrc_up, lrc_dn, lrc_mid = calc_lrc(df1h["close"], LRC_PERIOD, LRC_STDEV)
+    # The pure kernel consumes a `regime` dict; pass the raw detector output so
+    # evaluate_signal can read the "regime" key (BULL/BEAR/NEUTRAL).
+    decision = evaluate_signal(
+        df1h, df4h, df5, df1h,   # df1d slot: legacy scan doesn't fetch 1d,
+                                 # so pass df1h for shape-compat (unused by core).
+        symbol=symbol,
+        cfg=_cfg,
+        regime=regime_data,
+        health_state=_health_state,
+        now=datetime.now(timezone.utc),
+    )
 
-    rsi1h     = calc_rsi(df1h["close"], RSI_PERIOD)
-    cur_rsi1h = round(rsi1h.iloc[-1], 2)
+    # Legacy token: "LONG" | "SHORT" | None (distinct from the kernel's "NONE").
+    direction = None if decision.direction == "NONE" else decision.direction
 
-    bb_up1h, _, bb_dn1h = calc_bb(df1h["close"], BB_PERIOD, BB_STDEV)
+    # Pull indicators out of the decision for the report dict. These are the
+    # same values evaluate_signal just computed — no recomputation.
+    ind = decision.indicators
+    lrc_pct   = ind.get("lrc_pct")
+    lrc_up    = ind.get("lrc_upper")
+    lrc_dn    = ind.get("lrc_lower")
+    lrc_mid   = ind.get("lrc_mid")
+    cur_rsi1h = ind.get("rsi_1h")
+    bb_up1h_last = ind.get("bb_upper_1h")
+    bb_dn1h_last = ind.get("bb_lower_1h")
+    sma10_1h  = ind.get("sma10_1h")
+    sma20_1h  = ind.get("sma20_1h")
+    vol_1h    = ind.get("vol_1h")
+    vol_avg1h = ind.get("vol_avg_1h")
+    cvd_1h    = ind.get("cvd_1h")
+    cur_adx   = ind.get("adx_1h")
+    atr_val   = ind.get("atr_1h")
+    sma100_4h = ind.get("sma100_4h")
+    price_above_4h = ind.get("price_above_sma100_4h")
+    bull_div  = ind.get("bull_div_1h")
+    bear_div  = ind.get("bear_div_1h")
 
-    sma10_1h  = calc_sma(df1h["close"], 10).iloc[-1]
-    sma20_1h  = calc_sma(df1h["close"], 20).iloc[-1]
-
-    vol_avg1h = df1h["volume"].rolling(VOL_PERIOD).mean().iloc[-1]
-    vol_1h    = df1h["volume"].iloc[-1]
-
+    # Engulfings are not in the indicators dict (they're boolean conditions,
+    # not numeric indicators). Recompute here — cheap, read-only from df1h.
     bull_eng  = detect_bull_engulfing(df1h)
-    cvd_1h    = calc_cvd_delta(df1h, n=3)
-    
-    # Divergencias RSI (1H)
-    rsi_divs  = detect_rsi_divergence(df1h["close"], rsi1h, window=72)
-    bull_div  = rsi_divs["bull"]
-    bear_div  = rsi_divs["bear"]
+    bear_eng  = detect_bear_engulfing(df1h)
 
-    # ADX 1H (filtro de tendencia)
-    adx_1h    = calc_adx(df1h, 14)
-    cur_adx   = round(float(adx_1h.iloc[-1]), 2) if not pd.isna(adx_1h.iloc[-1]) else 0
-
-    # ── Indicadores 4H (macro) ────────────────────────────────────────────────
-    sma100_4h      = calc_sma(df4h["close"], 100).iloc[-1]
-    price_above_4h = bool(price > sma100_4h)
-
-    # ── Condición Primaria (1H) ───────────────────────────────────────────────
-    in_long_zone  = lrc_pct is not None and lrc_pct <= LRC_LONG_MAX
-    in_short_zone = lrc_pct is not None and lrc_pct >= LRC_SHORT_MIN
-
-    # ── Contexto macro 4H ─────────────────────────────────────────────────────
-    macro_long  = price_above_4h    # precio por encima de SMA100 en 4H
-    macro_short = not price_above_4h  # precio por debajo de SMA100 en 4H
-
-    # Bear engulfing (exclusion para SHORT)
-    bear_eng = detect_bear_engulfing(df1h)
-
-    # ── Condiciones de Exclusión (Spot V6) ────────────────────────────────────
+    # ── Condiciones de Exclusión (Spot V6) — legacy shape preserved ───────────
     excl = {
         "E1_BullEngulfing": {
             "activo": bull_eng,
@@ -1025,29 +1033,12 @@ def scan(symbol: str = None):
         },
     }
 
-    blocks_long = []
-    if bull_eng:
-        blocks_long.append("E1: BullEngulfing activo — posible micro-techo")
-    if bear_div:
-        blocks_long.append("E6: Divergencia bajista RSI (1H) — agotamiento alcista")
-
-    blocks_short = []
-    if bear_eng:
-        blocks_short.append("E1S: BearEngulfing activo — posible micro-suelo")
-    if bull_div:
-        blocks_short.append("E6S: Divergencia alcista RSI (1H) — agotamiento bajista")
-
-    # ── Determinar direccion activa (gateado por regime detector) ───────────
-    # LONG: cuando regime = BULL o NEUTRAL y precio en zona baja del canal
-    # SHORT: cuando regime = BEAR y precio en zona alta del canal
-    # Backtest full cycle 2022-2026 valido: +241% con LONG+SHORT regime-gated
-    direction = None
-    if in_long_zone and regime in ("LONG", "NEUTRAL"):
-        direction = "LONG"
-    elif in_short_zone and regime == "SHORT":
-        direction = "SHORT"
-
-    # ── Score de Confirmaciones 1H ────────────────────────────────────────────
+    # ── Score + confirmations (report-layer derivation from decision.indicators)
+    # The pure kernel exposes `decision.score` (0 when direction==NONE), but the
+    # legacy report always computed the LONG scoring block when direction was
+    # unset — callers + tests pin that shape. We reproduce it here without
+    # recomputing any indicators: the `add()` closure just reads from the
+    # already-computed `ind` dict.
     score = 0
     conf  = {}
 
@@ -1055,7 +1046,7 @@ def scan(symbol: str = None):
         nonlocal score
         pts_earned = pts if passed else 0
         score += pts_earned
-        entry = {"pass": passed, "pts": pts_earned, "max_pts": pts}
+        entry = {"pass": bool(passed), "pts": pts_earned, "max_pts": pts}
         if extra:
             entry.update(extra)
         conf[key] = entry
@@ -1068,8 +1059,8 @@ def scan(symbol: str = None):
         dist_res = abs(price - lrc_up) / price * 100 if lrc_up else 999
         add("C3_Resistencia_Cercana", 1, dist_res <= 1.5,
             {"dist_resistencia_pct": round(dist_res, 2)})
-        add("C4_BB_Superior",         1, price >= bb_up1h.iloc[-1],
-            {"bb_upper_1h": round(bb_up1h.iloc[-1], 2)})
+        add("C4_BB_Superior",         1, bb_up1h_last is not None and price >= bb_up1h_last,
+            {"bb_upper_1h": round(bb_up1h_last, 2) if bb_up1h_last is not None else None})
         add("C5_Volumen",             1, bool(vol_1h >= vol_avg1h),
             {"vol_ratio": round(vol_1h / vol_avg1h, 2)})
         add("C6_CVD_Delta_Negativo",  1, cvd_1h < 0,
@@ -1077,15 +1068,16 @@ def scan(symbol: str = None):
         add("C7_SMA10_menor_SMA20",   1, sma10_1h < sma20_1h,
             {"sma10": round(sma10_1h, 2), "sma20": round(sma20_1h, 2)})
     else:
-        # Score LONG (original)
+        # Score LONG (original — also the default when direction is None for
+        # legacy report parity).
         add("C1_RSI_Sobreventa",      2, cur_rsi1h < 40,
             {"rsi_1h": cur_rsi1h})
         add("C2_Divergencia_Alcista", 2, bull_div)
         dist_sup = abs(price - lrc_dn) / price * 100 if lrc_dn else 999
         add("C3_Soporte_Cercano",     1, dist_sup <= 1.5,
             {"dist_soporte_pct": round(dist_sup, 2)})
-        add("C4_BB_Inferior",         1, price <= bb_dn1h.iloc[-1],
-            {"bb_lower_1h": round(bb_dn1h.iloc[-1], 2)})
+        add("C4_BB_Inferior",         1, bb_dn1h_last is not None and price <= bb_dn1h_last,
+            {"bb_lower_1h": round(bb_dn1h_last, 2) if bb_dn1h_last is not None else None})
         add("C5_Volumen",             1, bool(vol_1h >= vol_avg1h),
             {"vol_ratio": round(vol_1h / vol_avg1h, 2)})
         add("C6_CVD_Delta_Positivo",  1, cvd_1h > 0,
@@ -1098,14 +1090,21 @@ def scan(symbol: str = None):
         "nota": "DXY verificar TradingView (DXY < SMA20 para LONG, > SMA20 para SHORT)",
     }
 
-    # ── Gatillo 5M ────────────────────────────────────────────────────────────
+    # ── Gatillo 5M (kept outside evaluate_signal because the report needs
+    # the detailed `trigger_details` dict, which the pure kernel does not
+    # expose — it returns only the boolean in decision.reasons). ──────────────
     if direction == "SHORT":
         trigger_active, trigger_details = check_trigger_5m_short(df5)
     else:
         trigger_active, trigger_details = check_trigger_5m(df5)
 
     # ── Sizing informativo ────────────────────────────────────────────────────
-    atr_val    = float(calc_atr(df1h, ATR_PERIOD).iloc[-1])
+    # Kept at the legacy 1% fixed formula: the existing downstream contract
+    # (tests, frontend "riesgo_usd" field, notification templates) pins this.
+    # The pure `compute_size` below layers a score-multiplier on top, which is
+    # the right model for future v2 sizing — we wire the call in (per #186 A5
+    # spec) and pass its result through the decision.reasons for observability
+    # / follow-up mapping in a separate task.
     capital    = 1000.0
     risk_usd   = capital * 0.01
     # Kill switch #138 PR 3: halve risk for REDUCED symbols.
@@ -1114,6 +1113,21 @@ def scan(symbol: str = None):
         risk_usd = apply_reduce_factor(risk_usd, symbol, _cfg)
     except Exception as e:
         log.warning("scan: reduce-factor lookup failed for %s: %s", symbol, e)
+
+    # compute_size is wired per #186 A5 but NOT mapped onto riesgo_usd to
+    # preserve the legacy report contract. Value is recorded in decision.reasons
+    # for future migration (epic #187 v2 sizing).
+    try:
+        _pure_size_usd = compute_size(
+            score=int(decision.score),
+            health_tier=_health_state,
+            capital=capital,
+            cfg=_cfg,
+        )
+        decision.reasons.setdefault("pure_size_usd", _pure_size_usd)
+    except Exception as _sz_err:
+        log.warning("scan: compute_size(score=%s, tier=%s) failed: %s",
+                    decision.score, _health_state, _sz_err)
 
     # Per-symbol ATR overrides from config (reuse _cfg loaded above)
     _sym_overrides = _cfg.get("symbol_overrides", {})
@@ -1139,6 +1153,11 @@ def scan(symbol: str = None):
     _tp_m = resolved["atr_tp_mult"]
     _be_m = resolved["atr_be_mult"]
 
+    # SL/TP: use the scan-resolved ATR multipliers (honors the legacy
+    # monkeypatchable resolve_direction_params). decision.sl_price / tp_price
+    # were computed by the pure kernel using its own resolver copy — those
+    # values agree whenever overrides aren't monkeypatched, but we recompute
+    # here to preserve the legacy branch structure under test.
     sl_dist    = atr_val * _sl_m
     tp_dist    = atr_val * _tp_m
 
@@ -1158,8 +1177,30 @@ def scan(symbol: str = None):
         qty_btc = (capital * 0.98) / price
         val_pos  = qty_btc * price
 
-    # ── Veredicto ─────────────────────────────────────────────────────────────
-    blocks = blocks_long if direction == "LONG" else blocks_short if direction == "SHORT" else []
+    # ── Veredicto (estado string + señal flag) ────────────────────────────────
+    # Reproduce the legacy branch structure:
+    #   - direction is None        → SIN SETUP
+    #   - blocks_auto present      → BLOQUEADA
+    #   - macro_4h adversa         → SETUP pero macro mala
+    #   - sin gatillo 5M           → SETUP válido, esperando gatillo
+    #   - todo OK                  → SEÑAL CONFIRMADA
+    # evaluate_signal produces a parallel estado string in decision.estado, but
+    # the legacy scan() estado format has slightly different macro phrasing —
+    # we keep the legacy template here to preserve exact-string parity.
+    blocks_long: list[str] = []
+    if bull_eng:
+        blocks_long.append("E1: BullEngulfing activo — posible micro-techo")
+    if bear_div:
+        blocks_long.append("E6: Divergencia bajista RSI (1H) — agotamiento alcista")
+    blocks_short: list[str] = []
+    if bear_eng:
+        blocks_short.append("E1S: BearEngulfing activo — posible micro-suelo")
+    if bull_div:
+        blocks_short.append("E6S: Divergencia alcista RSI (1H) — agotamiento bajista")
+
+    macro_long  = price_above_4h
+    macro_short = not price_above_4h
+    blocks   = blocks_long if direction == "LONG" else blocks_short if direction == "SHORT" else []
     macro_ok = macro_long if direction == "LONG" else macro_short if direction == "SHORT" else False
 
     if direction is None:

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -28,6 +28,9 @@ import logging
 import threading
 
 from data import market_data as md
+from strategy.indicators import (
+    calc_lrc, calc_rsi, calc_bb, calc_sma, calc_atr, calc_adx, calc_cvd_delta,
+)
 
 # Reconfigure stdout for Windows Unicode support
 try:
@@ -520,121 +523,10 @@ def _rate_limit():
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-#  INDICADORES
+#  INDICADORES — calc_lrc / calc_rsi / calc_bb / calc_sma / calc_atr / calc_adx
+#  moved to strategy/indicators.py (Epic #186 A2). Re-exported at the top of
+#  this module for backward compatibility.
 # ─────────────────────────────────────────────────────────────────────────────
-
-def calc_lrc(close: pd.Series, period=100, k=2.0):
-    """
-    Canal de Regresión Lineal.
-    Retorna: lrc_pct (0-100), upper, lower, mid
-    lrc_pct ≤ 25  →  zona LONG (cuartil inferior del canal)
-    """
-    if len(close) < period:
-        return None, None, None, None
-    y    = close.iloc[-period:].values
-    x    = np.arange(period)
-    m, b = np.polyfit(x, y, 1)
-    reg  = m * x + b
-    std  = np.std(y - reg)
-    upper = reg[-1] + k * std
-    lower = reg[-1] - k * std
-    mid   = reg[-1]
-    price = close.iloc[-1]
-    if abs(upper - lower) < 1e-10:
-        lrc_pct = 50.0
-    else:
-        lrc_pct = (price - lower) / (upper - lower) * 100
-        lrc_pct = max(0.0, min(100.0, lrc_pct))
-    return round(lrc_pct, 2), round(upper, 2), round(lower, 2), round(mid, 2)
-
-
-def calc_rsi(close: pd.Series, period=14):
-    delta    = close.diff()
-    gain     = delta.clip(lower=0)
-    loss     = (-delta).clip(lower=0)
-    avg_gain = gain.ewm(alpha=1 / period, adjust=False).mean()
-    avg_loss = loss.ewm(alpha=1 / period, adjust=False).mean()
-    rs       = avg_gain / avg_loss.replace(0, np.nan)
-    return (100 - 100 / (1 + rs)).fillna(50)
-
-
-def calc_bb(close: pd.Series, period=20, k=2.0):
-    sma = close.rolling(period).mean()
-    std = close.rolling(period).std(ddof=0)
-    return sma + k * std, sma, sma - k * std   # upper, mid, lower
-
-
-def calc_sma(close: pd.Series, period: int):
-    return close.rolling(period).mean()
-
-
-def calc_atr(df: pd.DataFrame, period=14) -> pd.Series:
-    """Average True Range — mide la volatilidad real del mercado."""
-    high = df["high"]
-    low = df["low"]
-    prev_close = df["close"].shift(1)
-    tr = pd.concat([
-        high - low,
-        (high - prev_close).abs(),
-        (low - prev_close).abs(),
-    ], axis=1).max(axis=1)
-    return tr.rolling(period).mean()
-
-
-def calc_adx(df: pd.DataFrame, period=14) -> pd.Series:
-    """
-    Average Directional Index — mide la fuerza de la tendencia (no su dirección).
-    ADX < 25  →  mercado lateral/ranging  (apto para mean-reversion)
-    ADX >= 25 →  mercado en tendencia     (evitar mean-reversion)
-
-    Pasos:
-      1. +DM / -DM desde highs/lows
-      2. Suavizar +DM, -DM y TR con EMA (periodo)
-      3. +DI = smoothed +DM / ATR * 100
-      4. -DI = smoothed -DM / ATR * 100
-      5. DX  = |+DI - -DI| / (+DI + -DI) * 100
-      6. ADX = EMA de DX (periodo)
-    """
-    high  = df["high"]
-    low   = df["low"]
-    close = df["close"]
-
-    # True Range
-    prev_close = close.shift(1)
-    tr = pd.concat([
-        high - low,
-        (high - prev_close).abs(),
-        (low  - prev_close).abs(),
-    ], axis=1).max(axis=1)
-
-    # +DM y -DM
-    up_move   = high.diff()
-    down_move = (-low).diff()   # equivale a low.shift(1) - low
-
-    plus_dm  = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
-    minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
-
-    plus_dm_s  = pd.Series(plus_dm,  index=df.index)
-    minus_dm_s = pd.Series(minus_dm, index=df.index)
-
-    # Suavizado con EMA (Wilder: alpha = 1/period)
-    alpha = 1.0 / period
-    atr_smooth    = tr.ewm(alpha=alpha, adjust=False).mean()
-    plus_dm_smooth  = plus_dm_s.ewm(alpha=alpha, adjust=False).mean()
-    minus_dm_smooth = minus_dm_s.ewm(alpha=alpha, adjust=False).mean()
-
-    # +DI y -DI
-    plus_di  = (plus_dm_smooth  / atr_smooth.replace(0, np.nan)) * 100
-    minus_di = (minus_dm_smooth / atr_smooth.replace(0, np.nan)) * 100
-
-    # DX
-    di_sum  = plus_di + minus_di
-    di_diff = (plus_di - minus_di).abs()
-    dx = (di_diff / di_sum.replace(0, np.nan)) * 100
-
-    # ADX = EMA de DX
-    adx = dx.ewm(alpha=alpha, adjust=False).mean()
-    return adx
 
 
 def detect_bull_engulfing(df: pd.DataFrame):
@@ -665,29 +557,7 @@ def detect_bear_engulfing(df: pd.DataFrame):
                and c["close"] <= p["open"])    # cierra <= open anterior
 
 
-def calc_cvd_delta(df: pd.DataFrame, n=3):
-    """Proxy CVD: volumen taker buy − sell últimas n barras.
-
-    Data layer bars carry only OHLCV (no taker-side metadata), so
-    approximate taker_buy_base from the bar's close position within
-    its high-low range, same heuristic the old bybit adapter used.
-    """
-    if "taker_buy_base" in df.columns:
-        taker_buy = df["taker_buy_base"]
-    else:
-        hl = (df["high"] - df["low"]).replace(0, 1e-9)
-        bullish = df["close"] >= df["open"]
-        taker_buy = pd.Series(
-            np.where(
-                bullish,
-                df["volume"] * (df["close"] - df["low"]) / hl,
-                df["volume"] * (df["high"] - df["close"]) / hl,
-            ),
-            index=df.index,
-        )
-    buy  = taker_buy.tail(n)
-    sell = (df["volume"] - taker_buy).tail(n)
-    return float((buy - sell).sum())
+# calc_cvd_delta moved to strategy/indicators.py (Epic #186 A2); see re-export at top.
 
 
 def detect_rsi_divergence(close: pd.Series, rsi: pd.Series, window=72):

--- a/health.py
+++ b/health.py
@@ -58,60 +58,131 @@ def _months_negative_consecutive(pnl_by_month: dict[str, float], now: datetime) 
     return streak
 
 
-def compute_rolling_metrics(symbol: str, conn, now: datetime | None = None) -> dict[str, Any]:
-    """Compute health metrics for `symbol` from the positions table.
+def compute_rolling_metrics_from_trades(
+    closed_trades: list[dict[str, Any]],
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Pure version: compute rolling metrics from a list of closed trades.
 
-    Only closed positions (`status='closed'`) are counted. `now` defaults to
-    `datetime.now(timezone.utc)` but is injectable for tests.
+    Each trade dict needs keys: `exit_ts` (ISO string), `pnl_usd` (float).
+    Extra keys are ignored.
+
+    Returns a dict with:
+      - trades_count_total (int)
+      - win_rate_20_trades (float | None) — None when no trades with exit_ts exist
+      - pnl_30d (float)
+      - pnl_by_month (dict "YYYY-MM" -> float)
+      - months_negative_consecutive (int)
+
+    Note: the DB-backed wrapper `compute_rolling_metrics` coerces None → 0.0
+    on win_rate_20_trades to preserve its historical contract.
+    """
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+
+    trades_count_total = len(closed_trades)
+
+    # Sort by exit_ts ascending for predictable slicing.
+    # Trades without exit_ts sort to the front (empty string) and get excluded
+    # from the last-20 window by the same filter the DB query applies.
+    sorted_trades = sorted(
+        closed_trades, key=lambda t: t.get("exit_ts") or ""
+    )
+
+    # Last 20 trades win rate — mirrors the DB query which restricts to
+    # rows where exit_ts IS NOT NULL.
+    trades_with_exit = [t for t in sorted_trades if t.get("exit_ts")]
+    last_20 = trades_with_exit[-20:]
+    if len(last_20) > 0:
+        # Explicit NULL/None check — avoids `(pnl or 0) > 0` silently treating
+        # breakeven (pnl=0.0) and NULL as losers via Python truthiness.
+        wins = sum(
+            1 for t in last_20
+            if t.get("pnl_usd") is not None and t["pnl_usd"] > 0
+        )
+        win_rate_20_trades: float | None = wins / len(last_20)
+    else:
+        win_rate_20_trades = None
+
+    # Last 30 days PnL
+    cutoff_30d = now - timedelta(days=30)
+    pnl_30d = 0.0
+    for t in sorted_trades:
+        exit_ts_str = t.get("exit_ts")
+        if not exit_ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(exit_ts_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        if ts >= cutoff_30d:
+            pnl_30d += float(t.get("pnl_usd") or 0)
+
+    # Monthly PnL aggregation
+    pnl_by_month: dict[str, float] = {}
+    for t in sorted_trades:
+        exit_ts_str = t.get("exit_ts")
+        if not exit_ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(exit_ts_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            continue
+        key = _month_key(ts)
+        pnl_by_month[key] = pnl_by_month.get(key, 0.0) + float(t.get("pnl_usd") or 0)
+
+    months_negative_consecutive = _months_negative_consecutive(pnl_by_month, now)
+
+    return {
+        "trades_count_total": trades_count_total,
+        "win_rate_20_trades": win_rate_20_trades,
+        "pnl_30d": pnl_30d,
+        "pnl_by_month": pnl_by_month,
+        "months_negative_consecutive": months_negative_consecutive,
+    }
+
+
+def compute_rolling_metrics(symbol: str, conn, now: datetime | None = None) -> dict[str, Any]:
+    """DB-backed wrapper around `compute_rolling_metrics_from_trades`.
+
+    Reads closed trades for `symbol` from the `positions` table and delegates
+    to the pure function. Behavior for callers is unchanged from the pre-#186
+    implementation:
+      - `trades_count_total` counts ALL closed rows (including those with NULL
+        exit_ts), matching the original `SELECT COUNT(*)`.
+      - `win_rate_20_trades` is coerced to 0.0 when there are no trades
+        (the pure function returns None in that case).
     """
     if now is None:
         now = datetime.now(timezone.utc)
 
-    cutoff_30d = (now - timedelta(days=30)).isoformat()
-
-    total = conn.execute(
+    # Original contract: trades_count_total includes rows with NULL exit_ts.
+    total_all_closed = conn.execute(
         "SELECT COUNT(*) FROM positions WHERE symbol=? AND status='closed'",
         (symbol,),
     ).fetchone()[0]
 
-    last20 = conn.execute(
-        """SELECT pnl_usd FROM positions
-           WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL
-           ORDER BY exit_ts DESC
-           LIMIT 20""",
+    # The pure function expects trades with exit_ts (it ignores None/empty).
+    cursor = conn.execute(
+        """SELECT exit_ts, pnl_usd FROM positions
+           WHERE symbol = ? AND status = 'closed'
+             AND exit_ts IS NOT NULL""",
         (symbol,),
-    ).fetchall()
-    if last20:
-        # Explicit NULL check — avoids `(pnl or 0) > 0` silently treating
-        # breakeven (pnl=0.0) and NULL as losers via Python truthiness.
-        winners = sum(1 for (pnl,) in last20 if pnl is not None and pnl > 0)
-        win_rate_20_trades = winners / len(last20)
+    )
+    closed_trades = [
+        {"exit_ts": row[0], "pnl_usd": row[1]}
+        for row in cursor.fetchall()
+    ]
+    metrics = compute_rolling_metrics_from_trades(closed_trades, now=now)
+
+    # Overwrite with the all-closed count to preserve the legacy contract.
+    metrics["trades_count_total"] = int(total_all_closed)
+    # Preserve legacy contract: empty-case win_rate is 0.0, always a float.
+    if metrics["win_rate_20_trades"] is None:
+        metrics["win_rate_20_trades"] = 0.0
     else:
-        win_rate_20_trades = 0.0
-
-    pnl_30d_row = conn.execute(
-        """SELECT COALESCE(SUM(pnl_usd), 0) FROM positions
-           WHERE symbol=? AND status='closed' AND exit_ts >= ?""",
-        (symbol, cutoff_30d),
-    ).fetchone()
-    pnl_30d = float(pnl_30d_row[0]) if pnl_30d_row else 0.0
-
-    by_month_rows = conn.execute(
-        """SELECT substr(exit_ts, 1, 7) AS ym, SUM(pnl_usd) AS pnl
-           FROM positions
-           WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL
-           GROUP BY ym""",
-        (symbol,),
-    ).fetchall()
-    pnl_by_month = {row[0]: float(row[1] or 0.0) for row in by_month_rows}
-
-    return {
-        "trades_count_total": int(total),
-        "win_rate_20_trades": float(win_rate_20_trades),
-        "pnl_30d": pnl_30d,
-        "pnl_by_month": pnl_by_month,
-        "months_negative_consecutive": _months_negative_consecutive(pnl_by_month, now),
-    }
+        metrics["win_rate_20_trades"] = float(metrics["win_rate_20_trades"])
+    return metrics
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/strategy/__init__.py
+++ b/strategy/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy module — pure trading logic shared by scanner and backtest (Epic #186)."""

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -149,6 +149,85 @@ def _regime_to_direction_token(regime_label: str | None) -> str:
     return "LONG"
 
 
+def _resolve_direction_params(
+    overrides: dict | None,
+    symbol: str,
+    direction: str,
+) -> dict | None:
+    """Resolve {atr_sl_mult, atr_tp_mult, atr_be_mult} for (symbol, direction).
+
+    Mirrors `btc_scanner.resolve_direction_params` byte-for-byte. Pulled into
+    strategy/core to keep the pure kernel self-contained. See spec §6.
+
+    Returns None if the direction is disabled for the symbol (`"short": null`).
+    """
+    defaults = {
+        "atr_sl_mult": ATR_SL_MULT_DEFAULT,
+        "atr_tp_mult": ATR_TP_MULT_DEFAULT,
+        "atr_be_mult": ATR_BE_MULT_DEFAULT,
+    }
+
+    if direction is None or direction == "NONE":
+        return defaults
+    if not isinstance(overrides, dict):
+        return defaults
+
+    entry = overrides.get(symbol, {})
+    if not isinstance(entry, dict):
+        return defaults
+
+    sentinel = object()
+    dir_key = direction.lower()
+    dir_block = entry.get(dir_key, sentinel)
+
+    if dir_block is None:
+        return None  # direction disabled
+
+    if isinstance(dir_block, dict):
+        return {
+            "atr_sl_mult": dir_block.get("atr_sl_mult",
+                                          entry.get("atr_sl_mult", defaults["atr_sl_mult"])),
+            "atr_tp_mult": dir_block.get("atr_tp_mult",
+                                          entry.get("atr_tp_mult", defaults["atr_tp_mult"])),
+            "atr_be_mult": dir_block.get("atr_be_mult",
+                                          entry.get("atr_be_mult", defaults["atr_be_mult"])),
+        }
+
+    return {
+        "atr_sl_mult": entry.get("atr_sl_mult", defaults["atr_sl_mult"]),
+        "atr_tp_mult": entry.get("atr_tp_mult", defaults["atr_tp_mult"]),
+        "atr_be_mult": entry.get("atr_be_mult", defaults["atr_be_mult"]),
+    }
+
+
+def _check_trigger_5m_long(df5: pd.DataFrame) -> bool:
+    """5-minute bullish trigger: bullish candle AND RSI recovering.
+
+    Mirrors `btc_scanner.check_trigger_5m` (returns only the boolean).
+    """
+    if len(df5) < 3:
+        return False
+    rsi5 = calc_rsi(df5["close"], RSI_PERIOD)
+    cur = df5.iloc[-1]
+    bullish_candle = bool(cur["close"] > cur["open"])
+    rsi_recovering = bool(rsi5.iloc[-1] > rsi5.iloc[-2])
+    return bullish_candle and rsi_recovering
+
+
+def _check_trigger_5m_short(df5: pd.DataFrame) -> bool:
+    """5-minute bearish trigger: bearish candle AND RSI falling.
+
+    Mirrors `btc_scanner.check_trigger_5m_short` (returns only the boolean).
+    """
+    if len(df5) < 3:
+        return False
+    rsi5 = calc_rsi(df5["close"], RSI_PERIOD)
+    cur = df5.iloc[-1]
+    bearish_candle = bool(cur["close"] < cur["open"])
+    rsi_falling = bool(rsi5.iloc[-1] < rsi5.iloc[-2])
+    return bearish_candle and rsi_falling
+
+
 @dataclass
 class SignalDecision:
     """Return shape of `evaluate_signal()`.
@@ -293,6 +372,20 @@ def evaluate_signal(
 
     decision.direction = direction
 
+    # ── Exclusion / block detection (engulfings + divergences) ─────────────
+    bull_eng = _detect_bull_engulfing(df1h)
+    bear_eng = _detect_bear_engulfing(df1h)
+    blocks_long: list[str] = []
+    if bull_eng:
+        blocks_long.append("E1: BullEngulfing activo — posible micro-techo")
+    if bear_div:
+        blocks_long.append("E6: Divergencia bajista RSI (1H) — agotamiento alcista")
+    blocks_short: list[str] = []
+    if bear_eng:
+        blocks_short.append("E1S: BearEngulfing activo — posible micro-suelo")
+    if bull_div:
+        blocks_short.append("E6S: Divergencia alcista RSI (1H) — agotamiento bajista")
+
     # ── Score (Spot V6 0-9) — mirrors btc_scanner.scan() C1-C7 ─────────────
     score = 0
     if direction == "SHORT":
@@ -345,5 +438,111 @@ def evaluate_signal(
 
     decision.score = int(score)
     decision.score_label = _score_label(score)
+
+    # ── Symbol / direction gating via config overrides ─────────────────────
+    sym_overrides = (cfg or {}).get("symbol_overrides", {}) if isinstance(cfg, dict) else {}
+    so_entry = sym_overrides.get(symbol, {}) if isinstance(sym_overrides, dict) else {}
+
+    if so_entry is False:
+        # Symbol disabled in config — same shape as scan() early return.
+        decision.direction = "NONE"
+        decision.score = 0
+        decision.score_label = _score_label(0)
+        decision.is_signal = False
+        decision.is_setup = False
+        decision.estado = f"\u26d4 {symbol} deshabilitado en config"
+        decision.reasons = {"symbol_disabled": True}
+        return decision
+
+    # If we picked a direction, check it's not disabled for this symbol.
+    if direction != "NONE":
+        resolved = _resolve_direction_params(sym_overrides, symbol, direction)
+        if resolved is None:
+            # Direction disabled for this (symbol, direction) pair.
+            decision.is_signal = False
+            decision.is_setup = False
+            decision.estado = f"\u26d4 {direction} deshabilitado para {symbol}"
+            decision.reasons = {
+                "direction_disabled": True,
+                "direction": direction,
+            }
+            return decision
+    else:
+        resolved = _resolve_direction_params(sym_overrides, symbol, direction)
+
+    sl_mult = resolved["atr_sl_mult"]
+    tp_mult = resolved["atr_tp_mult"]
+    be_mult = resolved["atr_be_mult"]
+
+    # ── SL / TP prices (ATR-based) ─────────────────────────────────────────
+    sl_dist = atr_val * sl_mult
+    tp_dist = atr_val * tp_mult
+
+    if direction == "NONE":
+        entry_price = None
+        sl_price = None
+        tp_price = None
+    else:
+        entry_price = round(price, 2)
+        if direction == "SHORT":
+            sl_price = round(price + sl_dist, 2)   # SL above for SHORT
+            tp_price = round(price - tp_dist, 2)   # TP below for SHORT
+        else:  # LONG
+            sl_price = round(price - sl_dist, 2)
+            tp_price = round(price + tp_dist, 2)
+
+    decision.entry_price = entry_price
+    decision.sl_price = sl_price
+    decision.tp_price = tp_price
+
+    # ── Macro check & 5M trigger ───────────────────────────────────────────
+    macro_ok = (
+        price_above_4h if direction == "LONG"
+        else (not price_above_4h) if direction == "SHORT"
+        else False
+    )
+    if direction == "SHORT":
+        trigger_active = _check_trigger_5m_short(df5m)
+    elif direction == "LONG":
+        trigger_active = _check_trigger_5m_long(df5m)
+    else:
+        trigger_active = False
+
+    blocks = blocks_long if direction == "LONG" else blocks_short if direction == "SHORT" else []
+
+    # ── Veredicto (Spanish human-readable estado) ──────────────────────────
+    if direction == "NONE":
+        estado = "\u23f3 SIN SETUP \u2014 LRC% fuera de zona (25%-75%)"
+        is_signal = False
+        is_setup = False
+    elif blocks:
+        estado = f"\U0001f6ab BLOQUEADA {direction} \u2014 {len(blocks)} exclusi\u00f3n(es) autom\u00e1tica"
+        is_signal = False
+        is_setup = False
+    elif not macro_ok:
+        macro_desc = "precio < SMA100 4H" if direction == "LONG" else "precio > SMA100 4H"
+        estado = f"\u26a0\ufe0f  SETUP {direction} \u2014 Macro 4H adversa ({macro_desc})"
+        is_signal = False
+        is_setup = False
+    elif not trigger_active:
+        estado = f"\U0001f550 SETUP {direction} V\u00c1LIDO \u2014 Esperando gatillo 5M"
+        is_signal = False
+        is_setup = True
+    else:
+        estado = f"\u2705 SE\u00d1AL {direction} + GATILLO CONFIRMADOS \u2014 Calidad: {_score_label(score)}"
+        is_signal = True
+        is_setup = True
+
+    decision.is_signal = is_signal
+    decision.is_setup = is_setup
+    decision.estado = estado
+    decision.reasons = {
+        "blocks": blocks,
+        "macro_ok": macro_ok,
+        "trigger_active": trigger_active,
+        "atr_sl_mult": sl_mult,
+        "atr_tp_mult": tp_mult,
+        "atr_be_mult": be_mult,
+    }
 
     return decision

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -17,6 +17,39 @@ from typing import Any
 
 import pandas as pd
 
+from strategy.indicators import (
+    calc_adx,
+    calc_atr,
+    calc_bb,
+    calc_cvd_delta,
+    calc_lrc,
+    calc_rsi,
+    calc_sma,
+)
+
+# Strategy parameters — kept in sync with btc_scanner constants. Duplicated
+# intentionally to keep `strategy/` self-contained (pure function with no
+# dependency on btc_scanner's module state). The indicator periods and zone
+# thresholds never change at runtime.
+LRC_PERIOD = 100
+LRC_STDEV = 2.0
+RSI_PERIOD = 14
+BB_PERIOD = 20
+BB_STDEV = 2.0
+VOL_PERIOD = 20
+ATR_PERIOD = 14
+ATR_SL_MULT_DEFAULT = 1.0
+ATR_TP_MULT_DEFAULT = 4.0
+ATR_BE_MULT_DEFAULT = 1.5
+
+LRC_LONG_MAX = 25.0
+LRC_SHORT_MIN = 75.0
+
+# Score tier thresholds (Spot V6, 0-9 scale)
+SCORE_MIN_HALF = 0
+SCORE_STANDARD = 2
+SCORE_PREMIUM = 4
+
 
 @dataclass
 class SignalDecision:
@@ -77,6 +110,61 @@ def evaluate_signal(
         `SignalDecision` with decision fields populated. Never raises on empty
         data — returns a NONE decision instead.
     """
-    # Skeleton (commit A): return NONE decision. Subsequent commits populate
-    # indicators, score, direction, entry/SL/TP fields.
-    return SignalDecision()
+    decision = SignalDecision()
+
+    # Guard: not enough bars to compute anything useful.
+    if len(df1h) == 0 or len(df4h) == 0:
+        return decision
+
+    # ── Indicators on 1H (primary signal timeframe) ────────────────────────
+    price = float(df1h["close"].iloc[-1])
+    lrc_pct, lrc_up, lrc_dn, lrc_mid = calc_lrc(df1h["close"], LRC_PERIOD, LRC_STDEV)
+
+    rsi1h_series = calc_rsi(df1h["close"], RSI_PERIOD)
+    cur_rsi1h = round(float(rsi1h_series.iloc[-1]), 2)
+
+    bb_up1h_series, _, bb_dn1h_series = calc_bb(df1h["close"], BB_PERIOD, BB_STDEV)
+    bb_up1h = float(bb_up1h_series.iloc[-1]) if not pd.isna(bb_up1h_series.iloc[-1]) else None
+    bb_dn1h = float(bb_dn1h_series.iloc[-1]) if not pd.isna(bb_dn1h_series.iloc[-1]) else None
+
+    sma10_1h = float(calc_sma(df1h["close"], 10).iloc[-1])
+    sma20_1h = float(calc_sma(df1h["close"], 20).iloc[-1])
+
+    vol_avg1h = float(df1h["volume"].rolling(VOL_PERIOD).mean().iloc[-1])
+    vol_1h = float(df1h["volume"].iloc[-1])
+
+    cvd_1h = calc_cvd_delta(df1h, n=3)
+
+    adx_1h_series = calc_adx(df1h, 14)
+    cur_adx = (
+        round(float(adx_1h_series.iloc[-1]), 2)
+        if not pd.isna(adx_1h_series.iloc[-1])
+        else 0.0
+    )
+
+    atr_val = float(calc_atr(df1h, ATR_PERIOD).iloc[-1])
+
+    # ── Indicators on 4H (macro context) ───────────────────────────────────
+    sma100_4h = float(calc_sma(df4h["close"], 100).iloc[-1])
+
+    # Populate diagnostics
+    decision.indicators = {
+        "price": price,
+        "lrc_pct": lrc_pct,
+        "lrc_upper": lrc_up,
+        "lrc_lower": lrc_dn,
+        "lrc_mid": lrc_mid,
+        "rsi_1h": cur_rsi1h,
+        "bb_upper_1h": bb_up1h,
+        "bb_lower_1h": bb_dn1h,
+        "sma10_1h": sma10_1h,
+        "sma20_1h": sma20_1h,
+        "vol_1h": vol_1h,
+        "vol_avg_1h": vol_avg1h,
+        "cvd_1h": cvd_1h,
+        "adx_1h": cur_adx,
+        "atr_1h": atr_val,
+        "sma100_4h": sma100_4h,
+    }
+
+    return decision

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -27,6 +27,11 @@ from strategy.indicators import (
     calc_sma,
 )
 
+# Imported lazily inside evaluate_signal to avoid circular imports:
+#   btc_scanner imports strategy.indicators; we re-import its helpers here.
+# Keeping these imports at call-time preserves isolation of the pure module
+# should btc_scanner ever depend on strategy.core in the future.
+
 # Strategy parameters — kept in sync with btc_scanner constants. Duplicated
 # intentionally to keep `strategy/` self-contained (pure function with no
 # dependency on btc_scanner's module state). The indicator periods and zone
@@ -49,6 +54,99 @@ LRC_SHORT_MIN = 75.0
 SCORE_MIN_HALF = 0
 SCORE_STANDARD = 2
 SCORE_PREMIUM = 4
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Pure candlestick / divergence helpers (mirror btc_scanner; no I/O, no state)
+#  Kept here instead of cross-importing to avoid coupling strategy/ to btc_scanner.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _detect_bull_engulfing(df: pd.DataFrame) -> bool:
+    """Bullish engulfing on the last two bars.
+
+    Matches `btc_scanner.detect_bull_engulfing` exactly.
+    """
+    if len(df) < 2:
+        return False
+    p, c = df.iloc[-2], df.iloc[-1]
+    return bool(p["close"] < p["open"]
+                and c["close"] > c["open"]
+                and c["open"] <= p["close"]
+                and c["close"] >= p["open"])
+
+
+def _detect_bear_engulfing(df: pd.DataFrame) -> bool:
+    """Bearish engulfing on the last two bars.
+
+    Matches `btc_scanner.detect_bear_engulfing` exactly.
+    """
+    if len(df) < 2:
+        return False
+    p, c = df.iloc[-2], df.iloc[-1]
+    return bool(p["close"] > p["open"]
+                and c["close"] < c["open"]
+                and c["open"] >= p["close"]
+                and c["close"] <= p["open"])
+
+
+def _detect_rsi_divergence(close: pd.Series, rsi: pd.Series, window: int = 72) -> dict:
+    """Detect bullish / bearish RSI divergence over the given window.
+
+    Matches `btc_scanner.detect_rsi_divergence` exactly (5-point local extrema).
+    """
+    if len(close) < window:
+        return {"bull": False, "bear": False}
+
+    p = close.iloc[-window:].values
+    r = rsi.iloc[-window:].values
+
+    mins = [i for i in range(2, window - 2)
+            if p[i] < p[i - 1] and p[i] < p[i - 2]
+            and p[i] < p[i + 1] and p[i] < p[i + 2]]
+    bull_div = False
+    if len(mins) >= 2:
+        a, b = mins[-2], mins[-1]
+        bull_div = bool(p[b] < p[a] and r[b] > r[a])
+
+    maxs = [i for i in range(2, window - 2)
+            if p[i] > p[i - 1] and p[i] > p[i - 2]
+            and p[i] > p[i + 1] and p[i] > p[i + 2]]
+    bear_div = False
+    if len(maxs) >= 2:
+        a, b = maxs[-2], maxs[-1]
+        bear_div = bool(p[b] > p[a] and r[b] < r[a])
+
+    return {"bull": bull_div, "bear": bear_div}
+
+
+def _score_label(score: int) -> str:
+    """Short tier label — dashboard-friendly, Spanish-neutral.
+
+    Note: `btc_scanner.score_label` returns a long human-readable string like
+    "PREMIUM ⭐⭐⭐ (sizing 150%)". That long string is a presentation concern
+    of the scanner's report; the pure kernel exposes the tier token only.
+    """
+    if score >= SCORE_PREMIUM:
+        return "PREMIUM"
+    if score >= SCORE_STANDARD:
+        return "STANDARD"
+    if score >= SCORE_MIN_HALF:
+        return "MINIMA"
+    return "INSUFICIENTE"
+
+
+def _regime_to_direction_token(regime_label: str | None) -> str:
+    """Map regime label → direction token used by scan().
+
+    Mirrors the logic in `btc_scanner.scan()`:
+        `regime = "LONG" if regime == "BULL" else "SHORT" if regime == "BEAR" else "LONG"`
+    i.e. both BULL and NEUTRAL/unknown allow LONG; only BEAR enables SHORT.
+    """
+    if regime_label == "BEAR":
+        return "SHORT"
+    # BULL, NEUTRAL, missing, or unknown all fall back to LONG-enabled
+    return "LONG"
 
 
 @dataclass
@@ -146,6 +244,12 @@ def evaluate_signal(
 
     # ── Indicators on 4H (macro context) ───────────────────────────────────
     sma100_4h = float(calc_sma(df4h["close"], 100).iloc[-1])
+    price_above_4h = bool(price > sma100_4h)
+
+    # RSI divergences on 1H
+    rsi_divs = _detect_rsi_divergence(df1h["close"], rsi1h_series, window=72)
+    bull_div = rsi_divs["bull"]
+    bear_div = rsi_divs["bear"]
 
     # Populate diagnostics
     decision.indicators = {
@@ -165,6 +269,81 @@ def evaluate_signal(
         "adx_1h": cur_adx,
         "atr_1h": atr_val,
         "sma100_4h": sma100_4h,
+        "price_above_sma100_4h": price_above_4h,
+        "bull_div_1h": bull_div,
+        "bear_div_1h": bear_div,
     }
+
+    # ── Zone + regime → direction ──────────────────────────────────────────
+    in_long_zone = lrc_pct is not None and lrc_pct <= LRC_LONG_MAX
+    in_short_zone = lrc_pct is not None and lrc_pct >= LRC_SHORT_MIN
+
+    regime_label = (regime or {}).get("regime")
+    regime_token = _regime_to_direction_token(regime_label)
+
+    # LONG when in low zone AND regime is LONG or NEUTRAL (mapped to LONG).
+    # SHORT only when in high zone AND regime is BEAR → SHORT.
+    # Everything else → NONE (middle band, or mismatched zone/regime pair).
+    if in_long_zone and regime_token in ("LONG", "NEUTRAL"):
+        direction = "LONG"
+    elif in_short_zone and regime_token == "SHORT":
+        direction = "SHORT"
+    else:
+        direction = "NONE"
+
+    decision.direction = direction
+
+    # ── Score (Spot V6 0-9) — mirrors btc_scanner.scan() C1-C7 ─────────────
+    score = 0
+    if direction == "SHORT":
+        # C1: RSI overbought
+        if cur_rsi1h > 60:
+            score += 2
+        # C2: bearish divergence
+        if bear_div:
+            score += 2
+        # C3: close to upper LRC band
+        dist_res = abs(price - lrc_up) / price * 100 if lrc_up else 999
+        if dist_res <= 1.5:
+            score += 1
+        # C4: price at/above upper Bollinger
+        if bb_up1h is not None and price >= bb_up1h:
+            score += 1
+        # C5: volume ≥ average
+        if bool(vol_1h >= vol_avg1h):
+            score += 1
+        # C6: negative CVD delta
+        if cvd_1h < 0:
+            score += 1
+        # C7: 10-SMA below 20-SMA (bearish crossover)
+        if sma10_1h < sma20_1h:
+            score += 1
+    elif direction == "LONG":
+        # C1: RSI oversold
+        if cur_rsi1h < 40:
+            score += 2
+        # C2: bullish divergence
+        if bull_div:
+            score += 2
+        # C3: close to lower LRC band
+        dist_sup = abs(price - lrc_dn) / price * 100 if lrc_dn else 999
+        if dist_sup <= 1.5:
+            score += 1
+        # C4: price at/below lower Bollinger
+        if bb_dn1h is not None and price <= bb_dn1h:
+            score += 1
+        # C5: volume ≥ average
+        if bool(vol_1h >= vol_avg1h):
+            score += 1
+        # C6: positive CVD delta
+        if cvd_1h > 0:
+            score += 1
+        # C7: 10-SMA above 20-SMA (bullish crossover)
+        if sma10_1h > sma20_1h:
+            score += 1
+    # direction == "NONE" → score stays 0 (matches scan: no confirmations added)
+
+    decision.score = int(score)
+    decision.score_label = _score_label(score)
 
     return decision

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -1,0 +1,82 @@
+"""Pure decision logic — the shared kernel between scanner and backtest (#186 A1).
+
+This module exposes `evaluate_signal(...)`: a PURE function that takes market
+data (OHLCV dataframes) and state (cfg, regime, health tier) and returns a
+`SignalDecision` describing the trading decision. No I/O, no global mutation,
+no network, no DB. Same inputs → same outputs.
+
+Callers (`btc_scanner.scan`, `backtest.simulate_strategy`) handle I/O around
+this pure kernel: fetching data, loading config, persisting results, publishing
+notifications.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass
+class SignalDecision:
+    """Return shape of `evaluate_signal()`.
+
+    All fields are Python primitives or simple containers — no numpy scalars,
+    no pandas objects. Safe to serialize / compare / dataclass-replace.
+    """
+
+    # Core decision
+    direction: str = "NONE"          # "LONG" | "SHORT" | "NONE"
+    score: int = 0                    # 0-9
+    score_label: str = ""             # "MINIMA" | "STANDARD" | "PREMIUM"
+    is_signal: bool = False
+    is_setup: bool = False
+
+    # Entry/exit prices (None when direction == "NONE")
+    entry_price: float | None = None
+    sl_price: float | None = None
+    tp_price: float | None = None
+
+    # Diagnostics — populated incrementally as evaluate_signal runs.
+    reasons: dict[str, Any] = field(default_factory=dict)
+    indicators: dict[str, Any] = field(default_factory=dict)
+    estado: str = ""                  # human-readable Spanish status
+
+
+def evaluate_signal(
+    df1h: pd.DataFrame,
+    df4h: pd.DataFrame,
+    df5m: pd.DataFrame,
+    df1d: pd.DataFrame,
+    symbol: str,
+    cfg: dict[str, Any],
+    regime: dict[str, Any],
+    health_state: str = "NORMAL",
+    now: datetime | None = None,
+) -> SignalDecision:
+    """Pure decision from market data + state.
+
+    Args:
+        df1h: 1-hour OHLCV bars (primary signal timeframe).
+        df4h: 4-hour OHLCV bars (macro context).
+        df5m: 5-minute OHLCV bars (entry trigger).
+        df1d: 1-day OHLCV bars (regime context — optional / may be unused).
+        symbol: Symbol being evaluated (e.g. "BTCUSDT"). Used for per-symbol
+            override resolution in `cfg["symbol_overrides"]`.
+        cfg: Config dict (typically the merged `load_config()` result). Reads
+            `symbol_overrides` for ATR multipliers.
+        regime: Regime detector output shape:
+            `{"regime": "BULL"|"BEAR"|"NEUTRAL", "score": float, "details": {}}`
+        health_state: Kill-switch tier for this symbol. Currently PAUSED short-
+            circuits to NONE; other tiers affect size (handled by caller).
+        now: Timestamp context (not currently used inside the pure function;
+            reserved for future time-aware checks).
+
+    Returns:
+        `SignalDecision` with decision fields populated. Never raises on empty
+        data — returns a NONE decision instead.
+    """
+    # Skeleton (commit A): return NONE decision. Subsequent commits populate
+    # indicators, score, direction, entry/SL/TP fields.
+    return SignalDecision()

--- a/strategy/indicators.py
+++ b/strategy/indicators.py
@@ -1,0 +1,144 @@
+"""Pure technical indicators shared between scanner and backtest (Epic #186)."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def calc_lrc(close: pd.Series, period=100, k=2.0):
+    """
+    Canal de Regresión Lineal.
+    Retorna: lrc_pct (0-100), upper, lower, mid
+    lrc_pct ≤ 25  →  zona LONG (cuartil inferior del canal)
+    """
+    if len(close) < period:
+        return None, None, None, None
+    y    = close.iloc[-period:].values
+    x    = np.arange(period)
+    m, b = np.polyfit(x, y, 1)
+    reg  = m * x + b
+    std  = np.std(y - reg)
+    upper = reg[-1] + k * std
+    lower = reg[-1] - k * std
+    mid   = reg[-1]
+    price = close.iloc[-1]
+    if abs(upper - lower) < 1e-10:
+        lrc_pct = 50.0
+    else:
+        lrc_pct = (price - lower) / (upper - lower) * 100
+        lrc_pct = max(0.0, min(100.0, lrc_pct))
+    return round(lrc_pct, 2), round(upper, 2), round(lower, 2), round(mid, 2)
+
+
+def calc_rsi(close: pd.Series, period=14):
+    delta    = close.diff()
+    gain     = delta.clip(lower=0)
+    loss     = (-delta).clip(lower=0)
+    avg_gain = gain.ewm(alpha=1 / period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, adjust=False).mean()
+    rs       = avg_gain / avg_loss.replace(0, np.nan)
+    return (100 - 100 / (1 + rs)).fillna(50)
+
+
+def calc_bb(close: pd.Series, period=20, k=2.0):
+    sma = close.rolling(period).mean()
+    std = close.rolling(period).std(ddof=0)
+    return sma + k * std, sma, sma - k * std   # upper, mid, lower
+
+
+def calc_sma(close: pd.Series, period: int):
+    return close.rolling(period).mean()
+
+
+def calc_atr(df: pd.DataFrame, period=14) -> pd.Series:
+    """Average True Range — mide la volatilidad real del mercado."""
+    high = df["high"]
+    low = df["low"]
+    prev_close = df["close"].shift(1)
+    tr = pd.concat([
+        high - low,
+        (high - prev_close).abs(),
+        (low - prev_close).abs(),
+    ], axis=1).max(axis=1)
+    return tr.rolling(period).mean()
+
+
+def calc_adx(df: pd.DataFrame, period=14) -> pd.Series:
+    """
+    Average Directional Index — mide la fuerza de la tendencia (no su dirección).
+    ADX < 25  →  mercado lateral/ranging  (apto para mean-reversion)
+    ADX >= 25 →  mercado en tendencia     (evitar mean-reversion)
+
+    Pasos:
+      1. +DM / -DM desde highs/lows
+      2. Suavizar +DM, -DM y TR con EMA (periodo)
+      3. +DI = smoothed +DM / ATR * 100
+      4. -DI = smoothed -DM / ATR * 100
+      5. DX  = |+DI - -DI| / (+DI + -DI) * 100
+      6. ADX = EMA de DX (periodo)
+    """
+    high  = df["high"]
+    low   = df["low"]
+    close = df["close"]
+
+    # True Range
+    prev_close = close.shift(1)
+    tr = pd.concat([
+        high - low,
+        (high - prev_close).abs(),
+        (low  - prev_close).abs(),
+    ], axis=1).max(axis=1)
+
+    # +DM y -DM
+    up_move   = high.diff()
+    down_move = (-low).diff()   # equivale a low.shift(1) - low
+
+    plus_dm  = np.where((up_move > down_move) & (up_move > 0), up_move, 0.0)
+    minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0.0)
+
+    plus_dm_s  = pd.Series(plus_dm,  index=df.index)
+    minus_dm_s = pd.Series(minus_dm, index=df.index)
+
+    # Suavizado con EMA (Wilder: alpha = 1/period)
+    alpha = 1.0 / period
+    atr_smooth    = tr.ewm(alpha=alpha, adjust=False).mean()
+    plus_dm_smooth  = plus_dm_s.ewm(alpha=alpha, adjust=False).mean()
+    minus_dm_smooth = minus_dm_s.ewm(alpha=alpha, adjust=False).mean()
+
+    # +DI y -DI
+    plus_di  = (plus_dm_smooth  / atr_smooth.replace(0, np.nan)) * 100
+    minus_di = (minus_dm_smooth / atr_smooth.replace(0, np.nan)) * 100
+
+    # DX
+    di_sum  = plus_di + minus_di
+    di_diff = (plus_di - minus_di).abs()
+    dx = (di_diff / di_sum.replace(0, np.nan)) * 100
+
+    # ADX = EMA de DX
+    adx = dx.ewm(alpha=alpha, adjust=False).mean()
+    return adx
+
+
+def calc_cvd_delta(df: pd.DataFrame, n=3):
+    """Proxy CVD: volumen taker buy − sell últimas n barras.
+
+    Data layer bars carry only OHLCV (no taker-side metadata), so
+    approximate taker_buy_base from the bar's close position within
+    its high-low range, same heuristic the old bybit adapter used.
+    """
+    if "taker_buy_base" in df.columns:
+        taker_buy = df["taker_buy_base"]
+    else:
+        hl = (df["high"] - df["low"]).replace(0, 1e-9)
+        bullish = df["close"] >= df["open"]
+        taker_buy = pd.Series(
+            np.where(
+                bullish,
+                df["volume"] * (df["close"] - df["low"]) / hl,
+                df["volume"] * (df["high"] - df["close"]) / hl,
+            ),
+            index=df.index,
+        )
+    buy  = taker_buy.tail(n)
+    sell = (df["volume"] - taker_buy).tail(n)
+    return float((buy - sell).sum())

--- a/strategy/sizing.py
+++ b/strategy/sizing.py
@@ -1,0 +1,43 @@
+"""Pure sizing logic — composes score tier x kill-switch health tier (#186 A4)."""
+from __future__ import annotations
+
+from typing import Any
+
+
+RISK_PER_TRADE = 0.01
+SCORE_PREMIUM = 4  # threshold for 1.5x
+SCORE_STANDARD = 2  # threshold for 1.0x (else 0.5x)
+
+
+def _score_multiplier(score: int) -> float:
+    if score >= SCORE_PREMIUM:
+        return 1.5
+    if score >= SCORE_STANDARD:
+        return 1.0
+    return 0.5
+
+
+def _health_multiplier(health_tier: str, cfg: dict[str, Any]) -> float:
+    """Returns multiplier based on kill switch tier.
+
+    PAUSED -> 0 (no trade). REDUCED/PROBATION -> configured factor. NORMAL/ALERT -> 1.0.
+    """
+    if health_tier == "PAUSED":
+        return 0.0
+    if health_tier in ("REDUCED", "PROBATION"):
+        ks_cfg = cfg.get("kill_switch", {})
+        return float(ks_cfg.get("reduce_size_factor", 0.5))
+    return 1.0
+
+
+def compute_size(
+    score: int,
+    health_tier: str,
+    capital: float,
+    cfg: dict[str, Any],
+) -> float:
+    """Return risk-adjusted size for a trade.
+
+    Composition: capital x RISK_PER_TRADE x score_mult x health_mult.
+    """
+    return capital * RISK_PER_TRADE * _score_multiplier(score) * _health_multiplier(health_tier, cfg)

--- a/tests/test_backtest_refactor_parity.py
+++ b/tests/test_backtest_refactor_parity.py
@@ -1,0 +1,134 @@
+"""Verify simulate_strategy output matches pre-refactor for apply_kill_switch=False (#186 A6).
+
+Pre-refactor baseline was captured with:
+    symbol=BTCUSDT, sim_start=2024-01-01, sim_end=2024-03-01
+    len(trades) == 24
+    equity[-1]["equity"] == 11021.66  (rel tol 1e-4)
+    sum(pnl_usd for t in trades) == 1021.66
+
+These values are pinned here so any future refactor that inadvertently changes
+trade-level behavior on the `apply_kill_switch=False` path will fail this test.
+"""
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+
+OHLCV_DB = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "ohlcv.db",
+)
+
+
+@pytest.mark.skipif(
+    not os.path.exists(OHLCV_DB), reason="requires cached market data (data/ohlcv.db)",
+)
+def test_simulate_strategy_parity_without_kill_switch(tmp_path, monkeypatch):
+    """With apply_kill_switch=False, refactored simulate_strategy produces the same
+    trade count + final equity + net PnL as the pre-refactor baseline on a pinned
+    window (BTCUSDT, 2024-01-01 → 2024-03-01).
+
+    This is the *critical* parity test for Epic #186 A6: any drift means the
+    rewire changed trade-level semantics on the default path, which was a
+    non-negotiable constraint of the refactor.
+    """
+    from backtest import simulate_strategy, get_cached_data
+    import btc_api
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    symbol = "BTCUSDT"
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    data_start = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    df1h = get_cached_data(symbol, "1h", start_date=data_start)
+    df4h = get_cached_data(symbol, "4h", start_date=data_start)
+    df5m = get_cached_data(symbol, "5m", start_date=data_start)
+    df1d = get_cached_data(symbol, "1d", start_date=data_start)
+
+    if df1h.empty or df4h.empty or df5m.empty:
+        pytest.skip("BTCUSDT market data not cached in data/ohlcv.db")
+
+    trades, equity = simulate_strategy(
+        df1h, df4h, df5m, symbol,
+        sim_start=start, sim_end=end,
+        df1d=df1d,
+    )
+
+    # Pinned from a pre-refactor capture (committed at the start of Task 6).
+    # If you're touching this test because the values changed, you've likely
+    # broken trade-level parity — re-read the Task 6 constraints before updating.
+    EXPECTED_TRADE_COUNT = 24
+    EXPECTED_FINAL_EQUITY = 11021.66
+    EXPECTED_NET_PNL = 1021.66
+
+    assert len(trades) == EXPECTED_TRADE_COUNT, (
+        f"trade count drift: {len(trades)} vs expected {EXPECTED_TRADE_COUNT}"
+    )
+    assert equity[-1]["equity"] == pytest.approx(EXPECTED_FINAL_EQUITY, rel=1e-4)
+    net_pnl = round(sum(t["pnl_usd"] for t in trades), 2)
+    assert net_pnl == pytest.approx(EXPECTED_NET_PNL, abs=0.01)
+
+
+@pytest.mark.skipif(
+    not os.path.exists(OHLCV_DB), reason="requires cached market data (data/ohlcv.db)",
+)
+def test_simulate_strategy_with_simulator_wires_correctly(tmp_path, monkeypatch):
+    """With apply_kill_switch=True + shared_simulator, closed trades feed the
+    simulator and the tier can evolve mid-backtest.
+
+    This test proves the simulator is WIRED, not a specific pnl number. The
+    actual tier depends on config + symbol performance in the window.
+    """
+    from backtest import simulate_strategy, get_cached_data
+    from backtest_kill_switch import KillSwitchSimulator
+    import btc_api
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    symbol = "BTCUSDT"
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    data_start = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    df1h = get_cached_data(symbol, "1h", start_date=data_start)
+    df4h = get_cached_data(symbol, "4h", start_date=data_start)
+    df5m = get_cached_data(symbol, "5m", start_date=data_start)
+    df1d = get_cached_data(symbol, "1d", start_date=data_start)
+
+    if df1h.empty or df4h.empty or df5m.empty:
+        pytest.skip("BTCUSDT market data not cached in data/ohlcv.db")
+
+    cfg_ks = {
+        "kill_switch": {
+            "enabled": True,
+            "min_trades_for_eval": 3,
+            "alert_win_rate_threshold": 0.30,
+            "reduce_size_factor": 0.5,
+            "pause_months_consecutive": 2,
+            "auto_recovery_enabled": True,
+        },
+    }
+    sim = KillSwitchSimulator(cfg_ks)
+
+    trades, _equity = simulate_strategy(
+        df1h, df4h, df5m, symbol,
+        sim_start=start, sim_end=end,
+        df1d=df1d,
+        apply_kill_switch=True,
+        shared_simulator=sim,
+        cfg=cfg_ks,
+    )
+
+    # Some trades should have happened on this symbol+window, and each one
+    # should have been fed to the simulator.
+    assert len(trades) > 0
+    assert symbol in sim.states
+    assert len(sim.states[symbol].closed_trades) == len(trades)
+    # Final tier must be one of the valid states.
+    assert sim.get_tier(symbol) in ("NORMAL", "ALERT", "REDUCED", "PAUSED")

--- a/tests/test_health_persistence.py
+++ b/tests/test_health_persistence.py
@@ -215,3 +215,56 @@ def test_reactivate_sets_manual_override(tmp_db):
         conn.close()
     assert row == ("NORMAL", 1)
     assert last_event[0] == "manual_override"
+
+
+def test_compute_rolling_metrics_from_trades_empty():
+    from health import compute_rolling_metrics_from_trades
+    from datetime import datetime, timezone
+    result = compute_rolling_metrics_from_trades([], now=datetime(2026, 4, 23, tzinfo=timezone.utc))
+    assert result["trades_count_total"] == 0
+    assert result["win_rate_20_trades"] is None
+    assert result["pnl_30d"] == 0.0
+    assert result["months_negative_consecutive"] == 0
+
+
+def test_compute_rolling_metrics_from_trades_basic():
+    from health import compute_rolling_metrics_from_trades
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 23, tzinfo=timezone.utc)
+    trades = [
+        {"exit_ts": "2026-04-10T12:00:00+00:00", "pnl_usd": 100.0},
+        {"exit_ts": "2026-04-15T12:00:00+00:00", "pnl_usd": -50.0},
+        {"exit_ts": "2026-04-20T12:00:00+00:00", "pnl_usd": 200.0},
+    ]
+    result = compute_rolling_metrics_from_trades(trades, now=now)
+    assert result["trades_count_total"] == 3
+    assert result["win_rate_20_trades"] == pytest.approx(2 / 3)
+    assert result["pnl_30d"] == pytest.approx(250.0)
+
+
+def test_compute_rolling_metrics_from_trades_months_consecutive():
+    from health import compute_rolling_metrics_from_trades
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 23, tzinfo=timezone.utc)
+    # 3 months all negative → months_negative_consecutive = 3
+    trades = [
+        {"exit_ts": "2026-01-15T12:00:00+00:00", "pnl_usd": -100.0},
+        {"exit_ts": "2026-02-10T12:00:00+00:00", "pnl_usd": -80.0},
+        {"exit_ts": "2026-03-05T12:00:00+00:00", "pnl_usd": -150.0},
+    ]
+    result = compute_rolling_metrics_from_trades(trades, now=now)
+    assert result["months_negative_consecutive"] == 3
+
+
+def test_compute_rolling_metrics_from_trades_win_rate_last_20():
+    from health import compute_rolling_metrics_from_trades
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 23, tzinfo=timezone.utc)
+    trades = []
+    for i in range(30):
+        ts = (now - timedelta(days=30 - i)).isoformat()
+        pnl = 100.0 if i % 5 == 0 else -20.0  # 1 win per 5 trades in last 20
+        trades.append({"exit_ts": ts, "pnl_usd": pnl})
+    result = compute_rolling_metrics_from_trades(trades, now=now)
+    # Last 20 have 4 wins / 20 = 0.20
+    assert result["win_rate_20_trades"] == pytest.approx(0.20)

--- a/tests/test_kill_switch_simulator.py
+++ b/tests/test_kill_switch_simulator.py
@@ -1,0 +1,74 @@
+"""Tests for the in-memory KillSwitchSimulator (#186 A6)."""
+from datetime import datetime, timezone, timedelta
+
+import pytest  # noqa: F401 — kept for future parametrize/fixtures
+
+
+def _cfg():
+    """Minimal kill-switch config that makes the state machine move with < 20 trades.
+
+    min_trades_for_eval is the gate the state machine opens only after enough trades
+    have been observed; lowering it to 10 lets the test fire transitions quickly.
+    """
+    return {
+        "kill_switch": {
+            "enabled": True,
+            "min_trades_for_eval": 10,
+            "alert_win_rate_threshold": 0.30,
+            "reduce_pnl_window_days": 14,
+            "reduce_size_factor": 0.5,
+            "pause_months_consecutive": 2,
+            "auto_recovery_enabled": True,
+        },
+    }
+
+
+def test_simulator_starts_normal():
+    from backtest_kill_switch import KillSwitchSimulator
+    sim = KillSwitchSimulator(_cfg())
+    assert sim.get_tier("BTCUSDT") == "NORMAL"
+
+
+def test_simulator_closed_trade_updates_state():
+    """A single closed trade below the min_trades gate holds NORMAL (insufficient_data)."""
+    from backtest_kill_switch import KillSwitchSimulator
+    sim = KillSwitchSimulator(_cfg())
+    now = datetime(2026, 4, 23, tzinfo=timezone.utc)
+    tier = sim.on_trade_close(
+        symbol="BTCUSDT",
+        exit_ts_iso="2026-04-20T12:00:00+00:00",
+        pnl_usd=100.0,
+        now=now,
+    )
+    assert tier == "NORMAL"
+
+
+def test_simulator_many_losses_trigger_degraded_tier():
+    """15 losses in a row should trip the state machine past NORMAL.
+
+    With min_trades_for_eval=10, after 10+ trades the rules activate. All trades
+    are losers, so pnl_30d < 0 and win rate = 0 → either REDUCED or ALERT.
+    """
+    from backtest_kill_switch import KillSwitchSimulator
+    sim = KillSwitchSimulator(_cfg())
+    now = datetime(2026, 4, 23, tzinfo=timezone.utc)
+    for i in range(15):
+        ts = (now - timedelta(days=14 - i)).isoformat()
+        sim.on_trade_close("ETHUSDT", ts, -50.0, now)
+    assert sim.get_tier("ETHUSDT") in ("ALERT", "REDUCED", "PAUSED")
+
+
+def test_simulator_shared_across_symbols_independent():
+    """Each symbol's state is tracked independently — a bad ETHUSDT doesn't
+    poison BTCUSDT."""
+    from backtest_kill_switch import KillSwitchSimulator
+    sim = KillSwitchSimulator(_cfg())
+    now = datetime(2026, 4, 23, tzinfo=timezone.utc)
+    for i in range(15):
+        sim.on_trade_close(
+            "ETHUSDT", (now - timedelta(days=14 - i)).isoformat(), -50.0, now,
+        )
+    # BTCUSDT has a single winning trade — it stays NORMAL.
+    sim.on_trade_close("BTCUSDT", now.isoformat(), 100.0, now)
+    assert sim.get_tier("ETHUSDT") in ("ALERT", "REDUCED", "PAUSED")
+    assert sim.get_tier("BTCUSDT") == "NORMAL"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1312,3 +1312,150 @@ class TestScanWritesToDecisionLog:
         assert rows[0]["per_symbol_tier"] in (
             "NORMAL", "ALERT", "REDUCED", "PAUSED", "PROBATION",
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  TESTS — scan() refactored to use strategy/core.evaluate_signal (#186 A5)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestScanRefactorParity:
+    """Scan output shape & values must be stable across the A5 rewire.
+
+    The A5 refactor moves the decision kernel (indicators → direction → score →
+    SL/TP → classification) from btc_scanner.scan() into strategy.core.evaluate_signal.
+    This class pins the fields that downstream consumers rely on:
+      - the webhook (trading_webhook.py builds Telegram payloads from rep keys)
+      - the notifier / signal dedupe (notifier reads score, direction, estado)
+      - the frontend (symbols grid reads price, lrc_1h, score, score_label)
+      - the legacy test helpers (expect sizing_1h.atr_1h etc.)
+    Adding/removing/renaming any of these keys silently breaks production.
+    """
+
+    def _synth_dfs(self):
+        """Reuse the same mocks the older TestScan uses, for determinism."""
+        return TestScan()._make_scan_mock()
+
+    @patch("btc_scanner.md.get_klines")
+    def test_scan_report_shape_is_stable(self, mock_klines, tmp_path, monkeypatch):
+        """Scan() must return a dict with ALL the keys downstream code expects.
+
+        This is a SHAPE test — the check is that every key the pre-refactor
+        report carried is still produced. If the A5 rewire drops a field by
+        accident, this test fires before production does.
+        """
+        import btc_api
+        db_path = str(tmp_path / "signals.db")
+        monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+        if hasattr(btc_api, "_db_conn"):
+            delattr(btc_api, "_db_conn")
+        btc_api.init_db()
+
+        df1h, df4h, df5m = self._synth_dfs()
+        mock_klines.side_effect = [df5m, df1h, df4h, df1h, df1h]
+
+        rep = scanner.scan("BTCUSDT")
+
+        # Top-level keys (downstream webhook / frontend / notifier read these).
+        required_top = [
+            "symbol", "timestamp", "estado", "score", "score_label",
+            "señal_activa", "gatillo_activo", "price", "direction",
+            "lrc_1h", "sizing_1h", "confirmations", "macro_4h",
+            "rsi_1h", "adx_1h", "blocks_auto", "exclusions",
+            "gatillo_5m", "regime", "errors",
+        ]
+        for key in required_top:
+            assert key in rep, f"Missing top-level key '{key}' — breaks downstream consumers"
+
+        # Nested sub-dicts: sizing_1h shape (frontend pins these + tests do too).
+        sz = rep["sizing_1h"]
+        for key in ("capital_usd", "riesgo_usd", "atr_1h",
+                    "atr_sl_mult", "atr_tp_mult", "atr_be_mult",
+                    "sl_mode", "sl_pct", "tp_pct",
+                    "sl_precio", "tp_precio",
+                    "qty_btc", "valor_pos", "pct_capital"):
+            assert key in sz, f"Missing sizing_1h['{key}'] — pre-refactor contract"
+
+        # lrc_1h has all 4 prices.
+        for key in ("pct", "upper", "lower", "mid"):
+            assert key in rep["lrc_1h"], f"Missing lrc_1h['{key}']"
+
+        # macro_4h has the SMA100 snapshot + price_above flag.
+        for key in ("sma100", "price_above"):
+            assert key in rep["macro_4h"], f"Missing macro_4h['{key}']"
+
+    @patch("btc_scanner.md.get_klines")
+    def test_scan_score_label_decorated_at_report_layer(
+        self, mock_klines, tmp_path, monkeypatch
+    ):
+        """score_label in rep is the DECORATED legacy string (stars + sizing %).
+
+        The pure kernel (strategy.core._score_label) returns the bare tier token
+        ("PREMIUM"), but scan()'s report must keep the legacy decoration
+        ("PREMIUM ⭐⭐⭐ (sizing 150%)") — downstream notifications + log
+        scrapers rely on it. This test guards against losing the decoration.
+        """
+        import btc_api
+        db_path = str(tmp_path / "signals.db")
+        monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+        if hasattr(btc_api, "_db_conn"):
+            delattr(btc_api, "_db_conn")
+        btc_api.init_db()
+
+        df1h, df4h, df5m = self._synth_dfs()
+        mock_klines.side_effect = [df5m, df1h, df4h, df1h, df1h]
+
+        rep = scanner.scan("BTCUSDT")
+        label = rep["score_label"]
+        # Legacy decorated format: includes "⭐" for PREMIUM/ESTÁNDAR/MÍNIMA,
+        # or "INSUFICIENTE" for score==0 (no stars).
+        assert isinstance(label, str) and len(label) > 0
+        # Decoration is a superset — we don't pin the exact string because the
+        # score depends on synthesized data, but we verify the label is NOT
+        # just the bare tier token (PREMIUM/STANDARD/MINIMA/INSUFICIENTE).
+        bare_tokens = {"PREMIUM", "STANDARD", "ESTANDAR", "MINIMA", "INSUFICIENTE"}
+        if rep["score"] > 0:
+            # For nonzero score, decoration adds stars + sizing suffix.
+            assert "⭐" in label, (
+                f"score_label '{label}' missing decoration — "
+                f"the refactor likely regressed to the bare strategy.core token"
+            )
+
+    @patch("btc_scanner.md.get_klines")
+    def test_scan_direction_disabled_path_preserved(
+        self, mock_klines, tmp_path, monkeypatch
+    ):
+        """The `direction_disabled` flag path still fires when the resolver
+        returns None for the active direction.
+
+        Regression guard: the A5 rewire MUST continue to call the scanner-level
+        `resolve_direction_params` (not the pure copy in strategy.core) so that
+        monkeypatched tests and config-disabled directions still flow through
+        the same code path.
+        """
+        import btc_api
+        db_path = str(tmp_path / "signals.db")
+        monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+        if hasattr(btc_api, "_db_conn"):
+            delattr(btc_api, "_db_conn")
+        btc_api.init_db()
+
+        df1h, df4h, df5m = self._synth_dfs()
+        mock_klines.side_effect = [df5m, df1h, df4h, df1h, df1h]
+
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({
+            "symbol_overrides": {
+                "BTCUSDT": {"long": None},
+            }
+        }))
+        monkeypatch.setattr(scanner, "SCRIPT_DIR", str(tmp_path))
+        # Force resolver to always signal "disabled" regardless of direction.
+        monkeypatch.setattr(
+            scanner,
+            "resolve_direction_params",
+            lambda overrides, symbol, direction: None,
+        )
+
+        rep = scanner.scan("BTCUSDT")
+        assert rep.get("direction_disabled") is True
+        assert rep.get("señal_activa") is False

--- a/tests/test_strategy_core.py
+++ b/tests/test_strategy_core.py
@@ -65,3 +65,98 @@ def test_evaluate_signal_stub_returns_decision_on_empty_df():
     )
     assert decision.direction == "NONE"
     assert decision.is_signal is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Commit B — indicators computation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _synth_ohlcv(n: int = 250, seed: int = 42, base: float = 100.0) -> pd.DataFrame:
+    """Build a synthetic OHLCV DataFrame with a DatetimeIndex.
+
+    Uses a simple random walk so indicators (LRC, RSI, BB, ATR, ADX) produce
+    non-degenerate values.
+    """
+    rng = np.random.default_rng(seed)
+    close = base + np.cumsum(rng.standard_normal(n) * 0.5)
+    noise = np.abs(rng.standard_normal(n)) * 0.3
+    df = pd.DataFrame({
+        "open":   np.roll(close, 1),
+        "high":   close + noise,
+        "low":    close - noise,
+        "close":  close,
+        "volume": rng.random(n) * 1000 + 100,
+    })
+    df.loc[0, "open"] = close[0]
+    idx = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    df.index = idx
+    return df
+
+
+def test_evaluate_signal_populates_indicators_lrc_rsi():
+    """indicators dict must contain lrc_pct, rsi_1h, adx_1h, atr_1h, sma100_4h."""
+    from strategy.core import evaluate_signal
+    df1h = _synth_ohlcv(n=250, seed=1, base=100.0)
+    df4h = _synth_ohlcv(n=200, seed=2, base=100.0)
+    df5m = _synth_ohlcv(n=250, seed=3, base=100.0)
+    df1d = _synth_ohlcv(n=100, seed=4, base=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "NEUTRAL", "score": 50, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    ind = decision.indicators
+    # Presence checks — values may vary with inputs but must exist and be numeric
+    assert "lrc_pct" in ind
+    assert ind["lrc_pct"] is None or (0.0 <= ind["lrc_pct"] <= 100.0)
+    assert "rsi_1h" in ind
+    assert 0.0 <= ind["rsi_1h"] <= 100.0
+    assert "adx_1h" in ind
+    assert "atr_1h" in ind
+    assert ind["atr_1h"] >= 0.0
+    assert "sma100_4h" in ind
+    assert ind["sma100_4h"] > 0.0
+    # Last price should be recorded
+    assert "price" in ind
+    assert ind["price"] > 0.0
+
+
+def test_evaluate_signal_indicators_match_btc_scanner():
+    """Side-by-side: evaluate_signal indicators must match btc_scanner calc_* on same inputs."""
+    from strategy.core import evaluate_signal
+    from strategy.indicators import (
+        calc_lrc, calc_rsi, calc_sma, calc_atr, calc_adx,
+    )
+    import btc_scanner
+
+    df1h = _synth_ohlcv(n=250, seed=11, base=50_000.0)
+    df4h = _synth_ohlcv(n=200, seed=12, base=50_000.0)
+    df5m = _synth_ohlcv(n=250, seed=13, base=50_000.0)
+    df1d = _synth_ohlcv(n=100, seed=14, base=50_000.0)
+
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "NEUTRAL", "score": 50, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+
+    # Re-run same indicator calls the OLD scan() would run and compare.
+    expected_lrc_pct, _, _, _ = calc_lrc(df1h["close"], btc_scanner.LRC_PERIOD, btc_scanner.LRC_STDEV)
+    expected_rsi_last = round(calc_rsi(df1h["close"], btc_scanner.RSI_PERIOD).iloc[-1], 2)
+    expected_adx_last_series = calc_adx(df1h, 14)
+    expected_adx_last = round(float(expected_adx_last_series.iloc[-1]), 2)
+    expected_atr_last = float(calc_atr(df1h, btc_scanner.ATR_PERIOD).iloc[-1])
+    expected_sma100_4h = float(calc_sma(df4h["close"], 100).iloc[-1])
+
+    assert decision.indicators["lrc_pct"] == pytest.approx(expected_lrc_pct, rel=1e-9)
+    assert decision.indicators["rsi_1h"] == pytest.approx(expected_rsi_last, rel=1e-9)
+    assert decision.indicators["adx_1h"] == pytest.approx(expected_adx_last, rel=1e-9)
+    assert decision.indicators["atr_1h"] == pytest.approx(expected_atr_last, rel=1e-9)
+    assert decision.indicators["sma100_4h"] == pytest.approx(expected_sma100_4h, rel=1e-9)

--- a/tests/test_strategy_core.py
+++ b/tests/test_strategy_core.py
@@ -160,3 +160,277 @@ def test_evaluate_signal_indicators_match_btc_scanner():
     assert decision.indicators["adx_1h"] == pytest.approx(expected_adx_last, rel=1e-9)
     assert decision.indicators["atr_1h"] == pytest.approx(expected_atr_last, rel=1e-9)
     assert decision.indicators["sma100_4h"] == pytest.approx(expected_sma100_4h, rel=1e-9)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Commit C — score 0-9 + direction selection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _downtrend_ohlcv(n: int = 250, seed: int = 42, start: float = 100.0,
+                     drop_bars: int = 20, drop_pct: float = 0.08) -> pd.DataFrame:
+    """Flat series then abrupt drop at the end → LRC pct ≈ 0 (deep LONG zone)."""
+    rng = np.random.default_rng(seed)
+    flat_len = n - drop_bars
+    flat = start + rng.standard_normal(flat_len) * 0.2
+    drop = np.linspace(start, start * (1 - drop_pct), drop_bars)
+    close = np.concatenate([flat, drop])[:n]
+    noise = np.abs(rng.standard_normal(n)) * 0.2
+    df = pd.DataFrame({
+        "open":   np.roll(close, 1),
+        "high":   close + noise,
+        "low":    close - noise,
+        "close":  close,
+        "volume": rng.random(n) * 1000 + 500,
+    })
+    df.loc[0, "open"] = close[0]
+    df.index = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    return df
+
+
+def _uptrend_ohlcv(n: int = 250, seed: int = 42, start: float = 100.0,
+                   rise_bars: int = 20, rise_pct: float = 0.08) -> pd.DataFrame:
+    """Flat series then abrupt rise at the end → LRC pct ≈ 100 (deep SHORT zone)."""
+    rng = np.random.default_rng(seed)
+    flat_len = n - rise_bars
+    flat = start + rng.standard_normal(flat_len) * 0.2
+    rise = np.linspace(start, start * (1 + rise_pct), rise_bars)
+    close = np.concatenate([flat, rise])[:n]
+    noise = np.abs(rng.standard_normal(n)) * 0.2
+    df = pd.DataFrame({
+        "open":   np.roll(close, 1),
+        "high":   close + noise,
+        "low":    close - noise,
+        "close":  close,
+        "volume": rng.random(n) * 1000 + 500,
+    })
+    df.loc[0, "open"] = close[0]
+    df.index = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    return df
+
+
+def _flat_ohlcv(n: int = 250, seed: int = 42, start: float = 100.0) -> pd.DataFrame:
+    """Flat series with low noise → LRC% near 50 (middle zone)."""
+    rng = np.random.default_rng(seed)
+    close = start + rng.standard_normal(n) * 0.1
+    noise = np.abs(rng.standard_normal(n)) * 0.05
+    df = pd.DataFrame({
+        "open":   np.roll(close, 1),
+        "high":   close + noise,
+        "low":    close - noise,
+        "close":  close,
+        "volume": rng.random(n) * 1000 + 500,
+    })
+    df.loc[0, "open"] = close[0]
+    df.index = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+    return df
+
+
+def test_evaluate_signal_direction_long_in_bull_regime():
+    """A downtrend (LRC low) under BULL/NEUTRAL regime should classify LONG."""
+    from strategy.core import evaluate_signal
+    df1h = _downtrend_ohlcv(n=250, seed=100, start=100.0)
+    df4h = _downtrend_ohlcv(n=200, seed=101, start=100.0)
+    df5m = _downtrend_ohlcv(n=250, seed=102, start=100.0)
+    df1d = _downtrend_ohlcv(n=100, seed=103, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BULL", "score": 75, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    # Direction is LONG because LRC pct ≤ 25 and regime maps BULL → LONG
+    assert decision.indicators["lrc_pct"] is not None
+    assert decision.indicators["lrc_pct"] <= 25.0, \
+        f"Synthetic downtrend should stay in LONG zone; got lrc_pct={decision.indicators['lrc_pct']}"
+    assert decision.direction == "LONG"
+    assert 0 <= decision.score <= 9
+
+
+def test_evaluate_signal_direction_short_in_bear_regime():
+    """An uptrend (LRC high) under BEAR regime should classify SHORT."""
+    from strategy.core import evaluate_signal
+    df1h = _uptrend_ohlcv(n=250, seed=200, start=100.0)
+    df4h = _uptrend_ohlcv(n=200, seed=201, start=100.0)
+    df5m = _uptrend_ohlcv(n=250, seed=202, start=100.0)
+    df1d = _uptrend_ohlcv(n=100, seed=203, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BEAR", "score": 20, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.indicators["lrc_pct"] is not None
+    assert decision.indicators["lrc_pct"] >= 75.0, \
+        f"Synthetic uptrend should stay in SHORT zone; got lrc_pct={decision.indicators['lrc_pct']}"
+    assert decision.direction == "SHORT"
+    assert 0 <= decision.score <= 9
+
+
+def test_evaluate_signal_direction_none_when_uptrend_under_bull():
+    """Uptrend (LRC high) under BULL regime → NONE (SHORT gated by BEAR only)."""
+    from strategy.core import evaluate_signal
+    df1h = _uptrend_ohlcv(n=250, seed=210, start=100.0)
+    df4h = _uptrend_ohlcv(n=200, seed=211, start=100.0)
+    df5m = _uptrend_ohlcv(n=250, seed=212, start=100.0)
+    df1d = _uptrend_ohlcv(n=100, seed=213, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BULL", "score": 80, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    # In SHORT zone but regime is BULL → SHORT is gated off, direction stays NONE
+    assert decision.indicators["lrc_pct"] >= 75.0
+    assert decision.direction == "NONE"
+
+
+def test_evaluate_signal_neutral_when_out_of_zone():
+    """LRC in the 25-75 middle band → direction is NONE regardless of regime."""
+    from strategy.core import evaluate_signal
+    df1h = _flat_ohlcv(n=250, seed=999)
+    df4h = _flat_ohlcv(n=200, seed=998)
+    df5m = _flat_ohlcv(n=250, seed=997)
+    df1d = _flat_ohlcv(n=100, seed=996)
+
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BULL", "score": 80, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    # Flat series tends to keep LRC near 50%; when in middle band, direction is NONE
+    lrc_pct = decision.indicators["lrc_pct"]
+    if lrc_pct is not None and 25.0 < lrc_pct < 75.0:
+        assert decision.direction == "NONE"
+        assert decision.is_signal is False
+
+
+def test_evaluate_signal_score_label_populated_when_direction():
+    """When direction is chosen, score_label matches tier classification."""
+    from strategy.core import evaluate_signal
+    df1h = _downtrend_ohlcv(n=250, seed=300, start=100.0)
+    df4h = _downtrend_ohlcv(n=200, seed=301, start=100.0)
+    df5m = _downtrend_ohlcv(n=250, seed=302, start=100.0)
+    df1d = _downtrend_ohlcv(n=100, seed=303, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BULL", "score": 75, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.direction != "NONE"
+    # Valid tiers per btc_scanner.score_label
+    assert decision.score_label in ("MINIMA", "STANDARD", "PREMIUM", "INSUFICIENTE")
+
+
+def test_evaluate_signal_score_matches_scanner_logic_long():
+    """Replicate scan()'s C1-C7 checks and assert evaluate_signal's score matches."""
+    from strategy.core import evaluate_signal
+    from strategy.indicators import (
+        calc_lrc, calc_rsi, calc_bb, calc_sma, calc_cvd_delta,
+    )
+    import btc_scanner
+
+    df1h = _downtrend_ohlcv(n=250, seed=400, start=100.0)
+    df4h = _downtrend_ohlcv(n=200, seed=401, start=100.0)
+    df5m = _downtrend_ohlcv(n=250, seed=402, start=100.0)
+    df1d = _downtrend_ohlcv(n=100, seed=403, start=100.0)
+
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BULL", "score": 75, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.direction == "LONG", \
+        f"Expected LONG for seed=400 downtrend; got {decision.direction}"
+
+    # Replicate scan()'s C1-C7 manually
+    price = float(df1h["close"].iloc[-1])
+    rsi1h = calc_rsi(df1h["close"], btc_scanner.RSI_PERIOD)
+    cur_rsi1h = round(float(rsi1h.iloc[-1]), 2)
+    _, lrc_up, lrc_dn, _ = calc_lrc(df1h["close"], btc_scanner.LRC_PERIOD, btc_scanner.LRC_STDEV)
+    bb_up1h, _, bb_dn1h = calc_bb(df1h["close"], btc_scanner.BB_PERIOD, btc_scanner.BB_STDEV)
+    sma10_1h = float(calc_sma(df1h["close"], 10).iloc[-1])
+    sma20_1h = float(calc_sma(df1h["close"], 20).iloc[-1])
+    vol_avg1h = float(df1h["volume"].rolling(btc_scanner.VOL_PERIOD).mean().iloc[-1])
+    vol_1h = float(df1h["volume"].iloc[-1])
+    cvd_1h = calc_cvd_delta(df1h, n=3)
+    rsi_divs = btc_scanner.detect_rsi_divergence(df1h["close"], rsi1h, window=72)
+    bull_div = rsi_divs["bull"]
+
+    expected_score = 0
+    if cur_rsi1h < 40: expected_score += 2           # C1
+    if bull_div: expected_score += 2                 # C2
+    dist_sup = abs(price - lrc_dn) / price * 100 if lrc_dn else 999
+    if dist_sup <= 1.5: expected_score += 1          # C3
+    if price <= bb_dn1h.iloc[-1]: expected_score += 1  # C4
+    if vol_1h >= vol_avg1h: expected_score += 1      # C5
+    if cvd_1h > 0: expected_score += 1               # C6
+    if sma10_1h > sma20_1h: expected_score += 1      # C7
+
+    assert decision.score == expected_score
+
+
+def test_evaluate_signal_score_matches_scanner_logic_short():
+    """Replicate scan()'s SHORT C1-C7 checks and assert evaluate_signal's score matches."""
+    from strategy.core import evaluate_signal
+    from strategy.indicators import (
+        calc_lrc, calc_rsi, calc_bb, calc_sma, calc_cvd_delta,
+    )
+    import btc_scanner
+
+    df1h = _uptrend_ohlcv(n=250, seed=500, start=100.0)
+    df4h = _uptrend_ohlcv(n=200, seed=501, start=100.0)
+    df5m = _uptrend_ohlcv(n=250, seed=502, start=100.0)
+    df1d = _uptrend_ohlcv(n=100, seed=503, start=100.0)
+
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BEAR", "score": 20, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.direction == "SHORT", \
+        f"Expected SHORT for seed=500 uptrend under BEAR; got {decision.direction}"
+
+    # Replicate scan()'s SHORT C1-C7
+    price = float(df1h["close"].iloc[-1])
+    rsi1h = calc_rsi(df1h["close"], btc_scanner.RSI_PERIOD)
+    cur_rsi1h = round(float(rsi1h.iloc[-1]), 2)
+    _, lrc_up, lrc_dn, _ = calc_lrc(df1h["close"], btc_scanner.LRC_PERIOD, btc_scanner.LRC_STDEV)
+    bb_up1h, _, bb_dn1h = calc_bb(df1h["close"], btc_scanner.BB_PERIOD, btc_scanner.BB_STDEV)
+    sma10_1h = float(calc_sma(df1h["close"], 10).iloc[-1])
+    sma20_1h = float(calc_sma(df1h["close"], 20).iloc[-1])
+    vol_avg1h = float(df1h["volume"].rolling(btc_scanner.VOL_PERIOD).mean().iloc[-1])
+    vol_1h = float(df1h["volume"].iloc[-1])
+    cvd_1h = calc_cvd_delta(df1h, n=3)
+    rsi_divs = btc_scanner.detect_rsi_divergence(df1h["close"], rsi1h, window=72)
+    bear_div = rsi_divs["bear"]
+
+    expected_score = 0
+    if cur_rsi1h > 60: expected_score += 2           # C1
+    if bear_div: expected_score += 2                 # C2
+    dist_res = abs(price - lrc_up) / price * 100 if lrc_up else 999
+    if dist_res <= 1.5: expected_score += 1          # C3
+    if price >= bb_up1h.iloc[-1]: expected_score += 1  # C4
+    if vol_1h >= vol_avg1h: expected_score += 1      # C5
+    if cvd_1h < 0: expected_score += 1               # C6
+    if sma10_1h < sma20_1h: expected_score += 1      # C7
+
+    assert decision.score == expected_score

--- a/tests/test_strategy_core.py
+++ b/tests/test_strategy_core.py
@@ -434,3 +434,227 @@ def test_evaluate_signal_score_matches_scanner_logic_short():
     if sma10_1h < sma20_1h: expected_score += 1      # C7
 
     assert decision.score == expected_score
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Commit D — entry/SL/TP, is_signal/is_setup, estado, symbol gating
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_evaluate_signal_entry_sl_tp_computed_for_long():
+    """LONG direction → entry=price, SL=price-atr*sl_mult, TP=price+atr*tp_mult."""
+    from strategy.core import evaluate_signal
+    df1h = _downtrend_ohlcv(n=250, seed=600, start=100.0)
+    df4h = _downtrend_ohlcv(n=200, seed=601, start=100.0)
+    df5m = _downtrend_ohlcv(n=250, seed=602, start=100.0)
+    df1d = _downtrend_ohlcv(n=100, seed=603, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BULL", "score": 75, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.direction == "LONG"
+    price = decision.indicators["price"]
+    atr = decision.indicators["atr_1h"]
+    # Defaults: SL = 1.0x ATR, TP = 4.0x ATR (from strategy.core module constants)
+    assert decision.entry_price == pytest.approx(round(price, 2), abs=1e-9)
+    assert decision.sl_price == pytest.approx(round(price - atr * 1.0, 2), abs=1e-9)
+    assert decision.tp_price == pytest.approx(round(price + atr * 4.0, 2), abs=1e-9)
+    # SL must be below entry, TP above entry for LONG
+    assert decision.sl_price < decision.entry_price
+    assert decision.tp_price > decision.entry_price
+
+
+def test_evaluate_signal_entry_sl_tp_computed_for_short():
+    """SHORT direction → SL above entry, TP below entry."""
+    from strategy.core import evaluate_signal
+    df1h = _uptrend_ohlcv(n=250, seed=700, start=100.0)
+    df4h = _uptrend_ohlcv(n=200, seed=701, start=100.0)
+    df5m = _uptrend_ohlcv(n=250, seed=702, start=100.0)
+    df1d = _uptrend_ohlcv(n=100, seed=703, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BEAR", "score": 20, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.direction == "SHORT"
+    price = decision.indicators["price"]
+    atr = decision.indicators["atr_1h"]
+    assert decision.entry_price == pytest.approx(round(price, 2), abs=1e-9)
+    assert decision.sl_price == pytest.approx(round(price + atr * 1.0, 2), abs=1e-9)
+    assert decision.tp_price == pytest.approx(round(price - atr * 4.0, 2), abs=1e-9)
+    # SL must be above entry, TP below entry for SHORT
+    assert decision.sl_price > decision.entry_price
+    assert decision.tp_price < decision.entry_price
+
+
+def test_evaluate_signal_entry_sl_tp_none_for_direction_none():
+    """Direction NONE → entry/SL/TP must be None."""
+    from strategy.core import evaluate_signal
+    df1h = _flat_ohlcv(n=250, seed=800)
+    df4h = _flat_ohlcv(n=200, seed=801)
+    df5m = _flat_ohlcv(n=250, seed=802)
+    df1d = _flat_ohlcv(n=100, seed=803)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "NEUTRAL", "score": 50, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    if decision.direction == "NONE":
+        assert decision.entry_price is None
+        assert decision.sl_price is None
+        assert decision.tp_price is None
+        assert decision.is_signal is False
+
+
+def test_evaluate_signal_honors_symbol_disabled_false():
+    """cfg['symbol_overrides'][symbol] == False → estado reports deshabilitado."""
+    from strategy.core import evaluate_signal
+    df1h = _downtrend_ohlcv(n=250, seed=900, start=100.0)
+    df4h = _downtrend_ohlcv(n=200, seed=901, start=100.0)
+    df5m = _downtrend_ohlcv(n=250, seed=902, start=100.0)
+    df1d = _downtrend_ohlcv(n=100, seed=903, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={"symbol_overrides": {"BTCUSDT": False}},
+        regime={"regime": "BULL", "score": 75, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.is_signal is False
+    assert "deshabilitado en config" in decision.estado
+    assert decision.reasons.get("symbol_disabled") is True
+
+
+def test_evaluate_signal_honors_direction_disabled():
+    """cfg['symbol_overrides'][symbol]['long'] == None → LONG disabled."""
+    from strategy.core import evaluate_signal
+    df1h = _downtrend_ohlcv(n=250, seed=1000, start=100.0)
+    df4h = _downtrend_ohlcv(n=200, seed=1001, start=100.0)
+    df5m = _downtrend_ohlcv(n=250, seed=1002, start=100.0)
+    df1d = _downtrend_ohlcv(n=100, seed=1003, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={"symbol_overrides": {"BTCUSDT": {"long": None}}},
+        regime={"regime": "BULL", "score": 75, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    # Direction is chosen LONG before config override check, then blocked.
+    assert decision.direction == "LONG"
+    assert decision.is_signal is False
+    assert "deshabilitado" in decision.estado
+    assert decision.reasons.get("direction_disabled") is True
+
+
+def test_evaluate_signal_honors_per_symbol_atr_multipliers():
+    """cfg['symbol_overrides'] with custom atr_sl_mult / atr_tp_mult changes SL/TP."""
+    from strategy.core import evaluate_signal
+    df1h = _downtrend_ohlcv(n=250, seed=1100, start=100.0)
+    df4h = _downtrend_ohlcv(n=200, seed=1101, start=100.0)
+    df5m = _downtrend_ohlcv(n=250, seed=1102, start=100.0)
+    df1d = _downtrend_ohlcv(n=100, seed=1103, start=100.0)
+    cfg = {
+        "symbol_overrides": {
+            "BTCUSDT": {"atr_sl_mult": 2.5, "atr_tp_mult": 6.0, "atr_be_mult": 2.0}
+        }
+    }
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg=cfg,
+        regime={"regime": "BULL", "score": 75, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.direction == "LONG"
+    price = decision.indicators["price"]
+    atr = decision.indicators["atr_1h"]
+    assert decision.sl_price == pytest.approx(round(price - atr * 2.5, 2), abs=1e-9)
+    assert decision.tp_price == pytest.approx(round(price + atr * 6.0, 2), abs=1e-9)
+    assert decision.reasons["atr_sl_mult"] == 2.5
+    assert decision.reasons["atr_tp_mult"] == 6.0
+    assert decision.reasons["atr_be_mult"] == 2.0
+
+
+def test_evaluate_signal_estado_contains_direction_when_setup():
+    """Spanish estado string must mention direction for a valid setup."""
+    from strategy.core import evaluate_signal
+    df1h = _downtrend_ohlcv(n=250, seed=1200, start=100.0)
+    df4h = _downtrend_ohlcv(n=200, seed=1201, start=100.0)
+    df5m = _downtrend_ohlcv(n=250, seed=1202, start=100.0)
+    df1d = _downtrend_ohlcv(n=100, seed=1203, start=100.0)
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "BULL", "score": 75, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2024, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.direction == "LONG"
+    assert "LONG" in decision.estado or "SIN SETUP" in decision.estado
+
+
+def test_evaluate_signal_parity_full_fields_against_scan_snapshot():
+    """Parity: evaluate_signal output matches scan()'s report fields on real data.
+
+    Skips when cached OHLCV is unavailable in the workspace.
+    """
+    import os
+    if not os.path.exists("data/ohlcv.db"):
+        pytest.skip("requires cached market data (data/ohlcv.db)")
+
+    import btc_scanner
+    from strategy.core import evaluate_signal
+    try:
+        from backtest import get_cached_data
+    except Exception:
+        pytest.skip("backtest.get_cached_data unavailable")
+
+    symbol = "BTCUSDT"
+    rep = btc_scanner.scan(symbol)
+
+    data_start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    df1h = get_cached_data(symbol, "1h", start_date=data_start)
+    df4h = get_cached_data(symbol, "4h", start_date=data_start)
+    df5m = get_cached_data(symbol, "5m", start_date=data_start)
+    df1d = get_cached_data(symbol, "1d", start_date=data_start)
+    if df1h is None or df4h is None or df1h.empty or df4h.empty:
+        pytest.skip("cached data insufficient for parity test")
+
+    cfg = {}  # scan() loads config.json — use empty cfg to keep test deterministic
+    # Rebuild regime dict in the shape evaluate_signal expects:
+    regime = {
+        "regime": rep.get("regime"),
+        "score": rep.get("regime_score"),
+        "details": rep.get("regime_details") or {},
+    }
+
+    decision = evaluate_signal(
+        df1h, df4h, df5m, df1d,
+        symbol=symbol, cfg=cfg,
+        regime=regime, health_state="NORMAL",
+        now=datetime.now(timezone.utc),
+    )
+
+    # Score / is_signal / LRC parity (the subset that doesn't depend on scan()'s
+    # extra I/O like health state / reduce factor).
+    scan_lrc = (rep.get("lrc_1h") or {}).get("pct")
+    if scan_lrc is not None:
+        assert decision.indicators["lrc_pct"] == pytest.approx(scan_lrc, rel=1e-6)
+    # Score and direction should agree (modulo disabled paths where scan() bails early)
+    if rep.get("direction") is not None and "deshabilitado" not in rep.get("estado", ""):
+        assert decision.score == rep.get("score", 0)
+        assert decision.direction == rep.get("direction")

--- a/tests/test_strategy_core.py
+++ b/tests/test_strategy_core.py
@@ -1,0 +1,67 @@
+"""Tests for strategy.core.evaluate_signal — parity with btc_scanner.scan() (#186 A1)."""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Commit A — SignalDecision dataclass tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_signal_decision_dataclass_constructs():
+    from strategy.core import SignalDecision
+    d = SignalDecision()
+    assert d.direction == "NONE"
+    assert d.score == 0
+    assert d.score_label == ""
+    assert d.is_signal is False
+    assert d.is_setup is False
+    assert d.entry_price is None
+    assert d.sl_price is None
+    assert d.tp_price is None
+    assert d.reasons == {}
+    assert d.indicators == {}
+    assert d.estado == ""
+
+
+def test_signal_decision_fields_populated():
+    from strategy.core import SignalDecision
+    d = SignalDecision(
+        direction="LONG",
+        score=6,
+        score_label="PREMIUM",
+        is_signal=True,
+        entry_price=50_000.0,
+        sl_price=49_000.0,
+        tp_price=55_000.0,
+    )
+    assert d.direction == "LONG"
+    assert d.is_signal is True
+    assert d.entry_price == 50_000.0
+    assert d.sl_price == 49_000.0
+    assert d.tp_price == 55_000.0
+
+
+def test_evaluate_signal_stub_returns_decision_on_empty_df():
+    """With insufficient data the function should return a NONE decision — not raise."""
+    from strategy.core import evaluate_signal
+    empty = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    decision = evaluate_signal(
+        df1h=empty,
+        df4h=empty,
+        df5m=empty,
+        df1d=empty,
+        symbol="BTCUSDT",
+        cfg={},
+        regime={"regime": "NEUTRAL", "score": 50, "details": {}},
+        health_state="NORMAL",
+        now=datetime(2026, 4, 23, tzinfo=timezone.utc),
+    )
+    assert decision.direction == "NONE"
+    assert decision.is_signal is False

--- a/tests/test_strategy_indicators.py
+++ b/tests/test_strategy_indicators.py
@@ -1,0 +1,92 @@
+"""Parity tests: strategy.indicators must match btc_scanner's existing output."""
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def sample_close_series():
+    np.random.seed(42)
+    prices = 100.0 + np.cumsum(np.random.randn(200) * 0.5)
+    return pd.Series(prices)
+
+
+@pytest.fixture
+def sample_ohlcv_df(sample_close_series):
+    n = len(sample_close_series)
+    noise = np.abs(np.random.randn(n)) * 0.3
+    return pd.DataFrame({
+        "open":  sample_close_series.shift(1).bfill(),
+        "high":  sample_close_series + noise,
+        "low":   sample_close_series - noise,
+        "close": sample_close_series,
+        "volume": np.random.rand(n) * 1000,
+        "taker_buy_base": np.random.rand(n) * 500,
+    })
+
+
+def test_calc_lrc_parity(sample_close_series):
+    from strategy.indicators import calc_lrc as new_impl
+    from btc_scanner import calc_lrc as old_impl
+    new_result = new_impl(sample_close_series, 100, 2.0)
+    old_result = old_impl(sample_close_series, 100, 2.0)
+    # calc_lrc returns tuple (lrc_pct, upper, lower, mid)
+    assert new_result[0] == pytest.approx(old_result[0], rel=1e-9)
+    for i in range(1, 4):
+        assert new_result[i] == pytest.approx(old_result[i], rel=1e-9)
+
+
+def test_calc_rsi_parity(sample_close_series):
+    from strategy.indicators import calc_rsi as new_impl
+    from btc_scanner import calc_rsi as old_impl
+    pd.testing.assert_series_equal(
+        new_impl(sample_close_series, 14),
+        old_impl(sample_close_series, 14),
+        check_names=False,
+    )
+
+
+def test_calc_bb_parity(sample_close_series):
+    from strategy.indicators import calc_bb as new_impl
+    from btc_scanner import calc_bb as old_impl
+    new_up, new_mid, new_dn = new_impl(sample_close_series, 20, 2.0)
+    old_up, old_mid, old_dn = old_impl(sample_close_series, 20, 2.0)
+    pd.testing.assert_series_equal(new_up, old_up, check_names=False)
+    pd.testing.assert_series_equal(new_mid, old_mid, check_names=False)
+    pd.testing.assert_series_equal(new_dn, old_dn, check_names=False)
+
+
+def test_calc_sma_parity(sample_close_series):
+    from strategy.indicators import calc_sma as new_impl
+    from btc_scanner import calc_sma as old_impl
+    pd.testing.assert_series_equal(
+        new_impl(sample_close_series, 50),
+        old_impl(sample_close_series, 50),
+        check_names=False,
+    )
+
+
+def test_calc_atr_parity(sample_ohlcv_df):
+    from strategy.indicators import calc_atr as new_impl
+    from btc_scanner import calc_atr as old_impl
+    pd.testing.assert_series_equal(
+        new_impl(sample_ohlcv_df, 14),
+        old_impl(sample_ohlcv_df, 14),
+        check_names=False,
+    )
+
+
+def test_calc_adx_parity(sample_ohlcv_df):
+    from strategy.indicators import calc_adx as new_impl
+    from btc_scanner import calc_adx as old_impl
+    pd.testing.assert_series_equal(
+        new_impl(sample_ohlcv_df, 14),
+        old_impl(sample_ohlcv_df, 14),
+        check_names=False,
+    )
+
+
+def test_calc_cvd_delta_parity(sample_ohlcv_df):
+    from strategy.indicators import calc_cvd_delta as new_impl
+    from btc_scanner import calc_cvd_delta as old_impl
+    assert new_impl(sample_ohlcv_df, 3) == pytest.approx(old_impl(sample_ohlcv_df, 3), rel=1e-9)

--- a/tests/test_strategy_sizing.py
+++ b/tests/test_strategy_sizing.py
@@ -1,0 +1,59 @@
+"""Tests for strategy.sizing.compute_size (#186 A4)."""
+import pytest
+
+
+def test_compute_size_normal_premium_score():
+    from strategy.sizing import compute_size
+    cfg = {"kill_switch": {"reduce_size_factor": 0.5}}
+    size = compute_size(score=6, health_tier="NORMAL", capital=10_000.0, cfg=cfg)
+    assert size == pytest.approx(150.0)
+
+
+def test_compute_size_normal_standard_score():
+    from strategy.sizing import compute_size
+    cfg = {"kill_switch": {"reduce_size_factor": 0.5}}
+    size = compute_size(score=3, health_tier="NORMAL", capital=10_000.0, cfg=cfg)
+    assert size == pytest.approx(100.0)
+
+
+def test_compute_size_normal_low_score():
+    from strategy.sizing import compute_size
+    cfg = {"kill_switch": {"reduce_size_factor": 0.5}}
+    size = compute_size(score=1, health_tier="NORMAL", capital=10_000.0, cfg=cfg)
+    assert size == pytest.approx(50.0)
+
+
+def test_compute_size_alert_same_as_normal():
+    """ALERT is notification-only; doesn't change sizing."""
+    from strategy.sizing import compute_size
+    cfg = {"kill_switch": {"reduce_size_factor": 0.5}}
+    size = compute_size(score=3, health_tier="ALERT", capital=10_000.0, cfg=cfg)
+    assert size == pytest.approx(100.0)
+
+
+def test_compute_size_reduced_halves():
+    from strategy.sizing import compute_size
+    cfg = {"kill_switch": {"reduce_size_factor": 0.5}}
+    size = compute_size(score=3, health_tier="REDUCED", capital=10_000.0, cfg=cfg)
+    assert size == pytest.approx(50.0)
+
+
+def test_compute_size_paused_is_zero():
+    from strategy.sizing import compute_size
+    cfg = {"kill_switch": {"reduce_size_factor": 0.5}}
+    size = compute_size(score=6, health_tier="PAUSED", capital=10_000.0, cfg=cfg)
+    assert size == 0.0
+
+
+def test_compute_size_probation_halves():
+    from strategy.sizing import compute_size
+    cfg = {"kill_switch": {"reduce_size_factor": 0.5}}
+    size = compute_size(score=3, health_tier="PROBATION", capital=10_000.0, cfg=cfg)
+    assert size == pytest.approx(50.0)
+
+
+def test_compute_size_custom_reduce_factor():
+    from strategy.sizing import compute_size
+    cfg = {"kill_switch": {"reduce_size_factor": 0.3}}
+    size = compute_size(score=3, health_tier="REDUCED", capital=10_000.0, cfg=cfg)
+    assert size == pytest.approx(30.0)


### PR DESCRIPTION
## Summary

Epic #186 refactor: extract trading decision logic from \`btc_scanner.scan()\` into a shared \`strategy/\` package. Ships **production rewire complete** (scan uses evaluate_signal) + **KillSwitchSimulator for backtests** + pure helpers everywhere. Ejecutado con subagent-driven-development siguiendo el plan del PR #206 (1411 líneas, 7 tasks).

## IMPORTANT: partial completion with known caveat

Tasks A1-A5 completely achieved their goal. **Task A6 (backtest rewire) took the MVP path documented in the plan**: ships the \`KillSwitchSimulator\` + tier wiring + byte-identical parity, but **does NOT swap \`simulate_strategy\`'s decision logic to use \`evaluate_signal()\`** — implementer detected numerical drift risk (Wilder's EMA ~2e-5 between full-df vs windowed iteration) that would shift trade scores by 1-2 points and break parity.

**What this means for Epic #186:**
- ✅ Production (\`scan()\`) uses shared \`evaluate_signal()\`.
- ✅ \`KillSwitchSimulator\` ready for kill switch v2 phase 2 features to simulate against.
- ⚠️ Backtest decision logic is still inline (separate from scan's). Full unification deferred to a follow-up PR.

**Follow-up recommended**: a separate PR that refactors \`evaluate_signal()\` to accept windowed slices (or makes \`simulate_strategy\` iterate full df once), then swaps the inline logic for \`evaluate_signal\` calls with per-indicator window-parity tests.

## Ships

### Batch 1 — Primitives (parallel-safe, no mutual deps)

- **A2** (\`1a9a782\`) — \`strategy/indicators.py\` — moved calc_lrc, calc_rsi, calc_bb, calc_sma, calc_atr, calc_adx, calc_cvd_delta. btc_scanner re-exports for backward compat. 7 parity tests.
- **A3** (\`b3f989d\`) — \`health.compute_rolling_metrics_from_trades\` pure; existing DB-backed function is now a thin wrapper. Preserves \`win_rate_20_trades=0.0\` semantics of the legacy for empty DB. 4 new tests.
- **A4** (\`8d833f7\`) — \`strategy/sizing.py\` — \`compute_size(score, health_tier, capital, cfg)\` pure. 8 tests covering score × tier matrix.

### Batch 2 — Central piece

- **A1** (4 sub-commits: \`B8D1626\`, \`E2D5064\`, \`A36801F\`, \`A505C87\`) — \`strategy/core.py\` with \`SignalDecision\` dataclass + \`evaluate_signal()\` pure function. 20 tests. Incremental commits: skeleton → indicators → score → direction/entry/SL/TP. Snapshot parity against \`scan()\` output verified when cached data present.

### Batch 3 — Rewires

- **A5** (\`875152c\`) — \`btc_scanner.scan()\` rewired to call \`evaluate_signal\` + \`compute_size\`. Report shape byte-identical. Known compromises documented: \`compute_size()\` called but result stored in \`decision.reasons[\"pure_size_usd\"]\` instead of \`sizing_1h.riesgo_usd\` (switching is a behavior change deferred to follow-up). 3 new parity tests.
- **A6** (\`f7695b9\`) — \`backtest_kill_switch.KillSwitchSimulator\` created + wired into \`simulate_strategy\`. Parity trade-level: 24 trades / \$11,021.66 final equity bit-identical on BTCUSDT 2024-01 → 2024-03. **Does NOT rewire \`simulate_strategy\` to use \`evaluate_signal\`** (see caveat above). 4 simulator tests + 2 parity tests.

## Test plan

- [x] Python suite: **676 passed**, 0 failed (baseline 628 + 48 new from all tasks).
- [x] Frontend suite: **21 passed** (unchanged — this PR doesn't touch frontend).
- [x] Indicator parity verified lossless.
- [x] Scan report shape unchanged.
- [x] Backtest parity (apply_kill_switch=False): trade-level + equity-curve byte-identical on pinned window.
- [x] KillSwitchSimulator: 4 isolated tests + integration test in simulate_strategy.

## Closes (partial)

Closes #188 (A1), #189 (A2), #190 (A3), #191 (A4), #192 (A5).
**Does NOT close #193 (A6)**: simulator shipped but evaluate_signal swap deferred. Epic #186 remains open pending follow-up PR for the full simulate_strategy rewire.

## Unblocks

Kill switch v2 Phase 2 (epic #187) can now start — the \`KillSwitchSimulator\` enables features B1-B5 to validate against backtest with tier state. Decision-parity between scan and backtest is 90%-there; features that depend on *identical* decision output between the two paths (unlikely — most features are about the kill switch tier behavior) should wait for the follow-up PR.

## Known caveats

1. \`compute_size()\` is NOT load-bearing yet. scan() still uses legacy sizing formula; \`compute_size()\` output stored for observability only.
2. \`simulate_strategy\` decision logic is still inline (not \`evaluate_signal\`). Intentional MVP path.
3. Score decoration (e.g. \"PREMIUM ⭐⭐⭐ (sizing 150%)\") happens at scan's report-assembly layer, NOT in evaluate_signal. Consistent with intent to keep evaluate_signal pure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)