### PR TITLE
feat(kill-switch-v2): B2 portfolio-level circuit breaker in shadow mode (#187)

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -928,6 +928,19 @@ def scan(symbol: str = None):
     except Exception as _obs_err:
         log.warning("observability.record_decision failed for %s: %s", symbol, _obs_err)
 
+    # Shadow mode for kill switch v2 (#187 B2): compute + log portfolio tier
+    # as engine='v2_shadow' alongside the v1 row. No effect on trading.
+    try:
+        from strategy.kill_switch_v2_shadow import emit_shadow_decision
+        current_price = float(df1h["close"].iloc[-1]) if not df1h.empty else 0.0
+        emit_shadow_decision(
+            symbol=symbol,
+            cfg=_cfg if _cfg else {},
+            now_price_by_symbol={symbol: current_price},
+        )
+    except Exception as _shadow_err:
+        log.warning("kill_switch_v2_shadow emission failed for %s: %s", symbol, _shadow_err)
+
     if _health_state == "PAUSED":
         rep.update({
             "estado": f"🛑 {symbol} PAUSED por kill switch (#138) — reactivar manualmente",

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -931,13 +931,10 @@ def scan(symbol: str = None):
     # Shadow mode for kill switch v2 (#187 B2): compute + log portfolio tier
     # as engine='v2_shadow' alongside the v1 row. No effect on trading.
     try:
-        from strategy.kill_switch_v2_shadow import emit_shadow_decision
-        current_price = float(df1h["close"].iloc[-1]) if not df1h.empty else 0.0
-        emit_shadow_decision(
-            symbol=symbol,
-            cfg=_cfg if _cfg else {},
-            now_price_by_symbol={symbol: current_price},
-        )
+        from strategy.kill_switch_v2_shadow import emit_shadow_decision, update_price
+        if not df1h.empty:
+            update_price(symbol, float(df1h["close"].iloc[-1]))
+        emit_shadow_decision(symbol=symbol, cfg=_cfg if _cfg else {})
     except Exception as _shadow_err:
         log.warning("kill_switch_v2_shadow emission failed for %s: %s", symbol, _shadow_err)
 

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -1,0 +1,56 @@
+"""Kill switch v2 shadow engine (#187 B2 — portfolio circuit breaker).
+
+Pure functions computing portfolio-level state from equity curves. Runs in
+shadow mode during Phase 2: writes to decision log with engine='v2_shadow';
+does NOT affect real trading. The actual v1 kill switch continues operating
+untouched.
+
+Operator-facing slider (0-100) interpolates thresholds linearly between
+tmin (laxo) and tmax (paranoid). Values come from config.defaults.json
+under kill_switch.v2.thresholds.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+# Defaults (match config.defaults.json). Used as fallback when config is incomplete.
+_DEFAULT_AGGRESSIVENESS = 50.0
+_DEFAULT_DD_REDUCED = {"min": -0.08, "max": -0.03}
+_DEFAULT_DD_FROZEN = {"min": -0.15, "max": -0.06}
+
+
+def interpolate_threshold(slider: float, t_min: float, t_max: float) -> float:
+    """Linearly interpolate a threshold value from the slider (0-100).
+
+    slider=0 → t_min (most permissive)
+    slider=100 → t_max (most strict)
+    """
+    slider = max(0.0, min(100.0, float(slider)))
+    return t_min + (slider / 100.0) * (t_max - t_min)
+
+
+def get_portfolio_thresholds(cfg: dict[str, Any]) -> dict[str, float]:
+    """Extract the slider-adjusted portfolio DD thresholds from config.
+
+    Returns:
+        {"reduced_dd": float, "frozen_dd": float}
+
+    Both values are negative (drawdowns). Falls back to defaults when config
+    keys are missing.
+    """
+    v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+    slider = v2_cfg.get("aggressiveness", _DEFAULT_AGGRESSIVENESS)
+    thresholds_cfg = v2_cfg.get("thresholds", {}) or {}
+
+    reduced_range = thresholds_cfg.get("portfolio_dd_reduced") or _DEFAULT_DD_REDUCED
+    frozen_range = thresholds_cfg.get("portfolio_dd_frozen") or _DEFAULT_DD_FROZEN
+
+    return {
+        "reduced_dd": interpolate_threshold(
+            slider, reduced_range["min"], reduced_range["max"]
+        ),
+        "frozen_dd": interpolate_threshold(
+            slider, frozen_range["min"], frozen_range["max"]
+        ),
+    }

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -108,3 +108,61 @@ def compute_portfolio_equity_curve(
         curve.append({"ts": "now_mtm", "equity": current_equity + mtm_total})
 
     return curve
+
+
+def compute_portfolio_dd(equity_curve: list[dict[str, Any]]) -> float:
+    """Peak-to-current drawdown % from an equity curve.
+
+    Returns negative value if in drawdown; 0.0 otherwise.
+    """
+    if not equity_curve:
+        return 0.0
+    peak = equity_curve[0]["equity"]
+    current = peak
+    for point in equity_curve:
+        eq = float(point["equity"])
+        if eq > peak:
+            peak = eq
+        current = eq
+    if peak <= 0:
+        return 0.0
+    return (current - peak) / peak
+
+
+def evaluate_portfolio_tier(
+    portfolio_dd: float,
+    concurrent_failures: int,
+    cfg: dict[str, Any],
+) -> dict[str, Any]:
+    """Compose portfolio tier from DD + concurrent failure count.
+
+    Tier precedence (most severe wins):
+        FROZEN > REDUCED > WARNED > NORMAL
+
+    Returns:
+        {"tier": str, "dd": float, "concurrent_failures": int,
+         "reduced_threshold": float, "frozen_threshold": float}
+    """
+    thresholds = get_portfolio_thresholds(cfg)
+    v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+    concurrent_alert_threshold = int(
+        v2_cfg.get("concurrent_alert_threshold", 3)
+    )
+
+    # FROZEN check (most severe)
+    if portfolio_dd <= thresholds["frozen_dd"]:
+        tier = "FROZEN"
+    elif portfolio_dd <= thresholds["reduced_dd"]:
+        tier = "REDUCED"
+    elif concurrent_failures >= concurrent_alert_threshold:
+        tier = "WARNED"
+    else:
+        tier = "NORMAL"
+
+    return {
+        "tier": tier,
+        "dd": portfolio_dd,
+        "concurrent_failures": concurrent_failures,
+        "reduced_threshold": thresholds["reduced_dd"],
+        "frozen_threshold": thresholds["frozen_dd"],
+    }

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -54,3 +54,57 @@ def get_portfolio_thresholds(cfg: dict[str, Any]) -> dict[str, float]:
             slider, frozen_range["min"], frozen_range["max"]
         ),
     }
+
+
+def compute_portfolio_equity_curve(
+    closed_trades: list[dict[str, Any]],
+    open_positions: list[dict[str, Any]],
+    capital_base: float,
+    now_price_by_symbol: dict[str, float],
+) -> list[dict[str, Any]]:
+    """Compute a portfolio equity curve by applying closed trades + open MTM.
+
+    Args:
+        closed_trades: list of {"symbol", "exit_ts", "pnl_usd"} — pnl added cumulatively.
+        open_positions: list of {"symbol", "entry_price", "qty", "direction"} — MTM'd at end.
+        capital_base: starting equity.
+        now_price_by_symbol: current price per symbol, used to MTM open positions.
+
+    Returns:
+        List of {"ts": str, "equity": float} points, time-ordered.
+    """
+    # Sort closed trades by exit_ts ascending
+    sorted_closed = sorted(closed_trades, key=lambda t: t.get("exit_ts", ""))
+
+    curve: list[dict[str, Any]] = []
+
+    # Starting point
+    start_ts = sorted_closed[0].get("exit_ts") if sorted_closed else "start"
+    curve.append({"ts": start_ts, "equity": capital_base})
+
+    # Apply each closed trade
+    current_equity = capital_base
+    for trade in sorted_closed:
+        pnl = float(trade.get("pnl_usd") or 0)
+        current_equity += pnl
+        curve.append({"ts": trade.get("exit_ts", ""), "equity": current_equity})
+
+    # Add MTM point for open positions
+    mtm_total = 0.0
+    for pos in open_positions:
+        sym = pos.get("symbol")
+        if sym not in now_price_by_symbol:
+            continue
+        entry = float(pos.get("entry_price") or 0)
+        qty = float(pos.get("qty") or 0)
+        direction = pos.get("direction", "LONG")
+        current_price = now_price_by_symbol[sym]
+        if direction == "SHORT":
+            mtm_total += (entry - current_price) * qty
+        else:
+            mtm_total += (current_price - entry) * qty
+
+    if mtm_total != 0.0:
+        curve.append({"ts": "now_mtm", "equity": current_equity + mtm_total})
+
+    return curve

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -1,0 +1,125 @@
+"""Shadow-mode glue for kill switch v2 (#187 B2).
+
+Reads state from DB (closed trades + open positions + current prices),
+calls the pure functions in strategy.kill_switch_v2, writes a decision
+to the observability log with engine='v2_shadow'.
+
+Fail-open: any exception is logged; v1 keeps operating untouched.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger("kill_switch_v2_shadow")
+
+
+def _load_closed_trades() -> list[dict[str, Any]]:
+    """Load closed positions from DB for portfolio equity computation."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            """SELECT symbol, exit_ts, pnl_usd
+               FROM positions
+               WHERE status = 'closed' AND exit_ts IS NOT NULL
+               ORDER BY exit_ts"""
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        {"symbol": r[0], "exit_ts": r[1], "pnl_usd": r[2] or 0.0}
+        for r in rows
+    ]
+
+
+def _load_open_positions() -> list[dict[str, Any]]:
+    """Load open positions from DB for MTM."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            """SELECT symbol, entry_price, qty, direction
+               FROM positions
+               WHERE status = 'open'"""
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        {
+            "symbol": r[0],
+            "entry_price": r[1] or 0.0,
+            "qty": r[2] or 0.0,
+            "direction": r[3] or "LONG",
+        }
+        for r in rows
+    ]
+
+
+def _count_concurrent_failures() -> int:
+    """Count symbols whose latest v1 decision is ALERT/REDUCED/PAUSED/PROBATION."""
+    import observability
+    state = observability.get_current_state(engine="v1")
+    return state["portfolio"]["concurrent_failures"]
+
+
+def emit_shadow_decision(
+    symbol: str,
+    cfg: dict[str, Any],
+    now_price_by_symbol: dict[str, float] | None = None,
+) -> None:
+    """Compute portfolio tier, write a v2_shadow row to the decision log.
+
+    Fail-open: any exception is caught and logged.
+    """
+    from strategy.kill_switch_v2 import (
+        compute_portfolio_equity_curve,
+        compute_portfolio_dd,
+        evaluate_portfolio_tier,
+        get_portfolio_thresholds,
+    )
+    import observability
+
+    try:
+        capital_base = float(cfg.get("capital_usd", 100_000.0))
+        closed = _load_closed_trades()
+        opens = _load_open_positions()
+        prices = now_price_by_symbol or {}
+
+        equity_curve = compute_portfolio_equity_curve(
+            closed_trades=closed,
+            open_positions=opens,
+            capital_base=capital_base,
+            now_price_by_symbol=prices,
+        )
+        portfolio_dd = compute_portfolio_dd(equity_curve)
+        concurrent = _count_concurrent_failures()
+
+        portfolio = evaluate_portfolio_tier(
+            portfolio_dd=portfolio_dd,
+            concurrent_failures=concurrent,
+            cfg=cfg,
+        )
+
+        v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+        slider = float(v2_cfg.get("aggressiveness", 50.0))
+
+        observability.record_decision(
+            symbol=symbol,
+            engine="v2_shadow",
+            per_symbol_tier="NORMAL",  # v2 per-symbol tier lands with B4 auto-cal
+            portfolio_tier=portfolio["tier"],
+            size_factor=1.0,  # v2 sizing lands later
+            skip=False,
+            reasons={
+                "portfolio_dd": portfolio_dd,
+                "reduced_threshold": portfolio["reduced_threshold"],
+                "frozen_threshold": portfolio["frozen_threshold"],
+                "concurrent_failures": concurrent,
+            },
+            scan_id=None,
+            slider_value=slider,
+            velocity_active=False,
+        )
+    except Exception as e:
+        log.warning("kill_switch_v2_shadow.emit_shadow_decision failed for %s: %s", symbol, e)

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -13,6 +13,26 @@ from typing import Any
 
 log = logging.getLogger("kill_switch_v2_shadow")
 
+# Matches btc_scanner.scan()'s hardcoded capital (see btc_scanner.py:1121).
+# Config doesn't currently expose this; the default must match the real
+# deployed value so shadow DD is not off by ~100×.
+_DEFAULT_CAPITAL_USD = 1000.0
+
+# Price cache accumulated across scan() calls. Each scan updates its symbol's
+# price via update_price(); emit_shadow_decision MTMs every open position
+# that has a cached price. Over one full scan cycle (~10 symbols), all live
+# symbols populate.
+_PRICE_CACHE: dict[str, float] = {}
+
+
+def update_price(symbol: str, price: float) -> None:
+    """Record the latest scanned price so MTM can see every open symbol."""
+    _PRICE_CACHE[symbol] = float(price)
+
+
+def _snapshot_prices() -> dict[str, float]:
+    return dict(_PRICE_CACHE)
+
 
 def _load_closed_trades() -> list[dict[str, Any]]:
     """Load closed positions from DB for portfolio equity computation."""
@@ -60,7 +80,8 @@ def _count_concurrent_failures() -> int:
     """Count symbols whose latest v1 decision is ALERT/REDUCED/PAUSED/PROBATION."""
     import observability
     state = observability.get_current_state(engine="v1")
-    return state["portfolio"]["concurrent_failures"]
+    portfolio = state.get("portfolio") or {}
+    return int(portfolio.get("concurrent_failures", 0))
 
 
 def emit_shadow_decision(
@@ -70,21 +91,24 @@ def emit_shadow_decision(
 ) -> None:
     """Compute portfolio tier, write a v2_shadow row to the decision log.
 
-    Fail-open: any exception is caught and logged.
+    Uses the module-level price cache for MTM. Callers can pass additional
+    prices via now_price_by_symbol; they're merged in. Fail-open: any
+    exception is caught and logged with full traceback.
     """
     from strategy.kill_switch_v2 import (
         compute_portfolio_equity_curve,
         compute_portfolio_dd,
         evaluate_portfolio_tier,
-        get_portfolio_thresholds,
     )
     import observability
 
     try:
-        capital_base = float(cfg.get("capital_usd", 100_000.0))
+        capital_base = float(cfg.get("capital_usd", _DEFAULT_CAPITAL_USD))
         closed = _load_closed_trades()
         opens = _load_open_positions()
-        prices = now_price_by_symbol or {}
+        prices = _snapshot_prices()
+        if now_price_by_symbol:
+            prices.update(now_price_by_symbol)
 
         equity_curve = compute_portfolio_equity_curve(
             closed_trades=closed,
@@ -107,9 +131,9 @@ def emit_shadow_decision(
         observability.record_decision(
             symbol=symbol,
             engine="v2_shadow",
-            per_symbol_tier="NORMAL",  # v2 per-symbol tier lands with B4 auto-cal
+            per_symbol_tier="NORMAL",
             portfolio_tier=portfolio["tier"],
-            size_factor=1.0,  # v2 sizing lands later
+            size_factor=1.0,
             skip=False,
             reasons={
                 "portfolio_dd": portfolio_dd,
@@ -122,4 +146,7 @@ def emit_shadow_decision(
             velocity_active=False,
         )
     except Exception as e:
-        log.warning("kill_switch_v2_shadow.emit_shadow_decision failed for %s: %s", symbol, e)
+        log.warning(
+            "kill_switch_v2_shadow.emit_shadow_decision failed for %s: %s",
+            symbol, e, exc_info=True,
+        )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -181,3 +181,26 @@ def test_get_current_state_filters_by_engine(tmp_db):
     state_v2 = get_current_state(engine="v2_shadow")
     assert state_v1["symbols"]["BTCUSDT"]["per_symbol_tier"] == "NORMAL"
     assert state_v2["symbols"]["BTCUSDT"]["per_symbol_tier"] == "ALERT"
+
+
+def test_get_current_state_engine_v2_shadow(tmp_db):
+    from observability import record_decision, get_current_state
+    record_decision(
+        symbol="BTCUSDT", engine="v1",
+        per_symbol_tier="NORMAL", portfolio_tier="NORMAL",
+        size_factor=1.0, skip=False, reasons={},
+        scan_id=None, slider_value=None, velocity_active=False,
+    )
+    record_decision(
+        symbol="BTCUSDT", engine="v2_shadow",
+        per_symbol_tier="NORMAL", portfolio_tier="REDUCED",
+        size_factor=1.0, skip=False,
+        reasons={"portfolio_dd": -0.06},
+        scan_id=None, slider_value=50.0, velocity_active=False,
+    )
+
+    v1_state = get_current_state(engine="v1")
+    shadow_state = get_current_state(engine="v2_shadow")
+
+    assert v1_state["symbols"]["BTCUSDT"]["portfolio_tier"] == "NORMAL"
+    assert shadow_state["symbols"]["BTCUSDT"]["portfolio_tier"] == "REDUCED"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1306,7 +1306,9 @@ class TestScanWritesToDecisionLog:
             # happens after the health-state lookup.
             pass
 
-        rows = observability.query_decisions(symbol="BTCUSDT")
+        # B2 (#187): scan() now also writes a v2_shadow row alongside v1.
+        # Filter to the v1 engine to keep this test focused on the v1 path.
+        rows = observability.query_decisions(symbol="BTCUSDT", engine="v1")
         assert len(rows) >= 1
         assert rows[0]["engine"] == "v1"
         assert rows[0]["per_symbol_tier"] in (
@@ -1459,3 +1461,49 @@ class TestScanRefactorParity:
         rep = scanner.scan("BTCUSDT")
         assert rep.get("direction_disabled") is True
         assert rep.get("señal_activa") is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  TESTS — scan() emits v2_shadow portfolio tier decision (#187 B2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestScanEmitsV2ShadowDecision:
+    def test_scan_writes_v2_shadow_row(self, tmp_path, monkeypatch):
+        """scan() writes BOTH engine='v1' AND engine='v2_shadow' rows to the log."""
+        import btc_api, btc_scanner, observability
+        db_path = str(tmp_path / "signals.db")
+        monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+        if hasattr(btc_api, "_db_conn"):
+            delattr(btc_api, "_db_conn")
+        btc_api.init_db()
+
+        # Mock market data fetch (Task 3 A6 pattern)
+        import pandas as pd
+        import numpy as np
+        def fake_klines(*a, **kw):
+            n = 250
+            idx = pd.date_range("2024-01-01", periods=n, freq="1h", tz="UTC")
+            prices = 50_000 + np.cumsum(
+                np.random.default_rng(42).standard_normal(n) * 100
+            )
+            return pd.DataFrame({
+                "open": prices, "high": prices * 1.005, "low": prices * 0.995,
+                "close": prices, "volume": np.full(n, 1000.0),
+                "taker_buy_base": np.full(n, 500.0),
+            }, index=idx)
+
+        monkeypatch.setattr(btc_scanner.md, "get_klines", fake_klines)
+        try:
+            btc_scanner.scan("BTCUSDT")
+        except Exception:
+            pass  # let exceptions in the indicator path happen — the decision log
+                   # writes come BEFORE any possible crash
+
+        v1_rows = observability.query_decisions(symbol="BTCUSDT", engine="v1")
+        shadow_rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+        assert len(v1_rows) >= 1, "v1 row must still be logged"
+        assert len(shadow_rows) >= 1, "v2_shadow row must be logged alongside v1"
+        # The shadow row should have a valid portfolio_tier
+        assert shadow_rows[0]["portfolio_tier"] in (
+            "NORMAL", "WARNED", "REDUCED", "FROZEN",
+        )

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -176,3 +176,145 @@ def test_compute_portfolio_equity_curve_missing_price_skips_mtm():
     # Only the start point remains (no MTM applied)
     assert len(curve) == 1
     assert curve[0]["equity"] == pytest.approx(100_000.0)
+
+
+def test_compute_portfolio_dd_from_flat_curve():
+    from strategy.kill_switch_v2 import compute_portfolio_dd
+    curve = [
+        {"ts": "a", "equity": 100_000.0},
+        {"ts": "b", "equity": 100_000.0},
+    ]
+    assert compute_portfolio_dd(curve) == pytest.approx(0.0)
+
+
+def test_compute_portfolio_dd_only_gains():
+    from strategy.kill_switch_v2 import compute_portfolio_dd
+    curve = [
+        {"ts": "a", "equity": 100_000.0},
+        {"ts": "b", "equity": 105_000.0},
+        {"ts": "c", "equity": 110_000.0},
+    ]
+    assert compute_portfolio_dd(curve) == pytest.approx(0.0)
+
+
+def test_compute_portfolio_dd_drawdown_from_peak():
+    from strategy.kill_switch_v2 import compute_portfolio_dd
+    # Peak 110k, valley 99k → DD = (99-110)/110 = -0.10
+    curve = [
+        {"ts": "a", "equity": 100_000.0},
+        {"ts": "b", "equity": 110_000.0},
+        {"ts": "c", "equity": 105_000.0},
+        {"ts": "d", "equity": 99_000.0},
+    ]
+    assert compute_portfolio_dd(curve) == pytest.approx(-0.10)
+
+
+def test_compute_portfolio_dd_current_at_peak_zero_dd():
+    from strategy.kill_switch_v2 import compute_portfolio_dd
+    # Went down then back up to peak
+    curve = [
+        {"ts": "a", "equity": 100_000.0},
+        {"ts": "b", "equity": 110_000.0},
+        {"ts": "c", "equity": 95_000.0},
+        {"ts": "d", "equity": 110_000.0},
+    ]
+    # DD is measured at LAST point vs running peak. Last == peak → 0.
+    assert compute_portfolio_dd(curve) == pytest.approx(0.0)
+
+
+def test_compute_portfolio_dd_empty_curve():
+    from strategy.kill_switch_v2 import compute_portfolio_dd
+    assert compute_portfolio_dd([]) == 0.0
+
+
+def test_evaluate_portfolio_tier_normal():
+    from strategy.kill_switch_v2 import evaluate_portfolio_tier
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced": {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen": {"min": -0.15, "max": -0.06},
+        },
+    }}}
+    # DD -0.01 → well above -0.055 reduced threshold → NORMAL
+    result = evaluate_portfolio_tier(
+        portfolio_dd=-0.01,
+        concurrent_failures=0,
+        cfg=cfg,
+    )
+    assert result["tier"] == "NORMAL"
+    assert result["dd"] == pytest.approx(-0.01)
+
+
+def test_evaluate_portfolio_tier_warned_by_concurrent_failures():
+    from strategy.kill_switch_v2 import evaluate_portfolio_tier
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "concurrent_alert_threshold": 3,
+        "thresholds": {
+            "portfolio_dd_reduced": {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen": {"min": -0.15, "max": -0.06},
+        },
+    }}}
+    # DD safe, but 3 concurrent failures → WARNED
+    result = evaluate_portfolio_tier(
+        portfolio_dd=-0.01,
+        concurrent_failures=3,
+        cfg=cfg,
+    )
+    assert result["tier"] == "WARNED"
+
+
+def test_evaluate_portfolio_tier_reduced_by_dd():
+    from strategy.kill_switch_v2 import evaluate_portfolio_tier
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced": {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen": {"min": -0.15, "max": -0.06},
+        },
+    }}}
+    # DD -0.07 crosses reduced threshold -0.055 → REDUCED
+    result = evaluate_portfolio_tier(
+        portfolio_dd=-0.07,
+        concurrent_failures=0,
+        cfg=cfg,
+    )
+    assert result["tier"] == "REDUCED"
+
+
+def test_evaluate_portfolio_tier_frozen_by_dd():
+    from strategy.kill_switch_v2 import evaluate_portfolio_tier
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced": {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen": {"min": -0.15, "max": -0.06},
+        },
+    }}}
+    # DD -0.12 crosses frozen threshold -0.105 → FROZEN
+    result = evaluate_portfolio_tier(
+        portfolio_dd=-0.12,
+        concurrent_failures=0,
+        cfg=cfg,
+    )
+    assert result["tier"] == "FROZEN"
+
+
+def test_evaluate_portfolio_tier_frozen_takes_priority_over_concurrent():
+    from strategy.kill_switch_v2 import evaluate_portfolio_tier
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "concurrent_alert_threshold": 3,
+        "thresholds": {
+            "portfolio_dd_reduced": {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen": {"min": -0.15, "max": -0.06},
+        },
+    }}}
+    result = evaluate_portfolio_tier(
+        portfolio_dd=-0.15,
+        concurrent_failures=5,  # also WARNED eligible
+        cfg=cfg,
+    )
+    # FROZEN is the most severe; takes priority
+    assert result["tier"] == "FROZEN"

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -69,3 +69,110 @@ def test_get_thresholds_missing_config_returns_defaults():
     # With defaults t_min=-0.08/-0.15 t_max=-0.03/-0.06 and slider=50
     assert thresholds["reduced_dd"] == pytest.approx(-0.055)
     assert thresholds["frozen_dd"] == pytest.approx(-0.105)
+
+
+def test_compute_portfolio_equity_curve_empty():
+    from strategy.kill_switch_v2 import compute_portfolio_equity_curve
+    curve = compute_portfolio_equity_curve(
+        closed_trades=[],
+        open_positions=[],
+        capital_base=100_000.0,
+        now_price_by_symbol={},
+    )
+    # Empty history — single snapshot at capital_base
+    assert len(curve) == 1
+    assert curve[0]["equity"] == pytest.approx(100_000.0)
+
+
+def test_compute_portfolio_equity_curve_closed_trades_only():
+    from strategy.kill_switch_v2 import compute_portfolio_equity_curve
+    # 2 closed trades: +200, -50 → cumulative equity steps
+    closed_trades = [
+        {"symbol": "BTCUSDT", "exit_ts": "2026-04-20T12:00:00+00:00", "pnl_usd": 200.0},
+        {"symbol": "ETHUSDT", "exit_ts": "2026-04-21T14:00:00+00:00", "pnl_usd": -50.0},
+    ]
+    curve = compute_portfolio_equity_curve(
+        closed_trades=closed_trades,
+        open_positions=[],
+        capital_base=100_000.0,
+        now_price_by_symbol={},
+    )
+    # 3 points: start, after trade 1, after trade 2
+    assert len(curve) == 3
+    assert curve[0]["equity"] == pytest.approx(100_000.0)
+    assert curve[1]["equity"] == pytest.approx(100_200.0)
+    assert curve[2]["equity"] == pytest.approx(100_150.0)
+
+
+def test_compute_portfolio_equity_curve_open_positions_mtm():
+    """Open positions add an MTM point at the end using now_price_by_symbol."""
+    from strategy.kill_switch_v2 import compute_portfolio_equity_curve
+    # 1 closed trade (+100), 1 open position entered at $50k, now $51k with 0.01 qty
+    closed_trades = [
+        {"symbol": "BTCUSDT", "exit_ts": "2026-04-20T12:00:00+00:00", "pnl_usd": 100.0},
+    ]
+    open_positions = [
+        {
+            "symbol": "BTCUSDT",
+            "entry_price": 50_000.0,
+            "qty": 0.01,
+            "direction": "LONG",
+        },
+    ]
+    now_prices = {"BTCUSDT": 51_000.0}
+    curve = compute_portfolio_equity_curve(
+        closed_trades=closed_trades,
+        open_positions=open_positions,
+        capital_base=100_000.0,
+        now_price_by_symbol=now_prices,
+    )
+    # Start 100k → after trade +100 → +MTM of (51k-50k)*0.01 = 10
+    # 3 points: [100_000, 100_100, 100_110]
+    assert len(curve) == 3
+    assert curve[-1]["equity"] == pytest.approx(100_110.0)
+
+
+def test_compute_portfolio_equity_curve_short_mtm():
+    """SHORT position MTM is (entry - current) * qty."""
+    from strategy.kill_switch_v2 import compute_portfolio_equity_curve
+    open_positions = [
+        {
+            "symbol": "ETHUSDT",
+            "entry_price": 3_000.0,
+            "qty": 1.0,
+            "direction": "SHORT",
+        },
+    ]
+    now_prices = {"ETHUSDT": 2_950.0}
+    curve = compute_portfolio_equity_curve(
+        closed_trades=[],
+        open_positions=open_positions,
+        capital_base=10_000.0,
+        now_price_by_symbol=now_prices,
+    )
+    # SHORT won (+50 per coin × 1 coin = +50)
+    # 2 points: start, end
+    assert curve[-1]["equity"] == pytest.approx(10_050.0)
+
+
+def test_compute_portfolio_equity_curve_missing_price_skips_mtm():
+    """If now_price_by_symbol is missing the open position's symbol, skip MTM for it."""
+    from strategy.kill_switch_v2 import compute_portfolio_equity_curve
+    open_positions = [
+        {
+            "symbol": "UNKNOWNUSDT",
+            "entry_price": 1.0,
+            "qty": 100.0,
+            "direction": "LONG",
+        },
+    ]
+    now_prices = {}  # empty
+    curve = compute_portfolio_equity_curve(
+        closed_trades=[],
+        open_positions=open_positions,
+        capital_base=100_000.0,
+        now_price_by_symbol=now_prices,
+    )
+    # Only the start point remains (no MTM applied)
+    assert len(curve) == 1
+    assert curve[0]["equity"] == pytest.approx(100_000.0)

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1,0 +1,71 @@
+"""Tests for strategy.kill_switch_v2 — portfolio circuit breaker (#187 B2)."""
+import pytest
+
+
+def test_interpolate_threshold_at_slider_0():
+    from strategy.kill_switch_v2 import interpolate_threshold
+    # slider=0 → t_min
+    assert interpolate_threshold(0, t_min=-0.08, t_max=-0.03) == pytest.approx(-0.08)
+
+
+def test_interpolate_threshold_at_slider_100():
+    from strategy.kill_switch_v2 import interpolate_threshold
+    # slider=100 → t_max (more strict)
+    assert interpolate_threshold(100, t_min=-0.08, t_max=-0.03) == pytest.approx(-0.03)
+
+
+def test_interpolate_threshold_at_slider_50():
+    from strategy.kill_switch_v2 import interpolate_threshold
+    # slider=50 → midpoint
+    assert interpolate_threshold(50, t_min=-0.08, t_max=-0.03) == pytest.approx(-0.055)
+
+
+def test_interpolate_threshold_linear():
+    from strategy.kill_switch_v2 import interpolate_threshold
+    # slider=25 → 25% of the way
+    assert interpolate_threshold(25, t_min=0.0, t_max=100.0) == pytest.approx(25.0)
+
+
+def test_get_thresholds_from_config_default_aggressiveness():
+    from strategy.kill_switch_v2 import get_portfolio_thresholds
+    cfg = {
+        "kill_switch": {
+            "v2": {
+                "aggressiveness": 50,
+                "thresholds": {
+                    "portfolio_dd_reduced": {"min": -0.08, "max": -0.03},
+                    "portfolio_dd_frozen": {"min": -0.15, "max": -0.06},
+                },
+            },
+        },
+    }
+    thresholds = get_portfolio_thresholds(cfg)
+    assert thresholds["reduced_dd"] == pytest.approx(-0.055)
+    assert thresholds["frozen_dd"] == pytest.approx(-0.105)
+
+
+def test_get_thresholds_from_config_aggressiveness_0():
+    from strategy.kill_switch_v2 import get_portfolio_thresholds
+    cfg = {
+        "kill_switch": {
+            "v2": {
+                "aggressiveness": 0,
+                "thresholds": {
+                    "portfolio_dd_reduced": {"min": -0.08, "max": -0.03},
+                    "portfolio_dd_frozen": {"min": -0.15, "max": -0.06},
+                },
+            },
+        },
+    }
+    thresholds = get_portfolio_thresholds(cfg)
+    assert thresholds["reduced_dd"] == pytest.approx(-0.08)
+    assert thresholds["frozen_dd"] == pytest.approx(-0.15)
+
+
+def test_get_thresholds_missing_config_returns_defaults():
+    from strategy.kill_switch_v2 import get_portfolio_thresholds
+    # No v2 config present — should return sensible defaults (slider=50)
+    thresholds = get_portfolio_thresholds({})
+    # With defaults t_min=-0.08/-0.15 t_max=-0.03/-0.06 and slider=50
+    assert thresholds["reduced_dd"] == pytest.approx(-0.055)
+    assert thresholds["frozen_dd"] == pytest.approx(-0.105)

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -318,3 +318,173 @@ def test_evaluate_portfolio_tier_frozen_takes_priority_over_concurrent():
     )
     # FROZEN is the most severe; takes priority
     assert result["tier"] == "FROZEN"
+
+
+# ── Shadow glue: price cache, default capital, fail-open ────────────────────
+
+
+@pytest.fixture
+def _clean_shadow_cache():
+    from strategy import kill_switch_v2_shadow
+    kill_switch_v2_shadow._PRICE_CACHE.clear()
+    yield
+    kill_switch_v2_shadow._PRICE_CACHE.clear()
+
+
+def test_update_price_accumulates_across_symbols(_clean_shadow_cache):
+    from strategy.kill_switch_v2_shadow import update_price, _snapshot_prices
+    update_price("BTCUSDT", 50_000.0)
+    update_price("ETHUSDT", 3_000.0)
+    update_price("ADAUSDT", 0.5)
+    snap = _snapshot_prices()
+    assert snap == {"BTCUSDT": 50_000.0, "ETHUSDT": 3_000.0, "ADAUSDT": 0.5}
+
+
+def test_update_price_overwrites_stale(_clean_shadow_cache):
+    from strategy.kill_switch_v2_shadow import update_price, _snapshot_prices
+    update_price("BTCUSDT", 50_000.0)
+    update_price("BTCUSDT", 51_000.0)
+    assert _snapshot_prices()["BTCUSDT"] == 51_000.0
+
+
+def test_default_capital_matches_scanner_hardcoded_1000():
+    """cfg without capital_usd must fall back to $1000 (matches btc_scanner.scan)."""
+    from strategy import kill_switch_v2_shadow
+    assert kill_switch_v2_shadow._DEFAULT_CAPITAL_USD == 1000.0
+
+
+def test_emit_shadow_uses_cache_for_multi_symbol_mtm(tmp_path, monkeypatch, _clean_shadow_cache):
+    """emit_shadow_decision MTMs every open position with a cached price,
+    not just the currently-scanned symbol."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision, update_price
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Seed 2 open positions in 2 different symbols, both priced
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, entry_ts) "
+            "VALUES('BTCUSDT', 'LONG', 50000, 0.01, 'open', '2026-04-20T10:00:00+00:00')"
+        )
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, entry_ts) "
+            "VALUES('ETHUSDT', 'LONG', 3000, 1.0, 'open', '2026-04-20T10:00:00+00:00')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Simulate two prior scans that populated the cache for both symbols
+    update_price("BTCUSDT", 51_000.0)   # +$10 on 0.01 qty
+    update_price("ETHUSDT", 3_050.0)    # +$50 on 1 qty
+
+    # Current scan is for RUNEUSDT (no open position, irrelevant) — but ETH
+    # and BTC MTMs should both land
+    emit_shadow_decision(symbol="RUNEUSDT", cfg={})
+
+    rows = observability.query_decisions(symbol="RUNEUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    # Capital $1000 + MTM +$60 → peak=current → DD = 0
+    # (No closed trades; equity only grows, so DD stays 0)
+    assert reasons["portfolio_dd"] == pytest.approx(0.0)
+
+
+def test_emit_shadow_fail_open_swallows_exceptions(tmp_path, monkeypatch, caplog, _clean_shadow_cache):
+    """If any internal call raises, emit_shadow_decision must not escape — v1 must keep running."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    import strategy.kill_switch_v2_shadow as shadow_mod
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    def _boom():
+        raise RuntimeError("simulated DB corruption")
+
+    monkeypatch.setattr(shadow_mod, "_load_closed_trades", _boom)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
+        emit_shadow_decision(symbol="BTCUSDT", cfg={})
+
+    # No exception escaped, warning logged with symbol context
+    assert any(
+        "kill_switch_v2_shadow.emit_shadow_decision failed for BTCUSDT"
+        in rec.getMessage()
+        for rec in caplog.records
+    )
+    # And no v2_shadow row was persisted
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 0
+
+
+def test_emit_shadow_default_capital_1000_applied(tmp_path, monkeypatch, _clean_shadow_cache):
+    """cfg without capital_usd → $1000 base, not $100,000."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Seed one closed trade: -$50 PnL
+    # With capital=$1000 → DD = -50/1000 = -0.05 (REDUCED band at slider=50)
+    # With capital=$100k → DD = -50/100_000 = -0.0005 (NORMAL — the bug)
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, pnl_usd) VALUES('BTCUSDT', 'LONG', 50000, 0.01, "
+            "'closed', '2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', -50.0)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["portfolio_dd"] == pytest.approx(-0.05)
+    # At slider=50, reduced=-0.055 → -0.05 is still NORMAL, but the number
+    # is at the right order of magnitude (bug would produce -0.0005).
+
+
+def test_emit_shadow_warning_includes_traceback(tmp_path, monkeypatch, caplog, _clean_shadow_cache):
+    """Fail-open warning must include exc_info=True so the traceback is loggable."""
+    import btc_api
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    import strategy.kill_switch_v2_shadow as shadow_mod
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    def _boom():
+        raise RuntimeError("deep error")
+
+    monkeypatch.setattr(shadow_mod, "_load_open_positions", _boom)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
+        emit_shadow_decision(symbol="BTCUSDT", cfg={})
+
+    # At least one record has exc_info (traceback) attached
+    assert any(rec.exc_info is not None for rec in caplog.records)


### PR DESCRIPTION
## Summary

First feature of Kill Switch v2 Phase 2 — **portfolio-level circuit breaker** (#187 B2). Computes aggregate portfolio drawdown from positions, maps to portfolio tier (NORMAL/WARNED/REDUCED/FROZEN) via slider-adjusted thresholds. Runs in SHADOW MODE: writes to decision log with `engine='v2_shadow'` alongside existing v1 path. **Zero effect on real trades.**

## What ships

- `strategy/kill_switch_v2.py` (new) — pure functions: `interpolate_threshold`, `get_portfolio_thresholds`, `compute_portfolio_equity_curve`, `compute_portfolio_dd`, `evaluate_portfolio_tier`.
- `strategy/kill_switch_v2_shadow.py` (new) — DB-glue that reads closed + open positions, calls pure functions, writes v2_shadow decision log row.
- `btc_scanner.scan()` — after v1 log write, emits parallel v2_shadow row. Fail-open.
- ~25 new tests (22 pure unit tests + 1 shadow integration + 1 observability smoke).

## Shadow mode behavior

- Every scan cycle now writes TWO rows to `kill_switch_decisions`: one `engine='v1'` (unchanged) and one `engine='v2_shadow'` (new).
- `v1` decides what actually happens in production (size factor, skip, etc.).
- `v2_shadow` decides what v2 WOULD do — portfolio tier based on real DD. Dashboard can compare side by side.
- Frontend dashboard (KillSwitchDashboard.tsx from #205) already queries via `engine=` filter — it can show v2_shadow without any frontend change.

## Threshold math

`kill_switch.v2.aggressiveness` (slider 0-100) interpolates thresholds linearly:
- `portfolio_dd_reduced`: min=-0.08 (slider=0, laxo) → max=-0.03 (slider=100, paranoid).
- `portfolio_dd_frozen`: min=-0.15 (laxo) → max=-0.06 (paranoid).

Default slider=50 → reduced=-0.055, frozen=-0.105.

## Intentionally NOT shipped

- Per-symbol v2 tier (will come with **B4** auto-calibration).
- Velocity triggers (**B1**).
- Regime-aware threshold modulation (**B3**).
- PROBATION tier (**B5**).
- Auto-calibrator daemon.
- Frontend display of v2_shadow vs v1 diff — dashboard already handles v2_shadow via existing engine filter; richer comparison UI lands later.

## Test plan

- [x] Pure unit tests: 22 covering interpolation, equity curve, DD computation, tier mapping, priority (FROZEN > REDUCED > WARNED > NORMAL).
- [x] Shadow integration: `TestScanEmitsV2ShadowDecision` verifies scan writes both v1 and v2_shadow rows.
- [x] Observability: smoke test confirms `engine='v2_shadow'` is queryable independently.
- [x] Full backend suite: 700 passing, no regressions.
- [x] Frontend suite: 21 passing unchanged.

## Closes

Addresses #196 (B2 portfolio-level circuit breaker). First feature of Phase 2 of Epic #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)