### PR TITLE
feat(kill-switch-v2): B3 regime-aware threshold modulation (shadow mode) (#187)

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -934,7 +934,26 @@ def scan(symbol: str = None):
         from strategy.kill_switch_v2_shadow import emit_shadow_decision, update_price
         if not df1h.empty:
             update_price(symbol, float(df1h["close"].iloc[-1]))
-        emit_shadow_decision(symbol=symbol, cfg=_cfg if _cfg else {})
+        # B3: read the global regime cache for regime-aware adjustment.
+        # Cache is daily; this is a cheap dict lookup once warm. If cache is
+        # empty (first ever run), _regime_score stays None → NEUTRAL default.
+        _regime_score = None
+        try:
+            _cached = get_cached_regime()
+            if _cached and isinstance(_cached, dict):
+                _score = _cached.get("score")
+                if _score is not None:
+                    _regime_score = float(_score)
+        except Exception as _rs_err:
+            log.warning(
+                "kill_switch_v2_shadow: regime score lookup failed for %s: %s",
+                symbol, _rs_err,
+            )
+        emit_shadow_decision(
+            symbol=symbol,
+            cfg=_cfg if _cfg else {},
+            regime_score=_regime_score,
+        )
     except Exception as _shadow_err:
         log.warning("kill_switch_v2_shadow emission failed for %s: %s", symbol, _shadow_err)
 

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -946,8 +946,9 @@ def scan(symbol: str = None):
                     _regime_score = float(_score)
         except Exception as _rs_err:
             log.warning(
-                "kill_switch_v2_shadow: regime score lookup failed for %s: %s",
-                symbol, _rs_err,
+                "kill_switch_v2_shadow: regime score lookup failed for %s: %s "
+                "— falling back to NEUTRAL default (no regime adjustment applied)",
+                symbol, _rs_err, exc_info=True,
             )
         emit_shadow_decision(
             symbol=symbol,

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -292,3 +292,20 @@ def compute_velocity_state(
         "velocity_cooldown_until": new_until,
         "velocity_last_trigger_ts": now.isoformat(),
     }
+
+
+def classify_regime(regime_score: float | None) -> str:
+    """Classify a regime score into a textual label.
+
+    >= 60 → BULL
+    40 <= score < 60 → NEUTRAL
+    < 40 → BEAR
+    None → UNKNOWN (fail-safe default)
+    """
+    if regime_score is None:
+        return "UNKNOWN"
+    if regime_score >= 60:
+        return "BULL"
+    if regime_score < 40:
+        return "BEAR"
+    return "NEUTRAL"

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -24,6 +24,9 @@ _DEFAULT_DD_FROZEN = {"min": -0.15, "max": -0.06}
 _DEFAULT_VELOCITY_SL_COUNT = {"min": 10, "max": 3}
 _DEFAULT_VELOCITY_WINDOW_HOURS = {"min": 24, "max": 6}
 _DEFAULT_VELOCITY_COOLDOWN_HOURS = 4.0
+_DEFAULT_REGIME_BULL_BONUS = 10.0
+_DEFAULT_REGIME_BEAR_PENALTY = 10.0
+_DEFAULT_REGIME_ADJUSTMENT_ENABLED = True
 
 
 def interpolate_threshold(slider: float, t_min: float, t_max: float) -> float:
@@ -309,3 +312,47 @@ def classify_regime(regime_score: float | None) -> str:
     if regime_score < 40:
         return "BEAR"
     return "NEUTRAL"
+
+
+def apply_regime_adjustment(
+    cfg: dict[str, Any],
+    regime_score: float | None,
+) -> dict[str, Any]:
+    """Return a new cfg with kill_switch.v2.aggressiveness adjusted by regime.
+
+    BULL (score >= 60):  slider += bull_bonus (stricter thresholds).
+    BEAR (score < 40):   slider -= bear_penalty (more laxo).
+    NEUTRAL:             no change.
+    regime_score None:   no change (fail-safe).
+    Disabled by cfg:     no change.
+
+    Result clamped to [0, 100]. Does NOT mutate the input cfg.
+    Missing cfg.kill_switch.v2 block → treated as empty (defaults applied).
+    """
+    import copy
+
+    cfg_eff = copy.deepcopy(cfg) if cfg else {}
+    ks = cfg_eff.setdefault("kill_switch", {})
+    v2 = ks.setdefault("v2", {})
+
+    enabled = (
+        v2.get("advanced_overrides", {}) or {}
+    ).get("regime_adjustment_enabled", _DEFAULT_REGIME_ADJUSTMENT_ENABLED)
+    if not enabled or regime_score is None:
+        return cfg_eff
+
+    base = float(v2.get("aggressiveness", _DEFAULT_AGGRESSIVENESS))
+    adjustments = v2.get("regime_adjustments", {}) or {}
+    bull_bonus = float(adjustments.get("bull_bonus", _DEFAULT_REGIME_BULL_BONUS))
+    bear_penalty = float(adjustments.get("bear_penalty", _DEFAULT_REGIME_BEAR_PENALTY))
+
+    label = classify_regime(regime_score)
+    if label == "BULL":
+        new_slider = base + bull_bonus
+    elif label == "BEAR":
+        new_slider = base - bear_penalty
+    else:
+        new_slider = base
+
+    v2["aggressiveness"] = max(0.0, min(100.0, new_slider))
+    return cfg_eff

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -233,6 +233,7 @@ def emit_shadow_decision(
 
     try:
         # B3: apply regime-aware adjustment to cfg (fail-safe: fall back to original)
+        _regime_adjustment_status = "ok"
         try:
             cfg_eff = _ks_v2.apply_regime_adjustment(cfg, regime_score)
         except Exception as _re:
@@ -240,7 +241,14 @@ def emit_shadow_decision(
                 "B3 regime adjustment failed for %s: %s",
                 symbol, _re, exc_info=True,
             )
-            cfg_eff = cfg
+            # Deepcopy on fallback for symmetry — success path returns a new dict
+            # so downstream consumers never share mutable state with the caller.
+            import copy as _copy
+            try:
+                cfg_eff = _copy.deepcopy(cfg)
+            except Exception:
+                cfg_eff = cfg if isinstance(cfg, dict) else {}
+            _regime_adjustment_status = "failed"
 
         capital_base = float(cfg.get("capital_usd", _DEFAULT_CAPITAL_USD))
         closed = _load_closed_trades()
@@ -303,6 +311,7 @@ def emit_shadow_decision(
                     "slider_effective": slider_effective,
                     "adjustment": slider_effective - slider_base,
                     "enabled": regime_enabled,
+                    "adjustment_status": _regime_adjustment_status,
                 },
             },
             scan_id=None,

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -211,22 +211,37 @@ def _evaluate_velocity(symbol: str, cfg: dict[str, Any]) -> bool:
 def emit_shadow_decision(
     symbol: str,
     cfg: dict[str, Any],
+    regime_score: float | None = None,
     now_price_by_symbol: dict[str, float] | None = None,
 ) -> None:
     """Compute portfolio tier, write a v2_shadow row to the decision log.
 
     Uses the module-level price cache for MTM. Callers can pass additional
-    prices via now_price_by_symbol; they're merged in. Fail-open: any
-    exception is caught and logged with full traceback.
+    prices via now_price_by_symbol; they're merged in. If regime_score is
+    provided, B3 regime-aware adjustment is applied to the slider before
+    threshold computation. Fail-open: any exception is caught and logged
+    with full traceback.
     """
     from strategy.kill_switch_v2 import (
         compute_portfolio_equity_curve,
         compute_portfolio_dd,
         evaluate_portfolio_tier,
+        classify_regime,
     )
+    from strategy import kill_switch_v2 as _ks_v2
     import observability
 
     try:
+        # B3: apply regime-aware adjustment to cfg (fail-safe: fall back to original)
+        try:
+            cfg_eff = _ks_v2.apply_regime_adjustment(cfg, regime_score)
+        except Exception as _re:
+            log.warning(
+                "B3 regime adjustment failed for %s: %s",
+                symbol, _re, exc_info=True,
+            )
+            cfg_eff = cfg
+
         capital_base = float(cfg.get("capital_usd", _DEFAULT_CAPITAL_USD))
         closed = _load_closed_trades()
         opens = _load_open_positions()
@@ -246,15 +261,23 @@ def emit_shadow_decision(
         portfolio = evaluate_portfolio_tier(
             portfolio_dd=portfolio_dd,
             concurrent_failures=concurrent,
-            cfg=cfg,
+            cfg=cfg_eff,
         )
 
-        v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
-        slider = float(v2_cfg.get("aggressiveness", 50.0))
+        # Slider values for telemetry
+        v2_base = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+        v2_eff = (cfg_eff.get("kill_switch", {}) or {}).get("v2", {}) or {}
+        slider_base = float(v2_base.get("aggressiveness", 50.0))
+        slider_effective = float(v2_eff.get("aggressiveness", slider_base))
+        regime_enabled = bool(
+            (v2_base.get("advanced_overrides", {}) or {}).get(
+                "regime_adjustment_enabled", True
+            )
+        )
 
         # B1 velocity triggers — fail-open; defaults to False if anything raises.
         try:
-            velocity_active = _evaluate_velocity(symbol, cfg)
+            velocity_active = _evaluate_velocity(symbol, cfg_eff)
         except Exception as _ve:
             log.warning(
                 "B1 velocity eval failed for %s: %s", symbol, _ve, exc_info=True,
@@ -273,9 +296,17 @@ def emit_shadow_decision(
                 "reduced_threshold": portfolio["reduced_threshold"],
                 "frozen_threshold": portfolio["frozen_threshold"],
                 "concurrent_failures": concurrent,
+                "regime": {
+                    "score": regime_score,
+                    "label": classify_regime(regime_score),
+                    "slider_base": slider_base,
+                    "slider_effective": slider_effective,
+                    "adjustment": slider_effective - slider_base,
+                    "enabled": regime_enabled,
+                },
             },
             scan_id=None,
-            slider_value=slider,
+            slider_value=slider_effective,
             velocity_active=velocity_active,
         )
     except Exception as e:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1509,3 +1509,12 @@ class TestScanEmitsV2ShadowDecision:
         )
         # B1: velocity_active is always a bool (False when no SLs / no trigger)
         assert shadow_rows[0]["velocity_active"] is False
+        # B3: regime telemetry block exists in reasons_json
+        import json
+        reasons = json.loads(shadow_rows[0]["reasons_json"])
+        assert "regime" in reasons, "reasons.regime block must be present"
+        regime = reasons["regime"]
+        assert regime["score"] is None or (0 <= regime["score"] <= 100)
+        assert regime["label"] in ("BULL", "NEUTRAL", "BEAR", "UNKNOWN")
+        # slider_value column must equal slider_effective from reasons
+        assert shadow_rows[0]["slider_value"] == regime["slider_effective"]

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1291,3 +1291,100 @@ def test_classify_regime_neutral_between_40_and_60():
 def test_classify_regime_none_returns_unknown():
     from strategy.kill_switch_v2 import classify_regime
     assert classify_regime(None) == "UNKNOWN"
+
+
+# ── B3: apply_regime_adjustment ─────────────────────────────────────────────
+
+
+def _v2_cfg_with_slider(slider: int) -> dict:
+    return {
+        "kill_switch": {
+            "v2": {
+                "aggressiveness": slider,
+                "regime_adjustments": {
+                    "bull_bonus": 10,
+                    "bear_penalty": 10,
+                },
+                "advanced_overrides": {"regime_adjustment_enabled": True},
+            }
+        }
+    }
+
+
+def test_apply_regime_adjustment_none_score_unchanged():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(50)
+    cfg_eff = apply_regime_adjustment(cfg, None)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 50
+
+
+def test_apply_regime_adjustment_bull_adds_bonus():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(50)
+    cfg_eff = apply_regime_adjustment(cfg, 75)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 60
+
+
+def test_apply_regime_adjustment_bear_subtracts_penalty():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(50)
+    cfg_eff = apply_regime_adjustment(cfg, 25)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 40
+
+
+def test_apply_regime_adjustment_neutral_unchanged():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(50)
+    cfg_eff = apply_regime_adjustment(cfg, 50)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 50
+
+
+def test_apply_regime_adjustment_boundary_60_is_bull():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(50)
+    cfg_eff = apply_regime_adjustment(cfg, 60)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 60
+
+
+def test_apply_regime_adjustment_boundary_40_is_neutral():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(50)
+    cfg_eff = apply_regime_adjustment(cfg, 40)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 50
+
+
+def test_apply_regime_adjustment_clamp_high():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(95)
+    cfg_eff = apply_regime_adjustment(cfg, 100)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 100
+
+
+def test_apply_regime_adjustment_clamp_low():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(5)
+    cfg_eff = apply_regime_adjustment(cfg, 0)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 0
+
+
+def test_apply_regime_adjustment_disabled_no_change():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(50)
+    cfg["kill_switch"]["v2"]["advanced_overrides"]["regime_adjustment_enabled"] = False
+    cfg_eff = apply_regime_adjustment(cfg, 75)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 50
+
+
+def test_apply_regime_adjustment_missing_regime_adjustments_uses_defaults():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = {"kill_switch": {"v2": {"aggressiveness": 50}}}
+    cfg_eff = apply_regime_adjustment(cfg, 75)
+    assert cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 60
+
+
+def test_apply_regime_adjustment_does_not_mutate_input():
+    from strategy.kill_switch_v2 import apply_regime_adjustment
+    cfg = _v2_cfg_with_slider(50)
+    cfg_eff = apply_regime_adjustment(cfg, 75)
+    cfg_eff["kill_switch"]["v2"]["aggressiveness"] = 999
+    assert cfg["kill_switch"]["v2"]["aggressiveness"] == 50

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1614,3 +1614,203 @@ def test_bull_regime_makes_reduced_threshold_stricter_enough_to_flip_tier(
     assert len(rows) == 2
     assert rows[0]["portfolio_tier"] == "REDUCED"  # BULL scan
     assert rows[1]["portfolio_tier"] == "NORMAL"   # NEUTRAL scan
+
+
+# ── B3: review follow-ups — hardening tests ─────────────────────────────────
+
+
+def test_bear_regime_makes_reduced_threshold_laxer_enough_to_flip_tier(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """BEAR penalty relaxes reduced_dd threshold enough to flip REDUCED to NORMAL."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', -57.0)",
+            ("2026-04-20T10:00:00+00:00", "2026-04-20T12:00:00+00:00"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced":  {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen":   {"min": -0.15, "max": -0.06},
+        },
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=50.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=25.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 2
+    assert rows[0]["portfolio_tier"] == "NORMAL"
+    assert rows[1]["portfolio_tier"] == "REDUCED"
+
+
+def test_emit_shadow_regime_score_zero_classified_as_bear_not_unknown(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """regime_score=0.0 classifies as BEAR (falsy value is not None)."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=0.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["regime"]["label"] == "BEAR"
+    assert reasons["regime"]["score"] == 0.0
+    assert reasons["regime"]["slider_effective"] == 40
+    assert reasons["regime"]["adjustment"] == -10
+
+
+def test_emit_shadow_bull_regime_cfg_eff_threaded_to_velocity_path(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """B3+B1 integration: cfg_eff is threaded into the velocity path."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc)
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: now)
+
+    conn = btc_api.get_db()
+    try:
+        for i in range(3):
+            ts = (now - timedelta(hours=i + 1)).isoformat()
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, "
+                "status, entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+                (ts, ts),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 100,
+        "thresholds": {
+            "velocity_sl_count":     {"min": 10, "max": 3},
+            "velocity_window_hours": {"min": 24, "max": 6},
+        },
+        "velocity_cooldown_hours": 4,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["regime"]["slider_base"] == 100
+    assert reasons["regime"]["slider_effective"] == 100
+    assert rows[0]["velocity_active"] is True
+
+
+def test_emit_shadow_adjustment_status_failed_when_regime_adjustment_raises(
+    tmp_path, monkeypatch, caplog, _clean_shadow_cache,
+):
+    """When apply_regime_adjustment raises, reasons.regime.adjustment_status='failed'."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    import strategy.kill_switch_v2_shadow as sh
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    from strategy import kill_switch_v2
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated regime failure")
+    monkeypatch.setattr(kill_switch_v2, "apply_regime_adjustment", _boom)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
+        emit_shadow_decision(symbol="BTCUSDT", cfg={}, regime_score=75.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["regime"]["adjustment_status"] == "failed"
+    assert reasons["regime"]["adjustment"] == 0
+
+
+def test_emit_shadow_adjustment_status_ok_on_normal_path(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """On the normal path, reasons.regime.adjustment_status='ok'."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["regime"]["adjustment_status"] == "ok"

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1554,3 +1554,63 @@ def test_emit_shadow_regime_adjustment_failure_falls_back_to_original_cfg(
     assert any(
         "B3 regime adjustment failed" in rec.getMessage() for rec in caplog.records
     )
+
+
+# ── B3: end-to-end tier-flip via regime adjustment ──────────────────────────
+
+
+def test_bull_regime_makes_reduced_threshold_stricter_enough_to_flip_tier(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """
+    DD=-0.052 on $1000 capital (= -$52 PnL):
+    - slider=50 (NEUTRAL): reduced_dd = (-0.08 + -0.03)/2 = -0.055 → DD=-0.052 is NORMAL.
+    - slider=60 (BULL bonus): reduced_dd = -0.08 + 0.6*(-0.03 - -0.08) = -0.05 → REDUCED.
+    Same DB state, only regime_score differs.
+    """
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', -52.0)",
+            ("2026-04-20T10:00:00+00:00", "2026-04-20T12:00:00+00:00"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced":  {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen":   {"min": -0.15, "max": -0.06},
+        },
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+
+    # First scan: NEUTRAL (score=50) → slider stays 50 → DD=-0.052 is NORMAL.
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=50.0)
+
+    # Second scan (same state): BULL (score=75) → slider=60 → reduced_dd=-0.05 → REDUCED.
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    # Rows ordered ts DESC (latest first)
+    assert len(rows) == 2
+    assert rows[0]["portfolio_tier"] == "REDUCED"  # BULL scan
+    assert rows[1]["portfolio_tier"] == "NORMAL"   # NEUTRAL scan

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1262,3 +1262,32 @@ def test_emit_shadow_partial_write_state_persists_when_record_decision_fails(
         "emit_shadow_decision failed" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+# ── B3: classify_regime ─────────────────────────────────────────────────────
+
+
+def test_classify_regime_bull_at_60():
+    from strategy.kill_switch_v2 import classify_regime
+    assert classify_regime(60) == "BULL"
+    assert classify_regime(75) == "BULL"
+    assert classify_regime(100) == "BULL"
+
+
+def test_classify_regime_bear_below_40():
+    from strategy.kill_switch_v2 import classify_regime
+    assert classify_regime(0) == "BEAR"
+    assert classify_regime(25) == "BEAR"
+    assert classify_regime(39.999) == "BEAR"
+
+
+def test_classify_regime_neutral_between_40_and_60():
+    from strategy.kill_switch_v2 import classify_regime
+    assert classify_regime(40) == "NEUTRAL"
+    assert classify_regime(50) == "NEUTRAL"
+    assert classify_regime(59.999) == "NEUTRAL"
+
+
+def test_classify_regime_none_returns_unknown():
+    from strategy.kill_switch_v2 import classify_regime
+    assert classify_regime(None) == "UNKNOWN"

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1388,3 +1388,169 @@ def test_apply_regime_adjustment_does_not_mutate_input():
     cfg_eff = apply_regime_adjustment(cfg, 75)
     cfg_eff["kill_switch"]["v2"]["aggressiveness"] = 999
     assert cfg["kill_switch"]["v2"]["aggressiveness"] == 50
+
+
+# ── B3: emit_shadow_decision with regime_score ──────────────────────────────
+
+
+def test_emit_shadow_without_regime_score_backwards_compatible(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """Calling emit_shadow_decision without regime_score preserves pre-B3 behavior."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["regime"]["label"] == "UNKNOWN"
+    assert reasons["regime"]["adjustment"] == 0
+    assert reasons["regime"]["score"] is None
+
+
+def test_emit_shadow_bull_regime_applies_adjustment(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """BULL (score=75) with base=50 → effective=60; slider_value column stores effective."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["regime"]["label"] == "BULL"
+    assert reasons["regime"]["score"] == 75.0
+    assert reasons["regime"]["slider_base"] == 50
+    assert reasons["regime"]["slider_effective"] == 60
+    assert reasons["regime"]["adjustment"] == 10
+    assert reasons["regime"]["enabled"] is True
+    assert rows[0]["slider_value"] == 60.0
+
+
+def test_emit_shadow_bear_regime_applies_penalty(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """BEAR (score=25) with base=50 → effective=40."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=25.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["regime"]["label"] == "BEAR"
+    assert reasons["regime"]["slider_effective"] == 40
+    assert reasons["regime"]["adjustment"] == -10
+    assert rows[0]["slider_value"] == 40.0
+
+
+def test_emit_shadow_regime_disabled_records_enabled_false(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """When regime_adjustment_enabled=False, no adjustment + telemetry shows enabled=False."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": False},
+    }}}
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["regime"]["enabled"] is False
+    assert reasons["regime"]["slider_effective"] == 50
+    assert reasons["regime"]["adjustment"] == 0
+
+
+def test_emit_shadow_regime_adjustment_failure_falls_back_to_original_cfg(
+    tmp_path, monkeypatch, caplog, _clean_shadow_cache,
+):
+    """If apply_regime_adjustment raises, shadow logs warning and uses original cfg."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    import strategy.kill_switch_v2_shadow as sh
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
+
+    from strategy import kill_switch_v2
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated regime failure")
+    monkeypatch.setattr(kill_switch_v2, "apply_regime_adjustment", _boom)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
+        emit_shadow_decision(symbol="BTCUSDT", cfg={}, regime_score=75.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    assert any(
+        "B3 regime adjustment failed" in rec.getMessage() for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary

Kill Switch v2 **B3 — regime-aware threshold modulation** (#187). The `aggressiveness` slider is modulated by global regime score before any threshold fn reads it. BULL (score ≥ 60) → +bull_bonus (stricter). BEAR (score < 40) → -bear_penalty (more laxo). NEUTRAL → unchanged. Result clamped to [0, 100]. Still shadow mode.

## What ships

- `strategy/kill_switch_v2.py` — `classify_regime(score) → str`, `apply_regime_adjustment(cfg, score) → new_cfg` (pure, no mutation).
- `strategy/kill_switch_v2_shadow.py` — `emit_shadow_decision` gains `regime_score` kwarg (default None = backwards-compat), fail-safe adjustment, downstream uses `cfg_eff`, `reasons.regime` telemetry block populated.
- `btc_scanner.py` — shadow block reads `get_cached_regime()` and passes `regime_score`.
- 21 new tests (4 classify + 11 apply + 5 shadow integration + 1 end-to-end tier flip + scanner assertion strengthening).

## Counter-intuitive by design

`slider=100=paranoid (strict)`. So:
- BULL → slider += bonus → stricter thresholds → trigger sooner at smaller DD.
- BEAR → slider -= penalty → more laxo → tolerate more DD.

Rationale: in BEAR, drawdowns are expected (don't panic); in BULL, significant DD is anomalous.

## Telemetry

- `kill_switch_decisions.slider_value` now stores the EFFECTIVE slider (post-adjustment).
- `reasons_json.regime` block records `{score, label, slider_base, slider_effective, adjustment, enabled}` for full traceability.

## Intentionally NOT shipped

- Per-symbol regime modulation (B3 is global-only).
- Other `advanced_overrides` axes (velocity_sensitivity, portfolio_dd_sensitivity, calibration_strictness) — with B4.
- Reacting to regime changes (BULL↔BEAR flip triggers recalibration) — B4 auto-calibrator daemon.
- Frontend UI for the regime block — dashboard already reads `reasons_json`; richer viz with B6.

## Test plan

- [x] Unit: `classify_regime` boundaries (4 tests).
- [x] Unit: `apply_regime_adjustment` boundaries, clamp, disabled, defaults, immutability (11 tests).
- [x] Shadow integration: backwards-compat, BULL, BEAR, disabled, fail-safe (5 tests).
- [x] End-to-end: DD=-0.052 on $1k capital flips NORMAL↔REDUCED via regime change (1 test).
- [x] Scanner integration: `TestScanEmitsV2ShadowDecision` asserts `reasons.regime` block + `slider_value == slider_effective`.
- [x] Backend: 754 passed (was 733, +21 new).
- [x] Frontend: 21 unchanged.

## Closes

Phase 2 of Epic #187. Spec: `docs/superpowers/specs/es/2026-04-24-kill-switch-v2-b3-regime-aware-design.md`. Plan: `docs/superpowers/plans/2026-04-24-kill-switch-v2-b3-regime-aware.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)