### PR TITLE
feat(kill-switch-v2): B4a per-symbol baselines (shadow mode) (#187 #198)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -1026,6 +1026,15 @@ def init_db():
             updated_at                TEXT NOT NULL
         )
     """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS kill_switch_v2_baseline (
+            symbol         TEXT PRIMARY KEY,
+            baseline_wr    REAL NOT NULL,
+            baseline_sigma REAL NOT NULL,
+            trades_count   INTEGER NOT NULL,
+            computed_at    TEXT NOT NULL
+        )
+    """)
     con.commit()
     con.close()
     log.info(f"DB inicializada: {DB_FILE}")

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -27,6 +27,9 @@ _DEFAULT_VELOCITY_COOLDOWN_HOURS = 4.0
 _DEFAULT_REGIME_BULL_BONUS = 10.0
 _DEFAULT_REGIME_BEAR_PENALTY = 10.0
 _DEFAULT_REGIME_ADJUSTMENT_ENABLED = True
+_DEFAULT_BASELINE_SIGMA_MULTIPLIER = {"min": 3.0, "max": 1.0}
+_DEFAULT_BASELINE_MIN_TRADES = 100
+_DEFAULT_BASELINE_STALE_DAYS = 7
 
 
 def interpolate_threshold(slider: float, t_min: float, t_max: float) -> float:
@@ -384,3 +387,21 @@ def compute_baseline_metrics(closed_trades: list[dict[str, Any]]) -> dict[str, A
     wr = wins / count
     sigma = math.sqrt(wr * (1.0 - wr))
     return {"wr": wr, "sigma": sigma, "count": count}
+
+
+def get_baseline_sigma_multiplier(cfg: dict[str, Any]) -> float:
+    """Slider-derived sigma multiplier (N) for ALERT threshold.
+
+    Reuses interpolate_threshold; range default {min: 3.0, max: 1.0}.
+    slider=0   → 3.0 (laxo, only extreme events trigger ALERT).
+    slider=50  → 2.0 (default 2-sigma, 95% CI).
+    slider=100 → 1.0 (paranoid, mild deviation triggers).
+    """
+    v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+    slider = v2_cfg.get("aggressiveness", _DEFAULT_AGGRESSIVENESS)
+    thresholds_cfg = v2_cfg.get("thresholds", {}) or {}
+    sigma_range = (
+        thresholds_cfg.get("baseline_sigma_multiplier")
+        or _DEFAULT_BASELINE_SIGMA_MULTIPLIER
+    )
+    return interpolate_threshold(slider, sigma_range["min"], sigma_range["max"])

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -405,3 +405,44 @@ def get_baseline_sigma_multiplier(cfg: dict[str, Any]) -> float:
         or _DEFAULT_BASELINE_SIGMA_MULTIPLIER
     )
     return interpolate_threshold(slider, sigma_range["min"], sigma_range["max"])
+
+
+def evaluate_per_symbol_tier(
+    rolling_wr_20: float | None,
+    baseline: dict[str, Any],
+    sigma_multiplier: float,
+    trades_count: int,
+    min_trades: int,
+) -> str:
+    """Decide per-symbol tier from baseline + recent performance.
+
+    Returns "NORMAL" or "ALERT".
+
+    Rules (in priority order):
+    1. trades_count < min_trades → "NORMAL" (insufficient evidence to calibrate).
+    2. rolling_wr_20 is None → "NORMAL" (no recent activity).
+    3. rolling_wr_20 < baseline.wr - sigma_multiplier * (baseline.sigma / sqrt(20))
+       → "ALERT".
+    4. else → "NORMAL".
+
+    The denominator sqrt(20) converts per-trade σ to the std dev of a
+    20-trade rolling-mean estimator (central limit theorem).
+
+    Boundary semantics: rolling_wr exactly equal to the threshold is NORMAL
+    (strict `<` triggers ALERT).
+    """
+    import math
+
+    if trades_count < min_trades:
+        return "NORMAL"
+    if rolling_wr_20 is None:
+        return "NORMAL"
+
+    baseline_wr = float(baseline.get("wr", 0.0))
+    baseline_sigma = float(baseline.get("sigma", 0.0))
+    window_sigma = baseline_sigma / math.sqrt(20)
+    threshold = baseline_wr - float(sigma_multiplier) * window_sigma
+
+    if rolling_wr_20 < threshold:
+        return "ALERT"
+    return "NORMAL"

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -356,3 +356,31 @@ def apply_regime_adjustment(
 
     v2["aggressiveness"] = max(0.0, min(100.0, new_slider))
     return cfg_eff
+
+
+def compute_baseline_metrics(closed_trades: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute per-symbol baseline metrics from a list of closed trades.
+
+    Args:
+        closed_trades: list of dicts with key `pnl_usd`. Other keys ignored.
+                       Trades with `pnl_usd is None` are skipped.
+
+    Returns:
+        {"wr": float, "sigma": float, "count": int}
+        - wr = wins / count where win = pnl_usd > 0 (breakeven 0.0 is a loss)
+        - sigma = sqrt(wr * (1 - wr)) — Bernoulli per-trade std dev
+        - count = number of trades with non-None pnl_usd
+
+    Empty input or all-None pnl → {"wr": 0.0, "sigma": 0.0, "count": 0}.
+    """
+    import math
+
+    valid = [t for t in closed_trades if t.get("pnl_usd") is not None]
+    count = len(valid)
+    if count == 0:
+        return {"wr": 0.0, "sigma": 0.0, "count": 0}
+
+    wins = sum(1 for t in valid if t["pnl_usd"] > 0)
+    wr = wins / count
+    sigma = math.sqrt(wr * (1.0 - wr))
+    return {"wr": wr, "sigma": sigma, "count": count}

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -251,8 +251,20 @@ def _load_baseline(symbol: str) -> dict[str, Any] | None:
 
 
 def _upsert_baseline(symbol: str, baseline: dict[str, Any], now) -> None:
-    """Upsert per-symbol baseline. computed_at is set to now.isoformat()."""
+    """Upsert per-symbol baseline. computed_at is set to now.isoformat().
+
+    Validates that baseline has the three required keys; raises KeyError on
+    missing keys instead of silently coercing to 0.0 (which would mask an
+    upstream bug producing an empty baseline dict).
+    """
     import btc_api
+
+    missing = [k for k in ("wr", "sigma", "count") if k not in baseline]
+    if missing:
+        raise KeyError(
+            f"_upsert_baseline: baseline dict missing required keys: {missing}"
+        )
+
     conn = btc_api.get_db()
     try:
         conn.execute(
@@ -266,9 +278,9 @@ def _upsert_baseline(symbol: str, baseline: dict[str, Any], now) -> None:
                  computed_at = excluded.computed_at""",
             (
                 symbol,
-                float(baseline.get("wr", 0.0)),
-                float(baseline.get("sigma", 0.0)),
-                int(baseline.get("count", 0)),
+                float(baseline["wr"]),
+                float(baseline["sigma"]),
+                int(baseline["count"]),
                 now.isoformat(),
             ),
         )
@@ -280,7 +292,13 @@ def _upsert_baseline(symbol: str, baseline: dict[str, Any], now) -> None:
 def _is_baseline_stale(
     computed_at: str | None, stale_days: float, now,
 ) -> bool:
-    """Return True if the baseline is missing, malformed, or older than stale_days."""
+    """Return True if the baseline is missing, malformed, in the future, or
+    older than stale_days.
+
+    A future timestamp (parsed > now) is treated as stale to guard against
+    clock skew or a buggy writer; otherwise the bogus future timestamp would
+    suppress recompute indefinitely.
+    """
     from datetime import datetime, timedelta, timezone
 
     if not computed_at:
@@ -290,6 +308,8 @@ def _is_baseline_stale(
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
     except (TypeError, ValueError):
+        return True
+    if parsed > now:
         return True
     return (now - parsed) > timedelta(days=float(stale_days))
 

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -208,6 +208,92 @@ def _evaluate_velocity(symbol: str, cfg: dict[str, Any]) -> bool:
         return False
 
 
+def _load_closed_trades_for_symbol(symbol: str) -> list[dict[str, Any]]:
+    """Load closed positions for a symbol with non-NULL exit_ts."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            """SELECT exit_ts, pnl_usd
+               FROM positions
+               WHERE symbol = ?
+                 AND status = 'closed'
+                 AND exit_ts IS NOT NULL
+               ORDER BY exit_ts""",
+            (symbol,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [{"exit_ts": r[0], "pnl_usd": r[1]} for r in rows]
+
+
+def _load_baseline(symbol: str) -> dict[str, Any] | None:
+    """Load per-symbol baseline. Returns None if no row exists."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            """SELECT baseline_wr, baseline_sigma, trades_count, computed_at
+               FROM kill_switch_v2_baseline
+               WHERE symbol = ?""",
+            (symbol,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    return {
+        "wr": row[0],
+        "sigma": row[1],
+        "count": row[2],
+        "computed_at": row[3],
+    }
+
+
+def _upsert_baseline(symbol: str, baseline: dict[str, Any], now) -> None:
+    """Upsert per-symbol baseline. computed_at is set to now.isoformat()."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO kill_switch_v2_baseline
+                 (symbol, baseline_wr, baseline_sigma, trades_count, computed_at)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(symbol) DO UPDATE SET
+                 baseline_wr = excluded.baseline_wr,
+                 baseline_sigma = excluded.baseline_sigma,
+                 trades_count = excluded.trades_count,
+                 computed_at = excluded.computed_at""",
+            (
+                symbol,
+                float(baseline.get("wr", 0.0)),
+                float(baseline.get("sigma", 0.0)),
+                int(baseline.get("count", 0)),
+                now.isoformat(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _is_baseline_stale(
+    computed_at: str | None, stale_days: float, now,
+) -> bool:
+    """Return True if the baseline is missing, malformed, or older than stale_days."""
+    from datetime import datetime, timedelta, timezone
+
+    if not computed_at:
+        return True
+    try:
+        parsed = datetime.fromisoformat(computed_at)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return True
+    return (now - parsed) > timedelta(days=float(stale_days))
+
+
 def emit_shadow_decision(
     symbol: str,
     cfg: dict[str, Any],

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -294,6 +294,79 @@ def _is_baseline_stale(
     return (now - parsed) > timedelta(days=float(stale_days))
 
 
+def _evaluate_per_symbol_tier_with_telemetry(
+    symbol: str, cfg: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    """Evaluate B4a per-symbol tier (NORMAL or ALERT) with full telemetry.
+
+    Lazy-refresh logic: if the cached baseline is missing or older than
+    `baseline_stale_days`, recompute from positions and upsert. If fresh,
+    reuse cached.
+
+    Returns:
+        (tier, telemetry) where telemetry contains the inputs the dashboard
+        needs to explain the decision (baseline_wr, sigma, rolling_wr,
+        sigma_multiplier, trades_count, baseline_stale, status="ok").
+
+    This function may raise on DB errors / malformed data — caller is
+    responsible for fail-open wrapping.
+    """
+    from strategy.kill_switch_v2 import (
+        compute_baseline_metrics,
+        evaluate_per_symbol_tier,
+        get_baseline_sigma_multiplier,
+    )
+    from health import compute_rolling_metrics_from_trades
+
+    now = _now()
+
+    v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+    min_trades = int(v2_cfg.get("baseline_min_trades", 100))
+    stale_days = float(v2_cfg.get("baseline_stale_days", 7))
+
+    closed_trades = _load_closed_trades_for_symbol(symbol)
+
+    cached = _load_baseline(symbol)
+    baseline_was_stale = cached is None or _is_baseline_stale(
+        cached.get("computed_at") if cached else None, stale_days, now,
+    )
+
+    if baseline_was_stale:
+        baseline = compute_baseline_metrics(closed_trades)
+        _upsert_baseline(symbol, baseline, now=now)
+    else:
+        baseline = {
+            "wr": cached["wr"],
+            "sigma": cached["sigma"],
+            "count": cached["count"],
+        }
+
+    rolling = compute_rolling_metrics_from_trades(closed_trades, now=now)
+    rolling_wr_20 = rolling.get("win_rate_20_trades")
+
+    sigma_multiplier = get_baseline_sigma_multiplier(cfg)
+
+    tier = evaluate_per_symbol_tier(
+        rolling_wr_20=rolling_wr_20,
+        baseline=baseline,
+        sigma_multiplier=sigma_multiplier,
+        trades_count=baseline["count"],
+        min_trades=min_trades,
+    )
+
+    telemetry = {
+        "tier": tier,
+        "status": "ok",
+        "baseline_wr": baseline["wr"],
+        "baseline_sigma": baseline["sigma"],
+        "rolling_wr_20": rolling_wr_20,
+        "sigma_multiplier": sigma_multiplier,
+        "trades_count": baseline["count"],
+        "baseline_stale": baseline_was_stale,
+    }
+    return tier, telemetry
+
+
 def emit_shadow_decision(
     symbol: str,
     cfg: dict[str, Any],

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -451,10 +451,32 @@ def emit_shadow_decision(
             )
             velocity_active = False
 
+        # B4a per-symbol tier — fail-open; defaults to NORMAL with status=failed.
+        try:
+            per_symbol_tier, per_symbol_telemetry = (
+                _evaluate_per_symbol_tier_with_telemetry(symbol, cfg_eff)
+            )
+        except Exception as _pe:
+            log.warning(
+                "B4a per-symbol tier eval failed for %s: %s",
+                symbol, _pe, exc_info=True,
+            )
+            per_symbol_tier = "NORMAL"
+            per_symbol_telemetry = {
+                "tier": "NORMAL",
+                "status": "failed",
+                "baseline_wr": None,
+                "baseline_sigma": None,
+                "rolling_wr_20": None,
+                "sigma_multiplier": None,
+                "trades_count": 0,
+                "baseline_stale": None,
+            }
+
         observability.record_decision(
             symbol=symbol,
             engine="v2_shadow",
-            per_symbol_tier="NORMAL",
+            per_symbol_tier=per_symbol_tier,
             portfolio_tier=portfolio["tier"],
             size_factor=1.0,
             skip=False,
@@ -472,6 +494,7 @@ def emit_shadow_decision(
                     "enabled": regime_enabled,
                     "adjustment_status": _regime_adjustment_status,
                 },
+                "per_symbol": per_symbol_telemetry,
             },
             scan_id=None,
             slider_value=slider_effective,

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1518,3 +1518,10 @@ class TestScanEmitsV2ShadowDecision:
         assert regime["label"] in ("BULL", "NEUTRAL", "BEAR", "UNKNOWN")
         # slider_value column must equal slider_effective from reasons
         assert shadow_rows[0]["slider_value"] == regime["slider_effective"]
+        # B4a: per-symbol tier block exists in reasons_json
+        assert "per_symbol" in reasons, "reasons.per_symbol block must be present"
+        per_symbol = reasons["per_symbol"]
+        assert per_symbol["tier"] in ("NORMAL", "ALERT")
+        assert per_symbol["status"] in ("ok", "failed")
+        # per_symbol_tier column must equal tier in reasons
+        assert shadow_rows[0]["per_symbol_tier"] == per_symbol["tier"]

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -2153,3 +2153,233 @@ def test_is_baseline_stale_old_returns_true():
     now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
     old = (now - timedelta(days=10)).isoformat()
     assert _is_baseline_stale(old, stale_days=7, now=now) is True
+
+
+# ── B4a: orchestration helper ───────────────────────────────────────────────
+
+
+def _seed_n_closed_trades(conn, symbol: str, n: int, win_rate: float):
+    """Helper: insert N closed trades with a target win rate."""
+    wins = int(round(n * win_rate))
+    losses = n - wins
+    for i in range(wins):
+        ts = f"2026-04-{(i % 28) + 1:02d}T12:00:00+00:00"
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, pnl_usd) VALUES "
+            "(?, 'LONG', 50000, 0.01, 'closed', ?, ?, 10.0)",
+            (symbol, ts, ts),
+        )
+    for i in range(losses):
+        ts = f"2026-04-{(i % 28) + 1:02d}T13:00:00+00:00"
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, pnl_usd) VALUES "
+            "(?, 'LONG', 50000, 0.01, 'closed', ?, ?, -5.0)",
+            (symbol, ts, ts),
+        )
+
+
+def test_evaluate_per_symbol_tier_with_telemetry_below_min_trades(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """count<100 → NORMAL; baseline still computed and persisted; status=ok."""
+    import btc_api
+    from strategy.kill_switch_v2_shadow import (
+        _evaluate_per_symbol_tier_with_telemetry, _load_baseline,
+    )
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(sh, "_now", lambda: now)
+
+    conn = btc_api.get_db()
+    try:
+        _seed_n_closed_trades(conn, "BTCUSDT", n=50, win_rate=0.5)
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+    }}}
+    tier, telemetry = _evaluate_per_symbol_tier_with_telemetry("BTCUSDT", cfg)
+
+    assert tier == "NORMAL"
+    assert telemetry["status"] == "ok"
+    assert telemetry["trades_count"] == 50
+    persisted = _load_baseline("BTCUSDT")
+    assert persisted is not None
+    assert persisted["count"] == 50
+
+
+def test_evaluate_per_symbol_tier_with_telemetry_alert_fires(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """120 trades historically wr=0.5; rolling_20 wr=0.0 → ALERT at slider=50 (N=2)."""
+    import btc_api
+    from strategy.kill_switch_v2_shadow import _evaluate_per_symbol_tier_with_telemetry
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(sh, "_now", lambda: now)
+
+    conn = btc_api.get_db()
+    try:
+        # 100 historical trades at WR=0.5 in March (so they don't dominate rolling-20)
+        for _ in range(50):
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', 10.0)",
+            )
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', -5.0)",
+            )
+        # Last 20 trades all losses (rolling_wr=0.0). Use a later date so they slice.
+        for i in range(20):
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+                "'2026-04-20T10:00:00+00:00', ?, -5.0)",
+                (f"2026-04-20T{(i % 24):02d}:00:00+00:00",),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+    }}}
+    tier, telemetry = _evaluate_per_symbol_tier_with_telemetry("BTCUSDT", cfg)
+
+    assert tier == "ALERT"
+    assert telemetry["status"] == "ok"
+    assert telemetry["rolling_wr_20"] == pytest.approx(0.0)
+    assert telemetry["trades_count"] >= 100
+
+
+def test_evaluate_per_symbol_tier_with_telemetry_uses_cached_baseline_when_fresh(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """Fresh baseline (≤7d old) is reused; trades_count reflects the cache, not a recompute."""
+    import btc_api
+    from strategy.kill_switch_v2_shadow import (
+        _evaluate_per_symbol_tier_with_telemetry, _upsert_baseline,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(sh, "_now", lambda: now)
+
+    _upsert_baseline(
+        "BTCUSDT",
+        {"wr": 0.7, "sigma": 0.458, "count": 150},
+        now=now - timedelta(days=1),
+    )
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+    }}}
+    tier, telemetry = _evaluate_per_symbol_tier_with_telemetry("BTCUSDT", cfg)
+
+    assert tier == "NORMAL"
+    assert telemetry["baseline_stale"] is False
+    assert telemetry["trades_count"] == 150
+    assert telemetry["status"] == "ok"
+
+
+def test_evaluate_per_symbol_tier_with_telemetry_recomputes_when_stale(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """Stale baseline (>7d old) triggers recompute; computed_at moves forward."""
+    import btc_api
+    from strategy.kill_switch_v2_shadow import (
+        _evaluate_per_symbol_tier_with_telemetry, _load_baseline, _upsert_baseline,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(sh, "_now", lambda: now)
+
+    _upsert_baseline(
+        "BTCUSDT",
+        {"wr": 0.5, "sigma": 0.5, "count": 50},
+        now=now - timedelta(days=10),
+    )
+    conn = btc_api.get_db()
+    try:
+        for i in range(100):
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+                "'2026-04-20T10:00:00+00:00', ?, 10.0)",
+                (f"2026-04-20T{(i % 24):02d}:00:00+00:00",),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+    }}}
+    tier, telemetry = _evaluate_per_symbol_tier_with_telemetry("BTCUSDT", cfg)
+
+    assert telemetry["baseline_stale"] is True
+    assert telemetry["baseline_wr"] == pytest.approx(1.0)
+    assert telemetry["trades_count"] == 100
+    persisted = _load_baseline("BTCUSDT")
+    assert persisted["computed_at"] == now.isoformat()

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -2554,3 +2554,167 @@ def test_emit_shadow_backwards_compat_b1_b2_b3_still_pass(
     assert reasons["regime"]["label"] == "BULL"
     assert reasons["per_symbol"]["tier"] == "NORMAL"
     assert rows[0]["velocity_active"] is False
+
+
+# ── B4a: review follow-ups — hardening tests ────────────────────────────────
+
+
+def test_evaluate_per_symbol_tier_at_exact_min_trades_boundary_is_alert_eligible():
+    """trades_count == min_trades is NOT below min — strict `<` semantics.
+
+    Pins the boundary: a symbol with exactly 100 trades enters the baseline
+    path (not the fallback). If a future refactor changes `<` to `<=`, this
+    test fails.
+    """
+    from strategy.kill_switch_v2 import evaluate_per_symbol_tier
+    baseline = {"wr": 0.5, "sigma": 0.5, "count": 100}
+    # rolling_wr=0.0 → well below threshold → ALERT (not blocked by fallback)
+    tier = evaluate_per_symbol_tier(
+        rolling_wr_20=0.0, baseline=baseline, sigma_multiplier=2.0,
+        trades_count=100, min_trades=100,
+    )
+    assert tier == "ALERT"
+
+
+def test_evaluate_per_symbol_tier_with_telemetry_cached_count_gates_decision(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """Cached baseline count<100 gates the tier even if live closed_trades>=100.
+
+    Pins the semantic that `_evaluate_per_symbol_tier_with_telemetry` passes
+    `baseline["count"]` (cached) — not the live `len(closed_trades)` — into
+    `evaluate_per_symbol_tier`. A future refactor to use live count would
+    silently shift tiering behavior.
+    """
+    import btc_api
+    from strategy.kill_switch_v2_shadow import (
+        _evaluate_per_symbol_tier_with_telemetry, _upsert_baseline,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(sh, "_now", lambda: now)
+
+    # Seed cached baseline with count=50 (below min) but FRESH (1 day ago)
+    _upsert_baseline(
+        "BTCUSDT",
+        {"wr": 0.5, "sigma": 0.5, "count": 50},
+        now=now - timedelta(days=1),
+    )
+
+    # Insert 200 live closed trades — enough that a recompute would give count>=100
+    conn = btc_api.get_db()
+    try:
+        for i in range(200):
+            ts_h = i % 24
+            ts = f"2026-04-20T{ts_h:02d}:00:00+00:00"
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, -5.0)",
+                (ts, ts),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+    }}}
+    tier, telemetry = _evaluate_per_symbol_tier_with_telemetry("BTCUSDT", cfg)
+
+    # Cached count=50 < min_trades=100 → fallback to NORMAL even though
+    # rolling_wr_20=0 is far below baseline_wr=0.5.
+    assert tier == "NORMAL"
+    assert telemetry["trades_count"] == 50, "cached count must gate the decision"
+    assert telemetry["baseline_stale"] is False
+
+
+def test_emit_shadow_per_symbol_fail_open_telemetry_keys_match_success_path(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """The fail-open telemetry sentinel must have the exact same key set as
+    the success-path telemetry. A dropped key would break dashboard joins.
+    """
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    import strategy.kill_switch_v2_shadow as sh
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc))
+
+    # Capture success-path keys via a normal call
+    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    import json
+    success_keys = set(json.loads(rows[0]["reasons_json"])["per_symbol"].keys())
+
+    # Reset DB to capture fail-open keys
+    btc_api.init_db()
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated per-symbol eval failure")
+    monkeypatch.setattr(sh, "_evaluate_per_symbol_tier_with_telemetry", _boom)
+
+    emit_shadow_decision(symbol="ETHUSDT", cfg={})
+    rows2 = observability.query_decisions(symbol="ETHUSDT", engine="v2_shadow")
+    fail_keys = set(json.loads(rows2[0]["reasons_json"])["per_symbol"].keys())
+
+    assert success_keys == fail_keys, (
+        f"fail-open sentinel keys {fail_keys} must equal success keys {success_keys}"
+    )
+
+
+def test_upsert_baseline_raises_on_missing_keys(tmp_path, monkeypatch):
+    """_upsert_baseline must raise (not silently coerce) when required keys missing.
+
+    Guards against an upstream bug producing {} silently persisting (0.0, 0.0, 0).
+    """
+    import btc_api
+    from strategy.kill_switch_v2_shadow import _upsert_baseline
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+
+    with pytest.raises(KeyError, match="missing required keys"):
+        _upsert_baseline("BTCUSDT", {}, now=now)
+
+    with pytest.raises(KeyError, match="missing required keys"):
+        _upsert_baseline("BTCUSDT", {"wr": 0.5}, now=now)
+
+
+def test_is_baseline_stale_future_timestamp_returns_true():
+    """A future computed_at is treated as stale to guard against clock skew."""
+    from strategy.kill_switch_v2_shadow import _is_baseline_stale
+    from datetime import datetime, timezone, timedelta
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    future = (now + timedelta(days=1)).isoformat()
+    assert _is_baseline_stale(future, stale_days=7, now=now) is True

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -2383,3 +2383,174 @@ def test_evaluate_per_symbol_tier_with_telemetry_recomputes_when_stale(
     assert telemetry["trades_count"] == 100
     persisted = _load_baseline("BTCUSDT")
     assert persisted["computed_at"] == now.isoformat()
+
+
+# ── B4a: emit_shadow_decision threads per_symbol_tier ───────────────────────
+
+
+def test_emit_shadow_writes_per_symbol_tier_normal_when_no_history(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """No closed trades → per_symbol_tier=NORMAL, reasons.per_symbol populated."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc))
+
+    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    assert rows[0]["per_symbol_tier"] == "NORMAL"
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert "per_symbol" in reasons
+    assert reasons["per_symbol"]["tier"] == "NORMAL"
+    assert reasons["per_symbol"]["status"] == "ok"
+    assert reasons["per_symbol"]["trades_count"] == 0
+
+
+def test_emit_shadow_writes_per_symbol_tier_alert_when_baseline_breaks(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """Per-symbol ALERT propagates to per_symbol_tier column AND reasons."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc))
+
+    conn = btc_api.get_db()
+    try:
+        for _ in range(50):
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', 10.0)",
+            )
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', -5.0)",
+            )
+        for i in range(20):
+            conn.execute(
+                "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+                "'2026-04-20T10:00:00+00:00', ?, -5.0)",
+                (f"2026-04-20T{(i % 24):02d}:00:00+00:00",),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert rows[0]["per_symbol_tier"] == "ALERT"
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["per_symbol"]["tier"] == "ALERT"
+    assert reasons["per_symbol"]["rolling_wr_20"] == pytest.approx(0.0)
+    assert reasons["per_symbol"]["trades_count"] >= 100
+
+
+def test_emit_shadow_per_symbol_fail_open_returns_normal_with_status_failed(
+    tmp_path, monkeypatch, caplog, _clean_shadow_cache,
+):
+    """If _evaluate_per_symbol_tier_with_telemetry raises, tier=NORMAL + status=failed."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    import strategy.kill_switch_v2_shadow as sh
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc))
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated per-symbol eval failure")
+    monkeypatch.setattr(sh, "_evaluate_per_symbol_tier_with_telemetry", _boom)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
+        emit_shadow_decision(symbol="BTCUSDT", cfg={})
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    assert rows[0]["per_symbol_tier"] == "NORMAL"
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert reasons["per_symbol"]["tier"] == "NORMAL"
+    assert reasons["per_symbol"]["status"] == "failed"
+    assert any(
+        "B4a per-symbol tier eval failed" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_emit_shadow_backwards_compat_b1_b2_b3_still_pass(
+    tmp_path, monkeypatch, _clean_shadow_cache,
+):
+    """The B4a additions don't break B1/B2/B3 behavior in a fresh DB."""
+    import btc_api, observability
+    from strategy.kill_switch_v2_shadow import emit_shadow_decision
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    import strategy.kill_switch_v2_shadow as sh
+    monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc))
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced":  {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen":   {"min": -0.15, "max": -0.06},
+            "velocity_sl_count":     {"min": 10, "max": 3},
+            "velocity_window_hours": {"min": 24, "max": 6},
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+    }}}
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+
+    rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
+    assert len(rows) == 1
+    import json
+    reasons = json.loads(rows[0]["reasons_json"])
+    assert "portfolio_dd" in reasons
+    assert "regime" in reasons
+    assert "per_symbol" in reasons
+    assert reasons["regime"]["label"] == "BULL"
+    assert reasons["per_symbol"]["tier"] == "NORMAL"
+    assert rows[0]["velocity_active"] is False

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -2029,3 +2029,127 @@ def test_evaluate_per_symbol_tier_paranoid_slider_triggers_easier():
     )
     assert tier_default == "NORMAL"
     assert tier_paranoid == "ALERT"
+
+
+# ── B4a: shadow DB glue ─────────────────────────────────────────────────────
+
+
+def test_load_closed_trades_for_symbol_filters_by_symbol_and_status(tmp_path, monkeypatch):
+    """Returns only closed trades for the target symbol with non-NULL exit_ts."""
+    import btc_api
+    from strategy.kill_switch_v2_shadow import _load_closed_trades_for_symbol
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+            "'2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', 10.0)",
+        )
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
+            "'2026-04-20T10:00:00+00:00', -5.0)",
+        )
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'open', "
+            "'2026-04-20T10:00:00+00:00')",
+        )
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, pnl_usd) VALUES "
+            "('ETHUSDT', 'LONG', 3000, 1.0, 'closed', "
+            "'2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', 20.0)",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rows = _load_closed_trades_for_symbol("BTCUSDT")
+    assert len(rows) == 1
+    assert rows[0]["pnl_usd"] == pytest.approx(10.0)
+    assert rows[0]["exit_ts"] == "2026-04-20T12:00:00+00:00"
+
+
+def test_load_baseline_returns_none_when_missing(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_shadow import _load_baseline
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    assert _load_baseline("BTCUSDT") is None
+
+
+def test_load_and_upsert_baseline_roundtrip(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_shadow import _load_baseline, _upsert_baseline
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    _upsert_baseline("BTCUSDT", {"wr": 0.55, "sigma": 0.497, "count": 150}, now=now)
+
+    loaded = _load_baseline("BTCUSDT")
+    assert loaded is not None
+    assert loaded["wr"] == pytest.approx(0.55)
+    assert loaded["sigma"] == pytest.approx(0.497)
+    assert loaded["count"] == 150
+    assert loaded["computed_at"] == now.isoformat()
+
+    _upsert_baseline(
+        "BTCUSDT", {"wr": 0.60, "sigma": 0.490, "count": 200},
+        now=datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc),
+    )
+    loaded2 = _load_baseline("BTCUSDT")
+    assert loaded2["wr"] == pytest.approx(0.60)
+    assert loaded2["count"] == 200
+    assert loaded2["computed_at"] == "2026-04-26T12:00:00+00:00"
+
+
+def test_is_baseline_stale_none_computed_at_returns_true():
+    from strategy.kill_switch_v2_shadow import _is_baseline_stale
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    assert _is_baseline_stale(None, stale_days=7, now=now) is True
+
+
+def test_is_baseline_stale_malformed_returns_true():
+    from strategy.kill_switch_v2_shadow import _is_baseline_stale
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    assert _is_baseline_stale("garbage", stale_days=7, now=now) is True
+
+
+def test_is_baseline_stale_fresh_returns_false():
+    from strategy.kill_switch_v2_shadow import _is_baseline_stale
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    fresh = (now - timedelta(days=3)).isoformat()
+    assert _is_baseline_stale(fresh, stale_days=7, now=now) is False
+
+
+def test_is_baseline_stale_old_returns_true():
+    from strategy.kill_switch_v2_shadow import _is_baseline_stale
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    old = (now - timedelta(days=10)).isoformat()
+    assert _is_baseline_stale(old, stale_days=7, now=now) is True

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1841,3 +1841,65 @@ def test_init_db_creates_kill_switch_v2_baseline_table(tmp_path, monkeypatch):
     assert "baseline_sigma" in cols
     assert "trades_count" in cols
     assert "computed_at" in cols
+
+
+# ── B4a: compute_baseline_metrics ───────────────────────────────────────────
+
+
+def test_compute_baseline_metrics_empty_trades():
+    from strategy.kill_switch_v2 import compute_baseline_metrics
+    result = compute_baseline_metrics([])
+    assert result == {"wr": 0.0, "sigma": 0.0, "count": 0}
+
+
+def test_compute_baseline_metrics_all_wins():
+    from strategy.kill_switch_v2 import compute_baseline_metrics
+    trades = [{"pnl_usd": 10.0}, {"pnl_usd": 5.0}, {"pnl_usd": 1.0}]
+    result = compute_baseline_metrics(trades)
+    assert result["wr"] == pytest.approx(1.0)
+    assert result["sigma"] == pytest.approx(0.0)
+    assert result["count"] == 3
+
+
+def test_compute_baseline_metrics_all_losses():
+    from strategy.kill_switch_v2 import compute_baseline_metrics
+    trades = [{"pnl_usd": -10.0}, {"pnl_usd": -5.0}]
+    result = compute_baseline_metrics(trades)
+    assert result["wr"] == pytest.approx(0.0)
+    assert result["sigma"] == pytest.approx(0.0)
+    assert result["count"] == 2
+
+
+def test_compute_baseline_metrics_mixed_60_40():
+    from strategy.kill_switch_v2 import compute_baseline_metrics
+    import math
+    trades = (
+        [{"pnl_usd": 10.0}] * 6
+        + [{"pnl_usd": -5.0}] * 4
+    )
+    result = compute_baseline_metrics(trades)
+    assert result["wr"] == pytest.approx(0.6)
+    assert result["sigma"] == pytest.approx(math.sqrt(0.24))
+    assert result["count"] == 10
+
+
+def test_compute_baseline_metrics_skips_none_pnl():
+    """Trades with pnl_usd=None are excluded from the count."""
+    from strategy.kill_switch_v2 import compute_baseline_metrics
+    trades = [
+        {"pnl_usd": 10.0},
+        {"pnl_usd": None},
+        {"pnl_usd": -5.0},
+    ]
+    result = compute_baseline_metrics(trades)
+    assert result["wr"] == pytest.approx(0.5)
+    assert result["count"] == 2
+
+
+def test_compute_baseline_metrics_treats_zero_as_loss():
+    """Breakeven (pnl_usd=0.0) counts as a loss."""
+    from strategy.kill_switch_v2 import compute_baseline_metrics
+    trades = [{"pnl_usd": 10.0}, {"pnl_usd": 0.0}]
+    result = compute_baseline_metrics(trades)
+    assert result["wr"] == pytest.approx(0.5)
+    assert result["count"] == 2

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1814,3 +1814,30 @@ def test_emit_shadow_adjustment_status_ok_on_normal_path(
     import json
     reasons = json.loads(rows[0]["reasons_json"])
     assert reasons["regime"]["adjustment_status"] == "ok"
+
+
+# ── B4a: schema smoke test ──────────────────────────────────────────────────
+
+
+def test_init_db_creates_kill_switch_v2_baseline_table(tmp_path, monkeypatch):
+    """init_db must create kill_switch_v2_baseline with the expected columns."""
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    conn = btc_api.get_db()
+    try:
+        cols = [r[1] for r in conn.execute(
+            "PRAGMA table_info(kill_switch_v2_baseline)"
+        ).fetchall()]
+    finally:
+        conn.close()
+
+    assert "symbol" in cols
+    assert "baseline_wr" in cols
+    assert "baseline_sigma" in cols
+    assert "trades_count" in cols
+    assert "computed_at" in cols

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1903,3 +1903,45 @@ def test_compute_baseline_metrics_treats_zero_as_loss():
     result = compute_baseline_metrics(trades)
     assert result["wr"] == pytest.approx(0.5)
     assert result["count"] == 2
+
+
+# ── B4a: get_baseline_sigma_multiplier ──────────────────────────────────────
+
+
+def test_get_baseline_sigma_multiplier_slider_0_laxo():
+    from strategy.kill_switch_v2 import get_baseline_sigma_multiplier
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 0,
+        "thresholds": {
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+    }}}
+    assert get_baseline_sigma_multiplier(cfg) == pytest.approx(3.0)
+
+
+def test_get_baseline_sigma_multiplier_slider_50_default():
+    from strategy.kill_switch_v2 import get_baseline_sigma_multiplier
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+    }}}
+    assert get_baseline_sigma_multiplier(cfg) == pytest.approx(2.0)
+
+
+def test_get_baseline_sigma_multiplier_slider_100_paranoid():
+    from strategy.kill_switch_v2 import get_baseline_sigma_multiplier
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 100,
+        "thresholds": {
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+    }}}
+    assert get_baseline_sigma_multiplier(cfg) == pytest.approx(1.0)
+
+
+def test_get_baseline_sigma_multiplier_missing_cfg_uses_defaults():
+    from strategy.kill_switch_v2 import get_baseline_sigma_multiplier
+    # Empty cfg → defaults (slider=50, range 3.0..1.0) → 2.0
+    assert get_baseline_sigma_multiplier({}) == pytest.approx(2.0)

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -1945,3 +1945,87 @@ def test_get_baseline_sigma_multiplier_missing_cfg_uses_defaults():
     from strategy.kill_switch_v2 import get_baseline_sigma_multiplier
     # Empty cfg → defaults (slider=50, range 3.0..1.0) → 2.0
     assert get_baseline_sigma_multiplier({}) == pytest.approx(2.0)
+
+
+# ── B4a: evaluate_per_symbol_tier ───────────────────────────────────────────
+
+
+def test_evaluate_per_symbol_tier_below_min_trades_returns_normal():
+    from strategy.kill_switch_v2 import evaluate_per_symbol_tier
+    baseline = {"wr": 0.5, "sigma": 0.5, "count": 50}
+    tier = evaluate_per_symbol_tier(
+        rolling_wr_20=0.0, baseline=baseline, sigma_multiplier=2.0,
+        trades_count=50, min_trades=100,
+    )
+    assert tier == "NORMAL"
+
+
+def test_evaluate_per_symbol_tier_rolling_none_returns_normal():
+    from strategy.kill_switch_v2 import evaluate_per_symbol_tier
+    baseline = {"wr": 0.5, "sigma": 0.5, "count": 200}
+    tier = evaluate_per_symbol_tier(
+        rolling_wr_20=None, baseline=baseline, sigma_multiplier=2.0,
+        trades_count=200, min_trades=100,
+    )
+    assert tier == "NORMAL"
+
+
+def test_evaluate_per_symbol_tier_well_above_threshold_returns_normal():
+    from strategy.kill_switch_v2 import evaluate_per_symbol_tier
+    baseline = {"wr": 0.5, "sigma": 0.5, "count": 200}
+    tier = evaluate_per_symbol_tier(
+        rolling_wr_20=0.50, baseline=baseline, sigma_multiplier=2.0,
+        trades_count=200, min_trades=100,
+    )
+    assert tier == "NORMAL"
+
+
+def test_evaluate_per_symbol_tier_below_threshold_returns_alert():
+    from strategy.kill_switch_v2 import evaluate_per_symbol_tier
+    baseline = {"wr": 0.5, "sigma": 0.5, "count": 200}
+    tier = evaluate_per_symbol_tier(
+        rolling_wr_20=0.20, baseline=baseline, sigma_multiplier=2.0,
+        trades_count=200, min_trades=100,
+    )
+    assert tier == "ALERT"
+
+
+def test_evaluate_per_symbol_tier_strict_less_than_at_boundary_normal():
+    """rolling_wr exactly at threshold should be NORMAL (strict `<` semantics)."""
+    from strategy.kill_switch_v2 import evaluate_per_symbol_tier
+    import math
+    threshold = 0.5 - 2.0 * (0.5 / math.sqrt(20))
+    baseline = {"wr": 0.5, "sigma": 0.5, "count": 200}
+    tier = evaluate_per_symbol_tier(
+        rolling_wr_20=threshold, baseline=baseline, sigma_multiplier=2.0,
+        trades_count=200, min_trades=100,
+    )
+    assert tier == "NORMAL"
+
+
+def test_evaluate_per_symbol_tier_sigma_zero_any_below_baseline_alerts():
+    """If baseline.sigma=0, threshold collapses to baseline.wr — any decrease triggers."""
+    from strategy.kill_switch_v2 import evaluate_per_symbol_tier
+    baseline = {"wr": 1.0, "sigma": 0.0, "count": 200}
+    tier = evaluate_per_symbol_tier(
+        rolling_wr_20=0.99, baseline=baseline, sigma_multiplier=2.0,
+        trades_count=200, min_trades=100,
+    )
+    assert tier == "ALERT"
+
+
+def test_evaluate_per_symbol_tier_paranoid_slider_triggers_easier():
+    """N=1 (slider=100) makes the threshold higher, easier to trigger ALERT."""
+    from strategy.kill_switch_v2 import evaluate_per_symbol_tier
+    baseline = {"wr": 0.5, "sigma": 0.5, "count": 200}
+
+    tier_default = evaluate_per_symbol_tier(
+        rolling_wr_20=0.30, baseline=baseline, sigma_multiplier=2.0,
+        trades_count=200, min_trades=100,
+    )
+    tier_paranoid = evaluate_per_symbol_tier(
+        rolling_wr_20=0.30, baseline=baseline, sigma_multiplier=1.0,
+        trades_count=200, min_trades=100,
+    )
+    assert tier_default == "NORMAL"
+    assert tier_paranoid == "ALERT"


### PR DESCRIPTION
## Summary

Kill Switch v2 **B4a — per-symbol baselines** (#198, scope §8.4 of epic #187). Computes per-symbol baseline metrics (WR + σ + count) from historical closed trades and evaluates per-symbol tier (NORMAL/ALERT) relative to baseline. Replaces the previously-hardcoded `per_symbol_tier="NORMAL"` in v2_shadow with real evaluation.

**Scope split context:** B4 originally combined per-symbol baselines (§8.4) + auto-calibrator daemon (§5). The split was documented at #187, #198, and #214 — this PR ships only baselines. The daemon lands in #214 (B4b).

## What ships

- `strategy/kill_switch_v2.py` — pure functions: `compute_baseline_metrics`, `get_baseline_sigma_multiplier`, `evaluate_per_symbol_tier`.
- `strategy/kill_switch_v2_shadow.py` — DB glue: `_load_closed_trades_for_symbol`, `_load_baseline`, `_upsert_baseline`, `_is_baseline_stale`, `_evaluate_per_symbol_tier_with_telemetry`. `emit_shadow_decision` swaps hardcoded `"NORMAL"` for the computed tier wrapped fail-open.
- `btc_api.init_db` — new `kill_switch_v2_baseline` table (symbol PK; baseline_wr, baseline_sigma, trades_count, computed_at).
- 33 new tests covering pure logic, DB glue, lazy-refresh, fail-open, and end-to-end scanner integration.

## Threshold formula

ALERT triggered when:
```
rolling_wr_20 < baseline_wr - N * (baseline_sigma / sqrt(20))
```

- `baseline_wr` = wins / count over full history (Bernoulli probability).
- `baseline_sigma` = sqrt(wr * (1-wr)) — per-trade Bernoulli std dev.
- `/sqrt(20)` factor converts per-trade σ into the std dev of a 20-trade rolling-mean estimator (CLT).
- `N = sigma_multiplier` is slider-derived: range [3.0 (laxo) ... 1.0 (paranoid)], default 2.0 at slider=50.

## Fallback rules

- `trades_count < 100` → `NORMAL` (insufficient evidence; B1/B2/B3 global-slider thresholds remain authoritative).
- `rolling_wr_20 is None` → `NORMAL`.
- Boundary: `rolling_wr == threshold` → `NORMAL` (strict `<`).

## Lazy refresh

Each scan checks `computed_at` of the cached baseline. Older than `baseline_stale_days` (default 7) or missing/malformed → recompute and persist. No daemon, no cron. When B4b daemon lands, it can invalidate cache via `UPDATE ... SET computed_at='1970-01-01'`.

## Telemetry

`reasons_json.per_symbol` block records:
`{tier, status, baseline_wr, baseline_sigma, rolling_wr_20, sigma_multiplier, trades_count, baseline_stale}`.

`per_symbol_tier` column reflects the computed tier (no longer hardcoded).

## Intentionally NOT shipped

- B4b auto-calibrator daemon (#214) — grid optimization + triggers + recommendations table.
- REDUCED/PAUSED tiers per-symbol — B5 PROBATION and beyond.
- Per-symbol regime adjustment — B3 is global by design.
- Frontend UI for the per_symbol block — dashboard already consumes `reasons_json`; rich viz with B6.
- Manual recalibration endpoint — B4b will include `POST /kill_switch/recalibrate`.

## Test plan

- [x] Unit: `compute_baseline_metrics` (empty/all-wins/all-losses/mixed/None-pnl/breakeven) — 6 tests.
- [x] Unit: `get_baseline_sigma_multiplier` (slider 0/50/100/missing) — 4 tests.
- [x] Unit: `evaluate_per_symbol_tier` (below-min, rolling-None, above/below threshold, exact-equality boundary, sigma=0 edge, paranoid-flips-to-ALERT) — 7 tests.
- [x] DB glue: `_load_closed_trades_for_symbol` filters by symbol+status+exit_ts; `_load_baseline`/`_upsert_baseline` roundtrip; `_is_baseline_stale` (None, malformed, fresh, old) — 7 tests.
- [x] Orchestration: below-min returns NORMAL but persists baseline; ALERT fires on rolling break; cached fresh baseline reused; stale baseline triggers recompute — 4 tests.
- [x] Integration: `emit_shadow_decision` writes per_symbol_tier column + reasons.per_symbol; fail-open returns NORMAL with status=failed; B1/B2/B3 backwards-compat preserved — 4 tests.
- [x] Scanner integration: `TestScanEmitsV2ShadowDecision` asserts reasons.per_symbol block + column equals reasons.tier.
- [x] Full backend: 792 passed (was 759, +33 new).
- [x] Frontend: 21 passed unchanged.

## Closes

#198. Spec: `docs/superpowers/specs/es/2026-04-25-kill-switch-v2-b4a-per-symbol-baselines-design.md`. Plan: `docs/superpowers/plans/2026-04-25-kill-switch-v2-b4a-per-symbol-baselines.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)