### PR TITLE
feat(kill-switch-v2): B4b.1 auto-calibrator daemon infrastructure (#187 #214)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -1674,6 +1674,71 @@ def kill_switch_recalibrate():
     return {"recommendation_id": rec_id, "status": result["status"]}
 
 
+@app.get(
+    "/kill_switch/recommendations",
+    summary="List auto-calibrator recommendations",
+    dependencies=[Depends(verify_api_key)],
+)
+def kill_switch_list_recommendations(
+    since: Optional[str] = Query(
+        None, description="ISO timestamp; only rows with ts >= since",
+    ),
+    status: Optional[str] = Query(
+        None,
+        description="Filter by status (pending, applied, ignored, "
+                    "superseded, no_feasible)",
+    ),
+    limit: int = Query(100, ge=1, le=1000),
+):
+    """List auto-calibrator recommendations, latest first."""
+    import json as _json
+
+    conn = get_db()
+    try:
+        sql = (
+            "SELECT id, ts, triggered_by, slider_value, projected_pnl, "
+            "projected_dd, status, applied_ts, applied_by, report_json "
+            "FROM kill_switch_recommendations WHERE 1=1"
+        )
+        params: list = []
+        if since:
+            sql += " AND ts >= ?"
+            params.append(since)
+        if status:
+            sql += " AND status = ?"
+            params.append(status)
+        sql += " ORDER BY ts DESC LIMIT ?"
+        params.append(int(limit))
+        rows = conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()
+
+    result = []
+    for r in rows:
+        d = {
+            "id": r[0],
+            "ts": r[1],
+            "triggered_by": r[2],
+            "slider_value": r[3],
+            "projected_pnl": r[4],
+            "projected_dd": r[5],
+            "status": r[6],
+            "applied_ts": r[7],
+            "applied_by": r[8],
+            "report": None,
+        }
+        try:
+            d["triggered_by"] = _json.loads(d["triggered_by"])
+        except (TypeError, ValueError):
+            pass
+        try:
+            d["report"] = _json.loads(r[9])
+        except (TypeError, ValueError):
+            d["report"] = None
+        result.append(d)
+    return result
+
+
 @app.get("/signals", summary="Historial de escaneos / señales")
 def list_signals(
     limit:        int             = Query(50,    ge=1, le=500),

--- a/btc_api.py
+++ b/btc_api.py
@@ -1035,6 +1035,24 @@ def init_db():
             computed_at    TEXT NOT NULL
         )
     """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS kill_switch_recommendations (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts              TEXT NOT NULL,
+            triggered_by    TEXT NOT NULL,
+            slider_value    REAL,
+            projected_pnl   REAL,
+            projected_dd    REAL,
+            status          TEXT NOT NULL,
+            applied_ts      TEXT,
+            applied_by      TEXT,
+            report_json     TEXT NOT NULL
+        )
+    """)
+    con.execute("""
+        CREATE INDEX IF NOT EXISTS idx_recommendations_ts
+            ON kill_switch_recommendations(ts)
+    """)
     con.commit()
     con.close()
     log.info(f"DB inicializada: {DB_FILE}")

--- a/btc_api.py
+++ b/btc_api.py
@@ -1644,6 +1644,36 @@ def force_scan(
     return {"scanned": len(results), "results": results}
 
 
+@app.post(
+    "/kill_switch/recalibrate",
+    summary="Manually trigger an auto-calibrator recommendation",
+    dependencies=[Depends(verify_api_key)],
+)
+def kill_switch_recalibrate():
+    """Manually trigger the auto-calibrator (#187 B4b.1).
+
+    In B4b.1 this returns no_feasible (stub fitness). B4b.2 (#216) will
+    replace the stub with v2-aware backtest grid optimization.
+    """
+    from strategy.kill_switch_v2_calibrator import (
+        run_optimization_stub, _persist_recommendation,
+    )
+    from datetime import datetime, timezone
+
+    cfg = load_config()
+    result = run_optimization_stub(cfg)
+    now = datetime.now(tz=timezone.utc)
+    rec_id = _persist_recommendation(
+        triggered_by=["manual"], result=result, now=now,
+    )
+    log.warning(
+        "Kill switch v2: recomendación id=%d (status=%s, triggered_by=manual). "
+        "Telegram pendiente B4b.3.",
+        rec_id, result["status"],
+    )
+    return {"recommendation_id": rec_id, "status": result["status"]}
+
+
 @app.get("/signals", summary="Historial de escaneos / señales")
 def list_signals(
     limit:        int             = Query(50,    ge=1, le=500),

--- a/btc_api.py
+++ b/btc_api.py
@@ -1540,6 +1540,17 @@ def start_scanner_thread():
     )
     health_thread.start()
     log.info("Health monitor thread started (daily @ 00:00 UTC)")
+
+    # Kill switch v2 auto-calibrator (#214 B4b.1)
+    from strategy.kill_switch_v2_calibrator import kill_switch_calibrator_loop
+    calibrator_thread = threading.Thread(
+        target=kill_switch_calibrator_loop,
+        args=(lambda: load_config(),),
+        daemon=True,
+        name="kill-switch-calibrator",
+    )
+    calibrator_thread.start()
+    log.info("Kill switch v2 calibrator thread started (daily @ 00:00 UTC)")
     return t
 
 

--- a/btc_api.py
+++ b/btc_api.py
@@ -1671,12 +1671,22 @@ def kill_switch_recalibrate():
     )
     from datetime import datetime, timezone
 
-    cfg = load_config()
-    result = run_optimization_stub(cfg)
-    now = datetime.now(tz=timezone.utc)
-    rec_id = _persist_recommendation(
-        triggered_by=["manual"], result=result, now=now,
-    )
+    try:
+        cfg = load_config()
+        result = run_optimization_stub(cfg)
+        now = datetime.now(tz=timezone.utc)
+        rec_id = _persist_recommendation(
+            triggered_by=["manual"], result=result, now=now,
+        )
+    except Exception as e:
+        log.error(
+            "POST /kill_switch/recalibrate failed: %s", e, exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"recalibrate failed: {type(e).__name__}: {e}",
+        )
+
     log.warning(
         "Kill switch v2: recomendación id=%d (status=%s, triggered_by=manual). "
         "Telegram pendiente B4b.3.",
@@ -1740,11 +1750,18 @@ def kill_switch_list_recommendations(
         }
         try:
             d["triggered_by"] = _json.loads(d["triggered_by"])
-        except (TypeError, ValueError):
-            pass
+        except (TypeError, ValueError) as e:
+            log.warning(
+                "Corrupted recommendation row id=%s: triggered_by JSON "
+                "parse failed (%s); raw=%r", r[0], e, r[2],
+            )
         try:
             d["report"] = _json.loads(r[9])
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as e:
+            log.warning(
+                "Corrupted recommendation row id=%s: report_json parse "
+                "failed (%s); raw=%r", r[0], e, r[9],
+            )
             d["report"] = None
         result.append(d)
     return result

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -16,7 +16,12 @@
     "reduce_pnl_window_days": 14,
     "reduce_size_factor": 0.5,
     "pause_months_consecutive": 2,
-    "auto_recovery_enabled": true
+    "auto_recovery_enabled": true,
+    "v2": {
+      "auto_calibrator": {
+        "safety_net_days": 30
+      }
+    }
   },
   "symbol_overrides": {
     "BTCUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5 },

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -135,3 +135,60 @@ def _load_last_recalibration_ts() -> str | None:
     finally:
         conn.close()
     return row[0] if row and row[0] else None
+
+
+def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
+    """Daily auto-calibrator loop.
+
+    Pattern mirrors health_monitor_loop. Wakes once per day, evaluates the
+    safety_net trigger, persists a stub recommendation if fired. Manual
+    triggers come through the FastAPI endpoint, not via this loop.
+
+    Fail-open: any exception inside an iteration is logged with exc_info;
+    the loop continues. stop_event.set() exits the loop cleanly.
+    """
+    import threading
+    from datetime import datetime, timedelta, timezone
+
+    if stop_event is None:
+        stop_event = threading.Event()
+
+    while not stop_event.is_set():
+        try:
+            cfg = cfg_fn()
+            v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+            auto_cal_cfg = v2_cfg.get("auto_calibrator", {}) or {}
+            safety_net_days = int(
+                auto_cal_cfg.get("safety_net_days", _DEFAULT_SAFETY_NET_DAYS)
+            )
+
+            now = datetime.now(tz=timezone.utc)
+            last_ts = _load_last_recalibration_ts()
+
+            if should_run_safety_net(last_ts, now, safety_net_days):
+                result = run_optimization_stub(cfg)
+                rec_id = _persist_recommendation(
+                    triggered_by=["safety_net"], result=result, now=now,
+                )
+                # Stub notification — real Telegram lands in B4b.3 (#217)
+                log.warning(
+                    "Kill switch v2: recomendación id=%d (status=%s, "
+                    "triggered_by=safety_net). Telegram pendiente B4b.3.",
+                    rec_id, result["status"],
+                )
+        except Exception as e:
+            log.warning(
+                "kill_switch_calibrator_loop iteration failed: %s",
+                e, exc_info=True,
+            )
+
+        # Sleep until next midnight UTC (or until stop_event is set)
+        now = datetime.now(tz=timezone.utc)
+        next_midnight = (now + timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0,
+        )
+        seconds = max(60.0, (next_midnight - now).total_seconds())
+        if stop_event.wait(seconds):
+            break
+
+    log.info("kill_switch_calibrator_loop exiting cleanly")

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -90,3 +90,48 @@ def run_optimization_stub(cfg: dict[str, Any]) -> dict[str, Any]:
             reason="v2 backtest pending B4b.2", now=now,
         ),
     }
+
+
+def _persist_recommendation(
+    triggered_by: list[str],
+    result: dict[str, Any],
+    now,
+) -> int:
+    """Insert a recommendation row. Returns the new row id."""
+    import json
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        cursor = conn.execute(
+            """INSERT INTO kill_switch_recommendations
+                 (ts, triggered_by, slider_value, projected_pnl, projected_dd,
+                  status, applied_ts, applied_by, report_json)
+               VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?)""",
+            (
+                now.isoformat(),
+                json.dumps(triggered_by),
+                result.get("slider_value"),
+                result.get("projected_pnl"),
+                result.get("projected_dd"),
+                result["status"],
+                json.dumps(result.get("report", {})),
+            ),
+        )
+        conn.commit()
+        return int(cursor.lastrowid)
+    finally:
+        conn.close()
+
+
+def _load_last_recalibration_ts() -> str | None:
+    """Return the latest ts from kill_switch_recommendations, or None."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            "SELECT MAX(ts) FROM kill_switch_recommendations",
+        ).fetchone()
+    finally:
+        conn.close()
+    return row[0] if row and row[0] else None

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -45,3 +45,48 @@ def should_run_safety_net(
     if parsed > now:
         return True
     return (now - parsed) > timedelta(days=float(safety_net_days))
+
+
+def build_no_feasible_report(reason: str, now) -> dict[str, Any]:
+    """Construct the report payload for stub no_feasible runs.
+
+    The `stub: True` flag is a sentinel for the dashboard / future B4b.2
+    code: stubs can be filtered out of the "real" recommendation list.
+    """
+    return {
+        "status": "no_feasible",
+        "reason": reason,
+        "ts": now.isoformat(),
+        "stub": True,
+    }
+
+
+def run_optimization_stub(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Stub fitness for B4b.1. Always returns no_feasible.
+
+    Will be replaced by run_optimization_v2 in B4b.2 (#216) which performs
+    grid optimization over slider 0..100 with a v2-aware backtest.
+
+    Args:
+        cfg: ignored (signature preserved for forward compatibility).
+
+    Returns:
+        {
+            "status": "no_feasible",
+            "slider_value": None,
+            "projected_pnl": None,
+            "projected_dd": None,
+            "report": {<no_feasible_report>},
+        }
+    """
+    from datetime import datetime, timezone
+    now = datetime.now(tz=timezone.utc)
+    return {
+        "status": "no_feasible",
+        "slider_value": None,
+        "projected_pnl": None,
+        "projected_dd": None,
+        "report": build_no_feasible_report(
+            reason="v2 backtest pending B4b.2", now=now,
+        ),
+    }

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -1,0 +1,47 @@
+"""Kill switch v2 auto-calibrator daemon (#187 #214 B4b.1).
+
+Daily-tick thread that evaluates triggers and persists stub recommendations
+to kill_switch_recommendations. The "intelligence" (v2-aware backtest + grid
+optimization) lands in B4b.2 (#216) — for now the fitness fn is a stub that
+always returns no_feasible.
+
+Only two triggers are wired: manual (via POST /kill_switch/recalibrate) and
+safety_net (30 days since last recalibration). The other three triggers
+(regime_change, portfolio_dd_degradation, event_cascade) come with B4b.3
+(#217) along with rate limiting and Telegram notifications.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger("kill_switch_v2_calibrator")
+
+_DEFAULT_SAFETY_NET_DAYS = 30
+
+
+def should_run_safety_net(
+    last_recalibration_ts: str | None,
+    now,
+    safety_net_days: int,
+) -> bool:
+    """Return True if safety_net should fire (>= safety_net_days since last).
+
+    last_recalibration_ts None → True (never recalibrated).
+    Malformed string → True (treat as never).
+    Future timestamp → True (clock skew guard).
+    Exactly safety_net_days ago → False (strict `>`).
+    """
+    from datetime import datetime, timedelta, timezone
+
+    if not last_recalibration_ts:
+        return True
+    try:
+        parsed = datetime.fromisoformat(last_recalibration_ts)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return True
+    if parsed > now:
+        return True
+    return (now - parsed) > timedelta(days=float(safety_net_days))

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -97,9 +97,21 @@ def _persist_recommendation(
     result: dict[str, Any],
     now,
 ) -> int:
-    """Insert a recommendation row. Returns the new row id."""
+    """Insert a recommendation row. Returns the new row id.
+
+    Validates that result has the required keys (status, report); raises
+    KeyError on missing keys instead of silently coercing report to {}.
+    Same pattern as B4a's _upsert_baseline guard — masks an upstream bug
+    producing malformed result dicts otherwise.
+    """
     import json
     import btc_api
+
+    missing = [k for k in ("status", "report") if k not in result]
+    if missing:
+        raise KeyError(
+            f"_persist_recommendation: result dict missing required keys: {missing}"
+        )
 
     conn = btc_api.get_db()
     try:
@@ -115,7 +127,7 @@ def _persist_recommendation(
                 result.get("projected_pnl"),
                 result.get("projected_dd"),
                 result["status"],
-                json.dumps(result.get("report", {})),
+                json.dumps(result["report"]),
             ),
         )
         conn.commit()

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -224,3 +224,155 @@ def test_load_last_recalibration_ts_returns_max_ts(tmp_path, monkeypatch):
     )
 
     assert _load_last_recalibration_ts() == later.isoformat()
+
+
+# ── B4b.1: kill_switch_calibrator_loop ──────────────────────────────────────
+
+
+def test_calibrator_loop_safety_net_fires_when_table_empty(
+    tmp_path, monkeypatch,
+):
+    """First-ever tick with empty table → safety_net fires + persists row."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import kill_switch_calibrator_loop
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    stop_event = threading.Event()
+    call_count = {"n": 0}
+
+    def fake_wait(seconds):
+        call_count["n"] += 1
+        stop_event.set()
+        return True
+
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {
+        "kill_switch": {"v2": {"auto_calibrator": {"safety_net_days": 30}}}
+    }
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    assert call_count["n"] == 1
+
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            "SELECT triggered_by, status FROM kill_switch_recommendations"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    import json
+    assert json.loads(rows[0][0]) == ["safety_net"]
+    assert rows[0][1] == "no_feasible"
+
+
+def test_calibrator_loop_does_not_fire_when_recent_recalibration(
+    tmp_path, monkeypatch,
+):
+    """If last recalibration was <30d ago, loop iteration skips persistence."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import (
+        kill_switch_calibrator_loop, _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime.now(tz=timezone.utc)
+    recent = now - timedelta(days=5)
+    _persist_recommendation(
+        triggered_by=["safety_net"],
+        result=run_optimization_stub({}),
+        now=recent,
+    )
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {
+        "kill_switch": {"v2": {"auto_calibrator": {"safety_net_days": 30}}}
+    }
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    conn = btc_api.get_db()
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM kill_switch_recommendations"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1
+
+
+def test_calibrator_loop_exits_cleanly_when_stop_event_set(
+    tmp_path, monkeypatch,
+):
+    """stop_event.set() before loop start → loop exits without doing work."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import kill_switch_calibrator_loop
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    stop_event = threading.Event()
+    stop_event.set()
+
+    cfg_fn = lambda: {}
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    conn = btc_api.get_db()
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM kill_switch_recommendations"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 0
+
+
+def test_calibrator_loop_iteration_failure_is_logged_not_propagated(
+    tmp_path, monkeypatch, caplog,
+):
+    """Exception in iteration body → logged with exc_info, loop continues."""
+    import btc_api, threading
+    import strategy.kill_switch_v2_calibrator as cal
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated cfg lookup failure")
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_calibrator"):
+        cal.kill_switch_calibrator_loop(_boom, stop_event=stop_event)
+
+    assert any(
+        "kill_switch_calibrator_loop iteration failed" in rec.getMessage()
+        for rec in caplog.records
+    )

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -543,3 +543,332 @@ def test_start_scanner_thread_launches_calibrator_thread(monkeypatch):
     btc_api.start_scanner_thread()
 
     assert "kill-switch-calibrator" in captured_threads
+
+
+# ── B4b.1: review follow-ups — hardening tests ──────────────────────────────
+
+
+def test_start_scanner_thread_starts_calibrator_target_callable(monkeypatch):
+    """Pin the contract: thread is constructed AND .start() is invoked AND
+    target is kill_switch_calibrator_loop.
+
+    Replaces the brittle __init__ patch with a FakeThread that records
+    construction args + start() calls. Pins what matters behaviorally.
+    """
+    import btc_api, threading
+    from strategy import kill_switch_v2_calibrator
+
+    captured = []
+    original_thread = threading.Thread
+
+    class FakeThread:
+        def __init__(self, target=None, args=(), daemon=None, name=None, **kwargs):
+            captured.append({
+                "target": target,
+                "args": args,
+                "daemon": daemon,
+                "name": name,
+            })
+            self._started = False
+            self.name = name
+
+        def start(self):
+            self._started = True
+
+    monkeypatch.setattr(threading, "Thread", FakeThread)
+
+    btc_api.start_scanner_thread()
+
+    # Find the calibrator thread
+    calibrator = next(
+        (c for c in captured if c["name"] == "kill-switch-calibrator"), None,
+    )
+    assert calibrator is not None, "kill-switch-calibrator thread must be constructed"
+    assert calibrator["target"] is kill_switch_v2_calibrator.kill_switch_calibrator_loop, (
+        "target must be kill_switch_calibrator_loop"
+    )
+    assert calibrator["daemon"] is True, "must be daemon=True"
+    # args is (cfg_fn,) — the lambda captures load_config
+    assert callable(calibrator["args"][0]), "first arg must be a cfg callable"
+
+
+def test_post_recalibrate_unauthenticated_rejected_when_api_key_configured(
+    tmp_path, monkeypatch,
+):
+    """When api_key is configured, POST without X-API-Key returns 401.
+
+    The API has backwards-compatible "no api_key configured = open access"
+    semantics (see verify_api_key in btc_api.py); this test forces a key
+    via load_config monkeypatch to validate the auth path actually rejects.
+    """
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    monkeypatch.setattr(btc_api, "load_config", lambda: {"api_key": "test-secret"})
+
+    client = TestClient(btc_api.app)
+    # No X-API-Key header → 401
+    resp = client.post("/kill_switch/recalibrate")
+    assert resp.status_code == 401
+
+    # Wrong key → 401
+    resp_wrong = client.post(
+        "/kill_switch/recalibrate", headers={"X-API-Key": "wrong-key"},
+    )
+    assert resp_wrong.status_code == 401
+
+    # Correct key → 200
+    resp_ok = client.post(
+        "/kill_switch/recalibrate", headers={"X-API-Key": "test-secret"},
+    )
+    assert resp_ok.status_code == 200
+
+
+def test_get_recommendations_unauthenticated_rejected_when_api_key_configured(
+    tmp_path, monkeypatch,
+):
+    """When api_key is configured, GET without X-API-Key returns 401."""
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    monkeypatch.setattr(btc_api, "load_config", lambda: {"api_key": "test-secret"})
+
+    client = TestClient(btc_api.app)
+    resp = client.get("/kill_switch/recommendations")
+    assert resp.status_code == 401
+
+
+def test_get_recommendations_filter_by_since(tmp_path, monkeypatch):
+    """`since` filter returns only rows with ts >= since (boundary inclusive)."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from strategy.kill_switch_v2_calibrator import (
+        _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    earlier = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+    middle = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc)
+    later = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    result = run_optimization_stub({})
+    _persist_recommendation(triggered_by=["safety_net"], result=result, now=earlier)
+    _persist_recommendation(triggered_by=["manual"], result=result, now=middle)
+    _persist_recommendation(triggered_by=["safety_net"], result=result, now=later)
+
+    try:
+        client = TestClient(btc_api.app)
+        # since=middle → returns middle + later (boundary inclusive via >=)
+        resp = client.get(
+            f"/kill_switch/recommendations?since={middle.isoformat()}",
+        )
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert len(rows) == 2
+        ts_returned = sorted(r["ts"] for r in rows)
+        assert ts_returned == sorted([middle.isoformat(), later.isoformat()])
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_get_recommendations_limit_caps_results(tmp_path, monkeypatch):
+    """`limit` parameter caps the number of returned rows."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from strategy.kill_switch_v2_calibrator import (
+        _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    base = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    result = run_optimization_stub({})
+    for i in range(5):
+        _persist_recommendation(
+            triggered_by=["manual"], result=result,
+            now=base + timedelta(minutes=i),
+        )
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.get("/kill_switch/recommendations?limit=2")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_calibrator_loop_persist_failure_logged_with_exc_info(
+    tmp_path, monkeypatch, caplog,
+):
+    """Mid-iteration failure in _persist_recommendation is logged with exc_info
+    via the outer try/except. Loop continues (next iteration would retry)."""
+    import btc_api, threading
+    import strategy.kill_switch_v2_calibrator as cal
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    def _boom_persist(*a, **kw):
+        raise RuntimeError("simulated DB persist failure")
+
+    monkeypatch.setattr(cal, "_persist_recommendation", _boom_persist)
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {
+        "kill_switch": {"v2": {"auto_calibrator": {"safety_net_days": 30}}}
+    }
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_calibrator"):
+        cal.kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    # Outer try/except catches RuntimeError and logs it
+    matching = [
+        rec for rec in caplog.records
+        if "kill_switch_calibrator_loop iteration failed" in rec.getMessage()
+    ]
+    assert len(matching) >= 1
+    # Verify exc_info attached (traceback captured)
+    assert any(rec.exc_info is not None for rec in matching)
+
+
+def test_persist_recommendation_raises_on_missing_status_key(tmp_path, monkeypatch):
+    """_persist_recommendation raises KeyError if result dict missing 'status'."""
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _persist_recommendation
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+
+    with pytest.raises(KeyError, match="missing required keys"):
+        _persist_recommendation(
+            triggered_by=["manual"],
+            result={"report": {}},  # missing "status"
+            now=now,
+        )
+
+    with pytest.raises(KeyError, match="missing required keys"):
+        _persist_recommendation(
+            triggered_by=["manual"],
+            result={"status": "no_feasible"},  # missing "report"
+            now=now,
+        )
+
+
+def test_post_recalibrate_returns_500_on_internal_failure(
+    tmp_path, monkeypatch, caplog,
+):
+    """If run_optimization_stub raises, endpoint returns 500 with detail
+    (not opaque FastAPI error) and logs with exc_info."""
+    import btc_api
+    import strategy.kill_switch_v2_calibrator as cal
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated optimization failure")
+    monkeypatch.setattr(cal, "run_optimization_stub", _boom)
+
+    try:
+        import logging
+        with caplog.at_level(logging.ERROR, logger=btc_api.log.name):
+            client = TestClient(btc_api.app, raise_server_exceptions=False)
+            resp = client.post("/kill_switch/recalibrate")
+
+        assert resp.status_code == 500
+        body = resp.json()
+        assert "recalibrate failed" in body.get("detail", "")
+        assert "RuntimeError" in body.get("detail", "")
+        # log.error captured with exc_info
+        assert any(
+            "POST /kill_switch/recalibrate failed" in rec.getMessage()
+            and rec.exc_info is not None
+            for rec in caplog.records
+        )
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_get_recommendations_logs_warning_on_corrupt_row(
+    tmp_path, monkeypatch, caplog,
+):
+    """If a row has corrupted triggered_by JSON, GET logs a warning with row id
+    and returns the raw value (does not silently discard)."""
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    # Insert a row with corrupted triggered_by (not valid JSON)
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, status, report_json) VALUES (?, ?, ?, ?)",
+            ("2026-04-25T12:00:00+00:00", "not-valid-json", "no_feasible", "{}"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    try:
+        import logging
+        with caplog.at_level(logging.WARNING, logger=btc_api.log.name):
+            client = TestClient(btc_api.app)
+            resp = client.get("/kill_switch/recommendations")
+
+        assert resp.status_code == 200
+        assert any(
+            "Corrupted recommendation row" in rec.getMessage()
+            for rec in caplog.records
+        )
+    finally:
+        btc_api.app.dependency_overrides.clear()

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -28,3 +28,54 @@ def test_init_db_creates_kill_switch_recommendations_table(tmp_path, monkeypatch
         "applied_ts", "applied_by", "report_json",
     }
     assert expected.issubset(set(cols))
+
+
+# ── B4b.1: should_run_safety_net ────────────────────────────────────────────
+
+
+def test_should_run_safety_net_none_returns_true():
+    from strategy.kill_switch_v2_calibrator import should_run_safety_net
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc)
+    assert should_run_safety_net(None, now, safety_net_days=30) is True
+
+
+def test_should_run_safety_net_malformed_returns_true():
+    from strategy.kill_switch_v2_calibrator import should_run_safety_net
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc)
+    assert should_run_safety_net("garbage", now, safety_net_days=30) is True
+
+
+def test_should_run_safety_net_29_days_ago_returns_false():
+    from strategy.kill_switch_v2_calibrator import should_run_safety_net
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc)
+    last = (now - timedelta(days=29)).isoformat()
+    assert should_run_safety_net(last, now, safety_net_days=30) is False
+
+
+def test_should_run_safety_net_31_days_ago_returns_true():
+    from strategy.kill_switch_v2_calibrator import should_run_safety_net
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc)
+    last = (now - timedelta(days=31)).isoformat()
+    assert should_run_safety_net(last, now, safety_net_days=30) is True
+
+
+def test_should_run_safety_net_exactly_30_days_returns_false():
+    """Boundary: at exactly 30 days, strict `>` keeps it NOT firing."""
+    from strategy.kill_switch_v2_calibrator import should_run_safety_net
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc)
+    last = (now - timedelta(days=30)).isoformat()
+    assert should_run_safety_net(last, now, safety_net_days=30) is False
+
+
+def test_should_run_safety_net_future_timestamp_returns_true():
+    """Clock skew guard: a future last_ts should still fire."""
+    from strategy.kill_switch_v2_calibrator import should_run_safety_net
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc)
+    future = (now + timedelta(days=1)).isoformat()
+    assert should_run_safety_net(future, now, safety_net_days=30) is True

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -415,3 +415,107 @@ def test_post_recalibrate_returns_recommendation_id(tmp_path, monkeypatch):
         assert row[1] == "no_feasible"
     finally:
         btc_api.app.dependency_overrides.clear()
+
+
+# ── B4b.1: GET /kill_switch/recommendations ─────────────────────────────────
+
+
+def test_get_recommendations_empty_returns_empty_list(tmp_path, monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.get("/kill_switch/recommendations")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_get_recommendations_returns_rows_ordered_desc(tmp_path, monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+    from strategy.kill_switch_v2_calibrator import (
+        _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    earlier = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+    later = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    result = run_optimization_stub({})
+    _persist_recommendation(
+        triggered_by=["safety_net"], result=result, now=earlier,
+    )
+    _persist_recommendation(
+        triggered_by=["manual"], result=result, now=later,
+    )
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.get("/kill_switch/recommendations")
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert len(rows) == 2
+        # Latest first
+        assert rows[0]["ts"] == later.isoformat()
+        assert rows[0]["triggered_by"] == ["manual"]
+        assert rows[1]["ts"] == earlier.isoformat()
+        assert rows[1]["triggered_by"] == ["safety_net"]
+        # Report block parsed
+        assert rows[0]["report"]["stub"] is True
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_get_recommendations_filter_by_status(tmp_path, monkeypatch):
+    """status=no_feasible filter returns only matching rows."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from strategy.kill_switch_v2_calibrator import (
+        _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    result = run_optimization_stub({})
+    _persist_recommendation(
+        triggered_by=["manual"], result=result, now=now,
+    )
+
+    try:
+        client = TestClient(btc_api.app)
+        resp_match = client.get(
+            "/kill_switch/recommendations?status=no_feasible",
+        )
+        assert resp_match.status_code == 200
+        assert len(resp_match.json()) == 1
+
+        resp_other = client.get(
+            "/kill_switch/recommendations?status=applied",
+        )
+        assert resp_other.status_code == 200
+        assert resp_other.json() == []
+    finally:
+        btc_api.app.dependency_overrides.clear()

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -376,3 +376,42 @@ def test_calibrator_loop_iteration_failure_is_logged_not_propagated(
         "kill_switch_calibrator_loop iteration failed" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+# ── B4b.1: POST /kill_switch/recalibrate ────────────────────────────────────
+
+
+def test_post_recalibrate_returns_recommendation_id(tmp_path, monkeypatch):
+    """POST /kill_switch/recalibrate creates a row + returns id + status."""
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post("/kill_switch/recalibrate")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "recommendation_id" in body
+        assert body["status"] == "no_feasible"
+
+        rec_id = body["recommendation_id"]
+        conn = btc_api.get_db()
+        try:
+            row = conn.execute(
+                "SELECT triggered_by, status FROM kill_switch_recommendations "
+                "WHERE id = ?", (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        import json
+        assert json.loads(row[0]) == ["manual"]
+        assert row[1] == "no_feasible"
+    finally:
+        btc_api.app.dependency_overrides.clear()

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -79,3 +79,39 @@ def test_should_run_safety_net_future_timestamp_returns_true():
     now = datetime(2026, 4, 25, 0, 0, tzinfo=timezone.utc)
     future = (now + timedelta(days=1)).isoformat()
     assert should_run_safety_net(future, now, safety_net_days=30) is True
+
+
+# ── B4b.1: build_no_feasible_report ─────────────────────────────────────────
+
+
+def test_build_no_feasible_report_shape():
+    from strategy.kill_switch_v2_calibrator import build_no_feasible_report
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    report = build_no_feasible_report(reason="test reason", now=now)
+    assert report["status"] == "no_feasible"
+    assert report["reason"] == "test reason"
+    assert report["ts"] == now.isoformat()
+    assert report["stub"] is True
+
+
+# ── B4b.1: run_optimization_stub ────────────────────────────────────────────
+
+
+def test_run_optimization_stub_returns_no_feasible_for_empty_cfg():
+    from strategy.kill_switch_v2_calibrator import run_optimization_stub
+    result = run_optimization_stub({})
+    assert result["status"] == "no_feasible"
+    assert result["slider_value"] is None
+    assert result["projected_pnl"] is None
+    assert result["projected_dd"] is None
+    assert result["report"]["stub"] is True
+
+
+def test_run_optimization_stub_returns_no_feasible_for_full_cfg():
+    """Stub ignores cfg contents; always returns no_feasible."""
+    from strategy.kill_switch_v2_calibrator import run_optimization_stub
+    cfg = {"kill_switch": {"v2": {"aggressiveness": 75}}}
+    result = run_optimization_stub(cfg)
+    assert result["status"] == "no_feasible"
+    assert "v2 backtest pending B4b.2" in result["report"]["reason"]

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -115,3 +115,112 @@ def test_run_optimization_stub_returns_no_feasible_for_full_cfg():
     result = run_optimization_stub(cfg)
     assert result["status"] == "no_feasible"
     assert "v2 backtest pending B4b.2" in result["report"]["reason"]
+
+
+# ── B4b.1: DB glue ──────────────────────────────────────────────────────────
+
+
+def test_persist_recommendation_inserts_row(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import (
+        _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone
+    import json
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    result = run_optimization_stub({})
+    rec_id = _persist_recommendation(
+        triggered_by=["manual"], result=result, now=now,
+    )
+    assert isinstance(rec_id, int)
+    assert rec_id > 0
+
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            "SELECT ts, triggered_by, slider_value, projected_pnl, "
+            "projected_dd, status, report_json "
+            "FROM kill_switch_recommendations WHERE id = ?",
+            (rec_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == now.isoformat()
+    assert json.loads(row[1]) == ["manual"]
+    assert row[2] is None
+    assert row[3] is None
+    assert row[4] is None
+    assert row[5] == "no_feasible"
+    parsed_report = json.loads(row[6])
+    assert parsed_report["status"] == "no_feasible"
+    assert parsed_report["stub"] is True
+
+
+def test_persist_recommendation_returns_distinct_ids(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import (
+        _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    result = run_optimization_stub({})
+    id1 = _persist_recommendation(
+        triggered_by=["safety_net"], result=result, now=now,
+    )
+    id2 = _persist_recommendation(
+        triggered_by=["manual"], result=result, now=now,
+    )
+    assert id2 > id1
+
+
+def test_load_last_recalibration_ts_empty_table(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _load_last_recalibration_ts
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    assert _load_last_recalibration_ts() is None
+
+
+def test_load_last_recalibration_ts_returns_max_ts(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import (
+        _persist_recommendation, _load_last_recalibration_ts, run_optimization_stub,
+    )
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    earlier = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
+    later = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    result = run_optimization_stub({})
+    _persist_recommendation(
+        triggered_by=["safety_net"], result=result, now=earlier,
+    )
+    _persist_recommendation(
+        triggered_by=["manual"], result=result, now=later,
+    )
+
+    assert _load_last_recalibration_ts() == later.isoformat()

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -519,3 +519,27 @@ def test_get_recommendations_filter_by_status(tmp_path, monkeypatch):
         assert resp_other.json() == []
     finally:
         btc_api.app.dependency_overrides.clear()
+
+
+# ── B4b.1: daemon launch ────────────────────────────────────────────────────
+
+
+def test_start_scanner_thread_launches_calibrator_thread(monkeypatch):
+    """start_scanner_thread spawns a thread named 'kill-switch-calibrator'."""
+    import btc_api, threading
+
+    captured_threads = []
+    real_thread_init = threading.Thread.__init__
+
+    def capture_init(self, *args, **kwargs):
+        captured_threads.append(kwargs.get("name", "<unnamed>"))
+        # Don't actually start anything destructive
+        kwargs["target"] = lambda *a, **kw: None
+        kwargs.pop("args", None)
+        return real_thread_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(threading.Thread, "__init__", capture_init)
+
+    btc_api.start_scanner_thread()
+
+    assert "kill-switch-calibrator" in captured_threads

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1,0 +1,30 @@
+"""Tests for strategy.kill_switch_v2_calibrator — auto-calibrator daemon (#187 #214 B4b.1)."""
+import pytest
+
+
+# ── B4b.1: schema smoke test ────────────────────────────────────────────────
+
+
+def test_init_db_creates_kill_switch_recommendations_table(tmp_path, monkeypatch):
+    """init_db must create kill_switch_recommendations with the expected columns."""
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    conn = btc_api.get_db()
+    try:
+        cols = [r[1] for r in conn.execute(
+            "PRAGMA table_info(kill_switch_recommendations)"
+        ).fetchall()]
+    finally:
+        conn.close()
+
+    expected = {
+        "id", "ts", "triggered_by", "slider_value",
+        "projected_pnl", "projected_dd", "status",
+        "applied_ts", "applied_by", "report_json",
+    }
+    assert expected.issubset(set(cols))


### PR DESCRIPTION
## Summary

Kill Switch v2 **B4b.1 — auto-calibrator daemon infrastructure** (#214, scope clarified during brainstorm). Ships the maquinaria of the auto-calibrator without the intelligence: new `kill_switch_recommendations` table, daily-tick thread, **stub fitness** (always `no_feasible`), 2 triggers (`manual` + `safety_net`), read-only API endpoints. The v2-aware backtest + grid optimization lands in B4b.2 (#216); auto-triggers + Telegram + apply/ignore UI in B4b.3 (#217).

## What ships

- `strategy/kill_switch_v2_calibrator.py` — pure helpers (`should_run_safety_net`, `build_no_feasible_report`), stub fitness (`run_optimization_stub`), DB glue (`_persist_recommendation`, `_load_last_recalibration_ts`), daemon entry (`kill_switch_calibrator_loop`).
- `btc_api.init_db` — new `kill_switch_recommendations` table (spec §5.4) + `idx_recommendations_ts` index.
- `btc_api.start_scanner_thread` — launches `kill-switch-calibrator` thread parallel to existing `health-monitor`.
- `POST /kill_switch/recalibrate` — manual trigger (sync inline).
- `GET /kill_switch/recommendations` — read-only list with `since` / `status` / `limit` filters.
- 23 new tests covering pure logic, DB glue, daemon loop (4 cases), endpoints (4 cases), thread launch.

## Stub fitness

`run_optimization_stub` always returns `status="no_feasible"` with `reason="v2 backtest pending B4b.2"` and `report.stub=True`. Operator sees explicit message — no mock numbers to confuse with real recommendations.

## Daemon behavior

- Daily tick at 00:00 UTC (mirrors `health_monitor_loop` pattern).
- Reads `safety_net_days` from cfg (default 30).
- Evaluates `should_run_safety_net`: fires on `last_ts is None` / malformed / future / `> safety_net_days` ago.
- Persists with `triggered_by=["safety_net"]`.
- Stub notification: `log.warning` only (Telegram in B4b.3).
- Fail-open: any iteration exception is logged with `exc_info`; loop continues.
- `stop_event.set()` exits cleanly.

## Manual trigger

`POST /kill_switch/recalibrate` runs the stub inline, persists with `triggered_by=["manual"]`, returns `{recommendation_id, status}`. Sync inline is appropriate for the stub (instantaneous); B4b.2 will migrate to async (thread on-demand + 202 Accepted) when the real backtest takes ~30-60s.

## Lifecycle states in B4b.1

- Inserted by stub: `no_feasible` (always).
- B4b.2 introduces: `pending` (when fitness finds feasible).
- B4b.3 introduces: `applied`, `ignored`, `superseded`.

## Intentionally NOT shipped

- Real fitness (B4b.2 #216) — v2-aware backtest + grid optimization.
- Auto-triggers `regime_change`, `portfolio_dd_degradation`, `event_cascade` (B4b.3 #217).
- Rate limiting (`max_per_day`, `min_cooldown_hours`) — unnecessary with instant stub.
- Telegram notifications (B4b.3) — `log.warning` only.
- Apply/ignore endpoints (B4b.3).
- Frontend UI (B4b.3 + B6).
- Superseded handling (B4b.3).

## Test plan

- [x] Unit: `should_run_safety_net` (None / malformed / 29d / 31d / 30d boundary / future) — 6 tests.
- [x] Unit: `build_no_feasible_report` shape; `run_optimization_stub` empty-cfg + full-cfg — 3 tests.
- [x] DB glue: `_persist_recommendation` columns + return id; `_load_last_recalibration_ts` empty + multi-row — 4 tests.
- [x] Daemon loop: empty-table fires; recent recalibration skips; stop_event clean exit; iteration exception logged — 4 tests.
- [x] API integration: `POST` returns id + DB row populated; `GET` empty list; `GET` rows ordered DESC; `GET` status filter — 4 tests.
- [x] Schema smoke + thread launch — 2 tests.
- [x] Backend: 820 passed (was 797 baseline, +23 new).
- [x] Frontend: 21 passed unchanged.

## Closes

#214 (scope: B4b.1 only — daemon infra). Spec: `docs/superpowers/specs/es/2026-04-25-kill-switch-v2-b4b1-daemon-infrastructure-design.md`. Plan: `docs/superpowers/plans/2026-04-25-kill-switch-v2-b4b1-daemon-infrastructure.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)