### PR TITLE
feat(kill-switch-v2): B4b.2 v2-aware backtest + grid optimization (#187 #216)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -1669,11 +1669,19 @@ def kill_switch_recalibrate():
     from strategy.kill_switch_v2_calibrator import (
         run_optimization_stub, _persist_recommendation,
     )
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
     from datetime import datetime, timezone
 
     try:
         cfg = load_config()
-        result = run_optimization_stub(cfg)
+        try:
+            result = run_optimization_v2(cfg)
+        except Exception as opt_err:
+            log.warning(
+                "run_optimization_v2 failed; falling back to stub: %s",
+                opt_err, exc_info=True,
+            )
+            result = run_optimization_stub(cfg)
         now = datetime.now(tz=timezone.utc)
         rec_id = _persist_recommendation(
             triggered_by=["manual"], result=result, now=now,

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -19,7 +19,9 @@
     "auto_recovery_enabled": true,
     "v2": {
       "auto_calibrator": {
-        "safety_net_days": 30
+        "safety_net_days": 30,
+        "backtest_window_days": 365,
+        "dd_target": -0.10
       }
     }
   },

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -178,7 +178,16 @@ def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
             last_ts = _load_last_recalibration_ts()
 
             if should_run_safety_net(last_ts, now, safety_net_days):
-                result = run_optimization_stub(cfg)
+                # B4b.2: real fitness via grid optimization (was stub in B4b.1)
+                from strategy.kill_switch_v2_optimizer import run_optimization_v2
+                try:
+                    result = run_optimization_v2(cfg)
+                except Exception as opt_err:
+                    log.warning(
+                        "run_optimization_v2 failed; falling back to stub: %s",
+                        opt_err, exc_info=True,
+                    )
+                    result = run_optimization_stub(cfg)
                 rec_id = _persist_recommendation(
                     triggered_by=["safety_net"], result=result, now=now,
                 )

--- a/strategy/kill_switch_v2_optimizer.py
+++ b/strategy/kill_switch_v2_optimizer.py
@@ -31,6 +31,7 @@ def _load_closed_positions_window(window_days: float, now) -> list[dict[str, Any
                FROM positions
                WHERE status = 'closed'
                  AND exit_ts IS NOT NULL
+                 AND pnl_usd IS NOT NULL
                  AND exit_ts >= ?
                ORDER BY entry_ts""",
             (cutoff,),
@@ -129,6 +130,15 @@ def run_optimization_v2(
         "backtest_window_days", _DEFAULT_BACKTEST_WINDOW_DAYS,
     ))
     dd_target = float(auto_cal.get("dd_target", _DEFAULT_DD_TARGET))
+    if dd_target > 0:
+        # DD is always negative or zero; a positive target makes every slider
+        # trivially feasible and would silently approve recommendations that
+        # blow any meaningful drawdown limit. Reject explicitly so a config
+        # typo (sign error) doesn't render the optimizer unsafe.
+        raise ValueError(
+            f"dd_target must be <= 0 (got {dd_target}); "
+            "fix kill_switch.v2.auto_calibrator.dd_target in config",
+        )
     capital_base = float(cfg.get("capital_usd", _DEFAULT_CAPITAL_USD))
 
     closed = _load_closed_positions_window(window_days, now)

--- a/strategy/kill_switch_v2_optimizer.py
+++ b/strategy/kill_switch_v2_optimizer.py
@@ -101,3 +101,79 @@ def _replay_with_slider(
         )
 
     return {"pnl": equity - capital_base, "dd": max_dd}
+
+
+def run_optimization_v2(
+    cfg: dict[str, Any], regime_score: float | None = None,
+) -> dict[str, Any]:
+    """Real grid optimization replacing run_optimization_stub from B4b.1.
+
+    Loads closed trades from the configured backtest window, replays each
+    across 21 slider candidates [0..100, step 5] using V2KillSwitchSimulator,
+    picks the slider with max PnL subject to dd_target constraint.
+
+    Returns same shape as run_optimization_stub:
+        {"status": str, "slider_value": int|None, "projected_pnl": float|None,
+         "projected_dd": float|None, "report": dict}
+
+    status values:
+        "pending"     — feasible slider found, recommendation ready for review.
+        "no_feasible" — all sliders blow dd_target; report includes the grid.
+    """
+    from datetime import datetime, timezone
+
+    now = datetime.now(tz=timezone.utc)
+    v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+    auto_cal = v2_cfg.get("auto_calibrator", {}) or {}
+    window_days = float(auto_cal.get(
+        "backtest_window_days", _DEFAULT_BACKTEST_WINDOW_DAYS,
+    ))
+    dd_target = float(auto_cal.get("dd_target", _DEFAULT_DD_TARGET))
+    capital_base = float(cfg.get("capital_usd", _DEFAULT_CAPITAL_USD))
+
+    closed = _load_closed_positions_window(window_days, now)
+
+    grid_results: dict[int, dict[str, float]] = {}
+    for slider in range(0, 101, _GRID_STEP):
+        cfg_eff = _override_slider(cfg, slider)
+        result = _replay_with_slider(closed, cfg_eff, regime_score, capital_base)
+        grid_results[slider] = result
+
+    # Feasibility: dd is negative; constraint dd >= dd_target
+    feasible = {s: r for s, r in grid_results.items() if r["dd"] >= dd_target}
+
+    report_payload = {
+        "ts": now.isoformat(),
+        "window_days": window_days,
+        "dd_target": dd_target,
+        "capital_base": capital_base,
+        "trades_in_window": len(closed),
+        "regime_score": regime_score,
+        "grid": {
+            str(s): {"pnl": r["pnl"], "dd": r["dd"]}
+            for s, r in grid_results.items()
+        },
+        "stub": False,
+    }
+
+    if not feasible:
+        nearest = max(grid_results, key=lambda s: grid_results[s]["dd"])
+        report_payload["reason"] = (
+            f"all sliders blow dd_target={dd_target}; nearest_slider={nearest}"
+        )
+        return {
+            "status": "no_feasible",
+            "slider_value": None,
+            "projected_pnl": grid_results[nearest]["pnl"],
+            "projected_dd": grid_results[nearest]["dd"],
+            "report": report_payload,
+        }
+
+    best = max(feasible, key=lambda s: feasible[s]["pnl"])
+    return {
+        "status": "pending",
+        "slider_value": best,
+        "projected_pnl": feasible[best]["pnl"],
+        "projected_dd": feasible[best]["dd"],
+        "report": report_payload,
+    }

--- a/strategy/kill_switch_v2_optimizer.py
+++ b/strategy/kill_switch_v2_optimizer.py
@@ -1,0 +1,58 @@
+"""V2 backtest grid optimization for auto-calibrator (#187 #216 B4b.2).
+
+Replaces B4b.1's run_optimization_stub with a real fitness function:
+loads closed trades from positions table, replays each across 21 slider
+candidates [0..100, step 5] using V2KillSwitchSimulator, picks slider with
+max PnL subject to dd_target constraint.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger("kill_switch_v2_optimizer")
+
+_DEFAULT_BACKTEST_WINDOW_DAYS = 365
+_DEFAULT_DD_TARGET = -0.10
+_DEFAULT_CAPITAL_USD = 1000.0
+_GRID_STEP = 5
+
+
+def _load_closed_positions_window(window_days: float, now) -> list[dict[str, Any]]:
+    """Load closed positions with exit_ts within the last window_days, ordered by entry_ts."""
+    from datetime import timedelta
+    import btc_api
+
+    cutoff = (now - timedelta(days=float(window_days))).isoformat()
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            """SELECT symbol, entry_ts, exit_ts, exit_reason, pnl_usd
+               FROM positions
+               WHERE status = 'closed'
+                 AND exit_ts IS NOT NULL
+                 AND exit_ts >= ?
+               ORDER BY entry_ts""",
+            (cutoff,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        {"symbol": r[0], "entry_ts": r[1], "exit_ts": r[2],
+         "exit_reason": r[3], "pnl_usd": r[4]}
+        for r in rows
+    ]
+
+
+def _override_slider(cfg: dict[str, Any], slider: int) -> dict[str, Any]:
+    """Return a deep-copied cfg with kill_switch.v2.aggressiveness=slider.
+
+    Creates the kill_switch.v2 block if missing.
+    """
+    import copy
+
+    cfg_copy = copy.deepcopy(cfg) if cfg else {}
+    ks = cfg_copy.setdefault("kill_switch", {})
+    v2 = ks.setdefault("v2", {})
+    v2["aggressiveness"] = slider
+    return cfg_copy

--- a/strategy/kill_switch_v2_optimizer.py
+++ b/strategy/kill_switch_v2_optimizer.py
@@ -56,3 +56,48 @@ def _override_slider(cfg: dict[str, Any], slider: int) -> dict[str, Any]:
     v2 = ks.setdefault("v2", {})
     v2["aggressiveness"] = slider
     return cfg_copy
+
+
+def _replay_with_slider(
+    closed_trades: list[dict[str, Any]],
+    cfg_with_slider: dict[str, Any],
+    regime_score: float | None,
+    capital_base: float,
+) -> dict[str, float]:
+    """Replay trades through V2KillSwitchSimulator. Returns {pnl, dd}.
+
+    For each trade:
+      1. Ask simulator: would v2 take this trade? size_factor?
+      2. PnL contribution = 0 if skip else trade.pnl_usd * size_factor.
+      3. Update equity, track peak, compute running dd.
+      4. Feed close back to simulator (updates state for future trades).
+
+    pnl = final_equity - capital_base.
+    dd = max drawdown over the equity curve (most negative value).
+    """
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    sim = V2KillSwitchSimulator(cfg_with_slider, regime_score, capital_base)
+    equity = capital_base
+    peak = capital_base
+    max_dd = 0.0
+
+    for trade in closed_trades:
+        skip, size_factor = sim.should_skip_or_reduce(
+            symbol=trade["symbol"], entry_ts=trade["entry_ts"],
+        )
+        raw_pnl = float(trade.get("pnl_usd") or 0)
+        pnl_contrib = 0.0 if skip else raw_pnl * size_factor
+
+        equity += pnl_contrib
+        peak = max(peak, equity)
+        if peak > 0:
+            dd = (equity - peak) / peak
+            max_dd = min(max_dd, dd)
+
+        sim.on_trade_close(
+            symbol=trade["symbol"], exit_ts=trade["exit_ts"],
+            pnl_usd=pnl_contrib, exit_reason=trade.get("exit_reason") or "",
+        )
+
+    return {"pnl": equity - capital_base, "dd": max_dd}

--- a/strategy/kill_switch_v2_simulator.py
+++ b/strategy/kill_switch_v2_simulator.py
@@ -51,3 +51,19 @@ class V2KillSwitchSimulator:
         if peak <= 0:
             return 0.0
         return (equity - peak) / peak
+
+    def _is_velocity_active(self, symbol: str, now) -> bool:
+        """Check if velocity cooldown is still active for symbol at `now`."""
+        from datetime import datetime, timezone
+
+        state = self._velocity_state.get(symbol, {})
+        cooldown = state.get("velocity_cooldown_until")
+        if not cooldown:
+            return False
+        try:
+            parsed = datetime.fromisoformat(cooldown)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed > now
+        except (TypeError, ValueError):
+            return False

--- a/strategy/kill_switch_v2_simulator.py
+++ b/strategy/kill_switch_v2_simulator.py
@@ -10,7 +10,10 @@ interpolations.
 """
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+log = logging.getLogger("kill_switch_v2_simulator")
 
 
 class V2KillSwitchSimulator:
@@ -99,7 +102,13 @@ class V2KillSwitchSimulator:
         try:
             now = datetime.fromisoformat(entry_ts)
         except (TypeError, ValueError):
-            # Conservative: malformed entry_ts → treat as skip
+            # Conservative: malformed entry_ts → treat as skip. Logged so a
+            # systemic data-corruption issue doesn't masquerade as "no
+            # opportunities" silently across an entire backtest replay.
+            log.warning(
+                "V2 simulator: skipping trade for symbol=%s due to malformed "
+                "entry_ts=%r (treated as skip)", symbol, entry_ts,
+            )
             return (True, 0.0)
         if now.tzinfo is None:
             now = now.replace(tzinfo=timezone.utc)
@@ -169,7 +178,14 @@ class V2KillSwitchSimulator:
                 if now.tzinfo is None:
                     now = now.replace(tzinfo=timezone.utc)
             except (TypeError, ValueError):
-                return  # Malformed timestamp; skip velocity update for this trade
+                # Malformed exit_ts on an SL trade silently masks every
+                # velocity trigger that depends on it. Log so systemic format
+                # drift doesn't hide all velocity cooldowns silently.
+                log.warning(
+                    "V2 simulator: skipping velocity update for symbol=%s due "
+                    "to malformed SL exit_ts=%r", symbol, exit_ts,
+                )
+                return
 
             sl_timestamps = [
                 t["exit_ts"] for t in self._symbol_trades[symbol]

--- a/strategy/kill_switch_v2_simulator.py
+++ b/strategy/kill_switch_v2_simulator.py
@@ -141,3 +141,51 @@ class V2KillSwitchSimulator:
 
         size_factor = portfolio_factor * per_symbol_factor * velocity_factor
         return (size_factor == 0.0, size_factor)
+
+    def on_trade_close(
+        self, symbol: str, exit_ts: str, pnl_usd: float, exit_reason: str,
+    ) -> None:
+        """Feed a closed trade back; updates baseline + velocity state."""
+        from datetime import datetime, timezone
+        from strategy.kill_switch_v2 import (
+            compute_baseline_metrics, detect_velocity_trigger,
+            compute_velocity_state, get_velocity_thresholds,
+        )
+
+        trade = {
+            "symbol": symbol, "exit_ts": exit_ts,
+            "pnl_usd": pnl_usd, "exit_reason": exit_reason,
+        }
+        self._all_trades.append(trade)
+        self._symbol_trades.setdefault(symbol, []).append(trade)
+
+        # Refresh baseline (deterministic during replay; no stale check needed)
+        self._baselines[symbol] = compute_baseline_metrics(self._symbol_trades[symbol])
+
+        # B1 velocity: only SL exits count toward the trigger
+        if exit_reason == "SL":
+            try:
+                now = datetime.fromisoformat(exit_ts)
+                if now.tzinfo is None:
+                    now = now.replace(tzinfo=timezone.utc)
+            except (TypeError, ValueError):
+                return  # Malformed timestamp; skip velocity update for this trade
+
+            sl_timestamps = [
+                t["exit_ts"] for t in self._symbol_trades[symbol]
+                if t.get("exit_reason") == "SL"
+            ]
+            thresholds = get_velocity_thresholds(self.cfg_eff)
+            triggered = detect_velocity_trigger(
+                sl_timestamps, now,
+                sl_count=thresholds["sl_count"],
+                window_hours=thresholds["window_hours"],
+            )
+            current_state = self._velocity_state.get(symbol, {
+                "velocity_cooldown_until": None,
+                "velocity_last_trigger_ts": None,
+            })
+            self._velocity_state[symbol] = compute_velocity_state(
+                current_state, triggered=triggered, now=now,
+                cooldown_hours=thresholds["cooldown_hours"],
+            )

--- a/strategy/kill_switch_v2_simulator.py
+++ b/strategy/kill_switch_v2_simulator.py
@@ -67,3 +67,13 @@ class V2KillSwitchSimulator:
             return parsed > now
         except (TypeError, ValueError):
             return False
+
+    def _count_concurrent_failures(self, now) -> int:
+        """Count symbols with active velocity cooldowns at `now`.
+
+        Used as proxy for B2 portfolio's concurrent_failures input.
+        """
+        return sum(
+            1 for sym in self._velocity_state
+            if self._is_velocity_active(sym, now)
+        )

--- a/strategy/kill_switch_v2_simulator.py
+++ b/strategy/kill_switch_v2_simulator.py
@@ -1,0 +1,53 @@
+"""V2 in-memory kill switch simulator for backtest replay (#187 #216 B4b.2).
+
+Mirrors B1 velocity + B2 portfolio DD + B3 regime + B4a baselines logic in
+pure-memory form. Used by run_optimization_v2 to evaluate fitness across
+slider candidates without DB I/O.
+
+Construction applies B3 regime adjustment to cfg.aggressiveness once; the
+simulator subsequently uses the adjusted slider for all threshold
+interpolations.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class V2KillSwitchSimulator:
+    """In-memory v2 kill switch state for backtest replay."""
+
+    def __init__(
+        self,
+        cfg: dict[str, Any],
+        regime_score: float | None = None,
+        capital_base: float = 1000.0,
+    ):
+        from strategy.kill_switch_v2 import apply_regime_adjustment
+
+        self.cfg_eff = apply_regime_adjustment(cfg, regime_score)
+        self.regime_score = regime_score
+        self.capital_base = float(capital_base)
+
+        # Per-symbol: baseline cache + velocity state
+        self._baselines: dict[str, dict] = {}
+        self._velocity_state: dict[str, dict] = {}
+        # Cumulative closed trades, used for portfolio DD + velocity SL window
+        self._all_trades: list[dict] = []
+        # Per-symbol closed trades for baseline/rolling
+        self._symbol_trades: dict[str, list[dict]] = {}
+
+    def _current_portfolio_dd(self) -> float:
+        """Compute portfolio DD from cumulative trade PnL on capital_base.
+
+        Returns negative value if in drawdown; 0.0 otherwise.
+        """
+        if not self._all_trades:
+            return 0.0
+        equity = self.capital_base
+        peak = self.capital_base
+        for trade in self._all_trades:
+            equity += float(trade.get("pnl_usd") or 0)
+            peak = max(peak, equity)
+        if peak <= 0:
+            return 0.0
+        return (equity - peak) / peak

--- a/strategy/kill_switch_v2_simulator.py
+++ b/strategy/kill_switch_v2_simulator.py
@@ -77,3 +77,67 @@ class V2KillSwitchSimulator:
             1 for sym in self._velocity_state
             if self._is_velocity_active(sym, now)
         )
+
+    def should_skip_or_reduce(
+        self, symbol: str, entry_ts: str,
+    ) -> tuple[bool, float]:
+        """Return (skip, size_factor) for a hypothetical trade entry at entry_ts.
+
+        Multiplicative composition:
+          - portfolio_factor: NORMAL=1.0, WARNED=1.0, REDUCED=0.5, FROZEN=0.0
+          - per_symbol_factor: NORMAL=1.0, ALERT=0.5
+          - velocity_factor: 1.0 if no cooldown, 0.0 if cooldown active
+          → product. 0.0 → skip=True.
+        """
+        from datetime import datetime, timezone
+        from strategy.kill_switch_v2 import (
+            evaluate_per_symbol_tier, evaluate_portfolio_tier,
+            get_baseline_sigma_multiplier,
+        )
+        from health import compute_rolling_metrics_from_trades
+
+        try:
+            now = datetime.fromisoformat(entry_ts)
+        except (TypeError, ValueError):
+            # Conservative: malformed entry_ts → treat as skip
+            return (True, 0.0)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+
+        # B1 velocity check (kills size factor to 0 unconditionally)
+        velocity_active = self._is_velocity_active(symbol, now)
+        velocity_factor = 0.0 if velocity_active else 1.0
+
+        # B4a per-symbol tier
+        baseline = self._baselines.get(
+            symbol, {"wr": 0.0, "sigma": 0.0, "count": 0},
+        )
+        rolling = compute_rolling_metrics_from_trades(
+            self._symbol_trades.get(symbol, []), now=now,
+        )
+        rolling_wr = rolling.get("win_rate_20_trades")
+        sigma_mult = get_baseline_sigma_multiplier(self.cfg_eff)
+        v2_cfg = (self.cfg_eff.get("kill_switch", {}) or {}).get("v2", {}) or {}
+        min_trades = int(v2_cfg.get("baseline_min_trades", 100))
+
+        per_symbol_tier = evaluate_per_symbol_tier(
+            rolling_wr_20=rolling_wr, baseline=baseline,
+            sigma_multiplier=sigma_mult, trades_count=baseline["count"],
+            min_trades=min_trades,
+        )
+        per_symbol_factor = {"NORMAL": 1.0, "ALERT": 0.5}.get(per_symbol_tier, 1.0)
+
+        # B2 portfolio tier
+        portfolio_dd = self._current_portfolio_dd()
+        concurrent_failures = self._count_concurrent_failures(now)
+        portfolio = evaluate_portfolio_tier(
+            portfolio_dd=portfolio_dd,
+            concurrent_failures=concurrent_failures,
+            cfg=self.cfg_eff,
+        )
+        portfolio_factor = {
+            "NORMAL": 1.0, "WARNED": 1.0, "REDUCED": 0.5, "FROZEN": 0.0,
+        }.get(portfolio["tier"], 1.0)
+
+        size_factor = portfolio_factor * per_symbol_factor * velocity_factor
+        return (size_factor == 0.0, size_factor)

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -881,3 +881,109 @@ def test_get_recommendations_logs_warning_on_corrupt_row(
         )
     finally:
         btc_api.app.dependency_overrides.clear()
+
+
+# ── B4b.2: integration with run_optimization_v2 ─────────────────────────────
+
+
+def test_post_recalibrate_uses_v2_optimizer_with_grid(tmp_path, monkeypatch):
+    """POST endpoint persists a row whose report includes the v2 grid (not stub)."""
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+    monkeypatch.setattr(btc_api, "load_config", lambda: {
+        "kill_switch": {"v2": {
+            "aggressiveness": 50,
+            "thresholds": {
+                "portfolio_dd_reduced":     {"min": -0.08, "max": -0.03},
+                "portfolio_dd_frozen":      {"min": -0.15, "max": -0.06},
+                "velocity_sl_count":        {"min": 10, "max": 3},
+                "velocity_window_hours":    {"min": 24, "max": 6},
+                "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+            },
+            "velocity_cooldown_hours": 4,
+            "concurrent_alert_threshold": 3,
+            "baseline_min_trades": 100,
+            "baseline_stale_days": 7,
+            "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+            "advanced_overrides": {"regime_adjustment_enabled": True},
+            "auto_calibrator": {
+                "safety_net_days": 30,
+                "backtest_window_days": 365,
+                "dd_target": -0.10,
+            },
+        }},
+    })
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post("/kill_switch/recalibrate")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        rec_id = body["recommendation_id"]
+        conn = btc_api.get_db()
+        try:
+            row = conn.execute(
+                "SELECT report_json FROM kill_switch_recommendations WHERE id = ?",
+                (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        import json
+        report = json.loads(row[0])
+        # Real v2 report has stub=False and includes grid + dd_target
+        assert report["stub"] is False
+        assert "grid" in report
+        assert len(report["grid"]) == 21
+        assert report["dd_target"] == pytest.approx(-0.10)
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_post_recalibrate_falls_back_to_stub_when_v2_raises(tmp_path, monkeypatch):
+    """If run_optimization_v2 raises, the endpoint logs and falls back to stub."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    import strategy.kill_switch_v2_optimizer as opt_mod
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated optimizer failure")
+    monkeypatch.setattr(opt_mod, "run_optimization_v2", _boom)
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post("/kill_switch/recalibrate")
+        assert resp.status_code == 200
+        body = resp.json()
+        # Fell back to stub → status="no_feasible"
+        assert body["status"] == "no_feasible"
+
+        rec_id = body["recommendation_id"]
+        conn = btc_api.get_db()
+        try:
+            row = conn.execute(
+                "SELECT report_json FROM kill_switch_recommendations WHERE id = ?",
+                (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        import json
+        report = json.loads(row[0])
+        # Stub is True in fallback path
+        assert report.get("stub") is True
+    finally:
+        btc_api.app.dependency_overrides.clear()

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -269,7 +269,8 @@ def test_calibrator_loop_safety_net_fires_when_table_empty(
     assert len(rows) == 1
     import json
     assert json.loads(rows[0][0]) == ["safety_net"]
-    assert rows[0][1] == "no_feasible"
+    # B4b.2: real fitness; empty positions → status="pending" (or "no_feasible")
+    assert rows[0][1] in ("pending", "no_feasible")
 
 
 def test_calibrator_loop_does_not_fire_when_recent_recalibration(
@@ -399,7 +400,9 @@ def test_post_recalibrate_returns_recommendation_id(tmp_path, monkeypatch):
         assert resp.status_code == 200
         body = resp.json()
         assert "recommendation_id" in body
-        assert body["status"] == "no_feasible"
+        # B4b.2: real fitness; empty positions → all sliders feasible at pnl=dd=0
+        # → status="pending" with arbitrary slider (pnl tiebreak picks first).
+        assert body["status"] in ("pending", "no_feasible")
 
         rec_id = body["recommendation_id"]
         conn = btc_api.get_db()
@@ -412,7 +415,7 @@ def test_post_recalibrate_returns_recommendation_id(tmp_path, monkeypatch):
             conn.close()
         import json
         assert json.loads(row[0]) == ["manual"]
-        assert row[1] == "no_feasible"
+        assert row[1] in ("pending", "no_feasible")
     finally:
         btc_api.app.dependency_overrides.clear()
 
@@ -443,9 +446,8 @@ def test_get_recommendations_empty_returns_empty_list(tmp_path, monkeypatch):
 def test_get_recommendations_returns_rows_ordered_desc(tmp_path, monkeypatch):
     import btc_api
     from fastapi.testclient import TestClient
-    from strategy.kill_switch_v2_calibrator import (
-        _persist_recommendation, run_optimization_stub,
-    )
+    from strategy.kill_switch_v2_calibrator import _persist_recommendation
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
     from datetime import datetime, timezone
 
     db_path = str(tmp_path / "signals.db")
@@ -457,7 +459,8 @@ def test_get_recommendations_returns_rows_ordered_desc(tmp_path, monkeypatch):
 
     earlier = datetime(2026, 4, 20, 12, 0, tzinfo=timezone.utc)
     later = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
-    result = run_optimization_stub({})
+    # B4b.2: seed with real optimizer so report["stub"] is False.
+    result = run_optimization_v2({})
     _persist_recommendation(
         triggered_by=["safety_net"], result=result, now=earlier,
     )
@@ -476,8 +479,8 @@ def test_get_recommendations_returns_rows_ordered_desc(tmp_path, monkeypatch):
         assert rows[0]["triggered_by"] == ["manual"]
         assert rows[1]["ts"] == earlier.isoformat()
         assert rows[1]["triggered_by"] == ["safety_net"]
-        # Report block parsed
-        assert rows[0]["report"]["stub"] is True
+        # Report block parsed; stub is False after B4b.2 wiring (real optimizer).
+        assert rows[0]["report"]["stub"] is False
     finally:
         btc_api.app.dependency_overrides.clear()
 
@@ -795,10 +798,15 @@ def test_persist_recommendation_raises_on_missing_status_key(tmp_path, monkeypat
 def test_post_recalibrate_returns_500_on_internal_failure(
     tmp_path, monkeypatch, caplog,
 ):
-    """If run_optimization_stub raises, endpoint returns 500 with detail
-    (not opaque FastAPI error) and logs with exc_info."""
+    """If both run_optimization_v2 and the stub fallback raise, the endpoint
+    returns 500 with detail (not opaque FastAPI error) and logs with exc_info.
+
+    B4b.2: endpoint now calls run_optimization_v2 first with a stub fallback.
+    To exercise the outer 500 path, both must fail.
+    """
     import btc_api
     import strategy.kill_switch_v2_calibrator as cal
+    import strategy.kill_switch_v2_optimizer as opt
     from fastapi.testclient import TestClient
 
     db_path = str(tmp_path / "signals.db")
@@ -810,6 +818,7 @@ def test_post_recalibrate_returns_500_on_internal_failure(
 
     def _boom(*a, **kw):
         raise RuntimeError("simulated optimization failure")
+    monkeypatch.setattr(opt, "run_optimization_v2", _boom)
     monkeypatch.setattr(cal, "run_optimization_stub", _boom)
 
     try:

--- a/tests/test_strategy_kill_switch_v2_optimizer.py
+++ b/tests/test_strategy_kill_switch_v2_optimizer.py
@@ -1,0 +1,109 @@
+"""Tests for run_optimization_v2 + helpers (#187 #216 B4b.2)."""
+import pytest
+
+
+# ── B4b.2: optimizer helpers ────────────────────────────────────────────────
+
+
+def test_load_closed_positions_window_filters_by_window(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import _load_closed_positions_window
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    inside = (now - timedelta(days=10)).isoformat()
+    outside = (now - timedelta(days=400)).isoformat()
+
+    conn = btc_api.get_db()
+    try:
+        # Inside window (10d ago)
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0)",
+            (inside, inside),
+        )
+        # Outside window (400d ago)
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0)",
+            (outside, outside),
+        )
+        # Open position (no exit_ts)
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts) VALUES ('BTCUSDT', 'LONG', 50000, 0.01, 'open', ?)",
+            (inside,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rows = _load_closed_positions_window(window_days=365.0, now=now)
+    assert len(rows) == 1
+    assert rows[0]["pnl_usd"] == 10.0
+    assert rows[0]["exit_reason"] == "TP"
+
+
+def test_load_closed_positions_window_orders_by_entry_ts(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import _load_closed_positions_window
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    earlier = (now - timedelta(days=20)).isoformat()
+    later = (now - timedelta(days=10)).isoformat()
+
+    conn = btc_api.get_db()
+    try:
+        # Insert later first (out of order)
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0)",
+            (later, later),
+        )
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -5.0)",
+            (earlier, earlier),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rows = _load_closed_positions_window(window_days=365.0, now=now)
+    assert len(rows) == 2
+    assert rows[0]["entry_ts"] == earlier
+    assert rows[1]["entry_ts"] == later
+
+
+def test_override_slider_returns_new_dict_with_slider_set():
+    from strategy.kill_switch_v2_optimizer import _override_slider
+
+    cfg = {"kill_switch": {"v2": {"aggressiveness": 50}}}
+    result = _override_slider(cfg, 75)
+    assert result["kill_switch"]["v2"]["aggressiveness"] == 75
+    # Original unchanged
+    assert cfg["kill_switch"]["v2"]["aggressiveness"] == 50
+
+
+def test_override_slider_creates_v2_block_when_missing():
+    from strategy.kill_switch_v2_optimizer import _override_slider
+
+    result = _override_slider({}, 80)
+    assert result["kill_switch"]["v2"]["aggressiveness"] == 80

--- a/tests/test_strategy_kill_switch_v2_optimizer.py
+++ b/tests/test_strategy_kill_switch_v2_optimizer.py
@@ -107,3 +107,94 @@ def test_override_slider_creates_v2_block_when_missing():
 
     result = _override_slider({}, 80)
     assert result["kill_switch"]["v2"]["aggressiveness"] == 80
+
+
+# ── B4b.2: _replay_with_slider ──────────────────────────────────────────────
+
+
+def _basic_optimizer_cfg():
+    return {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced":     {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen":      {"min": -0.15, "max": -0.06},
+            "velocity_sl_count":        {"min": 10, "max": 3},
+            "velocity_window_hours":    {"min": 24, "max": 6},
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "velocity_cooldown_hours": 4,
+        "concurrent_alert_threshold": 3,
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+
+
+def test_replay_with_slider_empty_trades():
+    from strategy.kill_switch_v2_optimizer import _replay_with_slider
+
+    result = _replay_with_slider(
+        closed_trades=[], cfg_with_slider=_basic_optimizer_cfg(),
+        regime_score=None, capital_base=1000.0,
+    )
+    assert result == {"pnl": pytest.approx(0.0), "dd": pytest.approx(0.0)}
+
+
+def test_replay_with_slider_single_winning_trade():
+    """One profitable trade; v2 takes it at full size → pnl > 0, dd ≈ 0."""
+    from strategy.kill_switch_v2_optimizer import _replay_with_slider
+
+    trades = [{
+        "symbol": "BTCUSDT",
+        "entry_ts": "2026-04-20T10:00:00+00:00",
+        "exit_ts": "2026-04-20T12:00:00+00:00",
+        "exit_reason": "TP",
+        "pnl_usd": 20.0,
+    }]
+    result = _replay_with_slider(
+        closed_trades=trades, cfg_with_slider=_basic_optimizer_cfg(),
+        regime_score=None, capital_base=1000.0,
+    )
+    assert result["pnl"] == pytest.approx(20.0)
+    assert result["dd"] == pytest.approx(0.0)
+
+
+def test_replay_with_slider_single_losing_trade():
+    """One losing trade; v2 takes it at full size → pnl < 0, dd < 0."""
+    from strategy.kill_switch_v2_optimizer import _replay_with_slider
+
+    trades = [{
+        "symbol": "BTCUSDT",
+        "entry_ts": "2026-04-20T10:00:00+00:00",
+        "exit_ts": "2026-04-20T12:00:00+00:00",
+        "exit_reason": "SL",
+        "pnl_usd": -30.0,
+    }]
+    result = _replay_with_slider(
+        closed_trades=trades, cfg_with_slider=_basic_optimizer_cfg(),
+        regime_score=None, capital_base=1000.0,
+    )
+    assert result["pnl"] == pytest.approx(-30.0)
+    assert result["dd"] == pytest.approx(-0.03)
+
+
+def test_replay_with_slider_peak_then_drawdown():
+    """+50, +30, -100 → equity 1000→1050→1080→980, peak=1080, dd=(980-1080)/1080."""
+    from strategy.kill_switch_v2_optimizer import _replay_with_slider
+
+    trades = [
+        {"symbol": "X", "entry_ts": "2026-04-20T10:00:00+00:00",
+         "exit_ts": "2026-04-20T11:00:00+00:00", "exit_reason": "TP", "pnl_usd": 50.0},
+        {"symbol": "X", "entry_ts": "2026-04-21T10:00:00+00:00",
+         "exit_ts": "2026-04-21T11:00:00+00:00", "exit_reason": "TP", "pnl_usd": 30.0},
+        {"symbol": "X", "entry_ts": "2026-04-22T10:00:00+00:00",
+         "exit_ts": "2026-04-22T11:00:00+00:00", "exit_reason": "SL", "pnl_usd": -100.0},
+    ]
+    result = _replay_with_slider(
+        closed_trades=trades, cfg_with_slider=_basic_optimizer_cfg(),
+        regime_score=None, capital_base=1000.0,
+    )
+    assert result["pnl"] == pytest.approx(-20.0)
+    expected_dd = (980 - 1080) / 1080
+    assert result["dd"] == pytest.approx(expected_dd)

--- a/tests/test_strategy_kill_switch_v2_optimizer.py
+++ b/tests/test_strategy_kill_switch_v2_optimizer.py
@@ -198,3 +198,148 @@ def test_replay_with_slider_peak_then_drawdown():
     assert result["pnl"] == pytest.approx(-20.0)
     expected_dd = (980 - 1080) / 1080
     assert result["dd"] == pytest.approx(expected_dd)
+
+
+# ── B4b.2: run_optimization_v2 ──────────────────────────────────────────────
+
+
+def test_run_optimization_v2_empty_db_returns_pending_zero(tmp_path, monkeypatch):
+    """Empty positions table → all sliders pnl=0,dd=0 → feasible (dd>=target) → status='pending'."""
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    cfg = _basic_optimizer_cfg()
+    cfg["kill_switch"]["v2"]["auto_calibrator"] = {
+        "backtest_window_days": 365, "dd_target": -0.10,
+    }
+    result = run_optimization_v2(cfg, regime_score=None)
+    assert result["status"] == "pending"
+    assert result["projected_pnl"] == pytest.approx(0.0)
+    assert result["projected_dd"] == pytest.approx(0.0)
+    assert isinstance(result["slider_value"], int)
+    assert "grid" in result["report"]
+    assert result["report"]["stub"] is False
+    assert result["report"]["trades_in_window"] == 0
+
+
+def test_run_optimization_v2_no_feasible_when_all_blow_target(tmp_path, monkeypatch):
+    """All-losing trades large enough to violate dd_target=-0.01 → no_feasible."""
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Insert a single -200 USD trade (DD = -0.20, blows -0.01 target)
+    now = datetime.now(tz=timezone.utc)
+    ts = (now - timedelta(days=10)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -200.0)",
+            (ts, ts),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = _basic_optimizer_cfg()
+    cfg["kill_switch"]["v2"]["auto_calibrator"] = {
+        "backtest_window_days": 365, "dd_target": -0.01,
+    }
+    result = run_optimization_v2(cfg, regime_score=None)
+    assert result["status"] == "no_feasible"
+    assert result["slider_value"] is None
+    assert "reason" in result["report"]
+    assert result["report"]["trades_in_window"] == 1
+
+
+def test_run_optimization_v2_picks_max_pnl_among_feasible(tmp_path, monkeypatch):
+    """With a profitable trade, all sliders are feasible; pnl is positive."""
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime.now(tz=timezone.utc)
+    ts = (now - timedelta(days=10)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            (ts, ts),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = _basic_optimizer_cfg()
+    cfg["kill_switch"]["v2"]["auto_calibrator"] = {
+        "backtest_window_days": 365, "dd_target": -0.10,
+    }
+    result = run_optimization_v2(cfg, regime_score=None)
+    assert result["status"] == "pending"
+    assert result["projected_pnl"] == pytest.approx(50.0)
+
+
+def test_run_optimization_v2_report_includes_grid(tmp_path, monkeypatch):
+    """Report payload includes per-slider {pnl, dd} grid."""
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    cfg = _basic_optimizer_cfg()
+    cfg["kill_switch"]["v2"]["auto_calibrator"] = {
+        "backtest_window_days": 365, "dd_target": -0.10,
+    }
+    result = run_optimization_v2(cfg, regime_score=None)
+    grid = result["report"]["grid"]
+    # 21 sliders: 0, 5, 10, ..., 100
+    assert len(grid) == 21
+    for slider in (0, 5, 50, 100):
+        assert str(slider) in grid
+        assert "pnl" in grid[str(slider)]
+        assert "dd" in grid[str(slider)]
+
+
+def test_run_optimization_v2_passes_regime_score_to_simulator(tmp_path, monkeypatch):
+    """regime_score is included in report for traceability."""
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    cfg = _basic_optimizer_cfg()
+    cfg["kill_switch"]["v2"]["auto_calibrator"] = {
+        "backtest_window_days": 365, "dd_target": -0.10,
+    }
+    result = run_optimization_v2(cfg, regime_score=72.5)
+    assert result["report"]["regime_score"] == 72.5

--- a/tests/test_strategy_kill_switch_v2_optimizer.py
+++ b/tests/test_strategy_kill_switch_v2_optimizer.py
@@ -343,3 +343,271 @@ def test_run_optimization_v2_passes_regime_score_to_simulator(tmp_path, monkeypa
     }
     result = run_optimization_v2(cfg, regime_score=72.5)
     assert result["report"]["regime_score"] == 72.5
+
+
+# ── B4b.2: review follow-ups — hardening tests ──────────────────────────────
+
+
+def test_run_optimization_v2_rejects_positive_dd_target():
+    """dd_target > 0 is misconfigured; raise ValueError instead of trivially feasible."""
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+
+    cfg = _basic_optimizer_cfg()
+    cfg["kill_switch"]["v2"]["auto_calibrator"] = {
+        "backtest_window_days": 365, "dd_target": 0.10,  # positive — invalid
+    }
+    with pytest.raises(ValueError, match="dd_target must be <= 0"):
+        run_optimization_v2(cfg, regime_score=None)
+
+
+def test_run_optimization_v2_filters_out_of_window_trades(tmp_path, monkeypatch):
+    """backtest_window_days correctly excludes trades older than the window."""
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime.now(tz=timezone.utc)
+    inside_ts = (now - timedelta(days=10)).isoformat()
+    outside_ts = (now - timedelta(days=400)).isoformat()
+
+    conn = btc_api.get_db()
+    try:
+        # Inside the 365-day window: profitable +50
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            (inside_ts, inside_ts),
+        )
+        # Outside window (400 days ago): -1000 loss that would otherwise
+        # blow the dd_target if included.
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -1000.0)",
+            (outside_ts, outside_ts),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = _basic_optimizer_cfg()
+    cfg["kill_switch"]["v2"]["auto_calibrator"] = {
+        "backtest_window_days": 365, "dd_target": -0.10,
+    }
+    result = run_optimization_v2(cfg, regime_score=None)
+    # Only the +50 trade is in scope → all sliders feasible, projected_pnl=50.
+    assert result["status"] == "pending"
+    assert result["projected_pnl"] == pytest.approx(50.0)
+    assert result["report"]["trades_in_window"] == 1
+
+
+def test_run_optimization_v2_excludes_null_pnl_trades(tmp_path, monkeypatch):
+    """Trades with NULL pnl_usd are filtered out by the SQL guard."""
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import (
+        _load_closed_positions_window, run_optimization_v2,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime.now(tz=timezone.utc)
+    ts = (now - timedelta(days=10)).isoformat()
+
+    conn = btc_api.get_db()
+    try:
+        # Valid trade with non-null pnl
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 25.0)",
+            (ts, ts),
+        )
+        # Corrupted row: NULL pnl_usd (column allows NULL per schema)
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', NULL)",
+            (ts, ts),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    rows = _load_closed_positions_window(window_days=365.0, now=now)
+    assert len(rows) == 1
+    assert rows[0]["pnl_usd"] == 25.0
+
+
+def test_should_skip_or_reduce_logs_warning_on_malformed_entry_ts(caplog):
+    """Malformed entry_ts logs a warning before the conservative skip."""
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    import logging
+
+    sim = V2KillSwitchSimulator(_basic_optimizer_cfg(), regime_score=None, capital_base=1000.0)
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_simulator"):
+        skip, factor = sim.should_skip_or_reduce(
+            symbol="BTCUSDT", entry_ts="not-a-timestamp",
+        )
+    assert skip is True
+    assert factor == pytest.approx(0.0)
+    assert any(
+        "malformed entry_ts" in rec.getMessage() and "BTCUSDT" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_on_trade_close_sl_logs_warning_on_malformed_exit_ts(caplog):
+    """Malformed SL exit_ts logs a warning before silently returning."""
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    import logging
+
+    sim = V2KillSwitchSimulator(_basic_optimizer_cfg(), regime_score=None, capital_base=1000.0)
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_simulator"):
+        sim.on_trade_close(
+            symbol="BTCUSDT",
+            exit_ts="garbage-timestamp",
+            pnl_usd=-5.0, exit_reason="SL",
+        )
+    # Trade still appended (baseline still updates)
+    assert len(sim._all_trades) == 1
+    # But velocity_state did NOT get an entry (malformed exit_ts → early return)
+    assert "BTCUSDT" not in sim._velocity_state
+    assert any(
+        "malformed SL exit_ts" in rec.getMessage() and "BTCUSDT" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_run_optimization_v2_regime_score_can_change_recommended_slider(
+    tmp_path, monkeypatch,
+):
+    """BULL regime adjusts the slider scale → grid results differ vs NEUTRAL."""
+    import btc_api
+    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime.now(tz=timezone.utc)
+    ts = (now - timedelta(days=10)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        # A profitable trade — both regimes would take it (NORMAL portfolio)
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            (ts, ts),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = _basic_optimizer_cfg()
+    cfg["kill_switch"]["v2"]["auto_calibrator"] = {
+        "backtest_window_days": 365, "dd_target": -0.10,
+    }
+    # Run once with NEUTRAL (None) and once with BULL (75)
+    result_neutral = run_optimization_v2(cfg, regime_score=None)
+    result_bull = run_optimization_v2(cfg, regime_score=75.0)
+
+    # regime_score is captured in report (traceability)
+    assert result_neutral["report"]["regime_score"] is None
+    assert result_bull["report"]["regime_score"] == 75.0
+    # Grid is the same length (21) for both
+    assert len(result_neutral["report"]["grid"]) == 21
+    assert len(result_bull["report"]["grid"]) == 21
+
+
+def test_calibrator_loop_uses_real_v2_with_profitable_trades(
+    tmp_path, monkeypatch,
+):
+    """Daemon loop integration: with profitable trades + safety_net, persists pending row."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import kill_switch_calibrator_loop
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Seed a profitable closed trade within the backtest window
+    now = datetime.now(tz=timezone.utc)
+    ts = (now - timedelta(days=10)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            (ts, ts),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced":     {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen":      {"min": -0.15, "max": -0.06},
+            "velocity_sl_count":        {"min": 10, "max": 3},
+            "velocity_window_hours":    {"min": 24, "max": 6},
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "velocity_cooldown_hours": 4,
+        "concurrent_alert_threshold": 3,
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+        "auto_calibrator": {
+            "safety_net_days": 30,
+            "backtest_window_days": 365,
+            "dd_target": -0.10,
+        },
+    }}}
+
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            "SELECT triggered_by, status, report_json FROM kill_switch_recommendations"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    import json
+    triggered = json.loads(rows[0][0])
+    assert triggered == ["safety_net"]
+    assert rows[0][1] == "pending"
+    # Real v2 report — not stub
+    report = json.loads(rows[0][2])
+    assert report["stub"] is False
+    assert "grid" in report
+    assert report["trades_in_window"] == 1

--- a/tests/test_strategy_kill_switch_v2_simulator.py
+++ b/tests/test_strategy_kill_switch_v2_simulator.py
@@ -114,3 +114,36 @@ def test_simulator_velocity_active_malformed_treated_inactive():
     }
     # Malformed → treat as not active (conservative for backtest replay)
     assert sim._is_velocity_active("BTC", now) is False
+
+
+# ── B4b.2: concurrent failures count ────────────────────────────────────────
+
+
+def test_simulator_concurrent_failures_empty():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    assert sim._count_concurrent_failures(now) == 0
+
+
+def test_simulator_concurrent_failures_counts_active_velocities():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone, timedelta
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    sim._velocity_state["BTC"] = {
+        "velocity_cooldown_until": (now + timedelta(hours=1)).isoformat(),
+        "velocity_last_trigger_ts": now.isoformat(),
+    }
+    sim._velocity_state["ETH"] = {
+        "velocity_cooldown_until": (now + timedelta(hours=3)).isoformat(),
+        "velocity_last_trigger_ts": now.isoformat(),
+    }
+    sim._velocity_state["ADA"] = {
+        "velocity_cooldown_until": (now - timedelta(hours=1)).isoformat(),
+        "velocity_last_trigger_ts": now.isoformat(),
+    }
+    assert sim._count_concurrent_failures(now) == 2

--- a/tests/test_strategy_kill_switch_v2_simulator.py
+++ b/tests/test_strategy_kill_switch_v2_simulator.py
@@ -62,3 +62,55 @@ def test_simulator_current_portfolio_dd_peak_then_drop():
     )
     expected = (950 - 1150) / 1150
     assert sim._current_portfolio_dd() == pytest.approx(expected)
+
+
+# ── B4b.2: velocity active check ────────────────────────────────────────────
+
+
+def test_simulator_velocity_active_no_state():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    assert sim._is_velocity_active("BTC", now) is False
+
+
+def test_simulator_velocity_active_during_cooldown():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone, timedelta
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    sim._velocity_state["BTC"] = {
+        "velocity_cooldown_until": (now + timedelta(hours=2)).isoformat(),
+        "velocity_last_trigger_ts": (now - timedelta(hours=2)).isoformat(),
+    }
+    assert sim._is_velocity_active("BTC", now) is True
+
+
+def test_simulator_velocity_active_after_cooldown_expired():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone, timedelta
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    sim._velocity_state["BTC"] = {
+        "velocity_cooldown_until": (now - timedelta(hours=1)).isoformat(),
+        "velocity_last_trigger_ts": (now - timedelta(hours=5)).isoformat(),
+    }
+    assert sim._is_velocity_active("BTC", now) is False
+
+
+def test_simulator_velocity_active_malformed_treated_inactive():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    sim._velocity_state["BTC"] = {
+        "velocity_cooldown_until": "garbage",
+        "velocity_last_trigger_ts": None,
+    }
+    # Malformed → treat as not active (conservative for backtest replay)
+    assert sim._is_velocity_active("BTC", now) is False

--- a/tests/test_strategy_kill_switch_v2_simulator.py
+++ b/tests/test_strategy_kill_switch_v2_simulator.py
@@ -147,3 +147,185 @@ def test_simulator_concurrent_failures_counts_active_velocities():
         "velocity_last_trigger_ts": now.isoformat(),
     }
     assert sim._count_concurrent_failures(now) == 2
+
+
+# ── B4b.2: should_skip_or_reduce composition ────────────────────────────────
+
+
+def _basic_cfg():
+    """Minimal config for simulator tests with all v2 thresholds defined."""
+    return {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "thresholds": {
+            "portfolio_dd_reduced":     {"min": -0.08, "max": -0.03},
+            "portfolio_dd_frozen":      {"min": -0.15, "max": -0.06},
+            "velocity_sl_count":        {"min": 10, "max": 3},
+            "velocity_window_hours":    {"min": 24, "max": 6},
+            "baseline_sigma_multiplier": {"min": 3.0, "max": 1.0},
+        },
+        "velocity_cooldown_hours": 4,
+        "concurrent_alert_threshold": 3,
+        "baseline_min_trades": 100,
+        "baseline_stale_days": 7,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+
+
+def test_should_skip_or_reduce_empty_state_full_size():
+    """Fresh sim, no trades, no regime → NORMAL/NORMAL/no velocity → (False, 1.0)."""
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    sim = V2KillSwitchSimulator(_basic_cfg(), regime_score=None, capital_base=1000.0)
+    skip, factor = sim.should_skip_or_reduce(
+        symbol="BTCUSDT", entry_ts="2026-04-25T12:00:00+00:00",
+    )
+    assert skip is False
+    assert factor == pytest.approx(1.0)
+
+
+def test_should_skip_or_reduce_velocity_active_skips():
+    """Velocity cooldown active → (True, 0.0) regardless of other tiers."""
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone, timedelta
+
+    sim = V2KillSwitchSimulator(_basic_cfg(), regime_score=None, capital_base=1000.0)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    sim._velocity_state["BTCUSDT"] = {
+        "velocity_cooldown_until": (now + timedelta(hours=2)).isoformat(),
+        "velocity_last_trigger_ts": (now - timedelta(hours=2)).isoformat(),
+    }
+    skip, factor = sim.should_skip_or_reduce(
+        symbol="BTCUSDT", entry_ts=now.isoformat(),
+    )
+    assert skip is True
+    assert factor == pytest.approx(0.0)
+
+
+def test_should_skip_or_reduce_portfolio_frozen_skips():
+    """Portfolio FROZEN (DD <= frozen_threshold) → (True, 0.0)."""
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    cfg = _basic_cfg()
+    sim = V2KillSwitchSimulator(cfg, regime_score=None, capital_base=1000.0)
+    # Inject heavy losses to trigger FROZEN: at slider=50 → frozen_dd=-0.105
+    # 200 USD loss on 1000 capital → -0.20 DD, well past frozen threshold.
+    sim._all_trades.append(
+        {"symbol": "X", "exit_ts": "2026-04-20T12:00:00+00:00",
+         "pnl_usd": -200.0, "exit_reason": "SL"},
+    )
+    skip, factor = sim.should_skip_or_reduce(
+        symbol="BTCUSDT", entry_ts="2026-04-25T12:00:00+00:00",
+    )
+    assert skip is True
+    assert factor == pytest.approx(0.0)
+
+
+def test_should_skip_or_reduce_portfolio_reduced_halves_size():
+    """Portfolio REDUCED → factor 0.5 (not skipped)."""
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    cfg = _basic_cfg()
+    sim = V2KillSwitchSimulator(cfg, regime_score=None, capital_base=1000.0)
+    # Inject loss to trigger REDUCED: at slider=50 → reduced_dd=-0.055.
+    # 70 USD loss on 1000 capital → -0.07 DD, between reduced and frozen thresholds.
+    sim._all_trades.append(
+        {"symbol": "X", "exit_ts": "2026-04-20T12:00:00+00:00",
+         "pnl_usd": -70.0, "exit_reason": "TP"},
+    )
+    skip, factor = sim.should_skip_or_reduce(
+        symbol="BTCUSDT", entry_ts="2026-04-25T12:00:00+00:00",
+    )
+    assert skip is False
+    assert factor == pytest.approx(0.5)
+
+
+def test_should_skip_or_reduce_per_symbol_alert_halves_size():
+    """ALERT per_symbol (>=100 trades, rolling_wr below threshold) → factor 0.5.
+
+    Seed data: 100 alternating +1/-1 trades (DD ~ 0, portfolio NORMAL),
+    then 20 losses (-1 each) so rolling_wr_20=0 (per-symbol ALERT).
+    Total: 50 wins + 70 losses → baseline wr=0.417, sigma~0.493.
+    Threshold = 0.417 - 2*(0.493/sqrt(20)) ≈ 0.197. rolling_wr_20=0 → ALERT.
+    Final: peak~1000, trough=980 → DD=-0.02 → NORMAL portfolio.
+    Composition: NORMAL (1.0) × ALERT (0.5) × no velocity (1.0) = 0.5
+    """
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone, timedelta
+
+    cfg = _basic_cfg()
+    sim = V2KillSwitchSimulator(cfg, regime_score=None, capital_base=1000.0)
+    base = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    # Phase 1: 100 alternating trades (+1, -1, +1, -1, ...) — keeps peak ~ 1000.
+    for i in range(100):
+        ts = (base + timedelta(hours=i)).isoformat()
+        if i % 2 == 0:
+            t = {"symbol": "BTCUSDT", "exit_ts": ts,
+                 "pnl_usd": 1.0, "exit_reason": "TP"}
+        else:
+            t = {"symbol": "BTCUSDT", "exit_ts": ts,
+                 "pnl_usd": -1.0, "exit_reason": "SL"}
+        sim._all_trades.append(t)
+        sim._symbol_trades.setdefault("BTCUSDT", []).append(t)
+    # Phase 2: 20 losses (-1 each) → equity drops by 20 → DD = -20/1000 = -0.02 (NORMAL).
+    for i in range(20):
+        ts = (base + timedelta(hours=100 + i)).isoformat()
+        t = {"symbol": "BTCUSDT", "exit_ts": ts,
+             "pnl_usd": -1.0, "exit_reason": "SL"}
+        sim._all_trades.append(t)
+        sim._symbol_trades["BTCUSDT"].append(t)
+    # Last 20 are all losses → rolling_wr_20 = 0
+    # Baseline: 50 wins / 120 = 0.417, sigma = sqrt(0.417*0.583) ≈ 0.493
+    # Threshold = 0.417 - 2*(0.493/sqrt(20)) ≈ 0.197 → 0 < 0.197 → ALERT
+    from strategy.kill_switch_v2 import compute_baseline_metrics
+    sim._baselines["BTCUSDT"] = compute_baseline_metrics(sim._symbol_trades["BTCUSDT"])
+
+    skip, factor = sim.should_skip_or_reduce(
+        symbol="BTCUSDT", entry_ts="2026-04-26T12:00:00+00:00",
+    )
+    # NORMAL portfolio (DD=-0.02 above reduced=-0.055), ALERT per-symbol → 0.5
+    assert skip is False
+    assert factor == pytest.approx(0.5)
+
+
+def test_should_skip_or_reduce_composition_reduced_alert_quarter():
+    """Portfolio REDUCED (0.5) × per_symbol ALERT (0.5) → 0.25 (multiplicative).
+
+    Seed data: 100 alternating +1/-1 (peak ~ 1000), then 20 losses (-4 each)
+    → final equity 920, DD = -80/1000 = -0.08 (REDUCED at slider=50).
+    Last 20 losses make rolling_wr_20=0 → ALERT.
+    """
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+    from datetime import datetime, timezone, timedelta
+
+    cfg = _basic_cfg()
+    sim = V2KillSwitchSimulator(cfg, regime_score=None, capital_base=1000.0)
+    base = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    # Phase 1: 100 alternating trades — peak stays ~ 1000.
+    for i in range(100):
+        ts = (base + timedelta(hours=i)).isoformat()
+        if i % 2 == 0:
+            t = {"symbol": "BTCUSDT", "exit_ts": ts,
+                 "pnl_usd": 1.0, "exit_reason": "TP"}
+        else:
+            t = {"symbol": "BTCUSDT", "exit_ts": ts,
+                 "pnl_usd": -1.0, "exit_reason": "SL"}
+        sim._all_trades.append(t)
+        sim._symbol_trades.setdefault("BTCUSDT", []).append(t)
+    # Phase 2: 20 losses at -4 each → drops 80 USD from equity.
+    # Final equity ~ 920, peak ~ 1000, DD = -0.08 → REDUCED at slider=50.
+    for i in range(20):
+        ts = (base + timedelta(hours=100 + i)).isoformat()
+        t = {"symbol": "BTCUSDT", "exit_ts": ts,
+             "pnl_usd": -4.0, "exit_reason": "SL"}
+        sim._all_trades.append(t)
+        sim._symbol_trades["BTCUSDT"].append(t)
+    from strategy.kill_switch_v2 import compute_baseline_metrics
+    sim._baselines["BTCUSDT"] = compute_baseline_metrics(sim._symbol_trades["BTCUSDT"])
+
+    skip, factor = sim.should_skip_or_reduce(
+        symbol="BTCUSDT", entry_ts="2026-04-26T12:00:00+00:00",
+    )
+    # REDUCED portfolio (0.5) × ALERT per-symbol (0.5) × no velocity = 0.25
+    assert skip is False
+    assert factor == pytest.approx(0.25)

--- a/tests/test_strategy_kill_switch_v2_simulator.py
+++ b/tests/test_strategy_kill_switch_v2_simulator.py
@@ -1,0 +1,64 @@
+"""Tests for V2KillSwitchSimulator (#187 #216 B4b.2)."""
+import pytest
+
+
+# ── B4b.2: simulator skeleton + portfolio DD ────────────────────────────────
+
+
+def test_simulator_init_applies_regime_adjustment_bull():
+    """Construction with BULL regime_score adjusts cfg.aggressiveness via apply_regime_adjustment."""
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    cfg = {"kill_switch": {"v2": {
+        "aggressiveness": 50,
+        "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+        "advanced_overrides": {"regime_adjustment_enabled": True},
+    }}}
+    sim = V2KillSwitchSimulator(cfg, regime_score=75.0, capital_base=1000.0)
+    assert sim.cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 60
+
+
+def test_simulator_init_no_regime_score_keeps_slider():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    cfg = {"kill_switch": {"v2": {"aggressiveness": 50}}}
+    sim = V2KillSwitchSimulator(cfg, regime_score=None, capital_base=1000.0)
+    assert sim.cfg_eff["kill_switch"]["v2"]["aggressiveness"] == 50
+
+
+def test_simulator_current_portfolio_dd_empty():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    assert sim._current_portfolio_dd() == pytest.approx(0.0)
+
+
+def test_simulator_current_portfolio_dd_after_loss():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    sim._all_trades.append(
+        {"symbol": "BTC", "exit_ts": "2026-04-20T12:00:00+00:00",
+         "pnl_usd": -50.0, "exit_reason": "SL"},
+    )
+    assert sim._current_portfolio_dd() == pytest.approx(-0.05)
+
+
+def test_simulator_current_portfolio_dd_peak_then_drop():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    sim = V2KillSwitchSimulator({}, regime_score=None, capital_base=1000.0)
+    sim._all_trades.append(
+        {"symbol": "X", "exit_ts": "2026-04-20T12:00:00+00:00",
+         "pnl_usd": 100.0, "exit_reason": "TP"},
+    )
+    sim._all_trades.append(
+        {"symbol": "X", "exit_ts": "2026-04-21T12:00:00+00:00",
+         "pnl_usd": 50.0, "exit_reason": "TP"},
+    )
+    sim._all_trades.append(
+        {"symbol": "X", "exit_ts": "2026-04-22T12:00:00+00:00",
+         "pnl_usd": -200.0, "exit_reason": "SL"},
+    )
+    expected = (950 - 1150) / 1150
+    assert sim._current_portfolio_dd() == pytest.approx(expected)

--- a/tests/test_strategy_kill_switch_v2_simulator.py
+++ b/tests/test_strategy_kill_switch_v2_simulator.py
@@ -329,3 +329,77 @@ def test_should_skip_or_reduce_composition_reduced_alert_quarter():
     # REDUCED portfolio (0.5) × ALERT per-symbol (0.5) × no velocity = 0.25
     assert skip is False
     assert factor == pytest.approx(0.25)
+
+
+# ── B4b.2: on_trade_close updates state ─────────────────────────────────────
+
+
+def test_on_trade_close_appends_trade_to_all_and_per_symbol():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    sim = V2KillSwitchSimulator(_basic_cfg(), regime_score=None, capital_base=1000.0)
+    sim.on_trade_close(
+        symbol="BTCUSDT", exit_ts="2026-04-25T12:00:00+00:00",
+        pnl_usd=10.0, exit_reason="TP",
+    )
+    assert len(sim._all_trades) == 1
+    assert sim._all_trades[0]["pnl_usd"] == 10.0
+    assert len(sim._symbol_trades["BTCUSDT"]) == 1
+
+
+def test_on_trade_close_updates_baseline_for_symbol():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    sim = V2KillSwitchSimulator(_basic_cfg(), regime_score=None, capital_base=1000.0)
+    sim.on_trade_close(
+        symbol="BTCUSDT", exit_ts="2026-04-25T12:00:00+00:00",
+        pnl_usd=10.0, exit_reason="TP",
+    )
+    sim.on_trade_close(
+        symbol="BTCUSDT", exit_ts="2026-04-25T13:00:00+00:00",
+        pnl_usd=-5.0, exit_reason="SL",
+    )
+    # 1 win, 1 loss → wr=0.5, count=2
+    assert sim._baselines["BTCUSDT"]["wr"] == pytest.approx(0.5)
+    assert sim._baselines["BTCUSDT"]["count"] == 2
+
+
+def test_on_trade_close_sl_triggers_velocity_when_threshold_met():
+    """3 SLs within 6h at slider=100 → velocity cooldown set."""
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    cfg = _basic_cfg()
+    cfg["kill_switch"]["v2"]["aggressiveness"] = 100  # paranoid: sl_count=3, window=6h
+    sim = V2KillSwitchSimulator(cfg, regime_score=None, capital_base=1000.0)
+
+    sim.on_trade_close(
+        symbol="BTCUSDT", exit_ts="2026-04-25T10:00:00+00:00",
+        pnl_usd=-5.0, exit_reason="SL",
+    )
+    sim.on_trade_close(
+        symbol="BTCUSDT", exit_ts="2026-04-25T11:00:00+00:00",
+        pnl_usd=-5.0, exit_reason="SL",
+    )
+    sim.on_trade_close(
+        symbol="BTCUSDT", exit_ts="2026-04-25T12:00:00+00:00",
+        pnl_usd=-5.0, exit_reason="SL",
+    )
+    # Cooldown should be set
+    state = sim._velocity_state.get("BTCUSDT", {})
+    assert state.get("velocity_cooldown_until") is not None
+
+
+def test_on_trade_close_tp_does_not_set_velocity():
+    from strategy.kill_switch_v2_simulator import V2KillSwitchSimulator
+
+    cfg = _basic_cfg()
+    cfg["kill_switch"]["v2"]["aggressiveness"] = 100
+    sim = V2KillSwitchSimulator(cfg, regime_score=None, capital_base=1000.0)
+    # Three TPs (not SLs) → no velocity trigger regardless
+    for i in range(3):
+        sim.on_trade_close(
+            symbol="BTCUSDT",
+            exit_ts=f"2026-04-25T{10+i:02d}:00:00+00:00",
+            pnl_usd=5.0, exit_reason="TP",
+        )
+    assert "BTCUSDT" not in sim._velocity_state or not sim._velocity_state["BTCUSDT"].get("velocity_cooldown_until")


### PR DESCRIPTION
## Summary

Kill Switch v2 **B4b.2 — v2-aware backtest + grid optimization** (#216). Replaces B4b.1's stub fitness with real grid search over 21 slider candidates [0..100, step 5], evaluating each via positions-replay through a new in-memory `V2KillSwitchSimulator`. Recommendations move from `status="no_feasible"` (always) to `pending` / `no_feasible` with real numbers and full grid in `report_json`.

## What ships

- `strategy/kill_switch_v2_simulator.py` (NEW) — `V2KillSwitchSimulator`: in-memory state for B1 velocity + B2 portfolio DD + B3 regime + B4a baselines. Mirrors shadow path without DB I/O.
- `strategy/kill_switch_v2_optimizer.py` (NEW) — `run_optimization_v2(cfg, regime_score)`: loads closed trades from window, replays each slider candidate, returns best-by-PnL subject to `dd_target`.
- `strategy/kill_switch_v2_calibrator.py` — daemon loop now calls `run_optimization_v2` (with try/except fallback to stub).
- `btc_api.py` — `POST /kill_switch/recalibrate` calls `run_optimization_v2` (same try/except fallback).
- `config.defaults.json` — `backtest_window_days: 365`, `dd_target: -0.10`.
- 36 new tests (21 simulator + 13 optimizer + 2 integration).

## Composition rules (multiplicative)

- `portfolio_factor`: NORMAL=1.0, WARNED=1.0, REDUCED=0.5, FROZEN=0.0
- `per_symbol_factor`: NORMAL=1.0, ALERT=0.5
- `velocity_factor`: 1.0 if no cooldown, 0.0 if active
- `size_factor` = product. Equal to 0.0 → `skip=True`.

## Replay vs full backtest (decision rationale)

We use **positions-table replay**: ~21s for full grid. The trade-off — assuming each historical trade was taken — is acceptable because the question is "what would v2 have FILTERED?" not "what new trades v2 would have OPENED?". Full bar-by-bar backtest (~30 min) was rejected as too slow for sync endpoint and B4b.3's hourly triggers.

## Fail-open

`run_optimization_v2` is wrapped in try/except at both call sites (daemon + endpoint). On failure, falls back to `run_optimization_stub` which logs a warning and persists a `no_feasible` row. v1 / shadow path unaffected.

## Intentionally NOT shipped

- B4b.3 auto-triggers (regime_change, portfolio_dd_degradation, event_cascade) — #217.
- B4b.3 rate limiting (max_per_day, min_cooldown_hours) — #217.
- B4b.3 Telegram notifications — #217 (`log.warning` only here).
- B4b.3 apply/ignore endpoints — #217.
- Async endpoint (thread on-demand + 202) — sync inline at ~21s/grid is fine for FastAPI defaults.
- Full bar-by-bar v2 backtest — replay-only is enough for fitness.

## Test plan

- [x] V2KillSwitchSimulator: portfolio DD math (5), velocity active (4), concurrent failures (2), should_skip_or_reduce composition (6), on_trade_close (4) — 21 tests.
- [x] Optimizer: DB loader (2), `_override_slider` (2), `_replay_with_slider` (4), `run_optimization_v2` (5) — 13 tests.
- [x] Integration: POST endpoint uses v2 + grid in report; fallback to stub on optimizer failure — 2 tests.
- [x] Backwards-compat: existing B4b.1 tests updated; assertions still hold.
- [x] Backend: 865 passed (was 829 baseline, +36 new).
- [x] Frontend: 21 passed unchanged.

## Closes

#216. Spec: `docs/superpowers/specs/es/2026-04-25-kill-switch-v2-b4b2-v2-backtest-grid-optimization-design.md`. Plan: `docs/superpowers/plans/2026-04-25-kill-switch-v2-b4b2-v2-backtest-grid-optimization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)