### PR TITLE
feat(kill-switch-v2): B4b.3 auto-triggers + Telegram + apply/ignore endpoints (#187 #217)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -1775,6 +1775,162 @@ def kill_switch_list_recommendations(
     return result
 
 
+@app.post(
+    "/kill_switch/recommendations/{rec_id}/apply",
+    summary="Apply a pending recommendation (operator action)",
+    dependencies=[Depends(verify_api_key)],
+)
+def kill_switch_apply_recommendation(rec_id: int):
+    """Apply a pending recommendation: write config override + mark applied.
+
+    Returns the updated row. 404 if not found, 400 if not pending.
+    """
+    from datetime import datetime, timezone
+
+    try:
+        conn = get_db()
+        try:
+            row = conn.execute(
+                """SELECT id, status, slider_value
+                   FROM kill_switch_recommendations WHERE id = ?""",
+                (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"recommendation {rec_id} not found")
+        if row[1] != "pending":
+            raise HTTPException(
+                status_code=400,
+                detail=f"recommendation {rec_id} is already {row[1]}",
+            )
+        slider_value = row[2]
+        if slider_value is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"recommendation {rec_id} has no slider_value to apply",
+            )
+
+        # Write config override
+        save_config({"kill_switch": {"v2": {"aggressiveness": int(slider_value)}}})
+
+        # Update DB row
+        now_iso = datetime.now(tz=timezone.utc).isoformat()
+        conn = get_db()
+        try:
+            conn.execute(
+                """UPDATE kill_switch_recommendations
+                   SET status = 'applied', applied_ts = ?, applied_by = 'operator'
+                   WHERE id = ?""",
+                (now_iso, rec_id),
+            )
+            conn.commit()
+            updated = conn.execute(
+                """SELECT id, ts, triggered_by, slider_value, projected_pnl,
+                          projected_dd, status, applied_ts, applied_by, report_json
+                   FROM kill_switch_recommendations WHERE id = ?""",
+                (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        log.warning(
+            "Kill switch v2: operator applied recomendación id=%d slider=%d",
+            rec_id, int(slider_value),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.error(
+            "POST /kill_switch/recommendations/%d/apply failed: %s",
+            rec_id, e, exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"apply failed: {type(e).__name__}: {e}",
+        )
+
+    return {
+        "id": updated[0], "ts": updated[1], "triggered_by": updated[2],
+        "slider_value": updated[3], "projected_pnl": updated[4],
+        "projected_dd": updated[5], "status": updated[6],
+        "applied_ts": updated[7], "applied_by": updated[8],
+    }
+
+
+@app.post(
+    "/kill_switch/recommendations/{rec_id}/ignore",
+    summary="Ignore a pending recommendation (operator action)",
+    dependencies=[Depends(verify_api_key)],
+)
+def kill_switch_ignore_recommendation(rec_id: int):
+    """Mark a pending recommendation as ignored (no config change).
+
+    404 if not found, 400 if not pending.
+    """
+    from datetime import datetime, timezone
+
+    try:
+        conn = get_db()
+        try:
+            row = conn.execute(
+                """SELECT id, status FROM kill_switch_recommendations WHERE id = ?""",
+                (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"recommendation {rec_id} not found")
+        if row[1] != "pending":
+            raise HTTPException(
+                status_code=400,
+                detail=f"recommendation {rec_id} is already {row[1]}",
+            )
+
+        now_iso = datetime.now(tz=timezone.utc).isoformat()
+        conn = get_db()
+        try:
+            conn.execute(
+                """UPDATE kill_switch_recommendations
+                   SET status = 'ignored', applied_ts = ?, applied_by = 'operator'
+                   WHERE id = ?""",
+                (now_iso, rec_id),
+            )
+            conn.commit()
+            updated = conn.execute(
+                """SELECT id, ts, triggered_by, slider_value, projected_pnl,
+                          projected_dd, status, applied_ts, applied_by, report_json
+                   FROM kill_switch_recommendations WHERE id = ?""",
+                (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        log.warning(
+            "Kill switch v2: operator ignored recomendación id=%d", rec_id,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.error(
+            "POST /kill_switch/recommendations/%d/ignore failed: %s",
+            rec_id, e, exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"ignore failed: {type(e).__name__}: {e}",
+        )
+
+    return {
+        "id": updated[0], "ts": updated[1], "triggered_by": updated[2],
+        "slider_value": updated[3], "projected_pnl": updated[4],
+        "projected_dd": updated[5], "status": updated[6],
+        "applied_ts": updated[7], "applied_by": updated[8],
+    }
+
+
 @app.get("/signals", summary="Historial de escaneos / señales")
 def list_signals(
     limit:        int             = Query(50,    ge=1, le=500),

--- a/btc_api.py
+++ b/btc_api.py
@@ -1811,9 +1811,23 @@ def kill_switch_apply_recommendation(rec_id: int):
                 status_code=400,
                 detail=f"recommendation {rec_id} has no slider_value to apply",
             )
+        slider_int = int(slider_value)
+        if not (0 <= slider_int <= 100):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"recommendation {rec_id} has out-of-range slider_value="
+                    f"{slider_int} (must be 0..100)"
+                ),
+            )
 
-        # Write config override
-        save_config({"kill_switch": {"v2": {"aggressiveness": int(slider_value)}}})
+        # Write config override. save_config only merges at kill_switch level
+        # (it replaces the entire v2 sub-dict), so do read-modify-write here to
+        # preserve other v2 keys (auto_calibrator, regime_adjustments, etc).
+        existing_cfg = load_config()
+        existing_v2 = (existing_cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+        merged_v2 = {**existing_v2, "aggressiveness": slider_int}
+        save_config({"kill_switch": {"v2": merged_v2}})
 
         # Update DB row
         now_iso = datetime.now(tz=timezone.utc).isoformat()

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -21,7 +21,12 @@
       "auto_calibrator": {
         "safety_net_days": 30,
         "backtest_window_days": 365,
-        "dd_target": -0.10
+        "dd_target": -0.10,
+        "max_per_day": 1,
+        "min_cooldown_hours": 6,
+        "event_cascade_window_hours": 72,
+        "event_cascade_min_symbols": 3,
+        "portfolio_dd_degradation_multiplier": 1.5
       }
     }
   },

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -325,6 +325,48 @@ def _load_last_calibration_regime_score() -> float | None:
         return None
 
 
+def _count_symbols_with_recent_alerts(window_hours: float) -> int:
+    """Count distinct symbols whose v2_shadow decisions in the last window_hours
+    have per_symbol_tier='ALERT' OR portfolio_tier IN ('REDUCED','FROZEN').
+    """
+    from datetime import datetime, timedelta, timezone
+    import btc_api
+
+    now = datetime.now(tz=timezone.utc)
+    cutoff = (now - timedelta(hours=float(window_hours))).isoformat()
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            """SELECT COUNT(DISTINCT symbol)
+               FROM kill_switch_decisions
+               WHERE engine = 'v2_shadow'
+                 AND ts >= ?
+                 AND (per_symbol_tier = 'ALERT'
+                      OR portfolio_tier IN ('REDUCED', 'FROZEN'))""",
+            (cutoff,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return int(row[0]) if row else 0
+
+
+def _mark_prior_pending_as_superseded(new_id: int) -> None:
+    """Mark all pending recommendations except `new_id` as superseded."""
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """UPDATE kill_switch_recommendations
+               SET status = 'superseded'
+               WHERE status = 'pending' AND id != ?""",
+            (int(new_id),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
     """Daily auto-calibrator loop.
 

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -136,7 +136,13 @@ def is_rate_limit_ok(
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
     except (TypeError, ValueError):
-        # Malformed ts → treat as no prior run (conservative for rate limit)
+        # Malformed ts → treat as no prior run. Logged so DB corruption or
+        # writer-format drift in kill_switch_recommendations.ts doesn't
+        # silently disable rate limiting.
+        log.warning(
+            "is_rate_limit_ok: malformed last_run_ts=%r — treating as no "
+            "prior run (allowing %s trigger)", last_run_ts, trigger_kind,
+        )
         return True
 
     elapsed = now - parsed
@@ -523,15 +529,25 @@ def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
 def _load_current_regime_score() -> float | None:
     """Read the current regime score from the cached daily detector.
 
-    Returns None if cache is empty / missing / malformed.
+    Returns None if cache is empty / missing / malformed. Errors are logged
+    so an import or runtime failure doesn't silently disable the
+    regime_change trigger forever.
     """
     try:
         from btc_scanner import get_cached_regime
-    except Exception:
+    except Exception as e:
+        log.warning(
+            "_load_current_regime_score: btc_scanner import failed: %s",
+            e, exc_info=True,
+        )
         return None
     try:
         cached = get_cached_regime()
-    except Exception:
+    except Exception as e:
+        log.warning(
+            "_load_current_regime_score: get_cached_regime() raised: %s",
+            e, exc_info=True,
+        )
         return None
     if not cached or not isinstance(cached, dict):
         return None
@@ -541,6 +557,10 @@ def _load_current_regime_score() -> float | None:
     try:
         return float(score)
     except (TypeError, ValueError):
+        log.warning(
+            "_load_current_regime_score: cached score is non-numeric: %r",
+            score,
+        )
         return None
 
 

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -408,14 +408,20 @@ def _send_telegram_recommendation(
 
 
 def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
-    """Daily auto-calibrator loop.
+    """Hourly auto-calibrator loop (#187 #217 B4b.3).
 
-    Pattern mirrors health_monitor_loop. Wakes once per day, evaluates the
-    safety_net trigger, persists a stub recommendation if fired. Manual
-    triggers come through the FastAPI endpoint, not via this loop.
+    Evaluates 4 triggers each iteration: safety_net, regime_change,
+    portfolio_dd_degradation, event_cascade. When any fires AND rate limit
+    passes, runs run_optimization_v2 (with stub fallback), persists the
+    recommendation, marks prior pending as superseded if status='pending',
+    and sends Telegram notification.
 
-    Fail-open: any exception inside an iteration is logged with exc_info;
-    the loop continues. stop_event.set() exits the loop cleanly.
+    Manual triggers come through the FastAPI endpoint (not via this loop).
+    Rate limit: max_per_day=1 + min_cooldown_hours=6 by default.
+    Bypasses: safety_net + manual.
+
+    Fail-open: any iteration exception is logged with exc_info; loop continues.
+    stop_event.set() exits the loop cleanly.
     """
     import threading
     from datetime import datetime, timedelta, timezone
@@ -427,47 +433,141 @@ def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
         try:
             cfg = cfg_fn()
             v2_cfg = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
-            auto_cal_cfg = v2_cfg.get("auto_calibrator", {}) or {}
-            safety_net_days = int(
-                auto_cal_cfg.get("safety_net_days", _DEFAULT_SAFETY_NET_DAYS)
-            )
+            auto_cal = v2_cfg.get("auto_calibrator", {}) or {}
 
             now = datetime.now(tz=timezone.utc)
-            last_ts = _load_last_recalibration_ts()
+            last_run_ts = _load_last_recalibration_ts()
+            today_count = _count_recalibrations_today(now)
+            max_per_day = int(auto_cal.get("max_per_day", 1))
+            cooldown_h = float(auto_cal.get("min_cooldown_hours", 6))
 
-            if should_run_safety_net(last_ts, now, safety_net_days):
-                # B4b.2: real fitness via grid optimization (was stub in B4b.1)
-                from strategy.kill_switch_v2_optimizer import run_optimization_v2
-                try:
-                    result = run_optimization_v2(cfg)
-                except Exception as opt_err:
-                    log.warning(
-                        "run_optimization_v2 failed; falling back to stub: %s",
-                        opt_err, exc_info=True,
+            # Evaluate all 4 triggers
+            triggers_fired: list[str] = []
+
+            # safety_net (daily threshold)
+            safety_net_days = int(auto_cal.get("safety_net_days", _DEFAULT_SAFETY_NET_DAYS))
+            if should_run_safety_net(last_run_ts, now, safety_net_days):
+                triggers_fired.append("safety_net")
+
+            # regime_change
+            current_regime = _load_current_regime_score()
+            last_calib_regime = _load_last_calibration_regime_score()
+            if should_run_regime_change(last_calib_regime, current_regime):
+                triggers_fired.append("regime_change")
+
+            # portfolio_dd_degradation
+            current_dd = _compute_current_portfolio_dd(cfg)
+            last_applied = _load_last_applied_recommendation()
+            last_proj_dd = (last_applied or {}).get("projected_dd")
+            multiplier = float(auto_cal.get("portfolio_dd_degradation_multiplier", 1.5))
+            if should_run_portfolio_dd_degradation(current_dd, last_proj_dd, multiplier):
+                triggers_fired.append("portfolio_dd_degradation")
+
+            # event_cascade
+            cascade_window = float(auto_cal.get("event_cascade_window_hours", 72))
+            cascade_threshold = int(auto_cal.get("event_cascade_min_symbols", 3))
+            symbols_count = _count_symbols_with_recent_alerts(cascade_window)
+            if should_run_event_cascade(symbols_count, cascade_threshold):
+                triggers_fired.append("event_cascade")
+
+            # Rate limit check (safety_net bypasses; auto otherwise)
+            if triggers_fired:
+                rate_kind = "safety_net" if "safety_net" in triggers_fired else "auto"
+                if is_rate_limit_ok(
+                    last_run_ts, now, max_per_day, today_count, cooldown_h, rate_kind,
+                ):
+                    # Real fitness with fallback to stub
+                    from strategy.kill_switch_v2_optimizer import run_optimization_v2
+                    try:
+                        result = run_optimization_v2(cfg, regime_score=current_regime)
+                    except Exception as opt_err:
+                        log.warning(
+                            "run_optimization_v2 failed; falling back to stub: %s",
+                            opt_err, exc_info=True,
+                        )
+                        result = run_optimization_stub(cfg)
+
+                    rec_id = _persist_recommendation(
+                        triggered_by=triggers_fired, result=result, now=now,
                     )
-                    result = run_optimization_stub(cfg)
-                rec_id = _persist_recommendation(
-                    triggered_by=["safety_net"], result=result, now=now,
-                )
-                # Stub notification — real Telegram lands in B4b.3 (#217)
-                log.warning(
-                    "Kill switch v2: recomendación id=%d (status=%s, "
-                    "triggered_by=safety_net). Telegram pendiente B4b.3.",
-                    rec_id, result["status"],
-                )
+
+                    if result["status"] == "pending":
+                        _mark_prior_pending_as_superseded(rec_id)
+                        _send_telegram_recommendation(
+                            rec_id, result, triggers_fired, cfg,
+                        )
+
+                    log.warning(
+                        "Kill switch v2: recomendación id=%d (status=%s, "
+                        "triggered_by=%s).",
+                        rec_id, result["status"], triggers_fired,
+                    )
         except Exception as e:
             log.warning(
                 "kill_switch_calibrator_loop iteration failed: %s",
                 e, exc_info=True,
             )
 
-        # Sleep until next midnight UTC (or until stop_event is set)
+        # Sleep until next hour UTC (changed from next_midnight in B4b.1)
         now = datetime.now(tz=timezone.utc)
-        next_midnight = (now + timedelta(days=1)).replace(
-            hour=0, minute=0, second=0, microsecond=0,
+        next_hour = (now + timedelta(hours=1)).replace(
+            minute=0, second=0, microsecond=0,
         )
-        seconds = max(60.0, (next_midnight - now).total_seconds())
+        seconds = max(60.0, (next_hour - now).total_seconds())
         if stop_event.wait(seconds):
             break
 
     log.info("kill_switch_calibrator_loop exiting cleanly")
+
+
+def _load_current_regime_score() -> float | None:
+    """Read the current regime score from the cached daily detector.
+
+    Returns None if cache is empty / missing / malformed.
+    """
+    try:
+        from btc_scanner import get_cached_regime
+    except Exception:
+        return None
+    try:
+        cached = get_cached_regime()
+    except Exception:
+        return None
+    if not cached or not isinstance(cached, dict):
+        return None
+    score = cached.get("score")
+    if score is None:
+        return None
+    try:
+        return float(score)
+    except (TypeError, ValueError):
+        return None
+
+
+def _compute_current_portfolio_dd(cfg: dict[str, Any]) -> float:
+    """Compute live portfolio DD from closed trades + open positions MTM.
+
+    Reuses kill_switch_v2.compute_portfolio_dd + compute_portfolio_equity_curve.
+    Returns 0.0 if anything fails (conservative — won't fire degradation trigger).
+    """
+    try:
+        from strategy.kill_switch_v2 import (
+            compute_portfolio_equity_curve, compute_portfolio_dd,
+        )
+        from strategy.kill_switch_v2_shadow import (
+            _load_closed_trades, _load_open_positions, _snapshot_prices,
+        )
+        capital_base = float(cfg.get("capital_usd", 1000.0))
+        equity_curve = compute_portfolio_equity_curve(
+            closed_trades=_load_closed_trades(),
+            open_positions=_load_open_positions(),
+            capital_base=capital_base,
+            now_price_by_symbol=_snapshot_prices(),
+        )
+        return float(compute_portfolio_dd(equity_curve))
+    except Exception as e:
+        log.warning(
+            "compute_current_portfolio_dd failed: %s",
+            e, exc_info=True,
+        )
+        return 0.0

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -76,6 +76,25 @@ def should_run_regime_change(
     )
 
 
+def should_run_portfolio_dd_degradation(
+    current_dd: float,
+    last_applied_projected_dd: float | None,
+    multiplier: float = 1.5,
+) -> bool:
+    """Fire if current DD is degrading vs the projected baseline.
+
+    Both args are negative (drawdowns). "Degradation" = more negative.
+    Threshold = multiplier * last_applied_projected_dd. Strict `<`.
+
+    Returns False if no applied recommendation exists yet, OR if the baseline
+    DD is 0/positive (no meaningful historical drawdown to amplify).
+    """
+    if last_applied_projected_dd is None or last_applied_projected_dd >= 0:
+        return False
+    threshold = multiplier * last_applied_projected_dd
+    return current_dd < threshold
+
+
 def build_no_feasible_report(reason: str, now) -> dict[str, Any]:
     """Construct the report payload for stub no_feasible runs.
 

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -95,6 +95,17 @@ def should_run_portfolio_dd_degradation(
     return current_dd < threshold
 
 
+def should_run_event_cascade(
+    symbols_in_alert_count: int,
+    threshold: int = 3,
+) -> bool:
+    """Fire if number of distinct symbols in ALERT-or-worse >= threshold.
+
+    Boundary: count == threshold returns True (>= semantics).
+    """
+    return symbols_in_alert_count >= threshold
+
+
 def build_no_feasible_report(reason: str, now) -> dict[str, Any]:
     """Construct the report payload for stub no_feasible runs.
 

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -47,6 +47,35 @@ def should_run_safety_net(
     return (now - parsed) > timedelta(days=float(safety_net_days))
 
 
+def _classify_regime_band(score: float) -> str:
+    """Helper: which band does this score fall into?
+
+    >= 60 → BULL, < 40 → BEAR, else NEUTRAL.
+    """
+    if score >= 60:
+        return "BULL"
+    if score < 40:
+        return "BEAR"
+    return "NEUTRAL"
+
+
+def should_run_regime_change(
+    last_calibration_regime_score: float | None,
+    current_regime_score: float | None,
+) -> bool:
+    """Fire if regime band changed since last calibration.
+
+    Returns False if either score is None (no baseline OR no current data).
+    Bands: <40 BEAR, 40-60 NEUTRAL, >=60 BULL.
+    """
+    if last_calibration_regime_score is None or current_regime_score is None:
+        return False
+    return (
+        _classify_regime_band(last_calibration_regime_score)
+        != _classify_regime_band(current_regime_score)
+    )
+
+
 def build_no_feasible_report(reason: str, now) -> dict[str, Any]:
     """Construct the report payload for stub no_feasible runs.
 

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -251,6 +251,80 @@ def _load_last_recalibration_ts() -> str | None:
     return row[0] if row and row[0] else None
 
 
+def _count_recalibrations_today(now) -> int:
+    """Count rows in kill_switch_recommendations persisted today (UTC)."""
+    import btc_api
+
+    today_prefix = now.strftime("%Y-%m-%d")
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM kill_switch_recommendations WHERE ts LIKE ?",
+            (today_prefix + "%",),
+        ).fetchone()
+    finally:
+        conn.close()
+    return int(row[0]) if row else 0
+
+
+def _load_last_applied_recommendation() -> dict[str, Any] | None:
+    """Return the most recent applied recommendation row as a dict, or None."""
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            """SELECT id, ts, slider_value, projected_pnl, projected_dd,
+                      status, applied_ts, applied_by, report_json
+               FROM kill_switch_recommendations
+               WHERE status = 'applied'
+               ORDER BY applied_ts DESC, id DESC
+               LIMIT 1""",
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    return {
+        "id": row[0], "ts": row[1], "slider_value": row[2],
+        "projected_pnl": row[3], "projected_dd": row[4],
+        "status": row[5], "applied_ts": row[6], "applied_by": row[7],
+        "report_json": row[8],
+    }
+
+
+def _load_last_calibration_regime_score() -> float | None:
+    """Read regime_score from the latest recommendation's report_json.
+
+    Returns None if no rows exist, report_json is malformed, or regime_score
+    field is missing.
+    """
+    import json
+    import btc_api
+
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            """SELECT report_json FROM kill_switch_recommendations
+               ORDER BY ts DESC, id DESC LIMIT 1""",
+        ).fetchone()
+    finally:
+        conn.close()
+    if not row or not row[0]:
+        return None
+    try:
+        report = json.loads(row[0])
+    except (TypeError, ValueError):
+        return None
+    score = report.get("regime_score")
+    if score is None:
+        return None
+    try:
+        return float(score)
+    except (TypeError, ValueError):
+        return None
+
+
 def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
     """Daily auto-calibrator loop.
 

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -106,6 +106,49 @@ def should_run_event_cascade(
     return symbols_in_alert_count >= threshold
 
 
+def is_rate_limit_ok(
+    last_run_ts: str | None,
+    now,
+    max_per_day_count: int,
+    today_count: int,
+    min_cooldown_hours: float,
+    trigger_kind: str,
+) -> bool:
+    """Whether a recalibration may run.
+
+    Bypass for trigger_kind in {"manual", "safety_net"}: always True.
+    Otherwise:
+      - last_run_ts None → True (no prior run)
+      - elapsed < cooldown_hours → False
+      - today_count >= max_per_day_count → False
+      - else → True
+    """
+    from datetime import datetime, timedelta, timezone
+
+    if trigger_kind in ("manual", "safety_net"):
+        return True
+
+    if not last_run_ts:
+        return True
+
+    try:
+        parsed = datetime.fromisoformat(last_run_ts)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        # Malformed ts → treat as no prior run (conservative for rate limit)
+        return True
+
+    elapsed = now - parsed
+    if elapsed < timedelta(hours=float(min_cooldown_hours)):
+        return False
+
+    if today_count >= int(max_per_day_count):
+        return False
+
+    return True
+
+
 def build_no_feasible_report(reason: str, now) -> dict[str, Any]:
     """Construct the report payload for stub no_feasible runs.
 

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -367,6 +367,46 @@ def _mark_prior_pending_as_superseded(new_id: int) -> None:
         conn.close()
 
 
+def _send_telegram_recommendation(
+    rec_id: int,
+    result: dict[str, Any],
+    triggered_by: list[str],
+    cfg: dict[str, Any],
+) -> None:
+    """Send a Telegram notification for a pending recommendation.
+
+    Wraps notifier.notify(SystemEvent(...), cfg). Fails open: any exception
+    is logged and swallowed so notifier failure doesn't break the daemon
+    or endpoint.
+    """
+    import notifier
+    from notifier.events import SystemEvent
+
+    try:
+        slider = result.get("slider_value")
+        pnl = result.get("projected_pnl")
+        dd = result.get("projected_dd")
+        slider_str = f"{slider}%" if slider is not None else "N/A"
+        pnl_str = f"+${pnl:.0f}" if isinstance(pnl, (int, float)) else "N/A"
+        dd_str = f"{dd:.2%}" if isinstance(dd, (int, float)) else "N/A"
+
+        message = (
+            f"Kill switch v2: nueva recomendación id={rec_id}. "
+            f"Slider {slider_str}, {pnl_str} proyectado, DD {dd_str}. "
+            f"Triggered by {triggered_by}. Ver dashboard."
+        )
+
+        notifier.notify(
+            SystemEvent(kind="kill_switch_v2_recommendation", message=message),
+            cfg=cfg,
+        )
+    except Exception as e:
+        log.warning(
+            "Telegram notification failed for rec_id=%s: %s",
+            rec_id, e, exc_info=True,
+        )
+
+
 def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
     """Daily auto-calibrator loop.
 

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1089,3 +1089,81 @@ def test_should_run_event_cascade_at_threshold_returns_true():
 def test_should_run_event_cascade_above_threshold_returns_true():
     from strategy.kill_switch_v2_calibrator import should_run_event_cascade
     assert should_run_event_cascade(symbols_in_alert_count=5, threshold=3) is True
+
+
+# ── B4b.3: is_rate_limit_ok ─────────────────────────────────────────────────
+
+
+def test_is_rate_limit_ok_manual_bypasses():
+    """Manual trigger always passes regardless of cooldown / max_per_day."""
+    from strategy.kill_switch_v2_calibrator import is_rate_limit_ok
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    last_run = (now).isoformat()  # just ran
+    assert is_rate_limit_ok(
+        last_run_ts=last_run, now=now,
+        max_per_day_count=1, today_count=5,
+        min_cooldown_hours=6.0, trigger_kind="manual",
+    ) is True
+
+
+def test_is_rate_limit_ok_safety_net_bypasses():
+    """safety_net guarantees a tick — bypasses cooldown."""
+    from strategy.kill_switch_v2_calibrator import is_rate_limit_ok
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    assert is_rate_limit_ok(
+        last_run_ts=now.isoformat(), now=now,
+        max_per_day_count=1, today_count=5,
+        min_cooldown_hours=6.0, trigger_kind="safety_net",
+    ) is True
+
+
+def test_is_rate_limit_ok_no_prior_run_returns_true():
+    """First-ever run for non-bypass trigger → True."""
+    from strategy.kill_switch_v2_calibrator import is_rate_limit_ok
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    assert is_rate_limit_ok(
+        last_run_ts=None, now=now,
+        max_per_day_count=1, today_count=0,
+        min_cooldown_hours=6.0, trigger_kind="auto",
+    ) is True
+
+
+def test_is_rate_limit_ok_within_cooldown_returns_false():
+    from strategy.kill_switch_v2_calibrator import is_rate_limit_ok
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    # 2h ago < 6h cooldown
+    last_run = (now - timedelta(hours=2)).isoformat()
+    assert is_rate_limit_ok(
+        last_run_ts=last_run, now=now,
+        max_per_day_count=1, today_count=0,
+        min_cooldown_hours=6.0, trigger_kind="auto",
+    ) is False
+
+
+def test_is_rate_limit_ok_after_cooldown_returns_true():
+    from strategy.kill_switch_v2_calibrator import is_rate_limit_ok
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    last_run = (now - timedelta(hours=7)).isoformat()
+    assert is_rate_limit_ok(
+        last_run_ts=last_run, now=now,
+        max_per_day_count=1, today_count=0,
+        min_cooldown_hours=6.0, trigger_kind="auto",
+    ) is True
+
+
+def test_is_rate_limit_ok_max_per_day_reached_returns_false():
+    """Even after cooldown elapsed, today_count >= max_per_day blocks."""
+    from strategy.kill_switch_v2_calibrator import is_rate_limit_ok
+    from datetime import datetime, timezone, timedelta
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    last_run = (now - timedelta(hours=10)).isoformat()
+    assert is_rate_limit_ok(
+        last_run_ts=last_run, now=now,
+        max_per_day_count=1, today_count=1,
+        min_cooldown_hours=6.0, trigger_kind="auto",
+    ) is False

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1026,3 +1026,47 @@ def test_should_run_regime_change_bull_to_bear_crosses_both_returns_true():
     """75 → 25 → crossed both 60 and 40 → True."""
     from strategy.kill_switch_v2_calibrator import should_run_regime_change
     assert should_run_regime_change(75.0, 25.0) is True
+
+
+# ── B4b.3: should_run_portfolio_dd_degradation ──────────────────────────────
+
+
+def test_should_run_portfolio_dd_degradation_no_baseline_returns_false():
+    from strategy.kill_switch_v2_calibrator import should_run_portfolio_dd_degradation
+    assert should_run_portfolio_dd_degradation(
+        current_dd=-0.10, last_applied_projected_dd=None, multiplier=1.5,
+    ) is False
+
+
+def test_should_run_portfolio_dd_degradation_above_threshold_returns_false():
+    """current_dd=-0.04, baseline=-0.05, threshold=1.5*-0.05=-0.075. -0.04 > -0.075 → False."""
+    from strategy.kill_switch_v2_calibrator import should_run_portfolio_dd_degradation
+    assert should_run_portfolio_dd_degradation(
+        current_dd=-0.04, last_applied_projected_dd=-0.05, multiplier=1.5,
+    ) is False
+
+
+def test_should_run_portfolio_dd_degradation_at_threshold_returns_false():
+    """Strict `<`: equal threshold doesn't fire."""
+    from strategy.kill_switch_v2_calibrator import should_run_portfolio_dd_degradation
+    # current=-0.075, baseline=-0.05, threshold=-0.075 exact
+    assert should_run_portfolio_dd_degradation(
+        current_dd=-0.075, last_applied_projected_dd=-0.05, multiplier=1.5,
+    ) is False
+
+
+def test_should_run_portfolio_dd_degradation_below_threshold_returns_true():
+    """current_dd=-0.10, baseline=-0.05, threshold=-0.075. -0.10 < -0.075 → True."""
+    from strategy.kill_switch_v2_calibrator import should_run_portfolio_dd_degradation
+    assert should_run_portfolio_dd_degradation(
+        current_dd=-0.10, last_applied_projected_dd=-0.05, multiplier=1.5,
+    ) is True
+
+
+def test_should_run_portfolio_dd_degradation_zero_baseline_returns_false():
+    """If baseline DD=0 (no historical drawdown), threshold is 0. Any negative current
+    crosses, but this is an edge case — treat as False (no meaningful baseline)."""
+    from strategy.kill_switch_v2_calibrator import should_run_portfolio_dd_degradation
+    assert should_run_portfolio_dd_degradation(
+        current_dd=-0.05, last_applied_projected_dd=0.0, multiplier=1.5,
+    ) is False

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1540,3 +1540,332 @@ def test_send_telegram_recommendation_swallows_notifier_errors(monkeypatch, capl
         "Telegram notification failed" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+# ── B4b.3: daemon iteration with full triggers ──────────────────────────────
+
+
+def test_calibrator_loop_uses_hourly_sleep(tmp_path, monkeypatch):
+    """Loop now sleeps until next_hour (was next_midnight in B4b.1)."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import kill_switch_calibrator_loop
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    captured_sleeps = []
+    stop_event = threading.Event()
+
+    def fake_wait(seconds):
+        captured_sleeps.append(seconds)
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {"kill_switch": {"v2": {
+        "auto_calibrator": {"safety_net_days": 30},
+    }}}
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    # Sleep should be < 1 hour (3600s); we slept toward "next hour"
+    assert len(captured_sleeps) == 1
+    assert captured_sleeps[0] <= 3600.0
+    assert captured_sleeps[0] >= 60.0  # min floor
+
+
+def test_calibrator_loop_rate_limit_blocks_repeated_auto_trigger(tmp_path, monkeypatch):
+    """Two iterations within cooldown: first persists, second is blocked."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import (
+        kill_switch_calibrator_loop, _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Pre-seed a recent (manual, 1h ago) recalibration so cooldown blocks auto triggers
+    one_hour_ago = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    _persist_recommendation(
+        triggered_by=["manual"],
+        result=run_optimization_stub({}),
+        now=one_hour_ago,
+    )
+
+    # Force an event_cascade by seeding ALERTs
+    now = datetime.now(tz=timezone.utc)
+    inside = (now - timedelta(hours=2)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        for sym in ("BTCUSDT", "ETHUSDT", "ADAUSDT"):
+            conn.execute(
+                "INSERT INTO kill_switch_decisions "
+                "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+                "VALUES (?, ?, 'v2_shadow', 'ALERT', 'NORMAL', 0.5, 0)",
+                (inside, sym),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {"kill_switch": {"v2": {
+        "auto_calibrator": {
+            "safety_net_days": 30,
+            "max_per_day": 1,
+            "min_cooldown_hours": 6,
+            "event_cascade_window_hours": 72,
+            "event_cascade_min_symbols": 3,
+            "portfolio_dd_degradation_multiplier": 1.5,
+        },
+    }}}
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    # Should have only the seed row — second persist blocked by cooldown
+    conn = btc_api.get_db()
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM kill_switch_recommendations"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1
+
+
+def test_calibrator_loop_event_cascade_fires_when_3_alerts_in_window(
+    tmp_path, monkeypatch,
+):
+    """3 distinct symbols in ALERT in last 72h → event_cascade fires + persists."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import kill_switch_calibrator_loop
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Seed 3 ALERT decisions for distinct symbols (within 72h)
+    now = datetime.now(tz=timezone.utc)
+    inside = (now - timedelta(hours=10)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        for sym in ("BTCUSDT", "ETHUSDT", "ADAUSDT"):
+            conn.execute(
+                "INSERT INTO kill_switch_decisions "
+                "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+                "VALUES (?, ?, 'v2_shadow', 'ALERT', 'NORMAL', 0.5, 0)",
+                (inside, sym),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {"kill_switch": {"v2": {
+        "auto_calibrator": {
+            "safety_net_days": 30,
+            "max_per_day": 1,
+            "min_cooldown_hours": 6,
+            "event_cascade_window_hours": 72,
+            "event_cascade_min_symbols": 3,
+            "portfolio_dd_degradation_multiplier": 1.5,
+            "backtest_window_days": 365,
+            "dd_target": -0.10,
+        },
+    }}}
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    # Should have persisted with event_cascade in triggered_by
+    import json
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            "SELECT triggered_by, status FROM kill_switch_recommendations"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    triggered = json.loads(rows[0][0])
+    # event_cascade triggered alongside any other firing trigger (e.g., safety_net)
+    assert "event_cascade" in triggered
+
+
+def test_calibrator_loop_pending_marks_prior_pending_as_superseded(
+    tmp_path, monkeypatch,
+):
+    """When a new pending recommendation persists, prior pending become superseded."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import (
+        kill_switch_calibrator_loop, _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Pre-seed a pending row from "yesterday"
+    yesterday = datetime.now(tz=timezone.utc) - timedelta(days=2)
+    pending_result = {
+        "status": "pending",
+        "slider_value": 60,
+        "projected_pnl": 100.0,
+        "projected_dd": -0.05,
+        "report": {"stub": False, "ts": yesterday.isoformat()},
+    }
+    _persist_recommendation(
+        triggered_by=["safety_net"], result=pending_result, now=yesterday,
+    )
+
+    # Add a profitable trade so v2 grid produces a new pending
+    inside = (datetime.now(tz=timezone.utc) - timedelta(days=10)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            (inside, inside),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    # safety_net 30d + last persist 2d ago → safety_net WON'T fire
+    # But we also seeded the cascade so let's keep cascade firing the new pending
+    inside_alert = (datetime.now(tz=timezone.utc) - timedelta(hours=10)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        for sym in ("BTCUSDT", "ETHUSDT", "ADAUSDT"):
+            conn.execute(
+                "INSERT INTO kill_switch_decisions "
+                "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+                "VALUES (?, ?, 'v2_shadow', 'ALERT', 'NORMAL', 0.5, 0)",
+                (inside_alert, sym),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg_fn = lambda: {"kill_switch": {"v2": {
+        "auto_calibrator": {
+            "safety_net_days": 30,
+            "max_per_day": 5,        # generous so cooldown doesn't block
+            "min_cooldown_hours": 1,
+            "event_cascade_window_hours": 72,
+            "event_cascade_min_symbols": 3,
+            "portfolio_dd_degradation_multiplier": 1.5,
+            "backtest_window_days": 365,
+            "dd_target": -0.10,
+        },
+    }}}
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            "SELECT id, status FROM kill_switch_recommendations ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+    statuses = {r[0]: r[1] for r in rows}
+    # Original pending (id=1) → superseded
+    assert statuses[1] == "superseded"
+    # New pending (id=2) → pending
+    assert statuses.get(2) == "pending"
+
+
+def test_calibrator_loop_pending_sends_telegram_notification(
+    tmp_path, monkeypatch,
+):
+    """When new pending persisted, _send_telegram_recommendation is called."""
+    import btc_api, threading
+    from strategy.kill_switch_v2_calibrator import kill_switch_calibrator_loop
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Seed cascade trigger
+    now = datetime.now(tz=timezone.utc)
+    inside = (now - timedelta(hours=5)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        for sym in ("BTCUSDT", "ETHUSDT", "ADAUSDT"):
+            conn.execute(
+                "INSERT INTO kill_switch_decisions "
+                "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+                "VALUES (?, ?, 'v2_shadow', 'ALERT', 'NORMAL', 0.5, 0)",
+                (inside, sym),
+            )
+        # Seed a profitable trade so v2 returns pending
+        conn.execute(
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
+            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            (inside, inside),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    captured = []
+    import strategy.kill_switch_v2_calibrator as cal_mod
+
+    def fake_send(rec_id, result, triggered_by, cfg):
+        captured.append({"rec_id": rec_id, "status": result["status"]})
+
+    monkeypatch.setattr(cal_mod, "_send_telegram_recommendation", fake_send)
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {"kill_switch": {"v2": {
+        "auto_calibrator": {
+            "safety_net_days": 30,
+            "max_per_day": 1,
+            "min_cooldown_hours": 6,
+            "event_cascade_window_hours": 72,
+            "event_cascade_min_symbols": 3,
+            "portfolio_dd_degradation_multiplier": 1.5,
+            "backtest_window_days": 365,
+            "dd_target": -0.10,
+        },
+    }}}
+    kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    assert len(captured) == 1
+    assert captured[0]["status"] == "pending"

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1070,3 +1070,22 @@ def test_should_run_portfolio_dd_degradation_zero_baseline_returns_false():
     assert should_run_portfolio_dd_degradation(
         current_dd=-0.05, last_applied_projected_dd=0.0, multiplier=1.5,
     ) is False
+
+
+# ── B4b.3: should_run_event_cascade ─────────────────────────────────────────
+
+
+def test_should_run_event_cascade_below_threshold_returns_false():
+    from strategy.kill_switch_v2_calibrator import should_run_event_cascade
+    assert should_run_event_cascade(symbols_in_alert_count=2, threshold=3) is False
+
+
+def test_should_run_event_cascade_at_threshold_returns_true():
+    """Boundary: count == threshold → True (>= semantics)."""
+    from strategy.kill_switch_v2_calibrator import should_run_event_cascade
+    assert should_run_event_cascade(symbols_in_alert_count=3, threshold=3) is True
+
+
+def test_should_run_event_cascade_above_threshold_returns_true():
+    from strategy.kill_switch_v2_calibrator import should_run_event_cascade
+    assert should_run_event_cascade(symbols_in_alert_count=5, threshold=3) is True

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -2047,3 +2047,242 @@ def test_post_apply_recommendation_auth_required(tmp_path, monkeypatch):
     client = TestClient(btc_api.app)
     resp = client.post("/kill_switch/recommendations/1/apply")
     assert resp.status_code == 401
+
+
+# ── B4b.3: review follow-ups — hardening tests ──────────────────────────────
+
+
+def test_apply_endpoint_preserves_other_v2_keys_in_config(tmp_path, monkeypatch):
+    """Apply should NOT clobber auto_calibrator/thresholds/regime_adjustments etc.
+
+    save_config has shallow merge at kill_switch level — naive
+    {"kill_switch":{"v2":{"aggressiveness":N}}} would replace entire v2.
+    Apply endpoint reads existing v2, merges only aggressiveness, writes back.
+    """
+    import btc_api, json
+    from fastapi.testclient import TestClient
+    from strategy.kill_switch_v2_calibrator import _persist_recommendation
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Create a real config.json with full v2 block
+    cfg_path = str(tmp_path / "config.json")
+    full_cfg = {
+        "kill_switch": {
+            "v2": {
+                "aggressiveness": 50,
+                "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
+                "auto_calibrator": {
+                    "safety_net_days": 30,
+                    "max_per_day": 1,
+                },
+                "thresholds": {"baseline_sigma_multiplier": {"min": 3.0, "max": 1.0}},
+            },
+        },
+    }
+    with open(cfg_path, "w") as f:
+        json.dump(full_cfg, f)
+    monkeypatch.setattr(btc_api, "CONFIG_FILE", cfg_path)
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    # Seed pending rec with slider=65
+    rec_id = _persist_recommendation(
+        triggered_by=["manual"],
+        result={
+            "status": "pending", "slider_value": 65,
+            "projected_pnl": 100.0, "projected_dd": -0.05,
+            "report": {"stub": False},
+        },
+        now=datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc),
+    )
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post(f"/kill_switch/recommendations/{rec_id}/apply")
+        assert resp.status_code == 200
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+    # Read config.json back — verify other v2 keys survived
+    with open(cfg_path) as f:
+        result_cfg = json.load(f)
+    v2 = result_cfg["kill_switch"]["v2"]
+    assert v2["aggressiveness"] == 65  # changed
+    # All other keys preserved (regression: bug clobbered them)
+    assert "regime_adjustments" in v2
+    assert v2["regime_adjustments"]["bull_bonus"] == 10
+    assert "auto_calibrator" in v2
+    assert v2["auto_calibrator"]["safety_net_days"] == 30
+    assert "thresholds" in v2
+
+
+def test_apply_endpoint_rejects_out_of_range_slider(tmp_path, monkeypatch):
+    """Slider must be in [0, 100]; corrupt rows with garbage values get 400."""
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    # Insert a row with slider=150 directly
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, slider_value, status, report_json) "
+            "VALUES ('2026-04-25T12:00:00+00:00', '[\"manual\"]', 150, 'pending', '{}')",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post("/kill_switch/recommendations/1/apply")
+        assert resp.status_code == 400
+        assert "out-of-range" in resp.json().get("detail", "").lower()
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_apply_endpoint_rejects_no_feasible_with_null_slider(tmp_path, monkeypatch):
+    """no_feasible recs are persisted with slider_value=NULL; cannot be applied."""
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    # Insert pending row with NULL slider (corrupt — would normally be no_feasible)
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, slider_value, status, report_json) "
+            "VALUES ('2026-04-25T12:00:00+00:00', '[\"manual\"]', NULL, 'pending', '{}')",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post("/kill_switch/recommendations/1/apply")
+        assert resp.status_code == 400
+        assert "no slider_value" in resp.json().get("detail", "").lower()
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_is_rate_limit_ok_logs_warning_on_malformed_ts(caplog):
+    """Malformed last_run_ts logs a warning before allowing the run."""
+    from strategy.kill_switch_v2_calibrator import is_rate_limit_ok
+    from datetime import datetime, timezone
+    import logging
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_calibrator"):
+        result = is_rate_limit_ok(
+            last_run_ts="not-a-timestamp", now=now,
+            max_per_day_count=1, today_count=0,
+            min_cooldown_hours=6.0, trigger_kind="auto",
+        )
+    assert result is True
+    assert any(
+        "malformed last_run_ts" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_load_current_regime_score_logs_warning_on_btc_scanner_failure(
+    monkeypatch, caplog,
+):
+    """If get_cached_regime raises, log a warning instead of silently failing."""
+    from strategy.kill_switch_v2_calibrator import _load_current_regime_score
+    import logging
+
+    # Make get_cached_regime raise
+    import btc_scanner
+    def boom():
+        raise RuntimeError("simulated regime cache failure")
+    monkeypatch.setattr(btc_scanner, "get_cached_regime", boom)
+
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_calibrator"):
+        result = _load_current_regime_score()
+
+    assert result is None
+    assert any(
+        "get_cached_regime() raised" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+def test_calibrator_loop_no_telegram_for_no_feasible(tmp_path, monkeypatch):
+    """no_feasible recommendations do NOT trigger Telegram (less noisy)."""
+    import btc_api, threading
+    import strategy.kill_switch_v2_calibrator as cal
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    captured = []
+    def fake_send(rec_id, result, triggered_by, cfg):
+        captured.append({"rec_id": rec_id, "status": result["status"]})
+    monkeypatch.setattr(cal, "_send_telegram_recommendation", fake_send)
+
+    # Force run_optimization_v2 to return no_feasible
+    import strategy.kill_switch_v2_optimizer as opt_mod
+    def fake_v2(cfg, regime_score=None):
+        return {
+            "status": "no_feasible", "slider_value": None,
+            "projected_pnl": None, "projected_dd": None,
+            "report": {"stub": False, "reason": "test"},
+        }
+    monkeypatch.setattr(opt_mod, "run_optimization_v2", fake_v2)
+
+    stop_event = threading.Event()
+    def fake_wait(seconds):
+        stop_event.set()
+        return True
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg_fn = lambda: {"kill_switch": {"v2": {
+        "auto_calibrator": {
+            "safety_net_days": 30,  # safety_net fires (no prior runs)
+            "max_per_day": 1,
+            "min_cooldown_hours": 6,
+            "event_cascade_window_hours": 72,
+            "event_cascade_min_symbols": 3,
+            "portfolio_dd_degradation_multiplier": 1.5,
+        },
+    }}}
+    cal.kill_switch_calibrator_loop(cfg_fn, stop_event=stop_event)
+
+    # Persisted, but Telegram NOT called for no_feasible
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            "SELECT status FROM kill_switch_recommendations"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+    assert rows[0][0] == "no_feasible"
+    assert captured == []  # No Telegram for no_feasible

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1869,3 +1869,181 @@ def test_calibrator_loop_pending_sends_telegram_notification(
 
     assert len(captured) == 1
     assert captured[0]["status"] == "pending"
+
+
+# ── B4b.3: apply / ignore endpoints ─────────────────────────────────────────
+
+
+def test_post_apply_recommendation_marks_applied_and_writes_config(
+    tmp_path, monkeypatch,
+):
+    """POST /apply transitions pending → applied, writes config override."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from strategy.kill_switch_v2_calibrator import _persist_recommendation
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    # Capture save_config calls
+    captured_updates = []
+    def fake_save_config(updates):
+        captured_updates.append(updates)
+        return updates
+    monkeypatch.setattr(btc_api, "save_config", fake_save_config)
+
+    # Seed a pending recommendation
+    from datetime import datetime, timezone
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    pending_result = {
+        "status": "pending", "slider_value": 65,
+        "projected_pnl": 123.4, "projected_dd": -0.06,
+        "report": {"stub": False},
+    }
+    rec_id = _persist_recommendation(
+        triggered_by=["manual"], result=pending_result, now=now,
+    )
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post(f"/kill_switch/recommendations/{rec_id}/apply")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "applied"
+        assert body["applied_by"] == "operator"
+
+        # save_config called with kill_switch.v2.aggressiveness=65
+        assert len(captured_updates) == 1
+        ks_v2 = captured_updates[0].get("kill_switch", {}).get("v2", {})
+        assert ks_v2.get("aggressiveness") == 65
+
+        # DB row updated
+        conn = btc_api.get_db()
+        try:
+            row = conn.execute(
+                "SELECT status, applied_by FROM kill_switch_recommendations WHERE id=?",
+                (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "applied"
+        assert row[1] == "operator"
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_post_apply_recommendation_404_when_missing(tmp_path, monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post("/kill_switch/recommendations/999/apply")
+        assert resp.status_code == 404
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_post_apply_recommendation_400_when_already_applied(tmp_path, monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+    monkeypatch.setattr(btc_api, "save_config", lambda updates: updates)
+
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, slider_value, status, applied_ts, applied_by, report_json) "
+            "VALUES ('2026-04-25T10:00:00+00:00', '[\"manual\"]', 65, 'applied', "
+            "'2026-04-25T11:00:00+00:00', 'operator', '{}')",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post("/kill_switch/recommendations/1/apply")
+        assert resp.status_code == 400
+        assert "already" in resp.json().get("detail", "").lower()
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_post_ignore_recommendation_marks_ignored(tmp_path, monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+    from strategy.kill_switch_v2_calibrator import _persist_recommendation
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.app.dependency_overrides[btc_api.verify_api_key] = lambda: None
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    rec_id = _persist_recommendation(
+        triggered_by=["manual"],
+        result={
+            "status": "pending", "slider_value": 65,
+            "projected_pnl": 100.0, "projected_dd": -0.05,
+            "report": {"stub": False},
+        },
+        now=now,
+    )
+
+    try:
+        client = TestClient(btc_api.app)
+        resp = client.post(f"/kill_switch/recommendations/{rec_id}/ignore")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ignored"
+
+        conn = btc_api.get_db()
+        try:
+            row = conn.execute(
+                "SELECT status, applied_by FROM kill_switch_recommendations WHERE id=?",
+                (rec_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row[0] == "ignored"
+        assert row[1] == "operator"
+    finally:
+        btc_api.app.dependency_overrides.clear()
+
+
+def test_post_apply_recommendation_auth_required(tmp_path, monkeypatch):
+    """Without dependency_overrides + with api_key configured → 401."""
+    import btc_api
+    from fastapi.testclient import TestClient
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    monkeypatch.setattr(btc_api, "load_config", lambda: {"api_key": "test-secret"})
+
+    client = TestClient(btc_api.app)
+    resp = client.post("/kill_switch/recommendations/1/apply")
+    assert resp.status_code == 401

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1482,3 +1482,61 @@ def test_mark_prior_pending_as_superseded_only_pending(tmp_path, monkeypatch):
     assert statuses[1] == "superseded"
     assert statuses[2] == "applied"   # untouched
     assert statuses[3] == "pending"    # the new one stays
+
+
+# ── B4b.3: Telegram wrapper ─────────────────────────────────────────────────
+
+
+def test_send_telegram_recommendation_calls_notifier_with_system_event(monkeypatch):
+    """Wrapper invokes notifier.notify with a SystemEvent."""
+    from strategy.kill_switch_v2_calibrator import _send_telegram_recommendation
+    from notifier.events import SystemEvent
+
+    captured = {}
+
+    def fake_notify(event, cfg):
+        captured["event"] = event
+        captured["cfg"] = cfg
+        return []
+
+    import notifier as notifier_module
+    monkeypatch.setattr(notifier_module, "notify", fake_notify)
+
+    result = {
+        "slider_value": 65,
+        "projected_pnl": 123.4,
+        "projected_dd": -0.06,
+    }
+    _send_telegram_recommendation(
+        rec_id=42, result=result, triggered_by=["safety_net"],
+        cfg={"notifier": {}},
+    )
+    assert isinstance(captured["event"], SystemEvent)
+    assert captured["event"].kind == "kill_switch_v2_recommendation"
+    assert "id=42" in captured["event"].message
+    assert "65%" in captured["event"].message
+    assert "safety_net" in captured["event"].message
+
+
+def test_send_telegram_recommendation_swallows_notifier_errors(monkeypatch, caplog):
+    """If notifier.notify raises, log warning + don't propagate."""
+    from strategy.kill_switch_v2_calibrator import _send_telegram_recommendation
+    import notifier as notifier_module
+
+    def boom(event, cfg):
+        raise RuntimeError("simulated notifier failure")
+    monkeypatch.setattr(notifier_module, "notify", boom)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_calibrator"):
+        # Should NOT raise
+        _send_telegram_recommendation(
+            rec_id=42,
+            result={"slider_value": 50, "projected_pnl": 0.0, "projected_dd": 0.0},
+            triggered_by=["manual"],
+            cfg={},
+        )
+    assert any(
+        "Telegram notification failed" in rec.getMessage()
+        for rec in caplog.records
+    )

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -987,3 +987,42 @@ def test_post_recalibrate_falls_back_to_stub_when_v2_raises(tmp_path, monkeypatc
         assert report.get("stub") is True
     finally:
         btc_api.app.dependency_overrides.clear()
+
+
+# ── B4b.3: should_run_regime_change ─────────────────────────────────────────
+
+
+def test_should_run_regime_change_first_call_returns_false():
+    """No baseline yet (last_calib_score=None) → False (no crossing to compare)."""
+    from strategy.kill_switch_v2_calibrator import should_run_regime_change
+    assert should_run_regime_change(None, 75.0) is False
+
+
+def test_should_run_regime_change_current_none_returns_false():
+    """No current data (e.g., regime cache empty) → False."""
+    from strategy.kill_switch_v2_calibrator import should_run_regime_change
+    assert should_run_regime_change(50.0, None) is False
+
+
+def test_should_run_regime_change_same_band_returns_false():
+    """Both in NEUTRAL band [40, 60) → no crossing."""
+    from strategy.kill_switch_v2_calibrator import should_run_regime_change
+    assert should_run_regime_change(45.0, 55.0) is False
+
+
+def test_should_run_regime_change_neutral_to_bull_crosses_60_returns_true():
+    """45 (NEUTRAL) → 70 (BULL) → crossed 60 → True."""
+    from strategy.kill_switch_v2_calibrator import should_run_regime_change
+    assert should_run_regime_change(45.0, 70.0) is True
+
+
+def test_should_run_regime_change_neutral_to_bear_crosses_40_returns_true():
+    """50 (NEUTRAL) → 30 (BEAR) → crossed 40 → True."""
+    from strategy.kill_switch_v2_calibrator import should_run_regime_change
+    assert should_run_regime_change(50.0, 30.0) is True
+
+
+def test_should_run_regime_change_bull_to_bear_crosses_both_returns_true():
+    """75 → 25 → crossed both 60 and 40 → True."""
+    from strategy.kill_switch_v2_calibrator import should_run_regime_change
+    assert should_run_regime_change(75.0, 25.0) is True

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1341,3 +1341,144 @@ def test_load_last_calibration_regime_score_handles_missing_field(tmp_path, monk
         conn.close()
 
     assert _load_last_calibration_regime_score() is None
+
+
+# ── B4b.3: DB glue (continued) ──────────────────────────────────────────────
+
+
+def test_count_symbols_with_recent_alerts_empty_returns_zero(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _count_symbols_with_recent_alerts
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    assert _count_symbols_with_recent_alerts(window_hours=72.0) == 0
+
+
+def test_count_symbols_with_recent_alerts_counts_distinct_symbols(tmp_path, monkeypatch):
+    """Distinct ALERT/REDUCED/FROZEN symbols within window — multiple rows per symbol = 1."""
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _count_symbols_with_recent_alerts
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime.now(tz=timezone.utc)
+    inside = (now - timedelta(hours=10)).isoformat()
+    outside = (now - timedelta(hours=100)).isoformat()
+
+    conn = btc_api.get_db()
+    try:
+        # BTC ALERT (inside)
+        conn.execute(
+            "INSERT INTO kill_switch_decisions "
+            "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+            "VALUES (?, 'BTCUSDT', 'v2_shadow', 'ALERT', 'NORMAL', 0.5, 0)",
+            (inside,),
+        )
+        # BTC ALERT again (inside) — should still count as 1 distinct symbol
+        conn.execute(
+            "INSERT INTO kill_switch_decisions "
+            "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+            "VALUES (?, 'BTCUSDT', 'v2_shadow', 'ALERT', 'NORMAL', 0.5, 0)",
+            ((now - timedelta(hours=5)).isoformat(),),
+        )
+        # ETH portfolio REDUCED (inside) — counts
+        conn.execute(
+            "INSERT INTO kill_switch_decisions "
+            "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+            "VALUES (?, 'ETHUSDT', 'v2_shadow', 'NORMAL', 'REDUCED', 0.5, 0)",
+            (inside,),
+        )
+        # ADA NORMAL/NORMAL (inside) — does NOT count
+        conn.execute(
+            "INSERT INTO kill_switch_decisions "
+            "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+            "VALUES (?, 'ADAUSDT', 'v2_shadow', 'NORMAL', 'NORMAL', 1.0, 0)",
+            (inside,),
+        )
+        # SOL ALERT (outside window) — does NOT count
+        conn.execute(
+            "INSERT INTO kill_switch_decisions "
+            "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+            "VALUES (?, 'SOLUSDT', 'v2_shadow', 'ALERT', 'NORMAL', 0.5, 0)",
+            (outside,),
+        )
+        # XRP FROZEN (inside) — counts
+        conn.execute(
+            "INSERT INTO kill_switch_decisions "
+            "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+            "VALUES (?, 'XRPUSDT', 'v2_shadow', 'NORMAL', 'FROZEN', 0.0, 1)",
+            (inside,),
+        )
+        # v1 engine ALERT (inside) — does NOT count (only v2_shadow)
+        conn.execute(
+            "INSERT INTO kill_switch_decisions "
+            "(ts, symbol, engine, per_symbol_tier, portfolio_tier, size_factor, skip) "
+            "VALUES (?, 'DOGEUSDT', 'v1', 'ALERT', 'NORMAL', 0.5, 0)",
+            (inside,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Distinct: BTC, ETH, XRP = 3
+    assert _count_symbols_with_recent_alerts(window_hours=72.0) == 3
+
+
+def test_mark_prior_pending_as_superseded_only_pending(tmp_path, monkeypatch):
+    """Only prior 'pending' rows get marked superseded; applied/ignored stay."""
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _mark_prior_pending_as_superseded
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    conn = btc_api.get_db()
+    try:
+        # 3 rows: pending(id=1), applied(id=2), pending(id=3 — the "new" one)
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, status, report_json) "
+            "VALUES ('2026-04-20T10:00:00+00:00', '[]', 'pending', '{}')",
+        )
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, status, applied_ts, applied_by, report_json) "
+            "VALUES ('2026-04-21T10:00:00+00:00', '[]', 'applied', "
+            "'2026-04-21T11:00:00+00:00', 'operator', '{}')",
+        )
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, status, report_json) "
+            "VALUES ('2026-04-25T10:00:00+00:00', '[]', 'pending', '{}')",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Mark prior pending as superseded; new id is 3
+    _mark_prior_pending_as_superseded(new_id=3)
+
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            "SELECT id, status FROM kill_switch_recommendations ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+    statuses = {r[0]: r[1] for r in rows}
+    assert statuses[1] == "superseded"
+    assert statuses[2] == "applied"   # untouched
+    assert statuses[3] == "pending"    # the new one stays

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1167,3 +1167,177 @@ def test_is_rate_limit_ok_max_per_day_reached_returns_false():
         max_per_day_count=1, today_count=1,
         min_cooldown_hours=6.0, trigger_kind="auto",
     ) is False
+
+
+# ── B4b.3: DB glue ──────────────────────────────────────────────────────────
+
+
+def test_count_recalibrations_today_empty_returns_zero(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _count_recalibrations_today
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    assert _count_recalibrations_today(now) == 0
+
+
+def test_count_recalibrations_today_counts_only_today_utc(tmp_path, monkeypatch):
+    """Rows with ts on different UTC days are NOT counted."""
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import (
+        _count_recalibrations_today, _persist_recommendation, run_optimization_stub,
+    )
+    from datetime import datetime, timezone, timedelta
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    today = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    yesterday = today - timedelta(days=1)
+    same_day_earlier = datetime(2026, 4, 25, 1, 0, tzinfo=timezone.utc)
+
+    result = run_optimization_stub({})
+    _persist_recommendation(triggered_by=["manual"], result=result, now=yesterday)
+    _persist_recommendation(triggered_by=["manual"], result=result, now=same_day_earlier)
+    _persist_recommendation(triggered_by=["manual"], result=result, now=today)
+
+    # 2 rows on 2026-04-25 UTC, 1 on 2026-04-24
+    assert _count_recalibrations_today(today) == 2
+
+
+def test_load_last_applied_recommendation_empty_returns_none(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _load_last_applied_recommendation
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    assert _load_last_applied_recommendation() is None
+
+
+def test_load_last_applied_recommendation_returns_latest_applied(tmp_path, monkeypatch):
+    """Returns the most recent row with status='applied'; ignores pending/ignored."""
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import (
+        _load_last_applied_recommendation,
+    )
+    from datetime import datetime, timezone
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc)
+    conn = btc_api.get_db()
+    try:
+        # pending row
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, slider_value, projected_pnl, projected_dd, status, report_json) "
+            "VALUES (?, '[\"manual\"]', 50, 100.0, -0.05, 'pending', '{}')",
+            ("2026-04-20T10:00:00+00:00",),
+        )
+        # applied row earlier
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, slider_value, projected_pnl, projected_dd, status, report_json) "
+            "VALUES (?, '[\"manual\"]', 60, 200.0, -0.04, 'applied', '{}')",
+            ("2026-04-22T10:00:00+00:00",),
+        )
+        # applied row later — this is what we want returned
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, slider_value, projected_pnl, projected_dd, status, report_json) "
+            "VALUES (?, '[\"manual\"]', 70, 300.0, -0.03, 'applied', '{}')",
+            ("2026-04-24T10:00:00+00:00",),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    row = _load_last_applied_recommendation()
+    assert row is not None
+    assert row["slider_value"] == 70
+    assert row["projected_dd"] == pytest.approx(-0.03)
+
+
+def test_load_last_calibration_regime_score_empty_returns_none(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _load_last_calibration_regime_score
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    assert _load_last_calibration_regime_score() is None
+
+
+def test_load_last_calibration_regime_score_extracts_from_report_json(tmp_path, monkeypatch):
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _load_last_calibration_regime_score
+    import json
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, slider_value, status, report_json) "
+            "VALUES (?, '[\"safety_net\"]', NULL, 'no_feasible', ?)",
+            (
+                "2026-04-25T10:00:00+00:00",
+                json.dumps({"regime_score": 72.5, "stub": False}),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert _load_last_calibration_regime_score() == pytest.approx(72.5)
+
+
+def test_load_last_calibration_regime_score_handles_missing_field(tmp_path, monkeypatch):
+    """If report_json lacks regime_score (or is malformed), return None."""
+    import btc_api
+    from strategy.kill_switch_v2_calibrator import _load_last_calibration_regime_score
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            "INSERT INTO kill_switch_recommendations "
+            "(ts, triggered_by, slider_value, status, report_json) "
+            "VALUES (?, '[\"safety_net\"]', NULL, 'no_feasible', '{}')",
+            ("2026-04-25T10:00:00+00:00",),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert _load_last_calibration_regime_score() is None


### PR DESCRIPTION
## Summary

Kill Switch v2 **B4b.3 — auto-triggers + Telegram + apply/ignore endpoints** (#217). Closes the auto-calibrator path.

## What ships

- 4 new pure trigger fns (`should_run_regime_change`, `should_run_portfolio_dd_degradation`, `should_run_event_cascade`) + `is_rate_limit_ok` with manual+safety_net bypass.
- 5 DB helpers (`_count_recalibrations_today`, `_load_last_applied_recommendation`, `_load_last_calibration_regime_score`, `_count_symbols_with_recent_alerts`, `_mark_prior_pending_as_superseded`).
- Telegram wrapper `_send_telegram_recommendation` via `notifier.notify(SystemEvent(kind="kill_switch_v2_recommendation"))`.
- Daemon body rewrite: hourly loop (was daily), evaluates 4 triggers, rate-limits, supersede, Telegram.
- `POST /kill_switch/recommendations/{id}/apply` + `/ignore` endpoints — operator transitions lifecycle, apply writes config override.
- 5 new config keys: `max_per_day`, `min_cooldown_hours`, `event_cascade_window_hours`, `event_cascade_min_symbols`, `portfolio_dd_degradation_multiplier`.
- 42 new tests (914 total backend, was 872; +42).

## Trigger semantics

| Trigger | Condition | Bypass cooldown? |
|---|---|---|
| `safety_net` | 30 days since last recalibration | Yes |
| `regime_change` | regime band changed (60/40 boundary cross) since last calibration | No |
| `portfolio_dd_degradation` | live DD < 1.5× last applied projected DD | No |
| `event_cascade` | ≥3 distinct symbols in ALERT/REDUCED/FROZEN in last 72h | No |
| `manual` (POST endpoint) | operator action | Yes |

## Lifecycle

- `pending` → Telegram fires + supersede prior pending
- `applied` → operator approved; config updated via `save_config`
- `ignored` → operator declined; no config change
- `superseded` → newer pending arrived
- `no_feasible` → no Telegram, no supersede

## Frontend deferred

Frontend badge + recommendations panel land with B6 (#200) per brainstorm decision.

## Test plan

- [x] Pure: 4 trigger fns + rate limit (20 tests)
- [x] DB glue: 5 helpers (10 tests)
- [x] Telegram wrapper (2 tests)
- [x] Daemon iteration: hourly + rate limit + cascade + supersede + Telegram (5 tests)
- [x] Endpoints: apply + ignore + 404 + 400 + auth (5 tests)
- [x] Backend: 914 passed (was 872, +42)
- [x] Frontend: 21 passed unchanged

## Closes

#217. Spec: \`docs/superpowers/specs/es/2026-04-25-kill-switch-v2-b4b3-auto-triggers-telegram-design.md\`. Plan: \`docs/superpowers/plans/2026-04-25-kill-switch-v2-b4b3-auto-triggers-telegram.md\`.

This is the FINAL B4b PR. After merge, the auto-calibrator runs autonomously: hourly checks, rate-limited optimizations, Telegram alerts, operator apply/ignore via API. Frontend visualization lands with B6 (#200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)