### PR TITLE
feat(kill-switch-v2): B5 PROBATION tier (#187 #199)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -1073,6 +1073,23 @@ def init_db():
     except Exception as e:
         log.warning(f"DB migration check: {e}")
 
+    # B5 PROBATION migration: add 3 columns to symbol_health if missing (#199)
+    try:
+        con_mig2 = get_db()
+        cols2 = [r[1] for r in con_mig2.execute("PRAGMA table_info(symbol_health)").fetchall()]
+        for col, ddl in (
+            ("probation_trades_remaining", "INTEGER"),
+            ("probation_started_at", "TEXT"),
+            ("paused_days_at_entry", "INTEGER"),
+        ):
+            if col not in cols2:
+                con_mig2.execute(f"ALTER TABLE symbol_health ADD COLUMN {col} {ddl}")
+                con_mig2.commit()
+                log.info(f"DB migration: added {col} column to symbol_health")
+        con_mig2.close()
+    except Exception as e:
+        log.warning(f"DB migration B5 PROBATION: {e}")
+
 
 def save_scan(rep: dict) -> int:
     symbol  = rep.get("symbol", "BTCUSDT")

--- a/btc_api.py
+++ b/btc_api.py
@@ -2529,9 +2529,10 @@ def get_kill_switch_current_state(engine: str = "v1"):
 
 @app.post("/health/reactivate/{symbol}", dependencies=[Depends(verify_api_key)])
 def post_health_reactivate(symbol: str, body: ReactivateRequest):
-    """Manually reset a symbol to NORMAL with manual_override=1."""
+    """Manually reactivate a PAUSED symbol — transitions PAUSED → PROBATION (B5 #199)."""
     from health import reactivate_symbol, get_symbol_state
-    reactivate_symbol(symbol.upper(), reason=body.reason)
+    cfg = load_config()
+    reactivate_symbol(symbol.upper(), reason=body.reason, cfg=cfg)
     return {"ok": True, "symbol": symbol.upper(), "state": get_symbol_state(symbol.upper())}
 
 

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -18,6 +18,15 @@
     "pause_months_consecutive": 2,
     "auto_recovery_enabled": true,
     "v2": {
+      "auto_recovery_mode": "smart_auto",
+      "probation": {
+        "trades_base": 10,
+        "trades_per_pause_day": 0.2,
+        "regression_wr_threshold": 0.10,
+        "regression_window_trades": 10,
+        "paused_to_probation_days": 14,
+        "size_factor": 0.5
+      },
       "auto_calibrator": {
         "safety_net_days": 30,
         "backtest_window_days": 365,

--- a/health.py
+++ b/health.py
@@ -345,6 +345,18 @@ def apply_transition(
         extra_sets = ""
         if manual_override is not None:
             extra_sets = ", manual_override = excluded.manual_override"
+
+        # B5: clear probation columns when transitioning OUT of PROBATION.
+        # When new_state == PROBATION, reactivate_symbol writes the columns
+        # explicitly via a separate path (see Task 5).
+        probation_reset = ""
+        if new_state != "PROBATION":
+            probation_reset = (
+                ", probation_trades_remaining = NULL"
+                ", probation_started_at = NULL"
+                ", paused_days_at_entry = NULL"
+            )
+
         # state_since must only advance when the state actually changes. A stale
         # from_state passed by a caller (or a concurrent write) that happens to match
         # the stored state would otherwise silently reset "time in state".
@@ -360,7 +372,8 @@ def apply_transition(
                   END,
                   last_evaluated_at = excluded.last_evaluated_at,
                   last_metrics_json = excluded.last_metrics_json
-                  {extra_sets}""",
+                  {extra_sets}
+                  {probation_reset}""",
             (symbol, new_state, now, now, metrics_json,
              int(manual_override) if manual_override is not None else 0),
         )

--- a/health.py
+++ b/health.py
@@ -70,12 +70,13 @@ def compute_rolling_metrics_from_trades(
     Returns a dict with:
       - trades_count_total (int)
       - win_rate_20_trades (float | None) — None when no trades with exit_ts exist
+      - win_rate_10_trades (float | None) — None when no trades with exit_ts exist
       - pnl_30d (float)
       - pnl_by_month (dict "YYYY-MM" -> float)
       - months_negative_consecutive (int)
 
     Note: the DB-backed wrapper `compute_rolling_metrics` coerces None → 0.0
-    on win_rate_20_trades to preserve its historical contract.
+    on win_rate_20_trades and win_rate_10_trades to preserve its historical contract.
     """
     if now is None:
         now = datetime.now(tz=timezone.utc)
@@ -103,6 +104,17 @@ def compute_rolling_metrics_from_trades(
         win_rate_20_trades: float | None = wins / len(last_20)
     else:
         win_rate_20_trades = None
+
+    # Last 10 trades win rate (B5: PROBATION regression check uses this)
+    last_10 = trades_with_exit[-10:]
+    if len(last_10) > 0:
+        wins_10 = sum(
+            1 for t in last_10
+            if t.get("pnl_usd") is not None and t["pnl_usd"] > 0
+        )
+        win_rate_10_trades: float | None = wins_10 / len(last_10)
+    else:
+        win_rate_10_trades = None
 
     # Last 30 days PnL
     cutoff_30d = now - timedelta(days=30)
@@ -136,6 +148,7 @@ def compute_rolling_metrics_from_trades(
     return {
         "trades_count_total": trades_count_total,
         "win_rate_20_trades": win_rate_20_trades,
+        "win_rate_10_trades": win_rate_10_trades,
         "pnl_30d": pnl_30d,
         "pnl_by_month": pnl_by_month,
         "months_negative_consecutive": months_negative_consecutive,
@@ -182,6 +195,10 @@ def compute_rolling_metrics(symbol: str, conn, now: datetime | None = None) -> d
         metrics["win_rate_20_trades"] = 0.0
     else:
         metrics["win_rate_20_trades"] = float(metrics["win_rate_20_trades"])
+    if metrics["win_rate_10_trades"] is None:
+        metrics["win_rate_10_trades"] = 0.0
+    else:
+        metrics["win_rate_10_trades"] = float(metrics["win_rate_10_trades"])
     return metrics
 
 

--- a/health.py
+++ b/health.py
@@ -309,6 +309,27 @@ def evaluate_state(
 #  PERSISTENCE
 # ─────────────────────────────────────────────────────────────────────────────
 
+def _decrement_probation_counter(symbol: str) -> None:
+    """Atomically decrement probation_trades_remaining if the symbol is in PROBATION.
+
+    Floored at 0. No-op if the symbol is not in PROBATION (uses a state-guarded
+    UPDATE so we don't accidentally write to non-PROBATION rows).
+    """
+    conn = _conn()
+    try:
+        conn.execute(
+            """UPDATE symbol_health
+               SET probation_trades_remaining = MAX(
+                     COALESCE(probation_trades_remaining, 0) - 1, 0
+               )
+               WHERE symbol = ? AND state = 'PROBATION'""",
+            (symbol,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -553,16 +574,22 @@ def evaluate_and_record(symbol: str, cfg: dict[str, Any], now: datetime | None =
     finally:
         conn.close()
 
-    current = get_symbol_state(symbol)
-    override = _get_manual_override(symbol)
+    # B5: inject current probation_trades_remaining into metrics so evaluate_state
+    # can apply the PROBATION branch. Read from the symbol_health row.
+    row = _get_symbol_health_row(symbol)
+    current = row["state"] if row else "NORMAL"
+    override = bool(row["manual_override"]) if row else False
+    if row is not None:
+        metrics["probation_trades_remaining"] = row["probation_trades_remaining"]
+
     new_state, reason = evaluate_state(metrics, current, override, ks_cfg)
 
     if new_state != current:
         apply_transition(symbol, new_state=new_state, reason=reason,
                          metrics=metrics, from_state=current)
         # One-shot notify on transitions into tiered states.
-        # PR 2 (#138): ALERT; PR 3 (#138): REDUCED; PR 4 (#138): PAUSED.
-        notify_on_states = {"ALERT", "REDUCED", "PAUSED"}
+        # B5: also notify on PROBATION entry so operators see auto-reactivations.
+        notify_on_states = {"ALERT", "REDUCED", "PAUSED", "PROBATION"}
         if new_state in notify_on_states and notify is not None and HealthEvent is not None:
             try:
                 notify(
@@ -635,11 +662,17 @@ def apply_reduce_factor(size: float, symbol: str, cfg: dict[str, Any]) -> float:
 
 def trigger_health_evaluation(symbol: str, cfg: dict[str, Any]) -> None:
     """Fire-and-forget health evaluation for a single symbol.
-    Swallows exceptions so callers (e.g. db_close_position) never crash."""
+    Swallows exceptions so callers (e.g. db_close_position) never crash.
+
+    B5: decrements probation_trades_remaining before evaluation when symbol
+    is in PROBATION (so the regression/completion check sees the post-trade
+    counter value).
+    """
     ks_cfg = (cfg.get("kill_switch") or {})
     if not ks_cfg.get("enabled", True):
         return
     try:
+        _decrement_probation_counter(symbol)
         evaluate_and_record(symbol, cfg)
     except Exception as e:  # noqa: BLE001
         log.error("health trigger failed for %s: %s", symbol, e, exc_info=True)

--- a/health.py
+++ b/health.py
@@ -418,14 +418,108 @@ def apply_transition(
         conn.close()
 
 
-def reactivate_symbol(symbol: str, reason: str = "manual") -> None:
-    """Manually reset a symbol to NORMAL with manual_override=1."""
-    current = get_symbol_state(symbol)
-    metrics = {"reactivation_reason": reason}
-    apply_transition(
-        symbol, new_state="NORMAL", reason="manual_override",
-        metrics=metrics, from_state=current, manual_override=1,
+def _get_symbol_health_row(symbol: str) -> dict[str, Any] | None:
+    """Return the symbol_health row for `symbol`, or None if absent.
+
+    Selected columns: state, state_since, manual_override,
+    probation_trades_remaining, probation_started_at, paused_days_at_entry.
+    """
+    conn = _conn()
+    try:
+        row = conn.execute(
+            """SELECT state, state_since, manual_override,
+                      probation_trades_remaining, probation_started_at,
+                      paused_days_at_entry
+               FROM symbol_health WHERE symbol=?""",
+            (symbol,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    return {
+        "state": row[0],
+        "state_since": row[1],
+        "manual_override": int(row[2] or 0),
+        "probation_trades_remaining": row[3],
+        "probation_started_at": row[4],
+        "paused_days_at_entry": row[5],
+    }
+
+
+def reactivate_symbol(
+    symbol: str,
+    reason: str = "manual",
+    cfg: dict[str, Any] | None = None,
+) -> None:
+    """Transition a PAUSED symbol → PROBATION (B5 #199).
+
+    `reason='manual'` sets manual_override=1; any other reason (e.g.
+    'auto_recovery') sets it to 0. Reads probation params from
+    cfg['kill_switch']['v2']['probation'] when provided; otherwise uses
+    spec defaults (trades_base=10, per_pause_day=0.2).
+
+    No-ops with a warning when the symbol is not currently PAUSED.
+    """
+    row = _get_symbol_health_row(symbol)
+    current = row["state"] if row else "NORMAL"
+
+    if current != "PAUSED":
+        log.warning(
+            "reactivate_symbol(%s): symbol is not in PAUSED (current=%s); skipping",
+            symbol, current,
+        )
+        return
+
+    # Compute days_paused from the PAUSED row's state_since.
+    state_since_iso = row["state_since"] if row else None
+    days_paused = 0
+    if state_since_iso:
+        try:
+            state_since_dt = datetime.fromisoformat(state_since_iso.replace("Z", "+00:00"))
+            days_paused = max(0, int((datetime.now(timezone.utc) - state_since_dt).days))
+        except (ValueError, AttributeError):
+            log.warning(
+                "reactivate_symbol(%s): invalid state_since=%r; treating days_paused=0",
+                symbol, state_since_iso,
+            )
+
+    # Pull probation params (with defaults).
+    prob_cfg = (((cfg or {}).get("kill_switch") or {}).get("v2") or {}).get("probation") or {}
+    trades_base = int(prob_cfg.get("trades_base", 10))
+    per_pause_day = float(prob_cfg.get("trades_per_pause_day", 0.2))
+    trades_remaining = compute_probation_trades_remaining(
+        days_paused, trades_base=trades_base, per_pause_day=per_pause_day,
     )
+
+    metrics = {
+        "reactivation_reason": reason,
+        "days_paused": days_paused,
+        "probation_trades_remaining": trades_remaining,
+    }
+    manual_override = 1 if reason == "manual" else 0
+
+    apply_transition(
+        symbol, new_state="PROBATION", reason=f"reactivated_{reason}",
+        metrics=metrics, from_state=current, manual_override=manual_override,
+    )
+
+    # apply_transition does NOT touch probation_* columns when entering PROBATION
+    # (it only resets them on exit). Write them here.
+    started_at = _now_iso()
+    conn = _conn()
+    try:
+        conn.execute(
+            """UPDATE symbol_health
+               SET probation_trades_remaining = ?,
+                   probation_started_at = ?,
+                   paused_days_at_entry = ?
+               WHERE symbol = ?""",
+            (trades_remaining, started_at, days_paused, symbol),
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/health.py
+++ b/health.py
@@ -228,7 +228,7 @@ def compute_probation_trades_remaining(
 #  STATE MACHINE (pure)
 # ─────────────────────────────────────────────────────────────────────────────
 
-VALID_STATES = ("NORMAL", "ALERT", "REDUCED", "PAUSED")
+VALID_STATES = ("NORMAL", "ALERT", "REDUCED", "PAUSED", "PROBATION")
 
 
 def evaluate_state(
@@ -241,6 +241,13 @@ def evaluate_state(
 
     Rule precedence (most severe wins):
       1. insufficient_data → hold current state
+      1b. PROBATION branch (only when current_state == PROBATION):
+            - WR_10 < regression_wr_threshold AND trades >= regression_window → PAUSED
+            - probation_trades_remaining (NULL/0) → NORMAL (probation_complete)
+            - else → hold PROBATION (probation_in_progress)
+          Severe regression is the ONLY downward path from PROBATION; the months-
+          negative cascade below is intentionally bypassed (a freshly reactivated
+          symbol still carries its past PAUSED months).
       2. months_negative_consecutive >= pause_months_consecutive → PAUSED
       3. pnl_30d < 0 → REDUCED
       4. win_rate_20_trades < alert_win_rate_threshold → ALERT
@@ -256,6 +263,27 @@ def evaluate_state(
     min_trades = int(config.get("min_trades_for_eval", 20))
     if metrics.get("trades_count_total", 0) < min_trades:
         return current_state, "insufficient_data"
+
+    # B5 PROBATION branch — only fires when current_state is already PROBATION.
+    # Read v2.probation sub-config (defaults match spec).
+    if current_state == "PROBATION":
+        v2_cfg = (config.get("v2") or {})
+        prob_cfg = (v2_cfg.get("probation") or {})
+        regression_wr = float(prob_cfg.get("regression_wr_threshold", 0.10))
+        regression_window = int(prob_cfg.get("regression_window_trades", 10))
+
+        wr_10 = metrics.get("win_rate_10_trades", 0.0) or 0.0
+        if (
+            metrics.get("trades_count_total", 0) >= regression_window
+            and wr_10 < regression_wr
+        ):
+            return "PAUSED", "regression_severe"
+
+        trades_remaining = metrics.get("probation_trades_remaining")
+        if trades_remaining is None or int(trades_remaining) <= 0:
+            return "NORMAL", "probation_complete"
+
+        return "PROBATION", "probation_in_progress"
 
     pause_threshold = int(config.get("pause_months_consecutive", 3))
     if metrics.get("months_negative_consecutive", 0) >= pause_threshold:

--- a/health.py
+++ b/health.py
@@ -345,7 +345,7 @@ def _is_portfolio_normal(cfg: dict[str, Any]) -> bool:
         try:
             n_failures = conn.execute(
                 """SELECT COUNT(*) FROM symbol_health
-                   WHERE state IN ('ALERT', 'REDUCED', 'PAUSED')"""
+                   WHERE state IN ('ALERT', 'REDUCED', 'PAUSED', 'PROBATION')"""
             ).fetchone()[0]
         finally:
             conn.close()
@@ -586,28 +586,58 @@ def reactivate_symbol(
         "probation_trades_remaining": trades_remaining,
     }
     manual_override = 1 if reason == "manual" else 0
+    metrics_json = json.dumps(metrics, default=str)
+    now_iso = _now_iso()
 
-    apply_transition(
-        symbol, new_state="PROBATION", reason=f"reactivated_{reason}",
-        metrics=metrics, from_state=current, manual_override=manual_override,
-    )
-
-    # apply_transition does NOT touch probation_* columns when entering PROBATION
-    # (it only resets them on exit). Write them here.
-    started_at = _now_iso()
+    # B5 C2 fix: single atomic transaction (state + probation columns + event row)
+    # to close the race window where a concurrent trigger_health_evaluation could
+    # read NULL counter and silently revert state to NORMAL between two writes.
     conn = _conn()
     try:
         conn.execute(
-            """UPDATE symbol_health
-               SET probation_trades_remaining = ?,
-                   probation_started_at = ?,
-                   paused_days_at_entry = ?
-               WHERE symbol = ?""",
-            (trades_remaining, started_at, days_paused, symbol),
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                manual_override, probation_trades_remaining,
+                probation_started_at, paused_days_at_entry)
+               VALUES (?, 'PROBATION', ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(symbol) DO UPDATE SET
+                 state = 'PROBATION',
+                 state_since = CASE
+                   WHEN symbol_health.state != 'PROBATION' THEN excluded.state_since
+                   ELSE symbol_health.state_since
+                 END,
+                 last_evaluated_at = excluded.last_evaluated_at,
+                 last_metrics_json = excluded.last_metrics_json,
+                 manual_override = excluded.manual_override,
+                 probation_trades_remaining = excluded.probation_trades_remaining,
+                 probation_started_at = excluded.probation_started_at,
+                 paused_days_at_entry = excluded.paused_days_at_entry""",
+            (symbol, now_iso, now_iso, metrics_json, manual_override,
+             trades_remaining, now_iso, days_paused),
+        )
+        conn.execute(
+            """INSERT INTO symbol_health_events
+               (symbol, from_state, to_state, trigger_reason, metrics_json, ts)
+               VALUES (?, ?, 'PROBATION', ?, ?, ?)""",
+            (symbol, current, f"reactivated_{reason}", metrics_json, now_iso),
         )
         conn.commit()
     finally:
         conn.close()
+
+    # B5 C1 fix: notify on PROBATION entry (auto + manual reactivations).
+    # Previously dead code in evaluate_and_record (which never returns
+    # PROBATION from a non-PROBATION current state).
+    if notify is not None and HealthEvent is not None:
+        try:
+            notify(
+                HealthEvent(symbol=symbol, from_state=current,
+                            to_state="PROBATION", reason=f"reactivated_{reason}",
+                            metrics=metrics),
+                cfg=cfg or {},
+            )
+        except Exception as e:  # noqa: BLE001
+            log.warning("health: PROBATION notify failed for %s: %s", symbol, e)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -643,8 +673,10 @@ def evaluate_and_record(symbol: str, cfg: dict[str, Any], now: datetime | None =
         apply_transition(symbol, new_state=new_state, reason=reason,
                          metrics=metrics, from_state=current)
         # One-shot notify on transitions into tiered states.
-        # B5: also notify on PROBATION entry so operators see auto-reactivations.
-        notify_on_states = {"ALERT", "REDUCED", "PAUSED", "PROBATION"}
+        # PROBATION is intentionally NOT in this set: evaluate_state never
+        # returns PROBATION from a non-PROBATION current state, so the only
+        # entry path is reactivate_symbol (which fires its own notify).
+        notify_on_states = {"ALERT", "REDUCED", "PAUSED"}
         if new_state in notify_on_states and notify is not None and HealthEvent is not None:
             try:
                 notify(

--- a/health.py
+++ b/health.py
@@ -186,6 +186,28 @@ def compute_rolling_metrics(symbol: str, conn, now: datetime | None = None) -> d
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+#  B5 PROBATION TIER (pure)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def compute_probation_trades_remaining(
+    days_paused: int,
+    trades_base: int = 10,
+    per_pause_day: float = 0.2,
+) -> int:
+    """Initial probation_trades_remaining when reactivating from PAUSED.
+
+    Formula: round(trades_base + per_pause_day * days_paused).
+    Example: 15 days paused → 10 + 0.2*15 = 13.
+
+    days_paused <= 0 returns `trades_base` unchanged (clock skew defensive).
+    """
+    if days_paused <= 0:
+        return int(trades_base)
+    return int(round(trades_base + per_pause_day * days_paused))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 #  STATE MACHINE (pure)
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/health.py
+++ b/health.py
@@ -616,6 +616,15 @@ def apply_reduce_factor(size: float, symbol: str, cfg: dict[str, Any]) -> float:
     if state == "REDUCED":
         factor = float(ks_cfg.get("reduce_size_factor", 0.5))
         return size * factor
+    if state == "PROBATION":
+        # Prefer v2.probation.size_factor; fall back to v1's reduce_size_factor.
+        v2_cfg = (ks_cfg.get("v2") or {})
+        prob_cfg = (v2_cfg.get("probation") or {})
+        factor = float(prob_cfg.get(
+            "size_factor",
+            ks_cfg.get("reduce_size_factor", 0.5),
+        ))
+        return size * factor
     return size
 
 

--- a/health.py
+++ b/health.py
@@ -330,6 +330,73 @@ def _decrement_probation_counter(symbol: str) -> None:
         conn.close()
 
 
+def _is_portfolio_normal(cfg: dict[str, Any]) -> bool:
+    """Return True if portfolio aggregate tier is NORMAL.
+
+    Reuses kill_switch_v2 helpers. Defensive: any failure → False (block
+    auto-recovery in unclear state).
+    """
+    try:
+        from strategy.kill_switch_v2 import evaluate_portfolio_tier
+        from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
+        portfolio_dd = _compute_current_portfolio_dd(cfg)
+        # Concurrent failures count: use existing health rows.
+        conn = _conn()
+        try:
+            n_failures = conn.execute(
+                """SELECT COUNT(*) FROM symbol_health
+                   WHERE state IN ('ALERT', 'REDUCED', 'PAUSED')"""
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        portfolio = evaluate_portfolio_tier(portfolio_dd, int(n_failures), cfg)
+        return portfolio.get("tier") == "NORMAL"
+    except Exception as e:  # noqa: BLE001
+        log.warning("_is_portfolio_normal failed: %s — treating as not-normal", e)
+        return False
+
+
+def _maybe_auto_reactivate(
+    symbol: str,
+    threshold_days: int,
+    cfg: dict[str, Any],
+) -> None:
+    """B5 daily-cron hook: PAUSED ≥ threshold days + portfolio NORMAL → PROBATION.
+
+    No-op when:
+      - symbol is not currently PAUSED
+      - paused-duration < threshold_days
+      - portfolio aggregate tier ≠ NORMAL
+    """
+    row = _get_symbol_health_row(symbol)
+    if row is None or row["state"] != "PAUSED":
+        return
+
+    state_since_iso = row["state_since"]
+    if not state_since_iso:
+        return
+    try:
+        state_since_dt = datetime.fromisoformat(state_since_iso.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return
+    days_paused = (datetime.now(timezone.utc) - state_since_dt).days
+    if days_paused < int(threshold_days):
+        return
+
+    if not _is_portfolio_normal(cfg):
+        log.info(
+            "_maybe_auto_reactivate(%s): portfolio gate blocks (not NORMAL); skipping",
+            symbol,
+        )
+        return
+
+    log.info(
+        "_maybe_auto_reactivate(%s): %d days in PAUSED, portfolio NORMAL → PROBATION",
+        symbol, days_paused,
+    )
+    reactivate_symbol(symbol, reason="auto_recovery", cfg=cfg)
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -607,18 +674,27 @@ def evaluate_and_record(symbol: str, cfg: dict[str, Any], now: datetime | None =
 def evaluate_all_symbols(cfg: dict[str, Any], now: datetime | None = None) -> dict[str, str]:
     """Evaluate every symbol in btc_scanner.DEFAULT_SYMBOLS. Returns {symbol: state}.
 
-    If kill_switch.enabled is False, returns {} without touching the DB.
-
-    Fail-fast semantics: if any per-symbol evaluation raises (e.g. a DB lock),
-    the exception propagates and later symbols are NOT evaluated. Callers that
-    want best-effort behavior (e.g. the daily cron in Task 6) should wrap this
-    in try/except and log partial-failure explicitly.
+    B5: before evaluating each symbol's metrics, runs auto-reactivation check
+    so a PAUSED symbol that crossed the cooldown threshold transitions to
+    PROBATION first, then gets evaluated as PROBATION on the same sweep.
     """
     ks_cfg = (cfg.get("kill_switch") or {})
     if not ks_cfg.get("enabled", True):
         return {}
     from btc_scanner import DEFAULT_SYMBOLS
-    return {sym: evaluate_and_record(sym, cfg, now=now) for sym in DEFAULT_SYMBOLS}
+
+    v2_cfg = (ks_cfg.get("v2") or {})
+    prob_cfg = (v2_cfg.get("probation") or {})
+    threshold_days = int(prob_cfg.get("paused_to_probation_days", 14))
+
+    out: dict[str, str] = {}
+    for sym in DEFAULT_SYMBOLS:
+        try:
+            _maybe_auto_reactivate(sym, threshold_days, cfg)
+        except Exception as e:  # noqa: BLE001
+            log.warning("auto_reactivate(%s) failed: %s", sym, e, exc_info=True)
+        out[sym] = evaluate_and_record(sym, cfg, now=now)
+    return out
 
 
 def apply_reduce_factor(size: float, symbol: str, cfg: dict[str, Any]) -> float:

--- a/health.py
+++ b/health.py
@@ -614,18 +614,6 @@ def reactivate_symbol(
 #  ORCHESTRATION
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _get_manual_override(symbol: str) -> bool:
-    conn = _conn()
-    try:
-        row = conn.execute(
-            "SELECT manual_override FROM symbol_health WHERE symbol=?",
-            (symbol,),
-        ).fetchone()
-    finally:
-        conn.close()
-    return bool(row[0]) if row else False
-
-
 def evaluate_and_record(symbol: str, cfg: dict[str, Any], now: datetime | None = None) -> str:
     """Compute metrics + evaluate state + persist. Returns the resulting state."""
     ks_cfg = (cfg.get("kill_switch") or {})
@@ -698,12 +686,18 @@ def evaluate_all_symbols(cfg: dict[str, Any], now: datetime | None = None) -> di
 
 
 def apply_reduce_factor(size: float, symbol: str, cfg: dict[str, Any]) -> float:
-    """Return `size` scaled by `reduce_size_factor` if the symbol is in REDUCED state.
+    """Return `size` scaled by the kill-switch tier factor.
 
-    Returns `size` unchanged for NORMAL/ALERT/PAUSED states, or if kill_switch is
-    disabled. Callers should use this at position-open time (btc_scanner.scan)
-    or at backtest-sim time (backtest.simulate_strategy) to halve risk on
-    symbols that have recent losses.
+    Scaling rules:
+      - REDUCED → size * `kill_switch.reduce_size_factor` (default 0.5)
+      - PROBATION → size * `kill_switch.v2.probation.size_factor`
+        (default 0.5; falls back to `reduce_size_factor` if absent)
+      - NORMAL/ALERT/PAUSED → size unchanged
+      - kill_switch.enabled=False → size unchanged
+
+    Callers should use this at position-open time (btc_scanner.scan) or at
+    backtest-sim time (backtest.simulate_strategy) to halve risk on symbols
+    that are in a degraded tier.
 
     Safe on any failure: swallows exceptions (returns original size). The
     kill-switch must never block a trade by raising in this hot path.

--- a/scripts/reactivate_symbol.py
+++ b/scripts/reactivate_symbol.py
@@ -41,7 +41,8 @@ def main() -> int:
     if before != "PAUSED":
         print(f"Note: {symbol} is not in PAUSED (current={before}). reactivate_symbol will no-op + warn.")
 
-    reactivate_symbol(symbol, reason=args.reason)
+    cfg = btc_api.load_config()
+    reactivate_symbol(symbol, reason=args.reason, cfg=cfg)
 
     after = get_symbol_state(symbol)
     print(f"State after:  {after}")

--- a/scripts/reactivate_symbol.py
+++ b/scripts/reactivate_symbol.py
@@ -1,12 +1,14 @@
-"""Manually reactivate a PAUSED symbol.
+"""Manually reactivate a PAUSED symbol — transitions PAUSED → PROBATION (B5 #199).
 
 Usage:
     python scripts/reactivate_symbol.py BTCUSDT --reason "backtest validated"
 
-Resets symbol_health.state to NORMAL and sets manual_override=1 so future
-evaluations respect the reactivation until a severe rule (e.g. 3mo neg
-again) triggers another transition. Records an event in
-symbol_health_events with trigger_reason='manual_override'.
+Transitions symbol_health.state from PAUSED to PROBATION. The symbol enters
+PROBATION with `probation_trades_remaining` computed from days_paused. Reason
+'manual' sets manual_override=1; any other reason sets it to 0 (e.g.
+'backtest_validated' implies operator-driven but auto-style).
+
+Records an event in symbol_health_events with trigger_reason='reactivated_<reason>'.
 """
 from __future__ import annotations
 
@@ -36,8 +38,8 @@ def main() -> int:
     before = get_symbol_state(symbol)
     print(f"State before: {before}")
 
-    if before == "NORMAL":
-        print(f"Note: {symbol} is already NORMAL. Proceeding anyway to set manual_override=1 + log event.")
+    if before != "PAUSED":
+        print(f"Note: {symbol} is not in PAUSED (current={before}). reactivate_symbol will no-op + warn.")
 
     reactivate_symbol(symbol, reason=args.reason)
 

--- a/strategy/sizing.py
+++ b/strategy/sizing.py
@@ -20,13 +20,24 @@ def _score_multiplier(score: int) -> float:
 def _health_multiplier(health_tier: str, cfg: dict[str, Any]) -> float:
     """Returns multiplier based on kill switch tier.
 
-    PAUSED -> 0 (no trade). REDUCED/PROBATION -> configured factor. NORMAL/ALERT -> 1.0.
+    PAUSED -> 0 (no trade). REDUCED -> reduce_size_factor.
+    PROBATION -> v2.probation.size_factor (falls back to reduce_size_factor).
+    NORMAL/ALERT -> 1.0.
     """
     if health_tier == "PAUSED":
         return 0.0
-    if health_tier in ("REDUCED", "PROBATION"):
+    if health_tier == "REDUCED":
         ks_cfg = cfg.get("kill_switch", {})
         return float(ks_cfg.get("reduce_size_factor", 0.5))
+    if health_tier == "PROBATION":
+        # Mirrors apply_reduce_factor's lookup order in health.py.
+        ks_cfg = cfg.get("kill_switch", {})
+        v2_cfg = (ks_cfg.get("v2") or {})
+        prob_cfg = (v2_cfg.get("probation") or {})
+        return float(prob_cfg.get(
+            "size_factor",
+            ks_cfg.get("reduce_size_factor", 0.5),
+        ))
     return 1.0
 
 

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -54,20 +54,41 @@ def test_get_health_events_returns_history(client):
 
 
 def test_post_health_reactivate_sets_manual_override(client):
+    """B5: PAUSED → PROBATION (was → NORMAL). manual_override=1 for reason='manual'."""
     from health import apply_transition
     metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
                 "pnl_30d": 0.0, "pnl_by_month": {},
-                "months_negative_consecutive": 0}
+                "months_negative_consecutive": 0,
+                "win_rate_10_trades": 0.5}
     apply_transition("JUP", "PAUSED", "3mo_consec_neg", metrics, "REDUCED")
 
-    resp = client.post("/health/reactivate/JUP", json={"reason": "backtest_ok"})
+    resp = client.post("/health/reactivate/JUP", json={"reason": "manual"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["ok"] is True
-    assert data["state"] == "NORMAL"
+    assert data["state"] == "PROBATION"
 
     # GET again and verify
     resp = client.get("/health/symbols")
     rows = {r["symbol"]: r for r in resp.json()["symbols"]}
-    assert rows["JUP"]["state"] == "NORMAL"
+    assert rows["JUP"]["state"] == "PROBATION"
     assert rows["JUP"]["manual_override"] == 1
+
+
+def test_post_health_reactivate_auto_recovery_no_manual_override(client):
+    """reason='auto_recovery' returns PROBATION but does NOT set manual_override."""
+    from health import apply_transition
+    metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
+                "pnl_30d": 0.0, "pnl_by_month": {},
+                "months_negative_consecutive": 0,
+                "win_rate_10_trades": 0.5}
+    apply_transition("UNI", "PAUSED", "3mo_consec_neg", metrics, "REDUCED")
+
+    resp = client.post("/health/reactivate/UNI", json={"reason": "auto_recovery"})
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "PROBATION"
+
+    resp = client.get("/health/symbols")
+    rows = {r["symbol"]: r for r in resp.json()["symbols"]}
+    assert rows["UNI"]["state"] == "PROBATION"
+    assert rows["UNI"]["manual_override"] == 0

--- a/tests/test_health_integration.py
+++ b/tests/test_health_integration.py
@@ -116,3 +116,95 @@ def test_kill_switch_disabled_in_config_skips_evaluation(tmp_db, monkeypatch):
     finally:
         conn.close()
     assert rows[0] == 0
+
+
+# ── B5 full lifecycle: PAUSED → PROBATION → NORMAL ──────────────────────────
+
+
+def test_paused_reactivate_to_probation_then_complete_after_n_trades(tmp_db):
+    """End-to-end: reactivate → PROBATION (13 trades) → 13 wins → NORMAL."""
+    from datetime import datetime, timezone, timedelta
+    import btc_api
+    from health import (
+        reactivate_symbol, trigger_health_evaluation, get_symbol_state,
+    )
+
+    # Seed 25 closed losing trades (so total >= min_trades_for_eval and pnl_30d > 0
+    # via subsequent wins). Using losses dated > 30 days ago to keep pnl_30d clean.
+    conn = btc_api.get_db()
+    try:
+        for i in range(25):
+            ts = (datetime.now(timezone.utc) - timedelta(days=180 + i)).isoformat()
+            conn.execute(
+                """INSERT INTO positions
+                   (symbol, direction, status, entry_price, entry_ts,
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 95.0, ?, 'SL', -5.0, -0.05)""",
+                (ts, ts),
+            )
+        # Insert PAUSED row for BTC, set 15 days ago
+        state_since = (datetime.now(timezone.utc) - timedelta(days=15)).isoformat()
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json)
+               VALUES ('BTC', 'PAUSED', ?, ?, '{}')""",
+            (state_since, state_since),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {
+        "enabled": True, "min_trades_for_eval": 20,
+        "alert_win_rate_threshold": 0.15, "reduce_size_factor": 0.5,
+        "pause_months_consecutive": 3, "auto_recovery_enabled": True,
+        "v2": {"probation": {
+            "trades_base": 10, "trades_per_pause_day": 0.2,
+            "regression_wr_threshold": 0.10, "regression_window_trades": 10,
+            "paused_to_probation_days": 14, "size_factor": 0.5,
+        }},
+    }}
+
+    # Manual reactivate → PROBATION with trades_remaining=13 (15 days * 0.2 + 10)
+    reactivate_symbol("BTC", reason="manual", cfg=cfg)
+    assert get_symbol_state("BTC") == "PROBATION"
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            "SELECT probation_trades_remaining FROM symbol_health WHERE symbol='BTC'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == 13
+
+    # Simulate 13 winning closed trades + trade hook each time.
+    # After the 13th, counter hits 0 → next eval transitions to NORMAL.
+    for i in range(13):
+        ts = (datetime.now(timezone.utc) - timedelta(hours=24 - i)).isoformat()
+        conn = btc_api.get_db()
+        try:
+            conn.execute(
+                """INSERT INTO positions
+                   (symbol, direction, status, entry_price, entry_ts,
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10)""",
+                (ts, ts),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        trigger_health_evaluation("BTC", cfg)
+
+    # After 13 wins, state must be NORMAL and probation columns NULL
+    assert get_symbol_state("BTC") == "NORMAL"
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            """SELECT probation_trades_remaining, probation_started_at,
+                      paused_days_at_entry FROM symbol_health WHERE symbol='BTC'"""
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] is None
+    assert row[1] is None
+    assert row[2] is None

--- a/tests/test_health_persistence.py
+++ b/tests/test_health_persistence.py
@@ -268,3 +268,78 @@ def test_compute_rolling_metrics_from_trades_win_rate_last_20():
     result = compute_rolling_metrics_from_trades(trades, now=now)
     # Last 20 have 4 wins / 20 = 0.20
     assert result["win_rate_20_trades"] == pytest.approx(0.20)
+
+
+# ── B5: PROBATION schema migration ──────────────────────────────────────────
+
+
+def test_init_db_adds_probation_columns(tmp_db):
+    """init_db must add probation_trades_remaining/started_at/paused_days_at_entry."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(symbol_health)").fetchall()}
+    finally:
+        conn.close()
+    assert "probation_trades_remaining" in cols
+    assert "probation_started_at" in cols
+    assert "paused_days_at_entry" in cols
+
+
+def test_init_db_migration_idempotent(tmp_path, monkeypatch):
+    """Re-running init_db on a DB that already has probation columns must not raise."""
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    btc_api.init_db()  # second call must be a no-op
+    conn = btc_api.get_db()
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(symbol_health)").fetchall()}
+    finally:
+        conn.close()
+    assert {"probation_trades_remaining", "probation_started_at", "paused_days_at_entry"} <= cols
+
+
+def test_apply_transition_clears_probation_columns_on_exit(tmp_db):
+    """When transitioning out of PROBATION, the 3 probation columns are reset to NULL."""
+    import btc_api
+    from health import apply_transition
+
+    metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
+               "pnl_30d": 0.0, "pnl_by_month": {},
+               "months_negative_consecutive": 0,
+               "win_rate_10_trades": 0.6}
+
+    # Seed PROBATION row with non-NULL probation columns
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                probation_trades_remaining, probation_started_at, paused_days_at_entry)
+               VALUES ('BTC', 'PROBATION', '2026-04-01T00:00:00+00:00',
+                       '2026-04-01T00:00:00+00:00', '{}', 13, '2026-04-01T00:00:00+00:00', 15)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Transition out of PROBATION
+    apply_transition("BTC", new_state="NORMAL", reason="probation_complete",
+                     metrics=metrics, from_state="PROBATION")
+
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            """SELECT state, probation_trades_remaining, probation_started_at,
+                      paused_days_at_entry FROM symbol_health WHERE symbol='BTC'"""
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "NORMAL"
+    assert row[1] is None
+    assert row[2] is None
+    assert row[3] is None

--- a/tests/test_health_persistence.py
+++ b/tests/test_health_persistence.py
@@ -193,7 +193,7 @@ def test_apply_transition_preserves_state_since_on_same_state(tmp_db):
 
 
 def test_reactivate_sets_manual_override(tmp_db):
-    """reactivate_symbol flips manual_override to 1 and emits event."""
+    """B5: reactivate_symbol PAUSED → PROBATION. reason!='manual' → manual_override=0; event=reactivated_<reason>."""
     from health import apply_transition, reactivate_symbol
     metrics = {"trades_count_total": 50, "win_rate_20_trades": 0.5,
                 "pnl_30d": 0.0, "pnl_by_month": {},
@@ -213,8 +213,8 @@ def test_reactivate_sets_manual_override(tmp_db):
         ).fetchone()
     finally:
         conn.close()
-    assert row == ("NORMAL", 1)
-    assert last_event[0] == "manual_override"
+    assert row == ("PROBATION", 0)
+    assert last_event[0] == "reactivated_backtest_validated"
 
 
 def test_compute_rolling_metrics_from_trades_empty():

--- a/tests/test_health_probation.py
+++ b/tests/test_health_probation.py
@@ -293,3 +293,75 @@ def test_daily_cron_eval_does_not_decrement_probation(tmp_db):
     row = _read_health_row("BTC")
     assert row[0] == "PROBATION"  # still in PROBATION
     assert row[1] == 5             # counter NOT decremented
+
+
+# ── Auto-reactivation in daily cron ─────────────────────────────────────────
+
+
+def test_auto_reactivate_paused_15d_portfolio_normal_promotes_to_probation(tmp_db):
+    """PAUSED 15 days + portfolio NORMAL → auto-promotes to PROBATION."""
+    from unittest.mock import patch
+    from health import _maybe_auto_reactivate, get_symbol_state
+    _seed_paused("BTC", days_ago=15)
+    cfg = {"kill_switch": {"enabled": True, "v2": {"probation": {
+        "paused_to_probation_days": 14, "trades_base": 10, "trades_per_pause_day": 0.2,
+    }}}}
+    with patch("health._is_portfolio_normal", return_value=True):
+        _maybe_auto_reactivate("BTC", threshold_days=14, cfg=cfg)
+    assert get_symbol_state("BTC") == "PROBATION"
+    row = _read_health_row("BTC")
+    assert row[1] == 13  # 10 + round(0.2*15)
+    assert row[4] == 0   # auto_recovery → manual_override=0
+
+
+def test_auto_reactivate_paused_below_threshold_stays_paused(tmp_db):
+    """PAUSED 10 days (< 14 threshold) → stays PAUSED."""
+    from unittest.mock import patch
+    from health import _maybe_auto_reactivate, get_symbol_state
+    _seed_paused("BTC", days_ago=10)
+    cfg = {"kill_switch": {"enabled": True, "v2": {"probation": {"paused_to_probation_days": 14}}}}
+    with patch("health._is_portfolio_normal", return_value=True):
+        _maybe_auto_reactivate("BTC", threshold_days=14, cfg=cfg)
+    assert get_symbol_state("BTC") == "PAUSED"
+
+
+def test_auto_reactivate_paused_15d_portfolio_reduced_stays_paused(tmp_db):
+    """PAUSED 15 days but portfolio REDUCED → portfolio gate blocks."""
+    from unittest.mock import patch
+    from health import _maybe_auto_reactivate, get_symbol_state
+    _seed_paused("BTC", days_ago=15)
+    cfg = {"kill_switch": {"enabled": True, "v2": {"probation": {"paused_to_probation_days": 14}}}}
+    with patch("health._is_portfolio_normal", return_value=False):
+        _maybe_auto_reactivate("BTC", threshold_days=14, cfg=cfg)
+    assert get_symbol_state("BTC") == "PAUSED"
+
+
+def test_auto_reactivate_threshold_exact_boundary_fires(tmp_db):
+    """PAUSED for exactly threshold_days → fires (>= semantics, per spec boundary)."""
+    from unittest.mock import patch
+    from health import _maybe_auto_reactivate, get_symbol_state
+    _seed_paused("BTC", days_ago=14)
+    cfg = {"kill_switch": {"enabled": True, "v2": {"probation": {"paused_to_probation_days": 14}}}}
+    with patch("health._is_portfolio_normal", return_value=True):
+        _maybe_auto_reactivate("BTC", threshold_days=14, cfg=cfg)
+    assert get_symbol_state("BTC") == "PROBATION"
+
+
+def test_evaluate_all_symbols_runs_auto_reactivate_for_each(tmp_db, monkeypatch):
+    """evaluate_all_symbols invokes auto-reactivation per symbol before metric eval."""
+    from unittest.mock import patch
+    from health import evaluate_all_symbols
+    cfg = {"kill_switch": {"enabled": True, "v2": {"probation": {"paused_to_probation_days": 14}}}}
+    # DEFAULT_SYMBOLS is an actual list; just monkeypatch it to a tiny set
+    import btc_scanner
+    monkeypatch.setattr(btc_scanner, "DEFAULT_SYMBOLS", ["AAA", "BBB"])
+    calls = []
+
+    def fake_maybe(symbol, threshold_days, cfg):
+        calls.append(symbol)
+
+    with patch("health._maybe_auto_reactivate", side_effect=fake_maybe), \
+         patch("health.evaluate_and_record", return_value="NORMAL"):
+        evaluate_all_symbols(cfg)
+
+    assert calls == ["AAA", "BBB"]

--- a/tests/test_health_probation.py
+++ b/tests/test_health_probation.py
@@ -1,0 +1,41 @@
+"""B5 PROBATION tier — pure functions + state machine + DB lifecycle (#187 #199)."""
+import pytest
+
+
+# ── compute_probation_trades_remaining ──────────────────────────────────────
+
+
+def test_compute_probation_trades_remaining_zero_days():
+    """No days in PAUSED → trades_base unchanged."""
+    from health import compute_probation_trades_remaining
+    assert compute_probation_trades_remaining(0, trades_base=10, per_pause_day=0.2) == 10
+
+
+def test_compute_probation_trades_remaining_negative_days_clamps():
+    """Negative days_paused (clock skew, etc.) → trades_base."""
+    from health import compute_probation_trades_remaining
+    assert compute_probation_trades_remaining(-3, trades_base=10, per_pause_day=0.2) == 10
+
+
+def test_compute_probation_trades_remaining_seven_days():
+    """7 days * 0.2 = 1.4 → rounds to 11 (10 + 1)."""
+    from health import compute_probation_trades_remaining
+    assert compute_probation_trades_remaining(7, trades_base=10, per_pause_day=0.2) == 11
+
+
+def test_compute_probation_trades_remaining_fifteen_days():
+    """15 days * 0.2 = 3 → 13 (spec example)."""
+    from health import compute_probation_trades_remaining
+    assert compute_probation_trades_remaining(15, trades_base=10, per_pause_day=0.2) == 13
+
+
+def test_compute_probation_trades_remaining_thirty_days():
+    """30 days * 0.2 = 6 → 16."""
+    from health import compute_probation_trades_remaining
+    assert compute_probation_trades_remaining(30, trades_base=10, per_pause_day=0.2) == 16
+
+
+def test_compute_probation_trades_remaining_default_args():
+    """Defaults match spec: trades_base=10, per_pause_day=0.2."""
+    from health import compute_probation_trades_remaining
+    assert compute_probation_trades_remaining(15) == 13

--- a/tests/test_health_probation.py
+++ b/tests/test_health_probation.py
@@ -39,3 +39,112 @@ def test_compute_probation_trades_remaining_default_args():
     """Defaults match spec: trades_base=10, per_pause_day=0.2."""
     from health import compute_probation_trades_remaining
     assert compute_probation_trades_remaining(15) == 13
+
+
+# ── reactivate_symbol PAUSED → PROBATION ────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def _seed_paused(symbol, days_ago):
+    """Insert a PAUSED row whose state_since is `days_ago` days before now."""
+    from datetime import datetime, timezone, timedelta
+    import btc_api
+    state_since = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json)
+               VALUES (?, 'PAUSED', ?, ?, '{}')""",
+            (symbol, state_since, state_since),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_health_row(symbol):
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            """SELECT state, probation_trades_remaining, probation_started_at,
+                      paused_days_at_entry, manual_override
+               FROM symbol_health WHERE symbol=?""",
+            (symbol,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return row
+
+
+def test_reactivate_symbol_paused_zero_days_to_probation_base_count(tmp_db):
+    """PAUSED for 0 days → PROBATION + trades_remaining=10 (default trades_base)."""
+    from health import reactivate_symbol
+    _seed_paused("BTC", days_ago=0)
+    reactivate_symbol("BTC", reason="manual")
+    row = _read_health_row("BTC")
+    assert row[0] == "PROBATION"
+    assert row[1] == 10
+    assert row[2] is not None  # probation_started_at populated
+    assert row[3] == 0
+
+
+def test_reactivate_symbol_paused_seven_days_to_probation_eleven(tmp_db):
+    """PAUSED for 7 days → PROBATION + trades_remaining=11 (10 + round(0.2*7) = 11)."""
+    from health import reactivate_symbol
+    _seed_paused("ETH", days_ago=7)
+    reactivate_symbol("ETH", reason="manual")
+    row = _read_health_row("ETH")
+    assert row[0] == "PROBATION"
+    assert row[1] == 11
+    assert row[3] == 7
+
+
+def test_reactivate_symbol_paused_fifteen_days_to_probation_thirteen(tmp_db):
+    """Spec example: 15 days paused → 13 trades_remaining."""
+    from health import reactivate_symbol
+    _seed_paused("DOGE", days_ago=15)
+    reactivate_symbol("DOGE", reason="manual")
+    row = _read_health_row("DOGE")
+    assert row[0] == "PROBATION"
+    assert row[1] == 13
+    assert row[3] == 15
+
+
+def test_reactivate_symbol_sets_manual_override_for_manual_reason(tmp_db):
+    """reason='manual' sets manual_override=1; reason='auto_recovery' sets 0."""
+    from health import reactivate_symbol
+    _seed_paused("UNI", days_ago=10)
+    reactivate_symbol("UNI", reason="manual")
+    assert _read_health_row("UNI")[4] == 1
+
+    _seed_paused("XLM", days_ago=10)
+    reactivate_symbol("XLM", reason="auto_recovery")
+    assert _read_health_row("XLM")[4] == 0
+
+
+def test_reactivate_symbol_noop_when_not_paused(tmp_db, caplog):
+    """Calling reactivate_symbol on a NORMAL symbol is a no-op + warning."""
+    import logging
+    from health import reactivate_symbol
+    # Seed NORMAL (no row → reactivate sees state='NORMAL' default)
+    with caplog.at_level(logging.WARNING, logger="health"):
+        reactivate_symbol("AVAX", reason="manual")
+    # Row may or may not exist; the key assertion is no PROBATION transition occurred.
+    row = _read_health_row("AVAX")
+    if row is not None:
+        assert row[0] != "PROBATION"
+    # Warning logged
+    assert any("not in PAUSED" in r.message or "not paused" in r.message.lower()
+               for r in caplog.records)

--- a/tests/test_health_probation.py
+++ b/tests/test_health_probation.py
@@ -148,3 +148,148 @@ def test_reactivate_symbol_noop_when_not_paused(tmp_db, caplog):
     # Warning logged
     assert any("not in PAUSED" in r.message or "not paused" in r.message.lower()
                for r in caplog.records)
+
+
+# ── Trade lifecycle hook ────────────────────────────────────────────────────
+
+
+def test_decrement_probation_counter_decreases_value(tmp_db):
+    """_decrement_probation_counter drops trades_remaining by 1."""
+    import btc_api
+    from health import _decrement_probation_counter
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                probation_trades_remaining, probation_started_at, paused_days_at_entry)
+               VALUES ('BTC', 'PROBATION', '2026-04-01T00:00:00+00:00',
+                       '2026-04-01T00:00:00+00:00', '{}', 13, '2026-04-01T00:00:00+00:00', 15)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _decrement_probation_counter("BTC")
+    row = _read_health_row("BTC")
+    assert row[1] == 12
+
+
+def test_decrement_probation_counter_noop_when_not_probation(tmp_db):
+    """When state is NOT PROBATION, decrement is a no-op (no row mutation)."""
+    import btc_api
+    from health import _decrement_probation_counter
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health (symbol, state, state_since, last_evaluated_at, last_metrics_json)
+               VALUES ('BTC', 'NORMAL', '2026-04-01T00:00:00+00:00',
+                       '2026-04-01T00:00:00+00:00', '{}')"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _decrement_probation_counter("BTC")  # must not raise, must not change anything
+    row = _read_health_row("BTC")
+    assert row[0] == "NORMAL"
+    assert row[1] is None  # was NULL, stays NULL
+
+
+def test_decrement_probation_counter_floors_at_zero(tmp_db):
+    """When counter is 0, decrement does not go negative."""
+    import btc_api
+    from health import _decrement_probation_counter
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                probation_trades_remaining, probation_started_at, paused_days_at_entry)
+               VALUES ('BTC', 'PROBATION', '2026-04-01T00:00:00+00:00',
+                       '2026-04-01T00:00:00+00:00', '{}', 0, '2026-04-01T00:00:00+00:00', 15)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _decrement_probation_counter("BTC")
+    row = _read_health_row("BTC")
+    assert row[1] == 0
+
+
+def test_trigger_health_evaluation_decrements_then_evaluates(tmp_db):
+    """trigger_health_evaluation on a PROBATION symbol decrements counter THEN evals."""
+    import btc_api
+    from health import trigger_health_evaluation, get_symbol_state
+
+    # Seed PROBATION with counter=1 — after decrement, counter=0 → evaluate_state sees
+    # 0 and returns NORMAL with reason="probation_complete".
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                probation_trades_remaining, probation_started_at, paused_days_at_entry)
+               VALUES ('BTC', 'PROBATION', '2026-04-01T00:00:00+00:00',
+                       '2026-04-01T00:00:00+00:00', '{}', 1, '2026-04-01T00:00:00+00:00', 15)"""
+        )
+        # Add 25 winning closed trades so trades_count_total >= min_trades_for_eval
+        for i in range(25):
+            conn.execute(
+                """INSERT INTO positions
+                   (symbol, direction, status, entry_price, entry_ts,
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10)""",
+                (f"2026-05-{1+i%28:02d}T12:00:00+00:00", f"2026-05-{1+i%28:02d}T13:00:00+00:00"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    cfg = {"kill_switch": {
+        "enabled": True, "min_trades_for_eval": 20,
+        "alert_win_rate_threshold": 0.15, "reduce_size_factor": 0.5,
+        "pause_months_consecutive": 3, "auto_recovery_enabled": True,
+        "v2": {"probation": {
+            "regression_wr_threshold": 0.10, "regression_window_trades": 10,
+        }},
+    }}
+    trigger_health_evaluation("BTC", cfg)
+    assert get_symbol_state("BTC") == "NORMAL"
+
+
+def test_daily_cron_eval_does_not_decrement_probation(tmp_db):
+    """evaluate_and_record (daily cron path) does NOT decrement probation counter."""
+    import btc_api
+    from health import evaluate_and_record
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                probation_trades_remaining, probation_started_at, paused_days_at_entry)
+               VALUES ('BTC', 'PROBATION', '2026-04-01T00:00:00+00:00',
+                       '2026-04-01T00:00:00+00:00', '{}', 5, '2026-04-01T00:00:00+00:00', 15)"""
+        )
+        # 25 winning trades — enough for eval but no regression
+        for i in range(25):
+            conn.execute(
+                """INSERT INTO positions
+                   (symbol, direction, status, entry_price, entry_ts,
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10)""",
+                (f"2026-05-{1+i%28:02d}T12:00:00+00:00", f"2026-05-{1+i%28:02d}T13:00:00+00:00"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    cfg = {"kill_switch": {
+        "enabled": True, "min_trades_for_eval": 20,
+        "alert_win_rate_threshold": 0.15, "reduce_size_factor": 0.5,
+        "pause_months_consecutive": 3, "auto_recovery_enabled": True,
+        "v2": {"probation": {
+            "regression_wr_threshold": 0.10, "regression_window_trades": 10,
+        }},
+    }}
+    evaluate_and_record("BTC", cfg)
+    row = _read_health_row("BTC")
+    assert row[0] == "PROBATION"  # still in PROBATION
+    assert row[1] == 5             # counter NOT decremented

--- a/tests/test_health_reduce_factor.py
+++ b/tests/test_health_reduce_factor.py
@@ -62,3 +62,51 @@ def test_reduce_factor_custom_value(tmp_db):
                      metrics=metrics, from_state="NORMAL")
     cfg = {"kill_switch": {"enabled": True, "reduce_size_factor": 0.25}}
     assert apply_reduce_factor(100.0, "ETH", cfg) == 25.0
+
+
+# ── B5: PROBATION size factor ──────────────────────────────────────────────
+
+
+def test_reduce_factor_applied_when_state_probation(tmp_db):
+    """PROBATION halves size like REDUCED."""
+    from health import apply_reduce_factor
+    import btc_api
+    # Seed PROBATION row directly
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                probation_trades_remaining, probation_started_at, paused_days_at_entry)
+               VALUES ('UNI', 'PROBATION', '2026-04-01T00:00:00+00:00',
+                       '2026-04-01T00:00:00+00:00', '{}', 13, '2026-04-01T00:00:00+00:00', 15)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    cfg = {"kill_switch": {"enabled": True, "reduce_size_factor": 0.5}}
+    assert apply_reduce_factor(1.0, "UNI", cfg) == 0.5
+    assert apply_reduce_factor(1000.0, "UNI", cfg) == 500.0
+
+
+def test_probation_size_factor_config_override(tmp_db):
+    """v2.probation.size_factor overrides reduce_size_factor for PROBATION only."""
+    from health import apply_reduce_factor
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                probation_trades_remaining, probation_started_at, paused_days_at_entry)
+               VALUES ('JUP', 'PROBATION', '2026-04-01T00:00:00+00:00',
+                       '2026-04-01T00:00:00+00:00', '{}', 13, '2026-04-01T00:00:00+00:00', 15)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    cfg = {"kill_switch": {
+        "enabled": True, "reduce_size_factor": 0.5,
+        "v2": {"probation": {"size_factor": 0.25}},
+    }}
+    assert apply_reduce_factor(1000.0, "JUP", cfg) == 250.0

--- a/tests/test_health_rolling_metrics.py
+++ b/tests/test_health_rolling_metrics.py
@@ -176,3 +176,49 @@ def test_current_month_in_progress_is_excluded_from_streak(tmp_db):
     finally:
         conn.close()
     assert metrics["months_negative_consecutive"] == 3  # not 4
+
+
+# ── B5: win_rate_10_trades ──────────────────────────────────────────────────
+
+
+def test_win_rate_10_trades_empty():
+    """No trades → win_rate_10_trades is None (mirrors win_rate_20_trades semantics)."""
+    from datetime import datetime, timezone
+    from health import compute_rolling_metrics_from_trades
+    metrics = compute_rolling_metrics_from_trades([], now=datetime(2026, 6, 15, tzinfo=timezone.utc))
+    assert metrics["win_rate_10_trades"] is None
+
+
+def test_win_rate_10_trades_uses_last_ten():
+    """win_rate_10_trades = winners in last 10 trades / 10."""
+    from datetime import datetime, timezone
+    from health import compute_rolling_metrics_from_trades
+    # 12 trades total: first 2 wins, last 10 = 3 wins / 7 losses → 0.3
+    trades = []
+    for i in range(2):
+        trades.append({"exit_ts": f"2026-04-{1+i:02d}T12:00:00+00:00", "pnl_usd": 50.0})
+    for i in range(10):
+        pnl = 50.0 if i < 3 else -10.0
+        trades.append({"exit_ts": f"2026-05-{1+i:02d}T12:00:00+00:00", "pnl_usd": pnl})
+    metrics = compute_rolling_metrics_from_trades(
+        trades, now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    assert metrics["win_rate_10_trades"] == 0.3
+
+
+def test_win_rate_10_trades_dbwrapper_coerces_none_to_zero(tmp_path, monkeypatch):
+    """compute_rolling_metrics (DB wrapper) coerces None → 0.0 same as for win_rate_20_trades."""
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    from datetime import datetime, timezone
+    from health import compute_rolling_metrics
+    conn = btc_api.get_db()
+    try:
+        metrics = compute_rolling_metrics("BTC", conn, now=datetime(2026, 6, 15, tzinfo=timezone.utc))
+    finally:
+        conn.close()
+    assert metrics["win_rate_10_trades"] == 0.0

--- a/tests/test_health_state_machine.py
+++ b/tests/test_health_state_machine.py
@@ -127,3 +127,96 @@ def test_invalid_current_state_raises_value_error():
     from health import evaluate_state
     with pytest.raises(ValueError, match="unknown current_state"):
         evaluate_state(_metrics(), "DISABLED", False, CFG)
+
+
+# ── B5: PROBATION branch ───────────────────────────────────────────────────
+
+
+CFG_PROB = {
+    "min_trades_for_eval": 20,
+    "alert_win_rate_threshold": 0.15,
+    "reduce_pnl_window_days": 30,
+    "reduce_size_factor": 0.5,
+    "pause_months_consecutive": 3,
+    "auto_recovery_enabled": True,
+    "v2": {
+        "probation": {
+            "regression_wr_threshold": 0.10,
+            "regression_window_trades": 10,
+        },
+    },
+}
+
+
+def _metrics_prob(total=50, wr20=0.5, wr10=0.5, pnl_30d=500.0,
+                   months_neg=0, trades_remaining=5):
+    return {
+        "trades_count_total": total,
+        "win_rate_20_trades": wr20,
+        "win_rate_10_trades": wr10,
+        "pnl_30d": pnl_30d,
+        "pnl_by_month": {},
+        "months_negative_consecutive": months_neg,
+        "probation_trades_remaining": trades_remaining,
+    }
+
+
+def test_probation_severe_regression_returns_to_paused():
+    """In PROBATION + WR<10% in last 10 trades + ≥10 closed → PAUSED."""
+    from health import evaluate_state
+    new, reason = evaluate_state(
+        _metrics_prob(total=50, wr10=0.05, trades_remaining=8),
+        "PROBATION", False, CFG_PROB,
+    )
+    assert new == "PAUSED"
+    assert reason == "regression_severe"
+
+
+def test_probation_completes_when_counter_zero():
+    """In PROBATION + counter == 0 + healthy WR → NORMAL."""
+    from health import evaluate_state
+    new, reason = evaluate_state(
+        _metrics_prob(total=50, wr10=0.5, trades_remaining=0),
+        "PROBATION", False, CFG_PROB,
+    )
+    assert new == "NORMAL"
+    assert reason == "probation_complete"
+
+
+def test_probation_holds_when_in_progress():
+    """In PROBATION + counter > 0 + healthy → hold PROBATION."""
+    from health import evaluate_state
+    new, reason = evaluate_state(
+        _metrics_prob(total=50, wr10=0.5, trades_remaining=5),
+        "PROBATION", False, CFG_PROB,
+    )
+    assert new == "PROBATION"
+    assert reason == "probation_in_progress"
+
+
+def test_probation_skips_regression_check_with_few_trades():
+    """In PROBATION + WR<10% but < 10 trades → skip regression check (insufficient evidence)."""
+    from health import evaluate_state
+    new, reason = evaluate_state(
+        _metrics_prob(total=5, wr10=0.0, trades_remaining=10),
+        "PROBATION", False, CFG_PROB,
+    )
+    # Insufficient data branch fires first (total < min_trades_for_eval=20)
+    assert new == "PROBATION"
+    assert reason == "insufficient_data"
+
+
+def test_probation_corrupt_null_counter_treated_as_zero():
+    """If probation_trades_remaining is missing (corrupt row), exit to NORMAL on next eval."""
+    from health import evaluate_state
+    metrics = _metrics_prob(total=50, wr10=0.5, trades_remaining=5)
+    metrics.pop("probation_trades_remaining")
+    new, reason = evaluate_state(metrics, "PROBATION", False, CFG_PROB)
+    assert new == "NORMAL"
+    assert reason == "probation_complete"
+
+
+def test_valid_states_includes_probation():
+    """VALID_STATES tuple now includes PROBATION."""
+    from health import VALID_STATES
+    assert "PROBATION" in VALID_STATES

--- a/tests/test_reactivate_symbol_cli.py
+++ b/tests/test_reactivate_symbol_cli.py
@@ -48,7 +48,7 @@ def test_cli_imports_and_runs(tmp_db):
     rc = mod.main()
 
     assert rc == 0
-    assert get_symbol_state("BTC") == "NORMAL"
+    assert get_symbol_state("BTC") == "PROBATION"
 
 
 def test_cli_accepts_lowercase_symbol(tmp_db):
@@ -68,4 +68,4 @@ def test_cli_accepts_lowercase_symbol(tmp_db):
     rc = mod.main()
 
     assert rc == 0
-    assert get_symbol_state("JUP") == "NORMAL"
+    assert get_symbol_state("JUP") == "PROBATION"


### PR DESCRIPTION
## Summary

- New PROBATION tier between PAUSED and NORMAL: post-reactivation symbols operate at `size_factor=0.5` for `trades_base + per_pause_day * days_paused` trades (default formula: 10 + 0.2 × days; 15 days paused → 13 trades).
- `reactivate_symbol` now transitions PAUSED → PROBATION (was: → NORMAL). Both manual operator action and auto-recovery (after N days + portfolio NORMAL) use the same code path.
- Trade lifecycle hook: every closed trade decrements `probation_trades_remaining`. Severe regression (rolling WR<10% in 10 trades) → back to PAUSED. Counter exhausted with no regression → NORMAL.
- Auto-reactivation piggy-backs on the existing `health_monitor_loop` daily cron (no new daemon).
- Single-transaction reactivation write (state + 3 probation columns + event row in one atomic commit) closes a race window where concurrent trade hooks could observe a NULL counter mid-write.
- Operator notification on PROBATION entry (manual + auto reactivations fire `notify(HealthEvent)` via the existing notifier infrastructure).

## Spec & plan

- Spec: `docs/superpowers/specs/es/2026-04-26-kill-switch-v2-b5-probation-tier-design.md` (on `docs/kill-switch-v2-b5-design`)
- Plan: `docs/superpowers/plans/2026-04-26-kill-switch-v2-b5-probation-tier.md` (on `docs/kill-switch-v2-b5-design`)

## Files changed

- `health.py` — VALID_STATES gains PROBATION; new pure fn `compute_probation_trades_remaining`; `compute_rolling_metrics_from_trades` adds `win_rate_10_trades`; `evaluate_state` PROBATION branch (placed BEFORE the months-negative cascade so PROBATION can only fall to PAUSED via severe regression); `reactivate_symbol` rewrite (atomic single-transaction write + notify on entry); `apply_transition` clears probation columns on exit; `apply_reduce_factor` PROBATION case; new helpers `_decrement_probation_counter`, `_get_symbol_health_row`, `_is_portfolio_normal`, `_maybe_auto_reactivate`; `evaluate_all_symbols` runs auto-reactivation per symbol.
- `btc_api.py` — idempotent ALTER adds 3 columns to `symbol_health`: `probation_trades_remaining`, `probation_started_at`, `paused_days_at_entry`. Endpoint `POST /health/reactivate/{symbol}` now passes `cfg=load_config()`.
- `config.defaults.json` — `kill_switch.v2.probation` block (6 keys: trades_base=10, trades_per_pause_day=0.2, regression_wr_threshold=0.10, regression_window_trades=10, paused_to_probation_days=14, size_factor=0.5) + `auto_recovery_mode`.
- `scripts/reactivate_symbol.py` — passes `cfg` to `reactivate_symbol`; updated docstring + non-PAUSED message.
- `strategy/sizing.py` — `compute_size` PROBATION case prefers `v2.probation.size_factor` (matches `apply_reduce_factor` lookup order).
- `tests/test_health_probation.py` (new, 21 tests).
- `tests/test_health_state_machine.py` (+6 PROBATION branch tests).
- `tests/test_health_rolling_metrics.py` (+3 win_rate_10_trades tests).
- `tests/test_health_persistence.py` (+3 schema migration tests + 1 updated reactivate test).
- `tests/test_health_reduce_factor.py` (+2 PROBATION size factor tests).
- `tests/test_health_endpoints.py` (1 updated + 1 new PROBATION endpoint test).
- `tests/test_health_integration.py` (+1 full-lifecycle test).
- `tests/test_reactivate_symbol_cli.py` (2 updated for PROBATION).

## Test plan

- [x] `pytest tests/ -q -m "not network"` → 957 passed, 0 failures (baseline 920 → +37 new tests on this branch)
- [x] `pytest tests/test_health_probation.py -v` → 21 PROBATION-only tests pass
- [x] `pytest tests/test_health_state_machine.py -v` → existing + 6 new pass
- [x] `pytest tests/test_health_endpoints.py -v` → endpoint tests updated/added pass
- [x] `python3 -c "from btc_api import load_config; c = load_config(); print(c['kill_switch']['v2']['probation'])"` → config loads with 6 keys
- [x] `python3 -c "import health; print(health.VALID_STATES)"` → tuple includes PROBATION
- [x] Idempotent migration verified: `init_db` runs cleanly on a pre-B5 schema and again on a post-B5 schema
- [ ] Manual smoke (post-merge): on a PAUSED symbol, `POST /health/reactivate/{symbol}` returns `{"state": "PROBATION"}`; subsequent winning trades decrement counter visible in `GET /health/symbols`; Telegram alert arrives for the PROBATION transition

## Composition with v2 (no change)

- v1 path: symbol in PROBATION → `size_factor=0.5`
- v2 simulator (B4b.2) path: per-symbol tier=ALERT → `size_factor=0.5`
- Multiplicative when both fire: 0.5 × 0.5 = 0.25 (per spec §4.4)

v2 simulator's per-symbol tier (B4a NORMAL/ALERT) remains independent. v2 modules untouched in this PR.

## Out of scope

- B6 frontend dashboard (#200) — UI for PROBATION state badge + counter is a separate PR.
- `mixed_manual_pause` mode — config key reserved (`auto_recovery_mode`) but only `smart_auto` path is wired in this PR.

## Implementation summary

13 commits on `feat/kill-switch-v2-b5-probation`, 12 atomic feature commits + 1 review-follow-up commit:
- 9 `feat`: new pure fn → rolling metrics → schema migration → state branch → reactivate rewrite → reduce factor → trade hook → auto-reactivation → config defaults
- 2 `test`: stale test cleanup + full-lifecycle integration test
- 1 `refactor`: docstring + dead code drop
- 1 `fix`: review follow-ups (atomic reactivate + notify + cfg passthrough + sizing.py PROBATION + portfolio failure tier alignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)