### PR TITLE
feat(kill-switch-v2): B6 dashboard observability (#187 #200)

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -2542,6 +2542,19 @@ def get_kill_switch_current_state(engine: str = "v1"):
     return observability.get_current_state(engine=engine)
 
 
+@app.get("/health/dashboard", dependencies=[Depends(verify_api_key)])
+def get_health_dashboard():
+    """B6: single-shot consolidated state for the kill switch dashboard.
+
+    Returns per-symbol full state + portfolio aggregate + 24h alert summary.
+    Read-only; safe even when kill_switch.enabled=False (returns last-evaluated
+    snapshot).
+    """
+    from health import get_dashboard_state
+    cfg = load_config()
+    return get_dashboard_state(cfg)
+
+
 @app.post("/health/reactivate/{symbol}", dependencies=[Depends(verify_api_key)])
 def post_health_reactivate(symbol: str, body: ReactivateRequest):
     """Manually reactivate a PAUSED symbol — transitions PAUSED → PROBATION (B5 #199)."""

--- a/btc_api.py
+++ b/btc_api.py
@@ -1053,6 +1053,21 @@ def init_db():
         CREATE INDEX IF NOT EXISTS idx_recommendations_ts
             ON kill_switch_recommendations(ts)
     """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS portfolio_health_events (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            from_tier       TEXT NOT NULL,
+            to_tier         TEXT NOT NULL,
+            reason          TEXT NOT NULL,
+            dd_pct          REAL,
+            concurrent      INTEGER,
+            ts              TEXT NOT NULL
+        )
+    """)
+    con.execute("""
+        CREATE INDEX IF NOT EXISTS idx_portfolio_events_ts
+            ON portfolio_health_events(ts DESC)
+    """)
     con.commit()
     con.close()
     log.info(f"DB inicializada: {DB_FILE}")

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2781,3 +2781,306 @@ button:focus-visible {
   border-radius: 4px;
   color: #ef4444;
 }
+
+/* ============================================================
+   Kill Switch v2 Dashboard B6 (#187 #200)
+   ============================================================ */
+
+/* Tier color tokens */
+:root {
+  --tier-normal: var(--green);
+  --tier-alert: var(--amber);
+  --tier-reduced: #fb923c;
+  --tier-paused: var(--red);
+  --tier-probation: #a78bfa;
+  --tier-warned: var(--amber);
+  --tier-frozen: var(--red);
+}
+
+.ks-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Alerts strip */
+.ks-alerts-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: 16px;
+}
+
+.ks-alert {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  font-weight: 500;
+}
+
+.ks-alert-info {
+  background: var(--blue-dim);
+  color: var(--blue);
+}
+
+.ks-alert-warning {
+  background: var(--amber-dim);
+  color: var(--amber);
+}
+
+.ks-alert-critical {
+  background: var(--red-dim);
+  color: var(--red);
+  font-weight: 600;
+}
+
+/* Portfolio panel */
+.ks-portfolio-panel {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) 2fr;
+  gap: 16px;
+  padding: 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: 16px;
+}
+
+.ks-portfolio-tier-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.ks-tier-large {
+  font-size: 18px;
+  padding: 6px 14px;
+}
+
+.ks-portfolio-metrics {
+  display: flex;
+  gap: 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.ks-portfolio-metrics .ks-metric {
+  display: flex;
+  flex-direction: column;
+}
+
+.ks-portfolio-metrics dt {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ks-portfolio-metrics dd {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.ks-portfolio-transitions {
+  display: flex;
+  flex-direction: column;
+}
+
+.ks-transitions-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.ks-transitions-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.ks-transition-flow {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+.ks-transition-reason {
+  color: var(--text-secondary);
+}
+
+.ks-transition-ts {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.ks-empty-text {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+/* Symbol grid v2 */
+.ks-symbol-grid-v2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+/* Symbol card v2 */
+.ks-symbol-card-v2 {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: background var(--transition);
+}
+
+.ks-symbol-card-v2:hover {
+  background: var(--bg-card-hover);
+}
+
+.ks-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ks-card-symbol {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.ks-tier-badge {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid currentColor;
+}
+
+.ks-tier-normal { color: var(--tier-normal); }
+.ks-tier-alert { color: var(--tier-alert); }
+.ks-tier-reduced { color: var(--tier-reduced); }
+.ks-tier-paused { color: var(--tier-paused); }
+.ks-tier-probation { color: var(--tier-probation); }
+
+/* Sparkline */
+.ks-sparkline {
+  display: flex;
+  gap: 1px;
+  height: 14px;
+}
+
+.ks-spark-cell {
+  flex: 1;
+  border-radius: 1px;
+}
+
+.ks-spark-win { background: var(--green); }
+.ks-spark-loss { background: var(--red); }
+.ks-spark-empty { background: var(--border-subtle); }
+
+/* Metrics block */
+.ks-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.ks-metric {
+  display: flex;
+  justify-content: space-between;
+}
+
+.ks-metric dt {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.ks-metric dd {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.ks-metrics .ks-pos { color: var(--green); }
+.ks-metrics .ks-neg { color: var(--red); }
+
+/* Last transition + next conditions */
+.ks-last-transition {
+  font-size: 11px;
+  color: var(--text-secondary);
+  border-top: 1px solid var(--border);
+  padding-top: 8px;
+}
+
+.ks-transition-arrow {
+  color: var(--text-muted);
+}
+
+.ks-next-conditions {
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  margin: 0;
+}
+
+/* Skeleton loaders */
+.ks-skeleton-strip,
+.ks-skeleton-portfolio,
+.ks-skeleton-card {
+  background: linear-gradient(
+    90deg,
+    var(--bg-card) 0%,
+    var(--bg-card-hover) 50%,
+    var(--bg-card) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--radius-md);
+  animation: ks-shimmer 1.5s ease-in-out infinite;
+}
+
+.ks-skeleton-strip { height: 44px; margin-bottom: 16px; }
+.ks-skeleton-portfolio { height: 120px; margin-bottom: 16px; }
+.ks-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
+}
+.ks-skeleton-card { height: 200px; }
+
+@keyframes ks-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ks-skeleton-strip,
+  .ks-skeleton-portfolio,
+  .ks-skeleton-card {
+    animation: none;
+  }
+  .ks-symbol-card-v2 {
+    transition: none;
+  }
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -24,6 +24,7 @@ import type {
   KillSwitchDecisionsResponse,
   KillSwitchCurrentStateResponse,
   KillSwitchEngine,
+  DashboardResponse,
 } from './types';
 
 const BASE_URL = '/api';
@@ -237,4 +238,8 @@ export async function getKillSwitchCurrentState(
   return request<KillSwitchCurrentStateResponse>(
     `/kill_switch/current_state?engine=${engine}`,
   );
+}
+
+export async function getHealthDashboard(): Promise<DashboardResponse> {
+  return request<DashboardResponse>('/health/dashboard');
 }

--- a/frontend/src/components/AlertsStrip.test.tsx
+++ b/frontend/src/components/AlertsStrip.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AlertsStrip from './AlertsStrip';
+import type { DashboardAlertSummary } from '../types';
+
+describe('AlertsStrip', () => {
+  it('renders nothing when items empty', () => {
+    const empty: DashboardAlertSummary = { items: [] };
+    const { container } = render(<AlertsStrip alerts={empty} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders alert item text', () => {
+    const alerts: DashboardAlertSummary = {
+      items: [
+        { kind: 'symbol_failures', text: '3 símbolos en ALERT', severity: 'warning', ts: '2026-04-26T12:00:00Z' },
+      ],
+    };
+    render(<AlertsStrip alerts={alerts} />);
+    expect(screen.getByText('3 símbolos en ALERT')).toBeInTheDocument();
+  });
+
+  it('applies severity class', () => {
+    const alerts: DashboardAlertSummary = {
+      items: [
+        { kind: 'portfolio_dd', text: 'Critical', severity: 'critical', ts: '2026-04-26T12:00:00Z' },
+      ],
+    };
+    const { container } = render(<AlertsStrip alerts={alerts} />);
+    expect(container.querySelector('.ks-alert-critical')).not.toBeNull();
+  });
+});

--- a/frontend/src/components/AlertsStrip.tsx
+++ b/frontend/src/components/AlertsStrip.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { DashboardAlertSummary } from '../types';
+
+interface AlertsStripProps {
+  alerts: DashboardAlertSummary;
+}
+
+const AlertsStrip: React.FC<AlertsStripProps> = ({ alerts }) => {
+  if (alerts.items.length === 0) return null;
+
+  return (
+    <div className="ks-alerts-strip" role="region" aria-label="Alertas recientes">
+      {alerts.items.map((item, i) => (
+        <span
+          key={i}
+          className={`ks-alert ks-alert-${item.severity}`}
+        >
+          {item.text}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default AlertsStrip;

--- a/frontend/src/components/KillSwitchDashboard.test.tsx
+++ b/frontend/src/components/KillSwitchDashboard.test.tsx
@@ -1,73 +1,86 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import KillSwitchDashboard from './KillSwitchDashboard';
+import type { DashboardResponse } from '../types';
 
 vi.mock('../api', () => ({
-  getKillSwitchCurrentState: vi.fn(),
+  getHealthDashboard: vi.fn(),
 }));
 
-import { getKillSwitchCurrentState } from '../api';
+import { getHealthDashboard } from '../api';
 
-describe('KillSwitchDashboard', () => {
+const emptyResponse: DashboardResponse = {
+  symbols: [],
+  portfolio: {
+    tier: 'NORMAL', dd_pct: 0, peak_equity: 1000, current_equity: 1000,
+    concurrent_failures: 0, recent_transitions: [],
+  },
+  alerts: { items: [] },
+  generated_at: '2026-04-26T00:00:00Z',
+};
+
+describe('KillSwitchDashboard (B6)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('shows portfolio tier NORMAL when no symbols reported', async () => {
-    (getKillSwitchCurrentState as ReturnType<typeof vi.fn>).mockResolvedValue({
-      symbols: {},
-      portfolio: { tier: 'NORMAL', concurrent_failures: 0 },
-    });
-    render(<KillSwitchDashboard />);
-    await waitFor(() => {
-      expect(getKillSwitchCurrentState).toHaveBeenCalled();
-    });
-    expect(screen.getByText(/Portfolio/i)).toBeInTheDocument();
-    expect(screen.getByText('NORMAL')).toBeInTheDocument();
+  it('shows skeleton on initial mount', () => {
+    (getHealthDashboard as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {}),  // never resolves
+    );
+    const { container } = render(<KillSwitchDashboard />);
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
   });
 
-  it('renders per-symbol tier cards for each symbol', async () => {
-    (getKillSwitchCurrentState as ReturnType<typeof vi.fn>).mockResolvedValue({
-      symbols: {
-        BTCUSDT: {
-          symbol: 'BTCUSDT', per_symbol_tier: 'NORMAL', portfolio_tier: 'NORMAL',
-          size_factor: 1.0, skip: false, velocity_active: false,
-          ts: '2026-04-23T12:00:00Z', reasons_json: '{}',
+  it('renders portfolio panel + empty symbol grid', async () => {
+    (getHealthDashboard as ReturnType<typeof vi.fn>).mockResolvedValue(emptyResponse);
+    render(<KillSwitchDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('NORMAL')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Sin datos aún/)).toBeInTheDocument();
+  });
+
+  it('renders symbol cards when data arrives', async () => {
+    const withSymbols: DashboardResponse = {
+      ...emptyResponse,
+      symbols: [
+        {
+          symbol: 'BTC', state: 'NORMAL', state_since: '2026-04-20T00:00:00Z',
+          manual_override: false,
+          metrics: {
+            trades_count_total: 50, win_rate_20_trades: 0.55, win_rate_10_trades: 0.5,
+            pnl_30d: 420, months_negative_consecutive: 0,
+            probation_trades_remaining: null, paused_days_at_entry: null,
+          },
+          last_transition: null, sparkline_20: Array(20).fill('W'),
+          next_conditions: 'Saludable',
         },
-        ETHUSDT: {
-          symbol: 'ETHUSDT', per_symbol_tier: 'ALERT', portfolio_tier: 'NORMAL',
-          size_factor: 1.0, skip: false, velocity_active: false,
-          ts: '2026-04-23T12:00:00Z', reasons_json: '{}',
-        },
-      },
-      portfolio: { tier: 'NORMAL', concurrent_failures: 1 },
-    });
+      ],
+    };
+    (getHealthDashboard as ReturnType<typeof vi.fn>).mockResolvedValue(withSymbols);
     render(<KillSwitchDashboard />);
     await waitFor(() => {
-      expect(screen.getByText('BTCUSDT')).toBeInTheDocument();
-      expect(screen.getByText('ETHUSDT')).toBeInTheDocument();
+      expect(screen.getByText('BTC')).toBeInTheDocument();
     });
   });
 
-  it('shows portfolio WARNED when threshold reached', async () => {
-    (getKillSwitchCurrentState as ReturnType<typeof vi.fn>).mockResolvedValue({
-      symbols: {},
-      portfolio: { tier: 'WARNED', concurrent_failures: 3 },
-    });
-    render(<KillSwitchDashboard />);
-    await waitFor(() => {
-      expect(screen.getByText('WARNED')).toBeInTheDocument();
-    });
-  });
-
-  it('survives API failure without crashing', async () => {
-    (getKillSwitchCurrentState as ReturnType<typeof vi.fn>).mockRejectedValue(
+  it('survives API failure: shows error banner without crashing', async () => {
+    (getHealthDashboard as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error('network'),
     );
     const { container } = render(<KillSwitchDashboard />);
     await waitFor(() => {
-      expect(getKillSwitchCurrentState).toHaveBeenCalled();
+      expect(getHealthDashboard).toHaveBeenCalled();
     });
     expect(container.querySelector('.ks-dashboard')).not.toBeNull();
+  });
+
+  it('renders aria-live region for polite announcements', async () => {
+    (getHealthDashboard as ReturnType<typeof vi.fn>).mockResolvedValue(emptyResponse);
+    const { container } = render(<KillSwitchDashboard />);
+    await waitFor(() => {
+      expect(container.querySelector('[aria-live="polite"]')).not.toBeNull();
+    });
   });
 });

--- a/frontend/src/components/KillSwitchDashboard.tsx
+++ b/frontend/src/components/KillSwitchDashboard.tsx
@@ -1,100 +1,95 @@
 // ============================================================
-// KillSwitchDashboard.tsx — Phase 1 MVP of kill switch v2 (#187)
-// Shows per-symbol tier grid + portfolio aggregate state.
-// Polls /kill_switch/current_state every 30s.
+// KillSwitchDashboard.tsx — B6 dashboard observability (#187 #200)
+// Polls /health/dashboard every 30s, renders alerts + portfolio + symbols.
 // ============================================================
 
-import React, { useEffect, useState } from 'react';
-import { getKillSwitchCurrentState } from '../api';
-import type {
-  KillSwitchCurrentStateResponse,
-  KillSwitchPerSymbolTier,
-  KillSwitchPortfolioTier,
-} from '../types';
+import React, { useEffect, useRef, useState } from 'react';
+import { getHealthDashboard } from '../api';
+import AlertsStrip from './AlertsStrip';
+import PortfolioPanel from './PortfolioPanel';
+import KillSwitchSymbolCard from './KillSwitchSymbolCard';
+import type { DashboardResponse } from '../types';
 
 const POLL_INTERVAL_MS = 30_000;
 
-const TIER_COLORS_PER_SYMBOL: Record<KillSwitchPerSymbolTier, string> = {
-  NORMAL: '#22c55e',
-  ALERT: '#f59e0b',
-  REDUCED: '#fb923c',
-  PAUSED: '#ef4444',
-  PROBATION: '#a78bfa',
-};
-
-const TIER_COLORS_PORTFOLIO: Record<KillSwitchPortfolioTier, string> = {
-  NORMAL: '#22c55e',
-  WARNED: '#f59e0b',
-  REDUCED: '#fb923c',
-  FROZEN: '#ef4444',
-};
-
 const KillSwitchDashboard: React.FC = () => {
-  const [state, setState] = useState<KillSwitchCurrentStateResponse | null>(null);
+  const [data, setData] = useState<DashboardResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const liveRegionRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let alive = true;
-    const fetchState = async () => {
+    let lastAnnouncement = 0;
+
+    const fetch = async () => {
       try {
-        const resp = await getKillSwitchCurrentState('v1');
+        const resp = await getHealthDashboard();
         if (!alive) return;
-        setState(resp);
+        setData(resp);  // KEEP previous on top until new arrives
         setError(null);
+        setLoading(false);
+        // Polite announcement (debounce to 1×/5s)
+        const now = Date.now();
+        if (liveRegionRef.current && now - lastAnnouncement > 5000) {
+          liveRegionRef.current.textContent = 'Datos actualizados';
+          lastAnnouncement = now;
+        }
       } catch (err) {
         if (!alive) return;
         setError(err instanceof Error ? err.message : 'Error');
+        setLoading(false);
       }
     };
-    fetchState();
-    const id = setInterval(fetchState, POLL_INTERVAL_MS);
+
+    fetch();
+    const id = setInterval(fetch, POLL_INTERVAL_MS);
     return () => {
       alive = false;
       clearInterval(id);
     };
   }, []);
 
-  const symbols = state ? Object.values(state.symbols) : [];
-  const portfolio = state?.portfolio ?? { tier: 'NORMAL' as const, concurrent_failures: 0 };
+  if (loading && !data) {
+    return (
+      <div className="ks-dashboard" aria-busy="true">
+        <div className="ks-skeleton-strip" />
+        <div className="ks-skeleton-portfolio" />
+        <div className="ks-skeleton-grid">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="ks-skeleton-card" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="ks-dashboard">
+        {error && (
+          <div className="ks-error">Error cargando kill switch: {error}</div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="ks-dashboard">
       {error && (
-        <div className="ks-error">Error cargando kill switch: {error}</div>
+        <div className="ks-error">Error refrescando: {error} (mostrando última data)</div>
       )}
 
-      <div className="ks-portfolio-card">
-        <div className="ks-portfolio-label">Portfolio</div>
-        <div
-          className="ks-portfolio-tier"
-          style={{ color: TIER_COLORS_PORTFOLIO[portfolio.tier] }}
-        >
-          {portfolio.tier}
-        </div>
-        <div className="ks-portfolio-meta">
-          {portfolio.concurrent_failures} símbolo(s) en ALERT/REDUCED/PAUSED
-        </div>
-      </div>
+      <div ref={liveRegionRef} role="status" aria-live="polite" className="ks-sr-only" />
 
-      <div className="ks-symbol-grid">
-        {symbols.map((s) => (
-          <div key={s.symbol} className="ks-symbol-card">
-            <div className="ks-symbol-name">{s.symbol}</div>
-            <div
-              className="ks-symbol-tier"
-              style={{ color: TIER_COLORS_PER_SYMBOL[s.per_symbol_tier] }}
-            >
-              {s.per_symbol_tier}
-            </div>
-            <div className="ks-symbol-meta">
-              size × {s.size_factor.toFixed(2)} · {s.skip ? 'skip' : 'operating'}
-            </div>
-            <div className="ks-symbol-ts">
-              {new Date(s.ts).toLocaleString('es-ES')}
-            </div>
-          </div>
+      <AlertsStrip alerts={data.alerts} />
+      <PortfolioPanel portfolio={data.portfolio} />
+
+      <div className="ks-symbol-grid-v2">
+        {data.symbols.map((s) => (
+          <KillSwitchSymbolCard key={s.symbol} state={s} />
         ))}
-        {symbols.length === 0 && (
+        {data.symbols.length === 0 && (
           <div className="ks-empty">Sin datos aún — esperando scans.</div>
         )}
       </div>

--- a/frontend/src/components/KillSwitchSymbolCard.test.tsx
+++ b/frontend/src/components/KillSwitchSymbolCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import KillSwitchSymbolCard from './KillSwitchSymbolCard';
+import type { DashboardSymbolState } from '../types';
+
+const baseState: DashboardSymbolState = {
+  symbol: 'BTC',
+  state: 'NORMAL',
+  state_since: '2026-04-20T00:00:00Z',
+  manual_override: false,
+  metrics: {
+    trades_count_total: 50,
+    win_rate_20_trades: 0.55,
+    win_rate_10_trades: 0.5,
+    pnl_30d: 420,
+    months_negative_consecutive: 0,
+    probation_trades_remaining: null,
+    paused_days_at_entry: null,
+  },
+  last_transition: null,
+  sparkline_20: Array(20).fill('W'),
+  next_conditions: 'Saludable — sin alertas activas.',
+};
+
+describe('KillSwitchSymbolCard', () => {
+  it('renders symbol name and tier badge', () => {
+    render(<KillSwitchSymbolCard state={baseState} />);
+    expect(screen.getByText('BTC')).toBeInTheDocument();
+    expect(screen.getByText('NORMAL')).toBeInTheDocument();
+  });
+
+  it('renders next_conditions text', () => {
+    render(<KillSwitchSymbolCard state={baseState} />);
+    expect(screen.getByText(/Saludable/)).toBeInTheDocument();
+  });
+
+  it('renders last transition reason when present', () => {
+    const withTransition: DashboardSymbolState = {
+      ...baseState,
+      state: 'PROBATION',
+      last_transition: {
+        from_state: 'PAUSED',
+        to_state: 'PROBATION',
+        reason: 'reactivated_manual',
+        ts: '2026-04-25T00:00:00Z',
+      },
+    };
+    render(<KillSwitchSymbolCard state={withTransition} />);
+    expect(screen.getByText(/reactivated_manual/)).toBeInTheDocument();
+  });
+
+  it('renders metrics: WR, pnl, trades', () => {
+    render(<KillSwitchSymbolCard state={baseState} />);
+    expect(screen.getByText('55%')).toBeInTheDocument();
+    expect(screen.getByText(/420/)).toBeInTheDocument();
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/KillSwitchSymbolCard.tsx
+++ b/frontend/src/components/KillSwitchSymbolCard.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import Sparkline from './Sparkline';
+import MetricsBlock from './MetricsBlock';
+import type { DashboardSymbolState, KillSwitchPerSymbolTier } from '../types';
+
+interface KillSwitchSymbolCardProps {
+  state: DashboardSymbolState;
+}
+
+const TIER_CLASS: Record<KillSwitchPerSymbolTier, string> = {
+  NORMAL: 'ks-tier-normal',
+  ALERT: 'ks-tier-alert',
+  REDUCED: 'ks-tier-reduced',
+  PAUSED: 'ks-tier-paused',
+  PROBATION: 'ks-tier-probation',
+};
+
+function formatRelativeTime(iso: string): string {
+  const ts = new Date(iso);
+  const diffMs = Date.now() - ts.getTime();
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (days > 0) return `hace ${days}d`;
+  if (hours > 0) return `hace ${hours}h`;
+  const mins = Math.floor(diffMs / (1000 * 60));
+  return `hace ${Math.max(1, mins)}m`;
+}
+
+const KillSwitchSymbolCard: React.FC<KillSwitchSymbolCardProps> = ({ state }) => {
+  const tierClass = TIER_CLASS[state.state] ?? 'ks-tier-normal';
+
+  return (
+    <article
+      className="ks-symbol-card-v2"
+      aria-labelledby={`ks-card-${state.symbol}`}
+    >
+      <header className="ks-card-header">
+        <h3 id={`ks-card-${state.symbol}`} className="ks-card-symbol">
+          {state.symbol}
+        </h3>
+        <span
+          className={`ks-tier-badge ${tierClass}`}
+          aria-label={`Tier: ${state.state}`}
+        >
+          {state.state}
+        </span>
+      </header>
+
+      <Sparkline outcomes={state.sparkline_20} />
+
+      <MetricsBlock metrics={state.metrics} />
+
+      {state.last_transition && (
+        <div className="ks-last-transition">
+          <span className="ks-transition-arrow">←</span>
+          {state.last_transition.from_state}
+          <span className="ks-transition-reason">
+            {' '}{state.last_transition.reason}
+          </span>
+          <span className="ks-transition-ts">
+            {' · '}{formatRelativeTime(state.last_transition.ts)}
+          </span>
+        </div>
+      )}
+
+      <p className="ks-next-conditions">{state.next_conditions}</p>
+    </article>
+  );
+};
+
+export default KillSwitchSymbolCard;

--- a/frontend/src/components/MetricsBlock.tsx
+++ b/frontend/src/components/MetricsBlock.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import type { DashboardSymbolMetrics } from '../types';
+
+interface MetricsBlockProps {
+  metrics: DashboardSymbolMetrics;
+}
+
+const fmtPct = (v: number): string => (v * 100).toFixed(0) + '%';
+const fmtUsd = (v: number): string => {
+  const sign = v >= 0 ? '+' : '−';
+  return `${sign}$${Math.abs(v).toFixed(0)}`;
+};
+
+const MetricsBlock: React.FC<MetricsBlockProps> = ({ metrics }) => {
+  return (
+    <dl className="ks-metrics">
+      <div className="ks-metric">
+        <dt>WR</dt>
+        <dd>{fmtPct(metrics.win_rate_20_trades)}</dd>
+      </div>
+      <div className="ks-metric">
+        <dt>pnl 30d</dt>
+        <dd className={metrics.pnl_30d >= 0 ? 'ks-pos' : 'ks-neg'}>
+          {fmtUsd(metrics.pnl_30d)}
+        </dd>
+      </div>
+      <div className="ks-metric">
+        <dt>trades</dt>
+        <dd>{metrics.trades_count_total}</dd>
+      </div>
+      {metrics.months_negative_consecutive > 0 && (
+        <div className="ks-metric">
+          <dt>meses neg</dt>
+          <dd>{metrics.months_negative_consecutive}</dd>
+        </div>
+      )}
+    </dl>
+  );
+};
+
+export default MetricsBlock;

--- a/frontend/src/components/PortfolioPanel.test.tsx
+++ b/frontend/src/components/PortfolioPanel.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PortfolioPanel from './PortfolioPanel';
+import type { DashboardPortfolioState } from '../types';
+
+const baseState: DashboardPortfolioState = {
+  tier: 'NORMAL',
+  dd_pct: -0.021,
+  peak_equity: 12450,
+  current_equity: 12189,
+  concurrent_failures: 1,
+  recent_transitions: [],
+};
+
+describe('PortfolioPanel', () => {
+  it('renders tier and DD%', () => {
+    render(<PortfolioPanel portfolio={baseState} />);
+    expect(screen.getByText('NORMAL')).toBeInTheDocument();
+    expect(screen.getByText(/-2\.1%/)).toBeInTheDocument();
+  });
+
+  it('renders concurrent failures count', () => {
+    render(<PortfolioPanel portfolio={baseState} />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders recent transitions when present', () => {
+    const withTransitions: DashboardPortfolioState = {
+      ...baseState,
+      recent_transitions: [
+        { from_tier: 'WARNED', to_tier: 'NORMAL', reason: 'recovered',
+          dd_pct: -0.01, concurrent: 1, ts: '2026-04-25T00:00:00Z' },
+      ],
+    };
+    render(<PortfolioPanel portfolio={withTransitions} />);
+    expect(screen.getByText(/recovered/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/PortfolioPanel.tsx
+++ b/frontend/src/components/PortfolioPanel.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import type { DashboardPortfolioState, KillSwitchPortfolioTier } from '../types';
+
+interface PortfolioPanelProps {
+  portfolio: DashboardPortfolioState;
+}
+
+const TIER_CLASS: Record<KillSwitchPortfolioTier, string> = {
+  NORMAL: 'ks-tier-normal',
+  WARNED: 'ks-tier-alert',
+  REDUCED: 'ks-tier-reduced',
+  FROZEN: 'ks-tier-paused',
+};
+
+const PortfolioPanel: React.FC<PortfolioPanelProps> = ({ portfolio }) => {
+  const tierClass = TIER_CLASS[portfolio.tier] ?? 'ks-tier-normal';
+  const ddPctText = (portfolio.dd_pct * 100).toFixed(1) + '%';
+
+  return (
+    <section className="ks-portfolio-panel" aria-label="Portfolio aggregate">
+      <div className="ks-portfolio-tier-card">
+        <span className={`ks-tier-badge ks-tier-large ${tierClass}`}>
+          {portfolio.tier}
+        </span>
+        <dl className="ks-portfolio-metrics">
+          <div className="ks-metric">
+            <dt>DD</dt><dd>{ddPctText}</dd>
+          </div>
+          <div className="ks-metric">
+            <dt>peak</dt><dd>${portfolio.peak_equity.toFixed(0)}</dd>
+          </div>
+          <div className="ks-metric">
+            <dt>failures</dt><dd>{portfolio.concurrent_failures}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="ks-portfolio-transitions">
+        <h4 className="ks-transitions-title">Transiciones recientes</h4>
+        {portfolio.recent_transitions.length === 0 ? (
+          <p className="ks-empty-text">— sin transiciones —</p>
+        ) : (
+          <ul className="ks-transitions-list">
+            {portfolio.recent_transitions.map((t, i) => (
+              <li key={i} className="ks-transition-row">
+                <span className="ks-transition-flow">
+                  {t.to_tier} ← {t.from_tier}
+                </span>
+                <span className="ks-transition-reason"> · {t.reason}</span>
+                <span className="ks-transition-ts">
+                  {' · '}{new Date(t.ts).toLocaleString('es-ES')}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default PortfolioPanel;

--- a/frontend/src/components/Sparkline.test.tsx
+++ b/frontend/src/components/Sparkline.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Sparkline from './Sparkline';
+
+describe('Sparkline', () => {
+  it('renders 20 cells', () => {
+    const { container } = render(
+      <Sparkline outcomes={Array(20).fill(null)} />,
+    );
+    const cells = container.querySelectorAll('.ks-spark-cell');
+    expect(cells).toHaveLength(20);
+  });
+
+  it('applies win class to W cells and loss class to L cells', () => {
+    const outcomes: Array<'W' | 'L' | null> = [
+      ...Array(15).fill(null),
+      'W', 'W', 'L', 'L', 'W',
+    ];
+    const { container } = render(<Sparkline outcomes={outcomes} />);
+    const cells = container.querySelectorAll('.ks-spark-cell');
+    expect(cells[15].className).toContain('ks-spark-win');
+    expect(cells[17].className).toContain('ks-spark-loss');
+    expect(cells[19].className).toContain('ks-spark-win');
+  });
+
+  it('aria-label summarizes wins/losses/empty count', () => {
+    const outcomes: Array<'W' | 'L' | null> = [
+      ...Array(10).fill(null),
+      'W', 'W', 'W', 'W', 'W', 'L', 'L', 'L', 'W', 'W',
+    ];
+    render(<Sparkline outcomes={outcomes} />);
+    const root = screen.getByLabelText(/wins/i);
+    expect(root).toBeInTheDocument();
+    // Should mention 7 wins, 3 losses, 10 sin datos
+    expect(root.getAttribute('aria-label')).toMatch(/7.*wins/i);
+    expect(root.getAttribute('aria-label')).toMatch(/3.*loss/i);
+  });
+});

--- a/frontend/src/components/Sparkline.tsx
+++ b/frontend/src/components/Sparkline.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface SparklineProps {
+  outcomes: Array<'W' | 'L' | null>;
+}
+
+const Sparkline: React.FC<SparklineProps> = ({ outcomes }) => {
+  const wins = outcomes.filter(o => o === 'W').length;
+  const losses = outcomes.filter(o => o === 'L').length;
+  const empty = outcomes.filter(o => o === null).length;
+  const ariaLabel = `Últimos ${outcomes.length} trades: ${wins} wins, ${losses} losses, ${empty} sin datos`;
+
+  return (
+    <div className="ks-sparkline" role="img" aria-label={ariaLabel}>
+      {outcomes.map((outcome, i) => {
+        const cls = outcome === 'W'
+          ? 'ks-spark-cell ks-spark-win'
+          : outcome === 'L'
+          ? 'ks-spark-cell ks-spark-loss'
+          : 'ks-spark-cell ks-spark-empty';
+        return <span key={i} className={cls} />;
+      })}
+    </div>
+  );
+};
+
+export default Sparkline;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -301,3 +301,72 @@ export interface KillSwitchCurrentStateResponse {
   symbols: { [symbol: string]: KillSwitchSymbolState };
   portfolio: KillSwitchPortfolioState;
 }
+
+// ─── Kill switch v2 dashboard (#187 B6) ───────────────────────────────
+
+export interface DashboardSymbolMetrics {
+  trades_count_total: number;
+  win_rate_20_trades: number;
+  win_rate_10_trades: number;
+  pnl_30d: number;
+  months_negative_consecutive: number;
+  probation_trades_remaining: number | null;
+  paused_days_at_entry: number | null;
+}
+
+export interface DashboardSymbolTransition {
+  from_state: string;
+  to_state: string;
+  reason: string;
+  ts: string;
+}
+
+export interface DashboardSymbolState {
+  symbol: string;
+  state: KillSwitchPerSymbolTier;
+  state_since: string | null;
+  manual_override: boolean;
+  metrics: DashboardSymbolMetrics;
+  last_transition: DashboardSymbolTransition | null;
+  sparkline_20: Array<'W' | 'L' | null>;
+  next_conditions: string;
+}
+
+export interface DashboardPortfolioTransition {
+  from_tier: string;
+  to_tier: string;
+  reason: string;
+  dd_pct: number;
+  concurrent: number;
+  ts: string;
+}
+
+export interface DashboardPortfolioState {
+  tier: KillSwitchPortfolioTier;
+  dd_pct: number;
+  peak_equity: number;
+  current_equity: number;
+  concurrent_failures: number;
+  recent_transitions: DashboardPortfolioTransition[];
+}
+
+export type DashboardAlertKind =
+  | 'symbol_failures' | 'portfolio_dd' | 'velocity_burst' | 'auto_reactivation';
+
+export interface DashboardAlertItem {
+  kind: DashboardAlertKind;
+  text: string;
+  severity: 'info' | 'warning' | 'critical';
+  ts: string;
+}
+
+export interface DashboardAlertSummary {
+  items: DashboardAlertItem[];
+}
+
+export interface DashboardResponse {
+  symbols: DashboardSymbolState[];
+  portfolio: DashboardPortfolioState;
+  alerts: DashboardAlertSummary;
+  generated_at: string;
+}

--- a/health.py
+++ b/health.py
@@ -986,3 +986,51 @@ def health_monitor_loop(cfg_fn, stop_event=None) -> None:
             log.info("health_monitor_loop: daily sweep complete")
         except Exception as e:  # noqa: BLE001
             log.error("health_monitor_loop sweep failed: %s", e, exc_info=True)
+
+
+def record_portfolio_transition(
+    from_tier: str,
+    to_tier: str,
+    reason: str,
+    dd_pct: float = 0.0,
+    concurrent: int = 0,
+) -> None:
+    """B6: Append a portfolio-tier transition row.
+
+    Idempotency / dedup is the caller's responsibility — fires only when a
+    transition actually happens (from_tier != to_tier).
+    """
+    if from_tier == to_tier:
+        return
+    conn = _conn()
+    try:
+        conn.execute(
+            """INSERT INTO portfolio_health_events
+               (from_tier, to_tier, reason, dd_pct, concurrent, ts)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (from_tier, to_tier, reason, float(dd_pct), int(concurrent), _now_iso()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def recent_portfolio_transitions(limit: int = 5) -> list[dict[str, Any]]:
+    """B6: Last N portfolio-tier transitions, newest first."""
+    conn = _conn()
+    try:
+        rows = conn.execute(
+            """SELECT from_tier, to_tier, reason, dd_pct, concurrent, ts
+               FROM portfolio_health_events
+               ORDER BY ts DESC LIMIT ?""",
+            (limit,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        {
+            "from_tier": r[0], "to_tier": r[1], "reason": r[2],
+            "dd_pct": r[3], "concurrent": r[4], "ts": r[5],
+        }
+        for r in rows
+    ]

--- a/health.py
+++ b/health.py
@@ -1119,9 +1119,14 @@ def get_dashboard_state(cfg: dict[str, Any]) -> dict[str, Any]:
                     days_in_paused = 0
 
             sparkline = sparkline_for_symbol(sym, conn, n=20)
-            next_conditions = compute_next_conditions(
-                state, metrics, manual_override, ks_cfg, days_in_paused,
-            )
+            if row is None:
+                # B6 spec: never-evaluated symbols get explicit placeholder copy,
+                # not the misleading "Saludable" that would come from compute_next_conditions("NORMAL", ...).
+                next_conditions = "Sin datos aún — esperando primer scan."
+            else:
+                next_conditions = compute_next_conditions(
+                    state, metrics, manual_override, ks_cfg, days_in_paused,
+                )
 
             symbols_out.append({
                 "symbol": sym,

--- a/health.py
+++ b/health.py
@@ -224,6 +224,79 @@ def compute_probation_trades_remaining(
     return int(round(trades_base + per_pause_day * days_paused))
 
 
+def compute_next_conditions(
+    state: str,
+    metrics: dict[str, Any],
+    manual_override: bool,
+    cfg: dict[str, Any],
+    days_in_paused: int = 0,
+) -> str:
+    """B6: Spanish text describing the gap to next tier change.
+
+    Pure function. Uses cfg thresholds + current metrics to phrase what
+    the operator should expect ("para salir de ALERT: WR>0.20 sobre 8 trades").
+
+    Args:
+        state: current per-symbol tier ("NORMAL"|"ALERT"|"REDUCED"|"PAUSED"|"PROBATION").
+        metrics: rolling metrics dict (output of compute_rolling_metrics).
+        manual_override: whether the symbol has manual_override=1.
+        cfg: kill_switch sub-config (already unwrapped).
+        days_in_paused: how many days the symbol has been in PAUSED (used for
+            auto-recovery countdown).
+
+    Returns: Spanish text, never None.
+    """
+    if state == "NORMAL":
+        return "Saludable — sin alertas activas."
+
+    if state == "ALERT":
+        threshold = float(cfg.get("alert_win_rate_threshold", 0.15))
+        wr20 = float(metrics.get("win_rate_20_trades", 0.0) or 0.0)
+        # wins needed = ceil(threshold * 20 - current_wins). current_wins = wr20*20.
+        import math
+        current_wins = int(round(wr20 * 20))
+        wins_needed = max(0, int(math.ceil(threshold * 20 - current_wins)))
+        return (
+            f"Para salir: WR>{threshold:.2f} sobre próximos 20 trades. "
+            f"Actual: WR={wr20:.2f} ({current_wins}/20 wins), faltan {wins_needed} wins."
+        )
+
+    if state == "REDUCED":
+        pnl_30d = float(metrics.get("pnl_30d", 0.0) or 0.0)
+        gap = max(0.0, -pnl_30d)
+        return (
+            f"Para salir: pnl_30d ≥ 0. Actual: ${pnl_30d:.2f}, "
+            f"faltan ${gap:.2f}."
+        )
+
+    if state == "PAUSED":
+        if manual_override:
+            return "Reactivación manual disponible vía POST /health/reactivate/{symbol}."
+        v2_cfg = (cfg.get("v2") or {})
+        prob_cfg = (v2_cfg.get("probation") or {})
+        threshold_days = int(prob_cfg.get("paused_to_probation_days", 14))
+        days_remaining = max(0, threshold_days - int(days_in_paused))
+        return (
+            f"Auto-recovery: en {days_remaining} días + portfolio NORMAL → PROBATION. "
+            f"Días en PAUSED: {days_in_paused}/{threshold_days}."
+        )
+
+    if state == "PROBATION":
+        trades_remaining = metrics.get("probation_trades_remaining")
+        wr10 = float(metrics.get("win_rate_10_trades", 0.0) or 0.0)
+        v2_cfg = (cfg.get("v2") or {})
+        prob_cfg = (v2_cfg.get("probation") or {})
+        regression_wr = float(prob_cfg.get("regression_wr_threshold", 0.10))
+        if trades_remaining is None:
+            return f"En PROBATION (sin contador). WR_10={wr10:.2f}."
+        return (
+            f"En PROBATION: {int(trades_remaining)} trades restantes (al llegar a 0 → NORMAL). "
+            f"Riesgo regresión: WR_10={wr10:.2f}, threshold={regression_wr:.2f}."
+        )
+
+    return f"Estado desconocido: {state}"
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  STATE MACHINE (pure)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/health.py
+++ b/health.py
@@ -492,6 +492,113 @@ def get_symbol_state(symbol: str) -> str:
     return row[0] if row else "NORMAL"
 
 
+def sparkline_for_symbol(symbol: str, conn, n: int = 20) -> list[str | None]:
+    """B6: Last n trade outcomes for `symbol`, oldest→newest, padded with None.
+
+    'W' if pnl_usd > 0, 'L' otherwise. Breakeven (pnl=0) counts as L.
+    Returns a list of length exactly n.
+    """
+    cursor = conn.execute(
+        """SELECT pnl_usd FROM positions
+           WHERE symbol = ? AND status = 'closed' AND exit_ts IS NOT NULL
+           ORDER BY exit_ts DESC LIMIT ?""",
+        (symbol, n),
+    )
+    raw = [row[0] for row in cursor.fetchall()]
+    raw.reverse()  # newest-first → oldest-first
+
+    outcomes: list[str | None] = []
+    for pnl in raw:
+        if pnl is not None and pnl > 0:
+            outcomes.append('W')
+        else:
+            outcomes.append('L')
+
+    # Pad with leading None until length == n
+    while len(outcomes) < n:
+        outcomes.insert(0, None)
+    return outcomes
+
+
+def summarize_recent_alerts(
+    conn=None,
+    window_hours: int = 24,
+) -> dict[str, Any]:
+    """B6: Aggregated 24h alert summary for the dashboard alerts strip.
+
+    Reads `symbol_health_events` for `symbol_failures` and `auto_reactivation`,
+    `kill_switch_decisions` for `velocity_burst`. Returns {"items": [...]}
+    where each item has kind/text/severity/ts.
+    """
+    if conn is None:
+        conn = _conn()
+        owns_conn = True
+    else:
+        owns_conn = False
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=window_hours)).isoformat()
+    items: list[dict[str, Any]] = []
+
+    try:
+        # symbol_failures: distinct symbols entering ALERT/REDUCED/PAUSED
+        rows = conn.execute(
+            """SELECT DISTINCT symbol, MAX(ts) AS latest
+               FROM symbol_health_events
+               WHERE ts >= ? AND to_state IN ('ALERT', 'REDUCED', 'PAUSED')
+               GROUP BY symbol""",
+            (cutoff,),
+        ).fetchall()
+        if rows:
+            n = len(rows)
+            latest_ts = max(r[1] for r in rows)
+            severity = "warning" if n >= 3 else "info"
+            items.append({
+                "kind": "symbol_failures",
+                "text": f"{n} símbolo(s) entraron en ALERT/REDUCED/PAUSED en últimas {window_hours}h",
+                "severity": severity,
+                "ts": latest_ts,
+            })
+
+        # auto_reactivation: PROBATION transitions with reason starting "reactivated_auto"
+        rows = conn.execute(
+            """SELECT COUNT(*) AS n, MAX(ts) AS latest
+               FROM symbol_health_events
+               WHERE ts >= ? AND to_state = 'PROBATION'
+                 AND trigger_reason LIKE 'reactivated_auto%'""",
+            (cutoff,),
+        ).fetchone()
+        if rows and rows[0] > 0:
+            items.append({
+                "kind": "auto_reactivation",
+                "text": f"{rows[0]} símbolo(s) auto-reactivados a PROBATION en últimas {window_hours}h",
+                "severity": "info",
+                "ts": rows[1],
+            })
+
+        # velocity_burst: count of decisions with velocity_active=1
+        rows = conn.execute(
+            """SELECT COUNT(*) AS n, MAX(ts) AS latest
+               FROM kill_switch_decisions
+               WHERE ts >= ? AND velocity_active = 1""",
+            (cutoff,),
+        ).fetchone()
+        if rows and rows[0] > 0:
+            items.append({
+                "kind": "velocity_burst",
+                "text": f"Velocity trigger fired {rows[0]} veces en últimas {window_hours}h",
+                "severity": "info",
+                "ts": rows[1],
+            })
+
+        # Sort newest-first
+        items.sort(key=lambda x: x["ts"], reverse=True)
+    finally:
+        if owns_conn:
+            conn.close()
+
+    return {"items": items}
+
+
 def _record_evaluation(symbol: str, metrics: dict[str, Any], new_state: str) -> None:
     """Update last_evaluated_at + last_metrics_json without changing state.
     Creates the row if it doesn't exist. No event is emitted."""

--- a/health.py
+++ b/health.py
@@ -1034,3 +1034,151 @@ def recent_portfolio_transitions(limit: int = 5) -> list[dict[str, Any]]:
         }
         for r in rows
     ]
+
+
+def get_dashboard_state(cfg: dict[str, Any]) -> dict[str, Any]:
+    """B6 orchestrator: assemble per-symbol + portfolio + alerts response.
+
+    Reads from DB; computes next_conditions; builds the full DashboardResponse
+    shape consumed by the frontend.
+    """
+    from btc_scanner import DEFAULT_SYMBOLS
+
+    ks_cfg = (cfg.get("kill_switch") or {})
+    now = datetime.now(timezone.utc)
+
+    conn = _conn()
+    try:
+        # Build symbol list: union of DEFAULT_SYMBOLS + any DB rows. This way
+        # the dashboard always shows the curated 10 (as NORMAL placeholders if
+        # not yet evaluated) AND any historical/legacy rows in symbol_health.
+        db_symbols = [
+            r[0] for r in conn.execute(
+                "SELECT DISTINCT symbol FROM symbol_health"
+            ).fetchall()
+        ]
+        seen: set[str] = set()
+        symbols_iter: list[str] = []
+        for sym in list(DEFAULT_SYMBOLS) + db_symbols:
+            if sym not in seen:
+                seen.add(sym)
+                symbols_iter.append(sym)
+
+        # Symbols
+        symbols_out: list[dict[str, Any]] = []
+        for sym in symbols_iter:
+            row = _get_symbol_health_row(sym)  # opens its own conn
+            if row is None:
+                # No row → NORMAL placeholder, empty metrics
+                state = "NORMAL"
+                state_since_iso = None
+                manual_override = False
+                metrics = {
+                    "trades_count_total": 0,
+                    "win_rate_20_trades": 0.0,
+                    "win_rate_10_trades": 0.0,
+                    "pnl_30d": 0.0,
+                    "months_negative_consecutive": 0,
+                    "probation_trades_remaining": None,
+                    "paused_days_at_entry": None,
+                }
+                last_transition = None
+            else:
+                state = row["state"]
+                state_since_iso = row.get("state_since")
+                manual_override = bool(row["manual_override"])
+                metrics = compute_rolling_metrics(sym, conn, now=now)
+                metrics["probation_trades_remaining"] = row.get("probation_trades_remaining")
+                metrics["paused_days_at_entry"] = row.get("paused_days_at_entry")
+                # last transition
+                lt_row = conn.execute(
+                    """SELECT from_state, to_state, trigger_reason, ts
+                       FROM symbol_health_events
+                       WHERE symbol = ? ORDER BY ts DESC LIMIT 1""",
+                    (sym,),
+                ).fetchone()
+                if lt_row is not None:
+                    last_transition = {
+                        "from_state": lt_row[0],
+                        "to_state": lt_row[1],
+                        "reason": lt_row[2],
+                        "ts": lt_row[3],
+                    }
+                else:
+                    last_transition = None
+
+            # days_in_paused — for next_conditions PAUSED branch
+            days_in_paused = 0
+            if state == "PAUSED" and state_since_iso:
+                try:
+                    state_since_dt = datetime.fromisoformat(
+                        state_since_iso.replace("Z", "+00:00")
+                    )
+                    days_in_paused = max(0, int((now - state_since_dt).days))
+                except (ValueError, AttributeError):
+                    days_in_paused = 0
+
+            sparkline = sparkline_for_symbol(sym, conn, n=20)
+            next_conditions = compute_next_conditions(
+                state, metrics, manual_override, ks_cfg, days_in_paused,
+            )
+
+            symbols_out.append({
+                "symbol": sym,
+                "state": state,
+                "state_since": state_since_iso,
+                "manual_override": manual_override,
+                "metrics": metrics,
+                "last_transition": last_transition,
+                "sparkline_20": sparkline,
+                "next_conditions": next_conditions,
+            })
+
+        # Portfolio
+        try:
+            from strategy.kill_switch_v2 import evaluate_portfolio_tier
+            from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
+            portfolio_dd = _compute_current_portfolio_dd(cfg)
+            n_failures = conn.execute(
+                """SELECT COUNT(*) FROM symbol_health
+                   WHERE state IN ('ALERT', 'REDUCED', 'PAUSED', 'PROBATION')"""
+            ).fetchone()[0]
+            portfolio_tier = evaluate_portfolio_tier(portfolio_dd, int(n_failures), cfg)
+            current_equity = float(cfg.get("capital_usd", 1000.0)) * (1.0 + portfolio_dd)
+            peak_equity = float(cfg.get("capital_usd", 1000.0))
+        except Exception:
+            log.warning("get_dashboard_state portfolio computation failed", exc_info=True)
+            portfolio_tier = {"tier": "NORMAL", "dd": 0.0, "concurrent_failures": 0}
+            portfolio_dd = 0.0
+            n_failures = 0
+            current_equity = float(cfg.get("capital_usd", 1000.0))
+            peak_equity = current_equity
+
+        portfolio_out = {
+            "tier": portfolio_tier["tier"],
+            "dd_pct": float(portfolio_dd),
+            "peak_equity": peak_equity,
+            "current_equity": current_equity,
+            "concurrent_failures": int(n_failures),
+            "recent_transitions": recent_portfolio_transitions(limit=5),
+        }
+
+        # Alerts (24h window) — append portfolio_dd item if non-NORMAL
+        alerts = summarize_recent_alerts(conn=conn, window_hours=24)
+        if portfolio_tier["tier"] != "NORMAL":
+            severity = "critical" if portfolio_tier["tier"] == "FROZEN" else "warning"
+            alerts["items"].insert(0, {
+                "kind": "portfolio_dd",
+                "text": f"Portfolio DD {portfolio_dd:.1%} — tier {portfolio_tier['tier']} activo",
+                "severity": severity,
+                "ts": now.isoformat(),
+            })
+    finally:
+        conn.close()
+
+    return {
+        "symbols": symbols_out,
+        "portfolio": portfolio_out,
+        "alerts": alerts,
+        "generated_at": now.isoformat(),
+    }

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -451,6 +451,22 @@ def emit_shadow_decision(
             cfg=cfg_eff,
         )
 
+        # B6: record portfolio-tier transitions for the dashboard
+        try:
+            from health import recent_portfolio_transitions, record_portfolio_transition
+            recent = recent_portfolio_transitions(limit=1)
+            prev_tier = recent[0]["to_tier"] if recent else "NORMAL"
+            if prev_tier != portfolio["tier"]:
+                record_portfolio_transition(
+                    from_tier=prev_tier,
+                    to_tier=portfolio["tier"],
+                    reason=f"shadow_eval_dd_{portfolio_dd:.4f}",
+                    dd_pct=float(portfolio_dd),
+                    concurrent=int(concurrent),
+                )
+        except Exception:
+            log.warning("record_portfolio_transition (shadow) failed", exc_info=True)
+
         # Slider values for telemetry
         v2_base = (cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
         v2_eff = (cfg_eff.get("kill_switch", {}) or {}).get("v2", {}) or {}

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -356,6 +356,23 @@ def test_get_health_dashboard_seeded_symbol_returns_full_state(client):
     assert "PROBATION" in btc["next_conditions"] or "trades" in btc["next_conditions"].lower()
 
 
+def test_get_health_dashboard_unevaluated_symbol_has_placeholder_text(client):
+    """B6 boundary: symbol with no row → next_conditions='Sin datos aún', not 'Saludable'.
+
+    Empty-DB DEFAULT_SYMBOLS appear as placeholders; their next_conditions must
+    explicitly say there's no data, NOT mislead operators with 'Saludable'.
+    """
+    resp = client.get("/health/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    # All symbols in empty DB are placeholders (no row in symbol_health)
+    for sym_state in data["symbols"]:
+        assert "Sin datos aún" in sym_state["next_conditions"], (
+            f"Placeholder symbol {sym_state['symbol']} should say "
+            f"'Sin datos aún' but got: {sym_state['next_conditions']}"
+        )
+
+
 def test_get_health_dashboard_disabled_kill_switch_still_returns(client, monkeypatch):
     """Even with kill_switch.enabled=False, the dashboard still serves a snapshot
     (read-only — useful for post-mortems)."""

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -279,3 +279,87 @@ def test_recent_portfolio_transitions_returns_last_5(tmp_db):
     # Newest first
     assert transitions[0]["reason"] == "reason_6"
     assert transitions[4]["reason"] == "reason_2"
+
+
+# ── GET /health/dashboard endpoint ─────────────────────────────────────────
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    return TestClient(btc_api.app)
+
+
+def test_get_health_dashboard_empty_db_returns_default_shape(client):
+    """Empty DB → portfolio NORMAL + symbols=[] (or all DEFAULT_SYMBOLS as NORMAL placeholders) + alerts.items=[]."""
+    resp = client.get("/health/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "symbols" in data
+    assert "portfolio" in data
+    assert "alerts" in data
+    assert "generated_at" in data
+    assert isinstance(data["symbols"], list)
+    assert data["alerts"]["items"] == []
+    assert data["portfolio"]["tier"] == "NORMAL"
+
+
+def test_get_health_dashboard_seeded_symbol_returns_full_state(client):
+    """One PROBATION symbol seeded → response includes all the fields."""
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        # Seed PROBATION row + 5 wins
+        conn.execute(
+            """INSERT INTO symbol_health
+               (symbol, state, state_since, last_evaluated_at, last_metrics_json,
+                manual_override, probation_trades_remaining, probation_started_at,
+                paused_days_at_entry)
+               VALUES ('BTC', 'PROBATION', '2026-04-20T00:00:00+00:00',
+                       '2026-04-26T00:00:00+00:00', '{}', 1,
+                       8, '2026-04-20T00:00:00+00:00', 15)"""
+        )
+        for i in range(5):
+            conn.execute(
+                """INSERT INTO positions
+                   (symbol, direction, status, entry_price, entry_ts,
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10)""",
+                (f"2026-04-2{1+i}T12:00:00+00:00", f"2026-04-2{1+i}T13:00:00+00:00"),
+            )
+        # Seed an event
+        conn.execute(
+            """INSERT INTO symbol_health_events
+               (symbol, from_state, to_state, trigger_reason, metrics_json, ts)
+               VALUES ('BTC', 'PAUSED', 'PROBATION', 'reactivated_manual',
+                       '{}', '2026-04-20T00:00:00+00:00')"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    resp = client.get("/health/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    btc = next(s for s in data["symbols"] if s["symbol"] == "BTC")
+    assert btc["state"] == "PROBATION"
+    assert btc["metrics"]["probation_trades_remaining"] == 8
+    assert len(btc["sparkline_20"]) == 20
+    assert btc["sparkline_20"][-5:] == ['W', 'W', 'W', 'W', 'W']
+    assert btc["last_transition"]["reason"] == "reactivated_manual"
+    assert "PROBATION" in btc["next_conditions"] or "trades" in btc["next_conditions"].lower()
+
+
+def test_get_health_dashboard_disabled_kill_switch_still_returns(client, monkeypatch):
+    """Even with kill_switch.enabled=False, the dashboard still serves a snapshot
+    (read-only — useful for post-mortems)."""
+    import btc_api
+    monkeypatch.setattr(btc_api, "load_config", lambda: {"kill_switch": {"enabled": False}})
+    resp = client.get("/health/dashboard")
+    assert resp.status_code == 200

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -224,3 +224,58 @@ def test_summarize_recent_alerts_excludes_events_outside_window(tmp_db):
     finally:
         conn.close()
     assert result["items"] == []
+
+
+# ── portfolio_health_events ────────────────────────────────────────────────
+
+
+def test_init_db_creates_portfolio_health_events_table(tmp_db):
+    import btc_api
+    conn = btc_api.get_db()
+    try:
+        rows = conn.execute(
+            """SELECT name FROM sqlite_master
+               WHERE type='table' AND name='portfolio_health_events'"""
+        ).fetchall()
+    finally:
+        conn.close()
+    assert len(rows) == 1
+
+
+def test_record_portfolio_transition_inserts_row(tmp_db):
+    import btc_api
+    from health import record_portfolio_transition
+    record_portfolio_transition(
+        from_tier="NORMAL", to_tier="WARNED",
+        reason="3_concurrent_failures", dd_pct=-0.02, concurrent=3,
+    )
+    conn = btc_api.get_db()
+    try:
+        row = conn.execute(
+            """SELECT from_tier, to_tier, reason, dd_pct, concurrent
+               FROM portfolio_health_events ORDER BY ts DESC LIMIT 1"""
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row[0] == "NORMAL"
+    assert row[1] == "WARNED"
+    assert row[2] == "3_concurrent_failures"
+    assert row[3] == -0.02
+    assert row[4] == 3
+
+
+def test_recent_portfolio_transitions_returns_last_5(tmp_db):
+    """Helper to fetch last 5 transitions for the dashboard panel."""
+    import btc_api
+    from health import record_portfolio_transition, recent_portfolio_transitions
+    for i in range(7):
+        record_portfolio_transition(
+            from_tier="NORMAL" if i % 2 else "WARNED",
+            to_tier="WARNED" if i % 2 else "NORMAL",
+            reason=f"reason_{i}", dd_pct=0.0, concurrent=i,
+        )
+    transitions = recent_portfolio_transitions(limit=5)
+    assert len(transitions) == 5
+    # Newest first
+    assert transitions[0]["reason"] == "reason_6"
+    assert transitions[4]["reason"] == "reason_2"

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -363,3 +363,27 @@ def test_get_health_dashboard_disabled_kill_switch_still_returns(client, monkeyp
     monkeypatch.setattr(btc_api, "load_config", lambda: {"kill_switch": {"enabled": False}})
     resp = client.get("/health/dashboard")
     assert resp.status_code == 200
+
+
+# ── Portfolio transition recording integration ──────────────────────────────
+
+
+def test_portfolio_tier_change_records_transition(tmp_db, monkeypatch):
+    """When portfolio tier changes between two shadow evaluations, a row is
+    appended to portfolio_health_events."""
+    import btc_api
+    from health import recent_portfolio_transitions
+
+    # Simulate: first eval NORMAL, second eval WARNED. Both via the same
+    # shadow path. We invoke the helper directly (the integration via
+    # kill_switch_v2_shadow is wired in step 4 below).
+    from health import record_portfolio_transition
+    record_portfolio_transition("NORMAL", "WARNED", reason="3_concurrent",
+                                 dd_pct=-0.01, concurrent=3)
+    record_portfolio_transition("WARNED", "REDUCED", reason="dd_threshold",
+                                 dd_pct=-0.04, concurrent=3)
+
+    transitions = recent_portfolio_transitions(limit=5)
+    assert len(transitions) == 2
+    assert transitions[0]["to_tier"] == "REDUCED"
+    assert transitions[1]["to_tier"] == "WARNED"

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -1,0 +1,80 @@
+"""B6 dashboard observability — pure fns + endpoint (#187 #200)."""
+import pytest
+
+
+# ── compute_next_conditions ─────────────────────────────────────────────────
+
+
+CFG_NC = {
+    "min_trades_for_eval": 20,
+    "alert_win_rate_threshold": 0.15,
+    "pause_months_consecutive": 3,
+    "v2": {"probation": {
+        "regression_wr_threshold": 0.10,
+        "regression_window_trades": 10,
+        "paused_to_probation_days": 14,
+    }},
+}
+
+
+def _metrics(wr20=0.5, wr10=0.5, pnl_30d=500.0, months_neg=0, total=50,
+              prob_remaining=None, paused_days=None):
+    return {
+        "trades_count_total": total,
+        "win_rate_20_trades": wr20,
+        "win_rate_10_trades": wr10,
+        "pnl_30d": pnl_30d,
+        "months_negative_consecutive": months_neg,
+        "probation_trades_remaining": prob_remaining,
+        "paused_days_at_entry": paused_days,
+    }
+
+
+def test_next_conditions_normal_returns_healthy():
+    from health import compute_next_conditions
+    text = compute_next_conditions("NORMAL", _metrics(), False, CFG_NC, 0)
+    assert "Saludable" in text
+
+
+def test_next_conditions_alert_text_includes_wr_and_wins_needed():
+    """ALERT with WR=0.10 (2/20 wins), threshold=0.15 (3/20) → wins_needed=1."""
+    from health import compute_next_conditions
+    text = compute_next_conditions("ALERT", _metrics(wr20=0.10), False, CFG_NC, 0)
+    assert "WR" in text and "0.15" in text
+    # Spec: text must mention what the threshold is and how many trades to evaluate.
+
+
+def test_next_conditions_reduced_text_mentions_pnl_30d():
+    from health import compute_next_conditions
+    text = compute_next_conditions(
+        "REDUCED", _metrics(pnl_30d=-50.0), False, CFG_NC, 0,
+    )
+    assert "pnl_30d" in text or "PnL" in text
+    assert "0" in text  # threshold or gap
+
+
+def test_next_conditions_paused_manual_override_text():
+    from health import compute_next_conditions
+    text = compute_next_conditions(
+        "PAUSED", _metrics(months_neg=4), True, CFG_NC, 0,
+    )
+    assert "manual" in text.lower() or "Reactivación manual" in text
+
+
+def test_next_conditions_paused_auto_text_includes_days_remaining():
+    """PAUSED 7 days, threshold 14 → 7 days remaining."""
+    from health import compute_next_conditions
+    text = compute_next_conditions(
+        "PAUSED", _metrics(months_neg=4), False, CFG_NC, days_in_paused=7,
+    )
+    # Should mention days remaining (14 - 7 = 7) or paused_to_probation_days threshold
+    assert "días" in text.lower()
+
+
+def test_next_conditions_probation_text_includes_trades_remaining():
+    from health import compute_next_conditions
+    text = compute_next_conditions(
+        "PROBATION", _metrics(prob_remaining=8), False, CFG_NC, 0,
+    )
+    assert "8" in text
+    assert "trades" in text.lower() or "PROBATION" in text or "NORMAL" in text

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -78,3 +78,149 @@ def test_next_conditions_probation_text_includes_trades_remaining():
     )
     assert "8" in text
     assert "trades" in text.lower() or "PROBATION" in text or "NORMAL" in text
+
+
+# ── sparkline_for_symbol ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def _insert_closed_position(conn, symbol, pnl, exit_ts):
+    conn.execute(
+        """INSERT INTO positions
+           (symbol, direction, status, entry_price, entry_ts,
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', ?, ?)""",
+        (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
+    )
+
+
+def test_sparkline_empty_returns_20_nones(tmp_db):
+    import btc_api
+    from health import sparkline_for_symbol
+    conn = btc_api.get_db()
+    try:
+        result = sparkline_for_symbol("BTC", conn)
+    finally:
+        conn.close()
+    assert len(result) == 20
+    assert all(x is None for x in result)
+
+
+def test_sparkline_3_wins_pads_with_leading_nones(tmp_db):
+    """3 wins → [None, None, ..., 'W', 'W', 'W'] in chronological order."""
+    import btc_api
+    from health import sparkline_for_symbol
+    conn = btc_api.get_db()
+    try:
+        for i in range(3):
+            _insert_closed_position(conn, "BTC", 10.0, f"2026-04-{1+i:02d}T12:00:00+00:00")
+        conn.commit()
+        result = sparkline_for_symbol("BTC", conn)
+    finally:
+        conn.close()
+    assert len(result) == 20
+    assert result[-3:] == ['W', 'W', 'W']
+    assert all(x is None for x in result[:-3])
+
+
+def test_sparkline_mixed_wins_losses(tmp_db):
+    """W/L based on pnl_usd>0."""
+    import btc_api
+    from health import sparkline_for_symbol
+    conn = btc_api.get_db()
+    try:
+        _insert_closed_position(conn, "BTC", 10.0, "2026-04-01T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", -5.0, "2026-04-02T12:00:00+00:00")
+        _insert_closed_position(conn, "BTC", 0.0, "2026-04-03T12:00:00+00:00")  # breakeven = L
+        conn.commit()
+        result = sparkline_for_symbol("BTC", conn)
+    finally:
+        conn.close()
+    assert result[-3:] == ['W', 'L', 'L']
+
+
+def test_sparkline_caps_at_20(tmp_db):
+    import btc_api
+    from health import sparkline_for_symbol
+    conn = btc_api.get_db()
+    try:
+        for i in range(25):
+            _insert_closed_position(conn, "BTC", 10.0, f"2026-04-{1+i%28:02d}T{i%24:02d}:00:00+00:00")
+        conn.commit()
+        result = sparkline_for_symbol("BTC", conn)
+    finally:
+        conn.close()
+    assert len(result) == 20
+    assert all(x == 'W' for x in result)
+
+
+# ── summarize_recent_alerts ─────────────────────────────────────────────────
+
+
+def _insert_health_event(conn, symbol, from_state, to_state, reason, ts):
+    conn.execute(
+        """INSERT INTO symbol_health_events
+           (symbol, from_state, to_state, trigger_reason, metrics_json, ts)
+           VALUES (?, ?, ?, ?, '{}', ?)""",
+        (symbol, from_state, to_state, reason, ts),
+    )
+
+
+def test_summarize_recent_alerts_empty_returns_empty_items(tmp_db):
+    import btc_api
+    from health import summarize_recent_alerts
+    conn = btc_api.get_db()
+    try:
+        result = summarize_recent_alerts(conn=conn, window_hours=24)
+    finally:
+        conn.close()
+    assert result["items"] == []
+
+
+def test_summarize_recent_alerts_3_alerts_emits_warning(tmp_db):
+    """3 distinct symbols entered ALERT → emits symbol_failures warning."""
+    from datetime import datetime, timezone, timedelta
+    import btc_api
+    from health import summarize_recent_alerts
+    now = datetime.now(timezone.utc)
+    recent_ts = (now - timedelta(hours=2)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        _insert_health_event(conn, "BTC", "NORMAL", "ALERT", "wr_below_threshold", recent_ts)
+        _insert_health_event(conn, "ETH", "NORMAL", "ALERT", "wr_below_threshold", recent_ts)
+        _insert_health_event(conn, "DOGE", "NORMAL", "ALERT", "wr_below_threshold", recent_ts)
+        conn.commit()
+        result = summarize_recent_alerts(conn=conn, window_hours=24)
+    finally:
+        conn.close()
+    items = result["items"]
+    assert any(i["kind"] == "symbol_failures" for i in items)
+    failure_item = next(i for i in items if i["kind"] == "symbol_failures")
+    assert "3" in failure_item["text"]
+    assert failure_item["severity"] == "warning"
+
+
+def test_summarize_recent_alerts_excludes_events_outside_window(tmp_db):
+    from datetime import datetime, timezone, timedelta
+    import btc_api
+    from health import summarize_recent_alerts
+    now = datetime.now(timezone.utc)
+    old_ts = (now - timedelta(hours=48)).isoformat()
+    conn = btc_api.get_db()
+    try:
+        _insert_health_event(conn, "BTC", "NORMAL", "ALERT", "wr_below_threshold", old_ts)
+        conn.commit()
+        result = summarize_recent_alerts(conn=conn, window_hours=24)
+    finally:
+        conn.close()
+    assert result["items"] == []


### PR DESCRIPTION
## Summary

- **Last subtask of epic #187 — closes the kill switch v2 epic**.
- New endpoint `GET /health/dashboard` consolidates per-symbol state + portfolio aggregate + 24h alert summary into a single fetch.
- Frontend `KillSwitchDashboard.tsx` refactored from monolithic 105 LOC to thin container + 5 reusable components: `AlertsStrip`, `PortfolioPanel`, `KillSwitchSymbolCard`, `Sparkline`, `MetricsBlock`.
- Smart "next conditions" text: backend computes the gap to the next tier change ("Para salir de ALERT: WR>0.20 sobre próximos 20 trades. Actual: WR=0.10, faltan 1 wins.") so operators see exactly what's needed.
- New `portfolio_health_events` table tracks portfolio-tier transitions, populated by the existing shadow eval path.
- Polite refresh: previous data stays visible during refetch (no flash); skeleton only on initial mount; aria-live region announces updates.
- Final-review follow-up: never-evaluated symbols show "Sin datos aún" instead of misleading "Saludable".

## Spec & plan

- Spec: `docs/superpowers/specs/es/2026-04-26-kill-switch-v2-b6-dashboard-design.md`
- Plan: `docs/superpowers/plans/2026-04-26-kill-switch-v2-b6-dashboard.md`

## Files changed

- `btc_api.py` — new `GET /health/dashboard` endpoint, `init_db` adds `portfolio_health_events` table.
- `health.py` — new pure fns `compute_next_conditions`, helpers `sparkline_for_symbol`, `summarize_recent_alerts`, `record_portfolio_transition`, `recent_portfolio_transitions`, orchestrator `get_dashboard_state`.
- `strategy/kill_switch_v2_shadow.py` — wires `record_portfolio_transition` into the existing shadow eval path.
- `frontend/src/types.ts` — `Dashboard*` types.
- `frontend/src/api.ts` — `getHealthDashboard()`.
- `frontend/src/components/KillSwitchDashboard.tsx` — refactored to thin container.
- `frontend/src/components/AlertsStrip.tsx` (new), `PortfolioPanel.tsx` (new), `KillSwitchSymbolCard.tsx` (new), `Sparkline.tsx` (new), `MetricsBlock.tsx` (new).
- `frontend/src/App.css` — design tokens for tiers + skeleton loaders + reduced-motion respect.
- 5 frontend test files (new + extended).
- `tests/test_health_dashboard.py` (new, 21 tests).

## Test plan

- [x] `pytest tests/ -q -m "not network"` — 978 passed (957 baseline + 21 new B6 tests)
- [x] `cd frontend && npm test -- --run` — 35 passed (all green)
- [x] `cd frontend && npm run build` — clean build, no TS errors

## Acceptance criteria from issue #200

1. ✅ Endpoint `GET /health/dashboard` retorna todo el estado para frontend
2. ✅ Componente React `KillSwitchDashboard.tsx` renderiza las dos visiones (per-symbol + portfolio)
3. ✅ Alertas agregadas — read directly from `symbol_health_events` for in-UI summary; existing notifier integration unchanged
4. ✅ Tests backend + frontend (Vitest)

## Composition with existing endpoints

`GET /health/dashboard` is additive. Existing endpoints (`/health/symbols`, `/health/events`, `/kill_switch/current_state`) remain unchanged.

## Final review notes

Whole-branch reviewer found 2 fix-ups + 1 deferred:
- ✅ FIXED: never-evaluated symbols now show 'Sin datos aún' (was misleading 'Saludable')
- ✅ FIXED: PR body test count corrected (978 not 977)
- ⏭ DEFERRED: connection-per-symbol N+1 in `get_dashboard_state` (~12 conns/request). Not a regression; bounded volume; refactor lift suggests follow-up issue rather than blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)