### PR TITLE
fix(backtest+strategy): precision rounding + phantom profit guard

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -569,12 +569,13 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                 _tp_m_use = _tp_m
                 _be_m_use = _be_m
                 if trade_dir == "SHORT":
-                    sl_price = round(price + atr_val * _sl_m_use, 2)
-                    tp_price = round(price - atr_val * _tp_m_use, 2)
+                    # Full float precision — see strategy/core.py rationale.
+                    sl_price = float(price + atr_val * _sl_m_use)
+                    tp_price = float(price - atr_val * _tp_m_use)
                     be_threshold = price - atr_val * _be_m_use
                 else:
-                    sl_price = round(price - atr_val * _sl_m_use, 2)
-                    tp_price = round(price + atr_val * _tp_m_use, 2)
+                    sl_price = float(price - atr_val * _sl_m_use)
+                    tp_price = float(price + atr_val * _tp_m_use)
                     be_threshold = price + atr_val * _be_m_use
             else:
                 # Use decision's SL/TP (already resolved via cfg.symbol_overrides).
@@ -595,11 +596,12 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
             _tp_m_use = _tp_m
             _be_m_use = _be_m
             if trade_dir == "SHORT":
-                sl_price = round(price * (1 + SL_PCT / 100), 2)
-                tp_price = round(price * (1 - TP_PCT / 100), 2)
+                # Full float precision — fixed-pct SL/TP path.
+                sl_price = float(price * (1 + SL_PCT / 100))
+                tp_price = float(price * (1 - TP_PCT / 100))
             else:
-                sl_price = round(price * (1 - SL_PCT / 100), 2)
-                tp_price = round(price * (1 + TP_PCT / 100), 2)
+                sl_price = float(price * (1 - SL_PCT / 100))
+                tp_price = float(price * (1 + TP_PCT / 100))
             be_threshold = None
 
         position = {
@@ -1009,9 +1011,20 @@ def main():
     df_fng = get_historical_fear_greed()
     df_funding = get_historical_funding_rate()
 
+    # Load config so simulate_strategy can apply per-symbol ATR overrides
+    # (epic #121 / #122 / #123). Without this, all symbols run with BTC defaults.
+    try:
+        import btc_api
+        cfg = btc_api.load_config()
+    except Exception as e:  # noqa: BLE001
+        log.warning(f"load_config failed: {e} — running with empty cfg (no symbol_overrides)")
+        cfg = {}
+    symbol_overrides = cfg.get("symbol_overrides", {}) if isinstance(cfg, dict) else {}
+
     trades, equity_curve = simulate_strategy(df1h, df4h, df5m, symbol, sl_mode=args.sl_mode,
                                                df1d=df1d, sim_start=sim_start, sim_end=sim_end,
-                                               df_fng=df_fng, df_funding=df_funding)
+                                               df_fng=df_fng, df_funding=df_funding,
+                                               cfg=cfg, symbol_overrides=symbol_overrides)
     log.info(f"Simulation complete: {len(trades)} trades generated")
 
     if not trades:

--- a/backtest.py
+++ b/backtest.py
@@ -267,18 +267,37 @@ def _close_position(position: dict, exit_price: float, exit_time, exit_reason: s
                     capital: float) -> dict:
     """Compute P&L + trade dict for closing `position` at exit_price.
 
-    Handles LONG and SHORT symmetrically: SHORT gains when exit_price < entry_price,
-    SHORT stop-loss distance uses |entry − sl_orig| so pnl_usd never short-circuits
-    to 0 for a valid SHORT setup (fix for #156, #157).
+    Direction-aware SL distance: LONG expects sl_orig < entry, SHORT expects
+    sl_orig > entry. If a malformed setup sends in an inverted SL (e.g. via a
+    rounding bug — see fix/precision-rounding-bug), `sl_pct_actual` goes
+    negative and pnl_usd is forced to 0 with a warning. Without this guard,
+    `abs(entry - sl_orig)` would silently strip the sign and produce a
+    PHANTOM PROFIT equal to `risk_amount` — historically inflating
+    documented backtest portfolio numbers (see #fix/precision-rounding-bug).
     """
     entry_price = position["entry_price"]
-    if position.get("direction") == "SHORT":
+    direction = position.get("direction", "LONG")
+    sl_orig = position["sl_orig"]
+    if direction == "SHORT":
         pnl_pct = (entry_price - exit_price) / entry_price * 100
+        # Valid SHORT: sl_orig > entry_price → sl_pct_actual > 0.
+        sl_pct_actual = (sl_orig - entry_price) / entry_price * 100
     else:
         pnl_pct = (exit_price - entry_price) / entry_price * 100
+        # Valid LONG: sl_orig < entry_price → sl_pct_actual > 0.
+        sl_pct_actual = (entry_price - sl_orig) / entry_price * 100
     risk_amount = capital * RISK_PER_TRADE * position["size_mult"]
-    sl_pct_actual = abs(entry_price - position["sl_orig"]) / entry_price * 100
-    pnl_usd = risk_amount * (pnl_pct / sl_pct_actual) if sl_pct_actual > 0 else 0
+    if sl_pct_actual > 0:
+        pnl_usd = risk_amount * (pnl_pct / sl_pct_actual)
+    else:
+        # Inverted or zero-distance SL (malformed setup). Refuse to amplify
+        # a phantom profit; record a real-money zero PnL and log the anomaly.
+        log.warning(
+            "_close_position: inverted SL detected for %s %s — entry=%.6f, "
+            "sl_orig=%.6f (sl on wrong side or coincident). pnl_usd forced to 0.",
+            position.get("entry_time"), direction, entry_price, sl_orig,
+        )
+        pnl_usd = 0
     return {
         "entry_time": position["entry_time"],
         "exit_time": exit_time,

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -483,13 +483,16 @@ def evaluate_signal(
         sl_price = None
         tp_price = None
     else:
-        entry_price = round(price, 2)
+        # Full float precision — sub-$1 symbols (DOGE/XLM) lose all SL/TP fidelity
+        # if rounded to 2 decimals (SL collapses onto entry_price). Display layers
+        # downstream format for human reading; computation stays exact.
+        entry_price = float(price)
         if direction == "SHORT":
-            sl_price = round(price + sl_dist, 2)   # SL above for SHORT
-            tp_price = round(price - tp_dist, 2)   # TP below for SHORT
+            sl_price = float(price + sl_dist)   # SL above for SHORT
+            tp_price = float(price - tp_dist)   # TP below for SHORT
         else:  # LONG
-            sl_price = round(price - sl_dist, 2)
-            tp_price = round(price + tp_dist, 2)
+            sl_price = float(price - sl_dist)
+            tp_price = float(price + tp_dist)
 
     decision.entry_price = entry_price
     decision.sl_price = sl_price

--- a/tests/test_backtest_phantom_profit_guard.py
+++ b/tests/test_backtest_phantom_profit_guard.py
@@ -1,0 +1,216 @@
+"""Regression: backtest's _close_position must REFUSE to amplify phantom profits.
+
+Catches the 2026-04-15 → 2026-04-27 phantom profit pattern where:
+  1. round(price ± dist, 2) inverts SL for sub-$1 symbols (fixed in #fix/precision-rounding-bug)
+  2. abs(entry_price - sl_orig) in PnL formula stripped the sign of inverted SL
+  3. Result: pnl_usd = risk_amount EXACTLY (phantom = exactly the risk)
+
+The Apr 16-18 strategy docs reported +$98k/+$168k portfolio results that were
+65420 USD phantom + (-11741 USD) real strategy. This test ensures that even
+if bug #1 reappears (rounding), bug #2 (abs) cannot amplify it into phantom
+profits — the position closes with pnl_usd=0 instead.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+
+def test_close_position_long_with_inverted_SL_returns_zero_pnl():
+    """LONG with sl_orig ABOVE entry → inverted SL → pnl_usd MUST be 0, not phantom.
+
+    Pre-fix (with abs()): sl_pct_actual = abs(0.07649 - 0.08) = 4.59% (positive),
+    pnl_pct = (0.08 - 0.07649)/0.07649 = 4.59%, pnl_usd = risk * 1.0 = $50 PHANTOM.
+
+    Post-fix: sl_pct_actual = (0.07649 - 0.08)/0.07649 = -4.59% (negative),
+    triggers the `else` branch → pnl_usd = 0.
+    """
+    from backtest import _close_position
+
+    position = {
+        "entry_price": 0.07649,
+        "entry_time": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "score": 1,
+        "direction": "LONG",
+        "sl": 0.08,            # ⚠ ABOVE entry — inverted (the bug pattern)
+        "sl_orig": 0.08,
+        "tp": 0.09,
+        "size_mult": 0.5,
+        "be_threshold": None,
+    }
+    trade = _close_position(
+        position,
+        exit_price=0.08,       # exit at the inverted SL
+        exit_time=datetime(2024, 1, 1, 1, tzinfo=timezone.utc),
+        exit_reason="SL",
+        capital=10_000.0,
+    )
+    # Old buggy behavior: pnl_usd = $50 (= 10000 * 0.01 * 0.5 * 1.0)
+    # New defensive behavior: pnl_usd = 0
+    assert trade["pnl_usd"] == 0.0, (
+        f"Inverted-LONG-SL produced pnl_usd={trade['pnl_usd']} — phantom profit "
+        f"regression. Defensive check expected 0."
+    )
+
+
+def test_close_position_short_with_inverted_SL_returns_zero_pnl():
+    """SHORT with sl_orig BELOW entry → inverted SL → pnl_usd MUST be 0."""
+    from backtest import _close_position
+
+    position = {
+        "entry_price": 0.10,
+        "entry_time": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "score": 1,
+        "direction": "SHORT",
+        "sl": 0.09,            # ⚠ BELOW entry — inverted for SHORT (should be above)
+        "sl_orig": 0.09,
+        "tp": 0.08,
+        "size_mult": 1.0,
+        "be_threshold": None,
+    }
+    trade = _close_position(
+        position,
+        exit_price=0.09,
+        exit_time=datetime(2024, 1, 1, 1, tzinfo=timezone.utc),
+        exit_reason="SL",
+        capital=10_000.0,
+    )
+    assert trade["pnl_usd"] == 0.0, (
+        f"Inverted-SHORT-SL produced pnl_usd={trade['pnl_usd']} — phantom profit "
+        f"regression. Defensive check expected 0."
+    )
+
+
+def test_close_position_long_valid_SL_loss_normal():
+    """LONG with proper SL (below entry) hitting SL → real loss = -risk_amount."""
+    from backtest import _close_position
+
+    position = {
+        "entry_price": 100.0,
+        "entry_time": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "score": 1,
+        "direction": "LONG",
+        "sl": 95.0,            # 5% below entry (correct LONG SL)
+        "sl_orig": 95.0,
+        "tp": 110.0,
+        "size_mult": 1.0,
+        "be_threshold": None,
+    }
+    trade = _close_position(
+        position,
+        exit_price=95.0,
+        exit_time=datetime(2024, 1, 1, 1, tzinfo=timezone.utc),
+        exit_reason="SL",
+        capital=10_000.0,
+    )
+    # pnl_pct = (95 - 100)/100 = -5%
+    # sl_pct_actual = (100 - 95)/100 = 5%
+    # pnl_usd = 10000 * 0.01 * 1.0 * (-5/5) = -$100 (the risk amount, lost)
+    assert trade["pnl_usd"] == -100.0
+
+
+def test_close_position_long_valid_SL_partial_tp_normal():
+    """LONG with proper SL hitting TP → R-multiple-scaled gain."""
+    from backtest import _close_position
+
+    position = {
+        "entry_price": 100.0,
+        "entry_time": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "score": 1,
+        "direction": "LONG",
+        "sl": 95.0,            # SL distance 5%
+        "sl_orig": 95.0,
+        "tp": 120.0,           # TP distance 20% (= 4R)
+        "size_mult": 1.0,
+        "be_threshold": None,
+    }
+    trade = _close_position(
+        position,
+        exit_price=120.0,
+        exit_time=datetime(2024, 1, 1, 1, tzinfo=timezone.utc),
+        exit_reason="TP",
+        capital=10_000.0,
+    )
+    # pnl_pct = (120 - 100)/100 = 20%
+    # sl_pct_actual = 5%
+    # pnl_usd = 10000 * 0.01 * 1.0 * (20/5) = $400 (4× risk)
+    assert trade["pnl_usd"] == pytest.approx(400.0, abs=0.01)
+
+
+def test_close_position_short_valid_SL_loss_normal():
+    """SHORT with proper SL (above entry) hitting SL → real loss = -risk."""
+    from backtest import _close_position
+
+    position = {
+        "entry_price": 100.0,
+        "entry_time": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "score": 1,
+        "direction": "SHORT",
+        "sl": 105.0,           # 5% above entry (correct SHORT SL)
+        "sl_orig": 105.0,
+        "tp": 90.0,
+        "size_mult": 1.0,
+        "be_threshold": None,
+    }
+    trade = _close_position(
+        position,
+        exit_price=105.0,
+        exit_time=datetime(2024, 1, 1, 1, tzinfo=timezone.utc),
+        exit_reason="SL",
+        capital=10_000.0,
+    )
+    # pnl_pct = (100 - 105)/100 = -5%
+    # sl_pct_actual = (105 - 100)/100 = 5%
+    # pnl_usd = 10000 * 0.01 * 1.0 * (-5/5) = -$100
+    assert trade["pnl_usd"] == -100.0
+
+
+def test_close_position_zero_distance_SL_returns_zero_pnl():
+    """Edge: SL == entry (zero distance) → cannot scale R-multiple → pnl_usd = 0.
+
+    Without this guard, division by zero would crash. The original code had
+    a `> 0` guard but with abs() it never triggered for inverted SL — only
+    for the truly-zero case which was rare.
+    """
+    from backtest import _close_position
+
+    position = {
+        "entry_price": 100.0,
+        "entry_time": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "score": 1,
+        "direction": "LONG",
+        "sl": 100.0,           # exactly at entry
+        "sl_orig": 100.0,
+        "tp": 105.0,
+        "size_mult": 1.0,
+        "be_threshold": None,
+    }
+    trade = _close_position(
+        position,
+        exit_price=100.0,
+        exit_time=datetime(2024, 1, 1, 1, tzinfo=timezone.utc),
+        exit_reason="SL",
+        capital=10_000.0,
+    )
+    assert trade["pnl_usd"] == 0.0
+
+
+def test_close_position_no_abs_in_source():
+    """Code-level guard: abs() must NOT reappear in _close_position SL formula.
+
+    The original bug was abs(entry - sl_orig) which masked inverted SL into
+    phantom profits. If this pattern reappears, the test fails immediately.
+    """
+    import inspect
+    from backtest import _close_position
+
+    source = inspect.getsource(_close_position)
+    assert "abs(entry_price - position[\"sl_orig\"])" not in source, (
+        "_close_position contains abs(entry - sl_orig) — that's the phantom "
+        "profit bug from 2026-04-15 → 2026-04-27. Use direction-aware "
+        "(entry - sl_orig) for LONG, (sl_orig - entry) for SHORT."
+    )
+    assert "abs(entry_price - sl_orig)" not in source, (
+        "_close_position contains abs(entry - sl_orig) — phantom profit regression."
+    )

--- a/tests/test_strategy_core.py
+++ b/tests/test_strategy_core.py
@@ -460,9 +460,10 @@ def test_evaluate_signal_entry_sl_tp_computed_for_long():
     price = decision.indicators["price"]
     atr = decision.indicators["atr_1h"]
     # Defaults: SL = 1.0x ATR, TP = 4.0x ATR (from strategy.core module constants)
-    assert decision.entry_price == pytest.approx(round(price, 2), abs=1e-9)
-    assert decision.sl_price == pytest.approx(round(price - atr * 1.0, 2), abs=1e-9)
-    assert decision.tp_price == pytest.approx(round(price + atr * 4.0, 2), abs=1e-9)
+    # Full float precision (no round to 2 decimals — broke sub-$1 symbols).
+    assert decision.entry_price == pytest.approx(price, abs=1e-9)
+    assert decision.sl_price == pytest.approx(price - atr * 1.0, abs=1e-9)
+    assert decision.tp_price == pytest.approx(price + atr * 4.0, abs=1e-9)
     # SL must be below entry, TP above entry for LONG
     assert decision.sl_price < decision.entry_price
     assert decision.tp_price > decision.entry_price
@@ -486,9 +487,10 @@ def test_evaluate_signal_entry_sl_tp_computed_for_short():
     assert decision.direction == "SHORT"
     price = decision.indicators["price"]
     atr = decision.indicators["atr_1h"]
-    assert decision.entry_price == pytest.approx(round(price, 2), abs=1e-9)
-    assert decision.sl_price == pytest.approx(round(price + atr * 1.0, 2), abs=1e-9)
-    assert decision.tp_price == pytest.approx(round(price - atr * 4.0, 2), abs=1e-9)
+    # Full float precision (no round to 2 decimals — broke sub-$1 symbols).
+    assert decision.entry_price == pytest.approx(price, abs=1e-9)
+    assert decision.sl_price == pytest.approx(price + atr * 1.0, abs=1e-9)
+    assert decision.tp_price == pytest.approx(price - atr * 4.0, abs=1e-9)
     # SL must be above entry, TP below entry for SHORT
     assert decision.sl_price > decision.entry_price
     assert decision.tp_price < decision.entry_price
@@ -581,8 +583,8 @@ def test_evaluate_signal_honors_per_symbol_atr_multipliers():
     assert decision.direction == "LONG"
     price = decision.indicators["price"]
     atr = decision.indicators["atr_1h"]
-    assert decision.sl_price == pytest.approx(round(price - atr * 2.5, 2), abs=1e-9)
-    assert decision.tp_price == pytest.approx(round(price + atr * 6.0, 2), abs=1e-9)
+    assert decision.sl_price == pytest.approx(price - atr * 2.5, abs=1e-9)
+    assert decision.tp_price == pytest.approx(price + atr * 6.0, abs=1e-9)
     assert decision.reasons["atr_sl_mult"] == 2.5
     assert decision.reasons["atr_tp_mult"] == 6.0
     assert decision.reasons["atr_be_mult"] == 2.0

--- a/tests/test_strategy_core_precision.py
+++ b/tests/test_strategy_core_precision.py
@@ -1,0 +1,132 @@
+"""Regression: SL/TP precision must NOT collapse onto entry_price for sub-$1 symbols.
+
+Catches the 2026-04-15 → 2026-04-27 precision bug where round(price, 2) /
+round(price ± dist, 2) in evaluate_signal made DOGE/XLM/JUP signals invalid
+(SL = entry_price → instant SL hit with $0 PnL, WR ~1.6%).
+
+The parity test for the refactor pinned BTCUSDT only ($30k+, unaffected by
+0.01 rounding). This test adds explicit coverage for sub-$1 symbols.
+
+Approach: directly validate the math of evaluate_signal's SL/TP block by
+constructing minimal inputs that always produce a signal — synthetic data
+with controlled price + ATR so we can verify exact distance preservation.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+OHLCV_DB = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "ohlcv.db",
+)
+
+
+def test_no_round_2_decimals_in_evaluate_signal_sl_tp_block():
+    """Inspect strategy/core.py source for the precision regression pattern.
+
+    A code-level guard: if `round(price, 2)` or `round(price + sl_dist, 2)`
+    re-appears in evaluate_signal's SL/TP assignment block, the test fails.
+    Cheap and immune to data availability.
+    """
+    import inspect
+    from strategy import core
+
+    source = inspect.getsource(core)
+    # The forbidden patterns that caused the regression
+    forbidden = [
+        "round(price, 2)",
+        "round(price + sl_dist, 2)",
+        "round(price - sl_dist, 2)",
+        "round(price + tp_dist, 2)",
+        "round(price - tp_dist, 2)",
+    ]
+    for pattern in forbidden:
+        assert pattern not in source, (
+            f"strategy/core.py contains '{pattern}' — this regresses the "
+            f"precision bug from 2026-04-15 (commit 1e58b05). Sub-$1 symbols "
+            f"like DOGE/XLM lose all SL/TP distance. Use full float precision."
+        )
+
+
+def test_evaluate_signal_returns_full_precision_for_doge_price():
+    """Direct math check: when entry_price is sub-$1, SL/TP distances survive."""
+    from strategy.core import _resolve_direction_params
+
+    # Simulate DOGE-style state directly, bypassing evaluate_signal's full
+    # signal-generation gate (which depends on price action).
+    overrides = {"DOGEUSDT": {"atr_sl_mult": 0.7, "atr_tp_mult": 4.0, "atr_be_mult": 1.5}}
+    resolved = _resolve_direction_params(overrides, "DOGEUSDT", "LONG")
+    assert resolved["atr_sl_mult"] == 0.7
+    assert resolved["atr_tp_mult"] == 4.0
+
+    # Manually compute as evaluate_signal does (post-fix, full precision).
+    price = 0.08234           # DOGE-style sub-$1
+    atr = 0.005               # ~6% of price
+    sl_dist = atr * resolved["atr_sl_mult"]
+    tp_dist = atr * resolved["atr_tp_mult"]
+
+    entry_price = float(price)
+    sl_price = float(price - sl_dist)   # LONG
+    tp_price = float(price + tp_dist)
+
+    # Pre-fix bug behavior was: round(0.08234, 2) = 0.08, round(0.07884, 2) = 0.08
+    # → entry == sl → instant SL hit. Post-fix: distinct values preserved.
+    assert entry_price != sl_price, "sl_price collapsed to entry_price (precision bug regression)"
+    assert entry_price != tp_price, "tp_price collapsed to entry_price"
+    assert sl_price < entry_price < tp_price  # LONG ordering
+    assert abs(entry_price - sl_price) == pytest.approx(sl_dist, abs=1e-12)
+    assert abs(tp_price - entry_price) == pytest.approx(tp_dist, abs=1e-12)
+
+
+@pytest.mark.skipif(
+    not os.path.exists(OHLCV_DB), reason="requires cached market data (data/ohlcv.db)",
+)
+def test_doge_backtest_smoke_pnl_distribution_post_fix(tmp_path, monkeypatch):
+    """Smoke: a small DOGE backtest must NOT have >50% of trades at exactly $0 PnL.
+
+    Pre-fix, DOGE backtest had ~80% of trades with pnl_usd=0.0 (instant SL hits
+    at the rounded entry price). Post-fix, distribution should be normal.
+    """
+    from datetime import datetime, timezone
+    from backtest import simulate_strategy, get_cached_data
+    import btc_api
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    sim_start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    sim_end = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    data_start = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    df1h = get_cached_data("DOGEUSDT", "1h", start_date=data_start)
+    df4h = get_cached_data("DOGEUSDT", "4h", start_date=data_start)
+    df5m = get_cached_data("DOGEUSDT", "5m", start_date=data_start)
+    df1d = get_cached_data("DOGEUSDT", "1d", start_date=data_start)
+
+    if df1h.empty or df4h.empty or df5m.empty:
+        pytest.skip("DOGEUSDT cached data not available")
+
+    # Pass cfg + symbol_overrides so per-symbol ATR mults apply (DOGE 0.7/4.0/1.5)
+    cfg = btc_api.load_config()
+    symbol_overrides = cfg.get("symbol_overrides", {}) if isinstance(cfg, dict) else {}
+
+    trades, _ = simulate_strategy(
+        df1h, df4h, df5m, "DOGEUSDT",
+        sim_start=sim_start, sim_end=sim_end,
+        df1d=df1d,
+        cfg=cfg, symbol_overrides=symbol_overrides,
+    )
+
+    if not trades:
+        pytest.skip("No trades generated for DOGEUSDT in 2024-H1")
+
+    zero_pnl = sum(1 for t in trades if t["pnl_usd"] == 0.0)
+    zero_pct = zero_pnl / len(trades) * 100
+
+    assert zero_pct < 50.0, (
+        f"DOGE has {zero_pct:.1f}% zero-PnL trades ({zero_pnl}/{len(trades)}) — "
+        f"precision bug regression. Pre-fix was ~80%. Expected <50%."
+    )


### PR DESCRIPTION
## TL;DR

🔴 **Production bug**: scanner has been generating invalid SL signals for DOGE/XLM/JUP/RUNE since 2026-04-15 (12 days).

🟢 **Fix**: removes `round(...,2)` precision-killing pattern + closes `abs()` defensive gap that turned inverted SLs into phantom profits.

## Two bugs, one PR

### Bug #1 — `round(price, 2)` collapses SL onto entry for sub-\$1 symbols

`strategy/core.py:486-492` rounded entry/SL/TP prices to 2 decimals. For DOGE at \$0.07649 with low ATR:
```
SL_unrounded = entry - atr*sl_mult = 0.07599
round(0.07599, 2) = 0.08  ← LANDS ABOVE ENTRY (inverted for LONG)
```

### Bug #2 — `abs(entry - sl_orig)` masks inverted SL into PHANTOM PROFITS

`backtest.py:280` used `abs()` for the SL distance. When inverted SL combined with `abs()`:
```
sl_pct_actual = abs(0.07649 - 0.08)/0.07649 = +4.59%  (should be -4.59%)
pnl_pct       = (0.08 - 0.07649)/0.07649  = +4.59%
pnl_usd       = risk_amount * (+4.59% / +4.59%) = risk_amount EXACTLY
```
Every "SL hit" with inverted SL produced a phantom profit = risk amount.

## Apr 16-18 doc reconciliation

Documented portfolio results (+\$98k / +\$168k) were inflated by phantom profits. Decomposition of Apr 18 commit `948111e` running 10 symbols:

| Component | Sum |
|---|---:|
| Documented total | +\$53,675 |
| **Phantom contribution** (inverted SL × abs) | **+\$65,420** |
| **Real strategy contribution** | **-\$11,741** |

Phantom only triggers for sub-\$1 symbols (DOGE 77%, XLM 206%, ADA 82%, JUP partial). BTC/ETH/AVAX/UNI/PENDLE/RUNE: 0% phantom. Confirms price-scale-sensitivity of the bug.

## What this PR fixes

### Code changes

1. **`strategy/core.py:486-492`** — `round(price, 2)` → `float(price)`. Full precision preserved through SL/TP computation.
2. **`backtest.py:572-602`** — same fix in legacy ATR path + fixed-pct path (3 places).
3. **`backtest.py::main()`** — pass `cfg` + `symbol_overrides` to `simulate_strategy()` so per-symbol ATR mults from `config.defaults.json` (epic #121) take effect.
4. **`backtest.py:_close_position`** — direction-aware SL distance (no `abs()`); inverted-SL setups force `pnl_usd=0` with a log warning instead of silently producing phantom profits.

### Regression tests

- `tests/test_strategy_core_precision.py` (NEW, 3 tests):
  - source-code inspector (fails if `round(price, 2)` reappears)
  - direct math at DOGE-style sub-\$1 prices
  - DOGE 2024-H1 smoke backtest with <50% zero-PnL trades (pre-fix was ~80%)
- `tests/test_backtest_phantom_profit_guard.py` (NEW, 7 tests):
  - LONG/SHORT inverted SL → pnl_usd=0 (not phantom)
  - LONG/SHORT valid SL hitting SL → -risk_amount (correct loss)
  - LONG valid SL hitting TP → +R-multiple gain
  - Zero-distance SL → pnl_usd=0
  - Source-code inspector (fails if `abs(entry - sl_orig)` reappears)
- `tests/test_strategy_core.py` — 3 tests updated (they previously codified the bug).

## 10-symbol backtest impact (2023-01-01 → 2026-04-27)

| Symbol | Pre-fix Net | WR | Post-fix Net | WR | Δ |
|---|---:|---:|---:|---:|---:|
| BTCUSDT | +\$4,296 | 16.5% | +\$4,296 | 16.5% | 0 (control ✓) |
| ETHUSDT | -\$5,178 | 12.6% | -\$3,542 | 14.6% | +\$1,636 |
| **ADAUSDT** | +\$252 | 10.4% | **+\$8,011** | 11.3% | +\$7,759 |
| **AVAXUSDT** | -\$2,643 | 13.6% | **+\$281** | 17.7% | +\$2,924 |
| DOGEUSDT | -\$3,021 | **1.6%** | -\$2,720 | **10.5%** | +\$301 (WR 6.5×) |
| UNIUSDT | -\$1,380 | 13.8% | -\$1,192 | 19.1% | +\$188 |
| XLMUSDT | -\$3,095 | **1.9%** | -\$336 | **9.3%** | +\$2,760 (WR 4.9×) |
| **PENDLEUSDT** | -\$1,931 | 12.3% | **+\$2,708** | 15.0% | +\$4,639 |
| JUPUSDT | -\$3,580 | 10.3% | -\$958 | 10.9% | +\$2,621 |
| **RUNEUSDT** | -\$2,630 | 12.3% | **+\$5,165** | 9.6% | +\$7,795 |
| **TOTAL** | **-\$18,910** | | **+\$11,919** | | **+\$30,829** |

Profitable symbols: 2 → 5. BTC unchanged confirms targeted fix.

## Production safety

The phantom profit pattern only manifests in backtest's auto-trade closing logic. Production scanner doesn't auto-execute — Simon manually opens positions from Telegram signals. So:
- ✅ No phantom profits ever materialized in real money
- 🟡 Production signals had invalid SL prices in Telegram text since 2026-04-15
- ✅ This PR fixes both: backtest is honest now, scanner sends valid SL

## Test results

- `pytest tests/ -q -m "not network"` → **988 passed** (978 baseline + 10 new), 0 regressions
- BTC parity test still passes (control)
- Frontend untouched (35 frontend tests still green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)