### PR TITLE
refactor(scanner): PR2 strategy/direction.py (#225)

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -33,15 +33,14 @@ from strategy.indicators import (
 )
 from strategy.constants import (
     LRC_PERIOD, LRC_STDEV, RSI_PERIOD, BB_PERIOD, BB_STDEV, VOL_PERIOD,
-    ATR_PERIOD, ATR_SL_MULT_DEFAULT, ATR_TP_MULT_DEFAULT, ATR_BE_MULT_DEFAULT,
+    ATR_PERIOD,
     LRC_LONG_MAX, LRC_SHORT_MIN, SCORE_MIN_HALF, SCORE_STANDARD, SCORE_PREMIUM,
 )
-# strategy.constants exports ATR_*_MULT_DEFAULT (rename in #186 to disambiguate
-# from per-symbol overrides). This module's existing call sites still use the
-# shorter ATR_SL_MULT/TP/BE names; aliases preserve those without renaming.
-ATR_SL_MULT = ATR_SL_MULT_DEFAULT
-ATR_TP_MULT = ATR_TP_MULT_DEFAULT
-ATR_BE_MULT = ATR_BE_MULT_DEFAULT
+# Re-exports for backward compatibility — moved to strategy/direction.py per #225 PR2
+from strategy.direction import (  # noqa: F401
+    ATR_SL_MULT, ATR_TP_MULT, ATR_BE_MULT,
+    resolve_direction_params, metrics_inc_direction_disabled,
+)
 
 # Re-exports for backward compatibility — moved to strategy/patterns.py per #225 PR1
 from strategy.patterns import (  # noqa: F401
@@ -359,60 +358,6 @@ def _classify_tune_result(count: int, profit_factor: float | None) -> str:
     return "dedicated"  # pf ≥ 1.3 (including inf)
 
 
-def resolve_direction_params(
-    overrides: dict | None,
-    symbol: str,
-    direction: str,
-) -> dict | None:
-    """Resolve {atr_sl_mult, atr_tp_mult, atr_be_mult} for (symbol, direction).
-
-    Returns None if the direction is disabled for that symbol (via `"short": null`).
-    Precedence: direction block (long/short) > flat dict > global defaults.
-    Case insensitive on direction.
-
-    Spec: See spec §6
-    """
-    defaults = {
-        "atr_sl_mult": ATR_SL_MULT,
-        "atr_tp_mult": ATR_TP_MULT,
-        "atr_be_mult": ATR_BE_MULT,
-    }
-
-    if direction is None:
-        return defaults
-
-    if not isinstance(overrides, dict):
-        return defaults
-
-    entry = overrides.get(symbol, {})
-    if not isinstance(entry, dict):
-        return defaults
-
-    sentinel = object()
-    dir_key = direction.lower()
-    dir_block = entry.get(dir_key, sentinel)
-
-    if dir_block is None:
-        return None  # direction disabled
-
-    if isinstance(dir_block, dict):
-        return {
-            "atr_sl_mult": dir_block.get("atr_sl_mult",
-                              entry.get("atr_sl_mult", defaults["atr_sl_mult"])),
-            "atr_tp_mult": dir_block.get("atr_tp_mult",
-                              entry.get("atr_tp_mult", defaults["atr_tp_mult"])),
-            "atr_be_mult": dir_block.get("atr_be_mult",
-                              entry.get("atr_be_mult", defaults["atr_be_mult"])),
-        }
-
-    # dir_block absent (sentinel) or wrong non-None type (e.g. string) — use flat or defaults
-    return {
-        "atr_sl_mult": entry.get("atr_sl_mult", defaults["atr_sl_mult"]),
-        "atr_tp_mult": entry.get("atr_tp_mult", defaults["atr_tp_mult"]),
-        "atr_be_mult": entry.get("atr_be_mult", defaults["atr_be_mult"]),
-    }
-
-
 # ── Parámetros de la estrategia Spot 1H ────────────────────────────────────
 SL_PCT         = 2.0      # Stop Loss  2.0%
 TP_PCT         = 4.0      # Take Profit 4.0%
@@ -711,16 +656,6 @@ def get_cached_regime() -> dict:
 # ─────────────────────────────────────────────────────────────────────────────
 #  SCANNER PRINCIPAL
 # ─────────────────────────────────────────────────────────────────────────────
-
-def metrics_inc_direction_disabled(symbol: str, direction: str) -> None:
-    """Increment the direction_disabled_skips_total metric."""
-    try:
-        from data import metrics
-        metrics.inc("direction_disabled_skips_total",
-                    labels={"symbol": symbol, "direction": direction})
-    except Exception:
-        pass  # metrics optional — don't crash scan on metric failure
-
 
 def scan(symbol: str = None):
     symbol = symbol or SYMBOL

--- a/strategy/direction.py
+++ b/strategy/direction.py
@@ -1,0 +1,78 @@
+"""Per-direction parameter resolution for scan() (extracted from btc_scanner.py per #225).
+
+resolve_direction_params: read symbol_overrides config and return per-direction
+ATR multipliers, or None if the direction is disabled for that symbol.
+"""
+from __future__ import annotations
+
+from strategy.constants import (
+    ATR_SL_MULT_DEFAULT, ATR_TP_MULT_DEFAULT, ATR_BE_MULT_DEFAULT,
+)
+
+# Module-level aliases (preserved from btc_scanner.py for backward compat).
+ATR_SL_MULT = ATR_SL_MULT_DEFAULT
+ATR_TP_MULT = ATR_TP_MULT_DEFAULT
+ATR_BE_MULT = ATR_BE_MULT_DEFAULT
+
+
+def resolve_direction_params(
+    overrides: dict | None,
+    symbol: str,
+    direction: str,
+) -> dict | None:
+    """Resolve {atr_sl_mult, atr_tp_mult, atr_be_mult} for (symbol, direction).
+
+    Returns None if the direction is disabled for that symbol (via `"short": null`).
+    Precedence: direction block (long/short) > flat dict > global defaults.
+    Case insensitive on direction.
+
+    Spec: docs/superpowers/specs/es/2026-04-20-per-symbol-regime-design.md §6
+    """
+    defaults = {
+        "atr_sl_mult": ATR_SL_MULT,
+        "atr_tp_mult": ATR_TP_MULT,
+        "atr_be_mult": ATR_BE_MULT,
+    }
+
+    if direction is None:
+        return defaults
+
+    if not isinstance(overrides, dict):
+        return defaults
+
+    entry = overrides.get(symbol, {})
+    if not isinstance(entry, dict):
+        return defaults
+
+    sentinel = object()
+    dir_key = direction.lower()
+    dir_block = entry.get(dir_key, sentinel)
+
+    if dir_block is None:
+        return None  # direction disabled
+
+    if isinstance(dir_block, dict):
+        return {
+            "atr_sl_mult": dir_block.get("atr_sl_mult",
+                              entry.get("atr_sl_mult", defaults["atr_sl_mult"])),
+            "atr_tp_mult": dir_block.get("atr_tp_mult",
+                              entry.get("atr_tp_mult", defaults["atr_tp_mult"])),
+            "atr_be_mult": dir_block.get("atr_be_mult",
+                              entry.get("atr_be_mult", defaults["atr_be_mult"])),
+        }
+
+    return {
+        "atr_sl_mult": entry.get("atr_sl_mult", defaults["atr_sl_mult"]),
+        "atr_tp_mult": entry.get("atr_tp_mult", defaults["atr_tp_mult"]),
+        "atr_be_mult": entry.get("atr_be_mult", defaults["atr_be_mult"]),
+    }
+
+
+def metrics_inc_direction_disabled(symbol: str, direction: str) -> None:
+    """Increment the direction_disabled_skips_total metric (no-op on failure)."""
+    try:
+        from data import metrics
+        metrics.inc("direction_disabled_skips_total",
+                    labels={"symbol": symbol, "direction": direction})
+    except Exception:
+        pass  # metrics optional — don't crash scan on metric failure

--- a/tests/test_direction_reexport.py
+++ b/tests/test_direction_reexport.py
@@ -1,0 +1,13 @@
+# tests/test_direction_reexport.py
+"""Identity tests: strategy.direction re-exports preserved on btc_scanner."""
+
+
+def test_direction_reexport_identity():
+    import btc_scanner
+    from strategy import direction
+
+    assert btc_scanner.resolve_direction_params is direction.resolve_direction_params
+    assert btc_scanner.metrics_inc_direction_disabled is direction.metrics_inc_direction_disabled
+    assert btc_scanner.ATR_SL_MULT is direction.ATR_SL_MULT
+    assert btc_scanner.ATR_TP_MULT is direction.ATR_TP_MULT
+    assert btc_scanner.ATR_BE_MULT is direction.ATR_BE_MULT


### PR DESCRIPTION
## Summary
Moves to `strategy/direction.py`:
- `resolve_direction_params`
- `metrics_inc_direction_disabled`
- `ATR_SL_MULT`, `ATR_TP_MULT`, `ATR_BE_MULT` aliases (now sourced from `strategy.constants`)

Re-exported from `btc_scanner` for backward compat. ~60 LOC moved.

## Risks-touched (from spec §8)
- [x] Re-export omission — mitigated by `tests/test_direction_reexport.py`
- [ ] Module-global identity drift — N/A (no module globals moved this PR)
- [ ] Monkeypatch namespace — N/A
- [x] Snapshot regen sin review — snapshot still byte-equal
- [ ] Kill switch v2 calibrator — N/A
- [ ] CLI behavior drift — N/A

## Verification log
```
$ pytest tests/test_scanner_snapshot.py -v
PASSED
$ pytest tests/test_direction_reexport.py -v
PASSED
$ pytest tests/ -q
1032 passed in 237.19s
$ wc -l btc_scanner.py
1278
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)