### PR TITLE
refactor(scanner): PR3 strategy/tune.py (#225)

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -48,6 +48,9 @@ from strategy.patterns import (  # noqa: F401
     score_label, check_trigger_5m, check_trigger_5m_short,
 )
 
+# Re-export for backward compatibility — moved to strategy/tune.py per #225 PR3
+from strategy.tune import _classify_tune_result  # noqa: F401
+
 # Reconfigure stdout for Windows Unicode support
 try:
     sys.stdout.reconfigure(encoding='utf-8')
@@ -323,39 +326,6 @@ def detect_regime_for_symbol(symbol: str | None, mode: str = "global") -> dict:
     _regime_cache[key] = result
     _save_regime_cache(_regime_cache)
     return result
-
-
-def _classify_tune_result(count: int, profit_factor: float | None) -> str:
-    """Classify a (symbol, direction) tuning result into one of three tiers.
-
-    Used by scripts/apply_tune_to_config.py to decide whether to commit a
-    dedicated triplet, fall back to a single-triplet per-symbol, or disable
-    the direction entirely.
-
-    Returns one of: "dedicated", "fallback", "disabled".
-
-    Rules (from spec §6):
-        N ≥ 30 AND PF ≥ 1.3   → "dedicated"
-        N ≥ 30 AND 1.0 ≤ PF < 1.3 → "fallback"
-        N < 30 OR PF < 1.0    → "disabled"
-        PF = inf (no losses)  → "dedicated" if N ≥ 30
-        PF is None or NaN     → "disabled" (insufficient info)
-    """
-    if count == 0 or profit_factor is None:
-        return "disabled"
-    try:
-        pf = float(profit_factor)
-    except (TypeError, ValueError):
-        return "disabled"
-    if np.isnan(pf):
-        return "disabled"
-    if count < 30:
-        return "disabled"
-    if pf < 1.0:
-        return "disabled"
-    if pf < 1.3:
-        return "fallback"
-    return "dedicated"  # pf ≥ 1.3 (including inf)
 
 
 # ── Parámetros de la estrategia Spot 1H ────────────────────────────────────

--- a/scripts/apply_tune_to_config.py
+++ b/scripts/apply_tune_to_config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
-from btc_scanner import _classify_tune_result  # noqa: E402
+from strategy.tune import _classify_tune_result  # noqa: E402
 
 
 def _triplet(best: dict) -> dict:

--- a/strategy/tune.py
+++ b/strategy/tune.py
@@ -1,0 +1,37 @@
+"""Tune-result classification for the auto-tune pipeline (extracted from btc_scanner.py per #225).
+
+Used by scripts/apply_tune_to_config.py to decide whether a (symbol, direction)
+tuning result yields a dedicated triplet, fallback to per-symbol, or disabled.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _classify_tune_result(count: int, profit_factor: float | None) -> str:
+    """Classify a (symbol, direction) tuning result into one of three tiers.
+
+    Returns one of: "dedicated", "fallback", "disabled".
+
+    Rules:
+        N ≥ 30 AND PF ≥ 1.3   → "dedicated"
+        N ≥ 30 AND 1.0 ≤ PF < 1.3 → "fallback"
+        N < 30 OR PF < 1.0    → "disabled"
+        PF = inf (no losses)  → "dedicated" if N ≥ 30
+        PF is None or NaN     → "disabled" (insufficient info)
+    """
+    if count == 0 or profit_factor is None:
+        return "disabled"
+    try:
+        pf = float(profit_factor)
+    except (TypeError, ValueError):
+        return "disabled"
+    if np.isnan(pf):
+        return "disabled"
+    if count < 30:
+        return "disabled"
+    if pf < 1.0:
+        return "disabled"
+    if pf < 1.3:
+        return "fallback"
+    return "dedicated"  # pf ≥ 1.3 (including inf)

--- a/tests/test_tier_classification.py
+++ b/tests/test_tier_classification.py
@@ -1,6 +1,6 @@
 import math
 import pytest
-from btc_scanner import _classify_tune_result
+from strategy.tune import _classify_tune_result
 
 
 class TestClassifyTuneResult:

--- a/tests/test_tune_reexport.py
+++ b/tests/test_tune_reexport.py
@@ -1,0 +1,5 @@
+# tests/test_tune_reexport.py
+def test_tune_reexport_identity():
+    import btc_scanner
+    from strategy import tune
+    assert btc_scanner._classify_tune_result is tune._classify_tune_result


### PR DESCRIPTION
## Summary
Moves to `strategy/tune.py`:
- `_classify_tune_result`

Migrated callers in the same commit:
- `scripts/apply_tune_to_config.py` — now imports from `strategy.tune`
- `tests/test_tier_classification.py` — now imports from `strategy.tune`

Re-export retained on `btc_scanner` for any other consumer (audited in PR8). ~30 LOC moved.

## Risks-touched (from spec §8)
- [x] Re-export omission — mitigated by `tests/test_tune_reexport.py`
- [ ] Module-global identity drift — N/A
- [ ] Monkeypatch namespace — N/A
- [x] `scripts/apply_tune_to_config.py` cron breaks — mitigated: re-export retained AND script migrated atomically
- [x] Snapshot regen sin review — snapshot still byte-equal
- [ ] Kill switch v2 calibrator — N/A
- [ ] CLI behavior drift — N/A

## Verification log
```
$ pytest tests/test_scanner_snapshot.py -v
PASSED
$ pytest tests/test_tune_reexport.py tests/test_tier_classification.py -v
13 passed
$ pytest tests/ -q
1033 passed, 6 skipped
$ python -c "from scripts.apply_tune_to_config import _classify_tune_result; print(_classify_tune_result(30, 1.5))"
dedicated
$ wc -l btc_scanner.py
    1248
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)