### PR TITLE
refactor(scanner): PR4 strategy/vol.py (#225)

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -51,6 +51,11 @@ from strategy.patterns import (  # noqa: F401
 # Re-export for backward compatibility — moved to strategy/tune.py per #225 PR3
 from strategy.tune import _classify_tune_result  # noqa: F401
 
+# Re-export for backward compatibility — moved to strategy/vol.py per #225 PR4
+from strategy.vol import (  # noqa: F401
+    annualized_vol_yang_zhang, TARGET_VOL_ANNUAL, VOL_LOOKBACK_DAYS,
+)
+
 # Reconfigure stdout for Windows Unicode support
 try:
     sys.stdout.reconfigure(encoding='utf-8')
@@ -81,41 +86,6 @@ LOG_FILE       = os.path.join(SCRIPT_DIR, "logs", "signals_log.txt")
 os.makedirs(os.path.join(SCRIPT_DIR, "logs"), exist_ok=True)
 
 SCAN_INTERVAL  = 300   # 5 minutos = cierre de vela 5M
-
-# ── Yang-Zhang vol estimator (diagnostic utility only — NOT applied to sizing) ──
-# The vol-normalized sizing idea of #125 was found to regress P&L in comparative
-# backtest: the per-symbol atr_sl_mult/tp tuning from epic #121 (735 sims) already
-# adapts to volatility structurally. Multiplying a flat vol_mult on top shrinks
-# the effective risk of the highest-validated symbols (DOGE, BTC, RUNE) and
-# undoes the gains. Function kept available for telemetry / future dashboards.
-TARGET_VOL_ANNUAL = 0.15   # reference target (not currently applied)
-VOL_LOOKBACK_DAYS = 30
-
-
-def annualized_vol_yang_zhang(df_daily: pd.DataFrame) -> float:
-    """Yang-Zhang annualized vol over daily bars (diagnostic utility).
-
-    Not wired into position sizing — see note above. Returns TARGET_VOL_ANNUAL
-    when fewer than 5 bars are available.
-    """
-    if len(df_daily) < 5:
-        return TARGET_VOL_ANNUAL
-    o = df_daily["open"].astype(float)
-    h = df_daily["high"].astype(float)
-    l = df_daily["low"].astype(float)
-    c = df_daily["close"].astype(float)
-    log_ho = np.log(h / o)
-    log_lo = np.log(l / o)
-    log_co = np.log(c / o)
-    log_oc_prev = np.log(o / c.shift(1)).dropna()
-    n = len(df_daily) - 1
-    k = 0.34 / (1.34 + (n + 1) / (n - 1))
-    sigma_on = log_oc_prev.var(ddof=1) if len(log_oc_prev) >= 2 else 0.0
-    sigma_oc = log_co.var(ddof=1)
-    sigma_rs = (log_ho * (log_ho - log_co) + log_lo * (log_lo - log_co)).mean()
-    var_daily = max(sigma_on + k * sigma_oc + (1 - k) * sigma_rs, 1e-10)
-    return float(np.sqrt(var_daily * 365))
-
 
 def _compute_price_score(df_daily: pd.DataFrame) -> int:
     """Score 0-100 bearish-to-bullish sobre daily bars. Pure function.

--- a/strategy/vol.py
+++ b/strategy/vol.py
@@ -1,0 +1,40 @@
+"""Yang-Zhang annualized volatility — diagnostic utility (extracted from btc_scanner.py per #225).
+
+NOT applied to position sizing. The vol-normalized sizing idea of #125 was
+found to regress P&L in comparative backtest: the per-symbol atr_sl_mult/tp
+tuning from epic #121 (735 sims) already adapts to volatility structurally.
+Function kept available for telemetry / future dashboards.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+TARGET_VOL_ANNUAL = 0.15   # reference target (not currently applied)
+VOL_LOOKBACK_DAYS = 30
+
+
+def annualized_vol_yang_zhang(df_daily: pd.DataFrame) -> float:
+    """Yang-Zhang annualized vol over daily bars (diagnostic utility).
+
+    Not wired into position sizing. Returns TARGET_VOL_ANNUAL when fewer
+    than 5 bars are available.
+    """
+    if len(df_daily) < 5:
+        return TARGET_VOL_ANNUAL
+    o = df_daily["open"].astype(float)
+    h = df_daily["high"].astype(float)
+    l = df_daily["low"].astype(float)
+    c = df_daily["close"].astype(float)
+    log_ho = np.log(h / o)
+    log_lo = np.log(l / o)
+    log_co = np.log(c / o)
+    log_oc_prev = np.log(o / c.shift(1)).dropna()
+    n = len(df_daily) - 1
+    k = 0.34 / (1.34 + (n + 1) / (n - 1))
+    sigma_on = log_oc_prev.var(ddof=1) if len(log_oc_prev) >= 2 else 0.0
+    sigma_oc = log_co.var(ddof=1)
+    sigma_rs = (log_ho * (log_ho - log_co) + log_lo * (log_lo - log_co)).mean()
+    var_daily = max(sigma_on + k * sigma_oc + (1 - k) * sigma_rs, 1e-10)
+    return float(np.sqrt(var_daily * 365))

--- a/tests/test_vol_calc.py
+++ b/tests/test_vol_calc.py
@@ -11,20 +11,20 @@ def _daily_df(opens, highs, lows, closes):
 
 class TestYangZhangVol:
     def test_zero_variance_bars_returns_tiny_floor(self):
-        from btc_scanner import annualized_vol_yang_zhang
+        from strategy.vol import annualized_vol_yang_zhang
         # All bars identical → variance zero → result near zero
         df = _daily_df([100.0] * 30, [100.0] * 30, [100.0] * 30, [100.0] * 30)
         vol = annualized_vol_yang_zhang(df)
         assert 0.0 <= vol < 0.01
 
     def test_short_series_returns_fallback(self):
-        from btc_scanner import annualized_vol_yang_zhang, TARGET_VOL_ANNUAL
+        from strategy.vol import annualized_vol_yang_zhang, TARGET_VOL_ANNUAL
         df = _daily_df([100.0] * 3, [101.0] * 3, [99.0] * 3, [100.0] * 3)
         vol = annualized_vol_yang_zhang(df)
         assert vol == TARGET_VOL_ANNUAL
 
     def test_typical_crypto_volatility_in_range(self):
-        from btc_scanner import annualized_vol_yang_zhang
+        from strategy.vol import annualized_vol_yang_zhang
         # Simulate ~2% daily range, 1% daily drift noise
         rng = np.random.default_rng(42)
         n = 30

--- a/tests/test_vol_reexport.py
+++ b/tests/test_vol_reexport.py
@@ -1,0 +1,7 @@
+# tests/test_vol_reexport.py
+def test_vol_reexport_identity():
+    import btc_scanner
+    from strategy import vol
+    assert btc_scanner.annualized_vol_yang_zhang is vol.annualized_vol_yang_zhang
+    assert btc_scanner.TARGET_VOL_ANNUAL is vol.TARGET_VOL_ANNUAL
+    assert btc_scanner.VOL_LOOKBACK_DAYS is vol.VOL_LOOKBACK_DAYS


### PR DESCRIPTION
## Summary
Moves to `strategy/vol.py`:
- `annualized_vol_yang_zhang`
- `TARGET_VOL_ANNUAL`, `VOL_LOOKBACK_DAYS` constants

Migrated `tests/test_vol_calc.py` to import from `strategy.vol`. Re-export retained on `btc_scanner`. Diagnostic-only utility (not wired into sizing). ~25 LOC moved.

## Risks-touched (from spec §8)
- [x] Re-export omission — mitigated by `tests/test_vol_reexport.py`
- [ ] Module-global identity drift — N/A
- [ ] Monkeypatch namespace — N/A
- [x] Snapshot regen sin review — snapshot still byte-equal
- [ ] Kill switch v2 calibrator — N/A
- [ ] CLI behavior drift — N/A

## Verification log
```
$ pytest tests/test_scanner_snapshot.py -v
PASSED
$ pytest tests/test_vol_reexport.py tests/test_vol_calc.py -v
4 passed
$ pytest tests/ -q
1034 passed in 265.73s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)