### PR TITLE
fix(scanner-tests): isolate scan() snapshot from runner's config.json (#225 follow-up)

### DIFF
--- a/tests/_fixtures/scanner_frozen.py
+++ b/tests/_fixtures/scanner_frozen.py
@@ -95,6 +95,12 @@ def _normalize(obj):
 def frozen_scan(monkeypatch, tmp_path):
     """Apply all monkeypatches needed to get deterministic scan() output."""
     monkeypatch.setattr("btc_scanner.datetime", _FrozenDatetime)
+    # PR0-PR8 fixture relied on config.json being absent in worktrees. On main
+    # config.json exists and may set regime_mode="hybrid" or other config that
+    # changes scan() output. Force scan() to find no config.json by redirecting
+    # SCRIPT_DIR to a fresh tmp_path. This makes the snapshot deterministic
+    # regardless of the runner's actual config.json contents.
+    monkeypatch.setattr("btc_scanner.SCRIPT_DIR", str(tmp_path))
     monkeypatch.setattr(md, "get_klines", _frozen_get_klines)
     monkeypatch.setattr(md, "prefetch", lambda *a, **kw: None)
     # PR6: regime moved to strategy.regime — patch the home module so the


### PR DESCRIPTION
## Summary

Hotfix for the snapshot test in `tests/test_scanner_snapshot.py` which passed in worktrees but failed on main after #225 landed.

**Root cause:** the `frozen_scan` fixture (introduced in PR0) didn't monkeypatch `scan()`'s config-loading path. `config.json` is gitignored, so worktrees didn't have it, and `scan()` defaulted to `regime_mode="global"`. On main where config.json exists with `regime_mode="hybrid"`, scan() takes the per-symbol path and produces a different report shape.

**Fix:** `tests/_fixtures/scanner_frozen.py` now monkeypatches `btc_scanner.SCRIPT_DIR` to `tmp_path` so `scan()`'s `os.path.exists(<SCRIPT_DIR>/config.json)` returns False, falling through to `_cfg = {}`. Same behavior the baseline was captured under.

## Why this wasn't caught earlier

PR0-PR8 each ran tests in their own `.worktrees/scanner-pr*` workspace. Worktrees don't carry gitignored files, so config.json was absent, and the snapshot test passed via the (accidentally) correct path. Running tests from main exposed the gap.

## Verification

```
$ pytest tests/test_scanner_snapshot.py -v
PASSED

$ pytest tests/ -q
1042 passed in 397.60s

$ git diff tests/_baselines/scan_btcusdt.json
(no output — baseline unchanged)
```

## Risks-touched (from #225 spec §8)
- [x] Snapshot regen sin review — baseline NOT regenerated; only fixture corrected.
- [x] Monkeypatch namespace — added one missing target (`btc_scanner.SCRIPT_DIR`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)