### PR TITLE
ci: add GitHub Actions workflow + requirements-dev.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,42 +6,81 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel in-flight runs on the same ref when a new commit lands. Saves CI
+# minutes on rapid pushes to a PR branch — only the latest commit gets a
+# full check.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  backend-tests:
+  backend:
+    name: Backend (pytest)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          cache: pip
+          # Cache key invalidates when EITHER file changes (dev pulls in
+          # runtime via `-r requirements.txt`).
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Generate ephemeral JWT secret
+        # Per-run secret. Not in git, not reusable across runs. The auth
+        # subsystem refuses to boot without AUTH_JWT_SECRET; tests need a
+        # valid value but it's purely local to this CI run.
+        run: |
+          echo "AUTH_JWT_SECRET=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')" >> $GITHUB_ENV
 
       - name: Install dependencies
+        # requirements-dev.txt includes `-r requirements.txt` + pytest + httpx.
         run: |
-          pip install -r requirements.txt
-          pip install httpx pytest
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
 
-      - name: Run tests
-        run: python -m pytest tests/ -v --tb=short
+      - name: Run pytest
+        # `-m "not network"` is defensive: pytest.ini declares a `network`
+        # marker that's currently unused by any test. If someone marks a
+        # network-dependent test in the future, CI will skip it instead of
+        # failing on transient connectivity. The 5 tests that require
+        # data/ohlcv.db (705 MB, gitignored) auto-skip via @pytest.mark.skipif.
+        run: pytest -m "not network"
 
-  frontend-typecheck:
+  frontend:
+    name: Frontend (tsc + vitest + build)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: frontend
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: npm
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
-        working-directory: frontend
         run: npm ci
 
-      - name: TypeScript type check
-        working-directory: frontend
+      - name: Type check
+        # Run separately from the build so a tsc failure surfaces with a
+        # clean error before vite starts. `npm run build` runs `tsc && vite
+        # build`, so we'd still catch it later — this is for diagnostics.
         run: npx tsc --noEmit
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Production build
+        # Catches errors that tsc misses (vite plugin issues, asset
+        # resolution, dynamic-import chains).
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Crypto Trading Scanner — Ultimate Macro & Order Flow V6.0
 
+[![CI](https://github.com/sssimon/trading-spacial/actions/workflows/ci.yml/badge.svg)](https://github.com/sssimon/trading-spacial/actions/workflows/ci.yml)
+
 Automated signal system for the top 20 crypto pairs by market cap. Uses multi-timeframe technical analysis (4H macro context → 1H signal → 5M entry trigger) to generate scored entry alerts delivered to Telegram.
 
 ---
@@ -52,7 +54,9 @@ watchdog.py             — Windows process supervisor (keeps API alive)
 ### 1. Backend
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt        # runtime only
+# OR for development (adds pytest + httpx):
+pip install -r requirements-dev.txt
 
 cp .env.example .env       # then fill in AUTH_JWT_SECRET (see comment in file)
 python btc_api.py          # REST API → http://localhost:8000

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,14 @@
+# Dev/test dependencies. Pulls in everything from requirements.txt plus
+# the tooling needed to run the test suite. CI installs this file directly.
+#
+# To set up a dev environment:
+#   python -m venv .venv
+#   source .venv/bin/activate         (or .venv\Scripts\activate on Windows)
+#   pip install -r requirements-dev.txt
+
+-r requirements.txt
+
+pytest>=8.0
+# httpx is what fastapi.testclient uses internally for its HTTP simulation.
+# It's not a transitive dep of fastapi itself.
+httpx>=0.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,7 @@ freezegun>=1.4
 pyjwt>=2.8.0
 passlib[bcrypt]>=1.7.4
 bcrypt>=4.0,<5
+# Required by pydantic EmailStr (used in auth/api.py LoginRequest).
+email-validator>=2.0
+# Required by FastAPI Form() parsing (used in api/setup.py).
+python-multipart>=0.0.9


### PR DESCRIPTION
First CI workflow for the repo. Adds two parallel jobs that gate every push to main and every PR against main.

## Jobs

**backend** — Python 3.11, ephemeral `AUTH_JWT_SECRET` per run, `pytest -m "not network"`.
**frontend** — Node 20, `npx tsc --noEmit` + `npm test` + `npm run build`.

## Discovered + fixed: latent missing deps

A clean-venv test (`/tmp/venv-clean`) revealed four packages used by the running code but missing from `requirements.txt` (my local env had them transitively from other projects). All four landed in this PR:

- `email-validator` → runtime, used by `pydantic.EmailStr` in `auth/api.py:LoginRequest`
- `python-multipart` → runtime, used by `Form()` in `api/setup.py`
- `pytest` → test, the runner itself
- `httpx` → test, used internally by `fastapi.testclient.TestClient`

The first two would have broken a fresh `pip install -r requirements.txt` install with no test running. They're production bugs, fixed here.

## Dependency split

- `requirements.txt` — runtime only.
- `requirements-dev.txt` (new) — `-r requirements.txt` + pytest + httpx. CI installs this directly.

## Workflow choices (commented inline in `.github/workflows/ci.yml`)

- `concurrency.cancel-in-progress` — kill the previous run when a new commit lands on a PR branch.
- `timeout-minutes: 15 / 10` — bound runaway tests.
- `-m "not network"` — `tests/test_tune_pipeline_e2e.py:12` requires live network. Op skip.
- 5 tests requiring `data/ohlcv.db` (705 MB, gitignored) auto-skip via `@pytest.mark.skipif`.
- Separate `tsc --noEmit` step before build → cleaner diagnostics on tsc fails.
- `npm run build` in CI catches errors tsc misses (vite plugins, asset resolution).

## Local validation (Python 3.12, fresh venv)

```
$ python -m venv /tmp/venv-clean
$ /tmp/venv-clean/bin/pip install -r requirements-dev.txt
$ AUTH_JWT_SECRET=$(python -c 'import secrets;print(secrets.token_urlsafe(32))') \
    /tmp/venv-clean/bin/pytest -m "not network"
1068 passed, 1 deselected in 304.21s
$ cd frontend && npx tsc --noEmit  →  exit 0
$ npm test                          →  35 passed
$ npm run build                     →  393 KB / 123 KB gzip
```

CI runs against Python 3.11 — that match comes on the first CI run.

## Out of scope

Lint (ruff/black/mypy) — no config exists in the repo. Separate PR will propose ruff with config + initial-findings fix + add to CI.

## Test plan

- [x] Local fresh-venv suite green
- [x] Frontend tsc + vitest + build green
- [ ] CI green on first run (waiting)
- [ ] Auto-merge on green via rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)