### PR TITLE
fix(tests): mark test_evaluate_signal_parity with @pytest.mark.network

### DIFF
--- a/tests/test_strategy_core.py
+++ b/tests/test_strategy_core.py
@@ -609,10 +609,21 @@ def test_evaluate_signal_estado_contains_direction_when_setup():
     assert "LONG" in decision.estado or "SIN SETUP" in decision.estado
 
 
+@pytest.mark.network
 def test_evaluate_signal_parity_full_fields_against_scan_snapshot():
     """Parity: evaluate_signal output matches scan()'s report fields on real data.
 
-    Skips when cached OHLCV is unavailable in the workspace.
+    Marked `network` because btc_scanner.scan() falls through to live
+    Binance/Bybit fetches when the local OHLCV cache is empty. The
+    pre-existing `os.path.exists("data/ohlcv.db")` skip is insufficient:
+    other components (data/_storage.py:init_schema) create the file empty
+    on first run, so the path-exists check passes but there's no data,
+    and the fetcher reaches the network. CI runners (US AWS) get HTTP 451
+    from Binance and HTTP 403 from Bybit's CloudFront. Skipped in CI by
+    `pytest -m "not network"`.
+
+    Skips when cached OHLCV is unavailable locally too — preserves the
+    original guard so a dev without ohlcv.db still doesn't blow up.
     """
     import os
     if not os.path.exists("data/ohlcv.db"):


### PR DESCRIPTION
## Why

Follow-up to PR #240. Main went red after CI was bootstrapped because `tests/test_strategy_core.py::test_evaluate_signal_parity_full_fields_against_scan_snapshot` calls `btc_scanner.scan()`, which falls through to live Binance/Bybit fetches when the local OHLCV cache is empty.

CI (GitHub Actions runners on US AWS) gets:
- Binance: `HTTP 451 Service unavailable from a restricted location`
- Bybit: `HTTP 403 The Amazon CloudFront distribution is configured to block access from your country`

The test had a `if not os.path.exists("data/ohlcv.db"): pytest.skip(...)` guard, but it's insufficient: `data/_storage.py:init_schema` creates an empty `.db` on first import, so path-exists passes but the cache has no rows → fetcher reaches the network.

## What

One-line change: `@pytest.mark.network` on the test function. The CI workflow already runs `pytest -m "not network"`, so this skips in CI while still running locally for devs with ohlcv.db cached. Pre-existing local skip preserved as a secondary guard.

## Verification

```
$ pytest -m "not network"
1067 passed, 2 deselected, 9 warnings in 141.41s (0:02:21)
```

(Was 1068 passed, 1 deselected. Now 1067 passed, 2 deselected — the test moved from FAILED in CI to deselected.)

## Follow-up tracked separately

Audit other tests that call `data/_fetcher` without a `network` marker. Opening issue post-merge.

## Test plan

- [x] Local fresh-venv suite green
- [ ] CI green on this PR run
- [ ] Merge after CI green (this time waiting via `gh pr checks --watch`, since `--auto` on this repo doesn't gate on CI without branch protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)