### PR TITLE
ci(deploy): add production deploy workflow for trading.sdar.dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,112 @@
+# Deploy in-place. Trade-off conocido: si el rsync de frontend falla
+# después del rsync de backend, el sistema queda con backend nuevo y
+# frontend viejo hasta el siguiente deploy. Aceptable mientras el sistema
+# sea single-user sin capital real. Para capital real, migrar a deploy
+# atómico con symlink swap (releases/<sha> → /var/www/trading current).
+#
+# Bootstrap manual del server requerido ANTES del primer deploy:
+#   docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md §6
+# El step "Verify .env exists" abajo falla fast si no se hizo.
+
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to trading.sdar.dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Frontend build
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HOST:    ${{ secrets.DEPLOY_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Verify .env exists on server (fail-fast if bootstrap missing)
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          if ! ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "test -f /var/www/trading/.env"; then
+            echo "::error::/var/www/trading/.env no existe en el server."
+            echo "::error::Ejecutar bootstrap manual primero (ver docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md §6)."
+            exit 1
+          fi
+
+      - name: rsync backend source
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            --exclude='tests/' --exclude='data/' --exclude='logs/' \
+            --exclude='*.db' --exclude='.venv/' --exclude='__pycache__/' \
+            --exclude='frontend/' --exclude='.git/' --exclude='.github/' \
+            --exclude='.coverage' --exclude='.pytest_cache/' \
+            --exclude='.worktrees/' --exclude='Backtesting_BTCUSDT/' \
+            --exclude='Dashboard/' --exclude='docs/' --exclude='*.bat' \
+            --exclude='*.ps1' --exclude='.env' --exclude='.env.*' \
+            --exclude='.claude/' \
+            ./ ubuntu@${HOST}:/var/www/trading/
+
+      - name: rsync frontend dist
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            frontend/dist/ ubuntu@${HOST}:/var/www/trading/dist/
+
+      - name: pip install + restart service
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "
+            cd /var/www/trading &&
+            .venv/bin/pip install --upgrade -r requirements.txt &&
+            sudo systemctl restart trading-spacial
+          "
+
+      - name: Health check
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          sleep 15
+          if ! ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "curl -fsS http://localhost:8100/health"; then
+            echo "::error::Health check falló. Logs del servicio:"
+            ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "sudo journalctl -u trading-spacial -n 80 --no-pager"
+            exit 1
+          fi
+
+      - name: Cleanup
+        if: always()
+        run: rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy.yml`, the auto-deploy pipeline for `https://trading.sdar.dev`. Final piece of the bootstrap puzzle (PR #243 merged the design spec; the server-side bootstrap is complete; this is what wires GitHub merges to actual deploys).

## What triggers it

- `push` to `main` only (not PRs — those run `ci.yml` for tests).
- `concurrency: deploy-production` with `cancel-in-progress: true`. Two commits in quick succession only deploy the latest.

## What it does, in order

1. `actions/checkout@v4`
2. `actions/setup-python@v5` (3.11) + `actions/setup-node@v4` (20, with npm cache)
3. **Frontend build**: `cd frontend && npm ci && npm run build` → `frontend/dist/`
4. **Setup SSH**: writes `secrets.DEPLOY_SSH_KEY` to `~/.ssh/deploy_key` (mode 600), `ssh-keyscan` for known_hosts
5. **Verify `.env` exists** on server (fail-fast if bootstrap not done — see spec §6)
6. **rsync backend source** with explicit excludes for `tests/`, `data/`, `logs/`, `*.db`, `.venv/`, `__pycache__/`, `frontend/`, `.git/`, `.github/`, `.env*`, `.claude/`, etc.
7. **rsync frontend dist** to `/var/www/trading/dist/`
8. **pip install** + `sudo systemctl restart trading-spacial` on the server
9. **Health check**: `curl -fsS http://localhost:8100/health` (5s grace). On failure, dumps last 80 journalctl lines from the unit and exits 1
10. Cleanup: `rm -f ~/.ssh/deploy_key` (always runs)

## Prerequisites

- Server-side bootstrap complete (Tasks A–F of the runbook): venv + `.env` + systemd unit + nginx + cert + fail2ban.
- GitHub Secrets configured (✓ already done): `DEPLOY_SSH_KEY`, `DEPLOY_HOST`.
- Spec reference: [`docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md`](docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md) §6 (bootstrap), §7 (this workflow).

## Expected behavior on first deploy after merge

- The frontend SPA loads at `https://trading.sdar.dev` ✓
- **Login form is visible but no login works** — there's no admin user in the DB yet. This is the documented post-deploy / pre-Task-I window described in spec §8.1. The `/health` endpoint is whitelisted in the auth middleware so the workflow's health check still passes — but if for any reason the first-boot lifespan takes >5s (cold OHLCV fetch from Binance, scanner thread startup), the health check could fail. If that happens, retry after admin creation (Task I) typically resolves it.
- Operator follow-up immediately after merge: SSH + `cd /var/www/trading && set -a && source .env && set +a && .venv/bin/python scripts/create_user.py --role admin`.

## In-place deploy trade-off

Documented as a comment in the file header: if the rsync of frontend fails after the rsync of backend, the system runs backend-new/frontend-old until the next deploy. Acceptable for single-user no-capital ops; future migration path is symlink-swap deploys (`releases/<sha>` → `current` symlink, atomic swap).

## Test plan

- [ ] Review YAML syntax — already validated locally with `python3 -c "yaml.safe_load(...)"`
- [ ] Confirm GH Secrets `DEPLOY_SSH_KEY` and `DEPLOY_HOST` are set in repo settings
- [ ] Confirm server bootstrap is complete: `sudo systemctl status trading-spacial` shows `enabled, inactive (dead)` (waiting for first deploy)
- [ ] Merge this PR and watch the Actions tab for the first run
- [ ] After deploy success, run `python scripts/create_user.py --role admin` via SSH (Task I)
- [ ] Browser-test `https://trading.sdar.dev` login flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)