### PR TITLE
fix(deploy): rsync data/ Python package, exclude only runtime artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           rsync -az --delete \
             -e "ssh -i ~/.ssh/deploy_key" \
-            --exclude='tests/' --exclude='data/' --exclude='logs/' \
+            --exclude='tests/' --exclude='logs/' \
             --exclude='*.db' --exclude='.venv/' --exclude='__pycache__/' \
             --exclude='frontend/' --exclude='.git/' --exclude='.github/' \
             --exclude='.coverage' --exclude='.pytest_cache/' \
@@ -76,6 +76,8 @@ jobs:
             --exclude='Dashboard/' --exclude='docs/' --exclude='*.bat' \
             --exclude='*.ps1' --exclude='.env' --exclude='.env.*' \
             --exclude='.claude/' \
+            --exclude='data/*.json' --exclude='data/*.csv' \
+            --exclude='data/*.xlsx' --exclude='data/backtest/' \
             ./ ubuntu@${HOST}:/var/www/trading/
 
       - name: rsync frontend dist


### PR DESCRIPTION
## Summary

Unblocks the trading.sdar.dev deploy. First deploy (PR #244, run 25116465233) failed at the health check step because the backend crashed on import:

```
File "/var/www/trading/api/ohlcv.py", line 9, in <module>
    from data import market_data as md
ImportError: cannot import name 'market_data' from 'data' (unknown location)
```

## Root cause

`data/` is **both** a Python source package and a runtime data directory:

| Type | Files |
|------|-------|
| **Python source code** (must rsync) | `data/__init__.py`, `_fetcher.py`, `_scheduler.py`, `_storage.py`, `cli.py`, `market_data.py`, `metrics.py`, `timeframes.py`, `providers/{__init__,base,binance,bybit}.py` |
| **Runtime artifacts** (must NOT rsync) | `ohlcv.db` (705 MB), `regime_cache.json`, `symbols_status.json`, `positions_summary.json`, `signals_history.csv`, `Calculadora_Position_Sizing.xlsx`, `Crypto_Trading_Tracker.xlsx`, `backtest/` (143 historical CSVs) |

The original `--exclude='data/'` was a blanket rule that killed the whole package, including the source code 18 modules in the codebase import from.

## Fix

Surgical excludes for only the runtime artifacts:

- Removed: `--exclude='data/'`
- Added: `--exclude='data/*.json' --exclude='data/*.csv' --exclude='data/*.xlsx' --exclude='data/backtest/'`
- `data/ohlcv.db` is already covered by the global `--exclude='*.db'`
- `data/__pycache__/` is already covered by the global `--exclude='__pycache__/'`

`rsync --exclude` items are neither transferred NOR deleted from the destination, so runtime files generated on the server (`regime_cache.json` etc.) survive across deploys. We do not use `--delete-excluded`.

## Verification done

- `find data/ -name "*.py"` → 12 source files identified
- `grep -rn "from data\|import data"` → 18 codebase files import from `data` package
- `grep -rn "data.backtest"` → **zero** matches; safe to exclude `data/backtest/`
- Inspected `data/` contents: confirmed all non-py items are runtime/historical artifacts
- YAML re-validated locally with `yaml.safe_load`

## Test plan

- [ ] Review the diff (single file, 1 line removed, 2 lines added)
- [ ] Merge to `main` — push triggers the workflow automatically
- [ ] Watch the run: `gh run watch --repo sssimon/trading-spacial`
- [ ] Expected: all steps green this time, including health check
- [ ] If green: SSH manual to create admin user (Task I per spec §8.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)