### PR TITLE
feat(strategy-validation): per-symbol cooldown auto-enforcement (Triple Barrier pacing)

### DIFF
--- a/api/telegram.py
+++ b/api/telegram.py
@@ -92,7 +92,7 @@ def build_telegram_message(rep: dict) -> str:
 
     lines += [
         "",
-        "*Verificar manualmente:* noticias macro, racha, capital, cooldown 6h, DXY",
+        "*Verificar manualmente:* noticias macro, racha, capital, DXY",
         f"_{symbol} Spot 1H V6_",
     ]
     return "\n".join(lines)

--- a/backtest.py
+++ b/backtest.py
@@ -82,6 +82,7 @@ RISK_PER_TRADE = 0.01  # 1% of capital per trade
 from strategy._validators import (
     validated_time_limit_hours as _shared_validated_tl_hours,
     validated_max_participation_rate as _shared_validated_max_pov,
+    validated_cooldown_hours as _shared_validated_cooldown_hours,
 )
 
 
@@ -91,6 +92,12 @@ def _validated_time_limit_hours(value, symbol: str) -> float | None:
 
 def _validated_max_participation_rate(value, symbol: str) -> float | None:
     return _shared_validated_max_pov(value, symbol, "simulate_strategy", log)
+
+
+def _validated_cooldown_hours(value, symbol: str) -> float:
+    return _shared_validated_cooldown_hours(
+        value, caller="simulate_strategy", symbol=symbol, logger=log, default=COOLDOWN_H,
+    )
 # 0.1% per side, Binance spot retail taker, no BNB discount. Conservative —
 # if production uses BNB discount (~0.075%), this overestimates fee cost.
 # Until A.0.2 (#277) the constant was defined here but never deducted from
@@ -650,10 +657,21 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         if _sim_start_ts and bar_time_naive < _sim_start_ts:
             continue
 
-        # ── Cooldown check ────────────────────────────────────────────────
+        # ── Cooldown check (per-symbol with COOLDOWN_H fallback) ──────────
+        # Default-fallback semantics: missing or invalid `cooldown_hours` →
+        # COOLDOWN_H global. Validator emits one throttled warning per
+        # (caller, symbol, error_kind) on rejection. Disabled symbols
+        # (`symbol_overrides[sym] = False`) guarded via isinstance.
+        _cd_overrides = symbol_overrides or (cfg or {}).get("symbol_overrides", {})
+        _so_raw = _cd_overrides.get(symbol.upper(), {})
+        _so_for_cd = _so_raw if isinstance(_so_raw, dict) else {}
+        _effective_cooldown = _validated_cooldown_hours(
+            _so_for_cd.get("cooldown_hours"), symbol,
+        )
+
         if last_exit_time is not None:
             hours_since = (bar_time - last_exit_time).total_seconds() / 3600
-            if hours_since < COOLDOWN_H:
+            if hours_since < _effective_cooldown:
                 continue
 
         # ── Evaluate entry signal via strategy.core.evaluate_signal (#186 A6) ─
@@ -792,7 +810,10 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
 
         # Legacy atr_* kwargs path skips the time-limit barrier AND the
         # participation cap — those callers (auto_tune / grid_search) must
-        # opt in by passing symbol_overrides explicitly.
+        # opt in by passing symbol_overrides explicitly. Cooldown is NOT
+        # bypassed: the cooldown check upstream uses COOLDOWN_H global as
+        # default-fallback (via validated_cooldown_hours), so legacy paths
+        # still observe the legacy 6h global cooldown.
         if legacy_override_active:
             _tl_h = None
         else:
@@ -1077,12 +1098,23 @@ def classify_market_regime(df1h: pd.DataFrame, trades: list[dict]) -> dict:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def generate_report(symbol: str, metrics: dict, regimes: dict, trades: list[dict],
-                    sim_start: datetime = None, sim_end: datetime = None) -> str:
+                    sim_start: datetime = None, sim_end: datetime = None,
+                    symbol_overrides: dict | None = None) -> str:
     """Generate markdown report."""
     m = metrics
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     period_start = sim_start.strftime("%Y-%m-%d") if sim_start else "N/A"
     period_end = sim_end.strftime("%Y-%m-%d") if sim_end else "present"
+
+    # Resolve effective per-symbol cooldown for the methodology section.
+    # Defaults to COOLDOWN_H global when no override or invalid value.
+    # Disabled-symbol guard (mirrors the simulate_strategy resolution):
+    # symbol_overrides[sym] can be `False` (not a dict).
+    _so_raw = (symbol_overrides or {}).get(symbol.upper(), {})
+    _so_for_eff = _so_raw if isinstance(_so_raw, dict) else {}
+    _eff_cd = _validated_cooldown_hours(
+        _so_for_eff.get("cooldown_hours"), symbol,
+    )
 
     report = f"""# Strategy Backtest Report — Spot V6
 
@@ -1116,7 +1148,7 @@ def generate_report(symbol: str, metrics: dict, regimes: dict, trades: list[dict
 - **Entry conditions:** LRC% <= 25 (1H) + Price > SMA100 (4H) + Bullish 5M trigger + No exclusions
 - **Exit:** Fixed SL at -{SL_PCT}% or TP at +{TP_PCT}% (whichever hit first)
 - **Position sizing:** 1% risk per trade, multiplied by score tier (0.5x / 1x / 1.5x)
-- **Constraints:** One position at a time, {COOLDOWN_H}h cooldown between trades
+- **Constraints:** One position at a time, {_eff_cd:g}h cooldown (default {COOLDOWN_H}h)
 - **Fees:** Not deducted from P&L (Binance spot = 0.1% per side)
 - **Indicators:** Same functions as live scanner (`btc_scanner.py`)
 
@@ -1325,7 +1357,8 @@ def main():
     print(f"{'='*60}\n")
 
     # Generate and save report
-    report = generate_report(symbol, metrics, regimes, trades, sim_start=sim_start, sim_end=sim_end)
+    report = generate_report(symbol, metrics, regimes, trades, sim_start=sim_start, sim_end=sim_end,
+                             symbol_overrides=symbol_overrides)
     report_path = os.path.join(SCRIPT_DIR, "docs", "strategy-backtest-report.md")
     os.makedirs(os.path.dirname(report_path), exist_ok=True)
     with open(report_path, "w", encoding="utf-8") as f:

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -114,14 +114,74 @@ except (AttributeError, io.UnsupportedOperation):
 log = logging.getLogger("btc_scanner")
 
 
-# Per-symbol participation cap wrapper around the shared validator.
 from strategy._validators import (
     validated_max_participation_rate as _shared_validated_max_pov,
+    validated_cooldown_hours as _shared_validated_cooldown_hours,
 )
 
 
 def _validated_max_participation_rate(value, symbol: str) -> float | None:
     return _shared_validated_max_pov(value, symbol, "scan", log)
+
+
+def _validated_cooldown_hours(value, symbol: str) -> float:
+    return _shared_validated_cooldown_hours(
+        value, caller="scan", symbol=symbol, logger=log, default=COOLDOWN_H,
+    )
+
+
+# Module-level throttle for DB-failure log emissions (warning OR error severity)
+# from _build_e5_cooldown. Keyed by (symbol, exception type name) — one log line
+# per (symbol, kind) per process.
+_db_fail_warned: set[tuple[str, str]] = set()
+
+
+def _build_e5_cooldown(symbol: str, cfg: dict) -> dict:
+    """Return E5_Cooldown dict (activo bool blocks trade when True)."""
+    # Lazy import of db_last_exit_ts dodges a module-load cycle. Fail-open on
+    # DB error: silently blocking legit signals on a transient query failure
+    # is worse than treating the symbol as cooldown-free + logging.
+    # Disabled symbol pattern: cfg.symbol_overrides[sym] can be `False` (not
+    # a dict) to disable trading on that symbol. Guard against `False.get(...)`.
+    raw = (cfg or {}).get("symbol_overrides", {}).get(symbol, {})
+    overrides = raw if isinstance(raw, dict) else {}
+    effective_cd = _validated_cooldown_hours(overrides.get("cooldown_hours"), symbol)
+
+    try:
+        from db.positions import db_last_exit_ts  # noqa: PLC0415
+        last_exit_dt = db_last_exit_ts(symbol)
+    except Exception as e:  # noqa: BLE001
+        # Throttle: one log line per (symbol, exc-type) per process.
+        # SQLite Operational/Database errors surface as `error` (real bug
+        # signal); other exceptions stay at `warning` (transient / config).
+        import sqlite3  # noqa: PLC0415
+        warn_key = (symbol, type(e).__name__)
+        if warn_key not in _db_fail_warned:
+            _db_fail_warned.add(warn_key)
+            # DatabaseError covers OperationalError (subclass). OSError catches
+            # disk-full / permission-denied / missing-parent-dir on DB open.
+            severe = isinstance(e, (sqlite3.DatabaseError, OSError))
+            (log.error if severe else log.warning)(
+                "scan: db_last_exit_ts failed for %s — treating as no prior exits",
+                symbol, exc_info=True,
+            )
+        last_exit_dt = None
+
+    if last_exit_dt is None:
+        return {
+            "activo": False,
+            "nota": "Sin trades previos — cooldown libre",
+            "hours_since_last_exit": None,
+            "cooldown_hours_required": effective_cd,
+        }
+
+    hours_since = (datetime.now(timezone.utc) - last_exit_dt).total_seconds() / 3600
+    return {
+        "activo": hours_since < effective_cd,
+        "nota": f"Han pasado {hours_since:.1f}h vs requirement {effective_cd}h",
+        "hours_since_last_exit": round(hours_since, 2),
+        "cooldown_hours_required": effective_cd,
+    }
 
 # ─────────────────────────────────────────────────────────────────────────────
 #  CONFIGURACIÓN
@@ -330,10 +390,7 @@ def scan(symbol: str = None):
             "activo": "VERIFICAR_MANUAL",
             "nota":   "Capital disponible > $100 (o > 10% del capital inicial)",
         },
-        "E5_Cooldown": {
-            "activo": "VERIFICAR_MANUAL",
-            "nota":   f"¿Han pasado ≥ {COOLDOWN_H}h desde el último trade?",
-        },
+        "E5_Cooldown": _build_e5_cooldown(symbol, _cfg),
         "E6_Divergencia_Bajista": {
             "activo": bear_div,
             "nota":   "Precio sube + RSI baja (1H) — peligro de reversión bajista",
@@ -539,6 +596,25 @@ def scan(symbol: str = None):
     if bull_div:
         blocks_short.append("E6S: Divergencia alcista RSI (1H) — agotamiento bajista")
 
+    # Derive cooldown-active flag from the E5 dict populated by
+    # _build_e5_cooldown. isinstance bool guard is defensive against
+    # future shape regressions.
+    _e5 = excl["E5_Cooldown"]
+    _e5_cooldown_active = isinstance(_e5.get("activo"), bool) and _e5["activo"]
+
+    if _e5_cooldown_active:
+        # Append to both direction lists for CLI + frontend visibility — the
+        # report's `blocks_auto` field shows the active direction's list.
+        # Done BEFORE the verdict ladder so the list is complete; the verdict
+        # branch on `_e5_cooldown_active` (below) will fire before `elif blocks`,
+        # so the more-informative cooldown estado wins precedence.
+        _e5_msg = (
+            f"E5: cooldown activo "
+            f"({_e5['hours_since_last_exit']}h vs {_e5['cooldown_hours_required']}h)"
+        )
+        blocks_long.append(_e5_msg)
+        blocks_short.append(_e5_msg)
+
     macro_long  = price_above_4h
     macro_short = not price_above_4h
     blocks   = blocks_long if direction == "LONG" else blocks_short if direction == "SHORT" else []
@@ -573,6 +649,20 @@ def scan(symbol: str = None):
                 "scan: liquidity_cap_skip %s %s (24h liquidity unobservable)",
                 symbol, direction,
             )
+        señal = False
+    elif _e5_cooldown_active:
+        # Operational pacing constraint — fires before signal-quality blocks
+        # because even a clean setup must wait for the cooldown to elapse.
+        estado = (
+            f"🚫 BLOQUEADA {direction} — cooldown activo "
+            f"({_e5['hours_since_last_exit']}h desde último exit vs "
+            f"{_e5['cooldown_hours_required']}h requeridas)"
+        )
+        log.info(
+            "scan: e5_cooldown_active %s %s hours_since=%s required=%s",
+            symbol, direction,
+            _e5["hours_since_last_exit"], _e5["cooldown_hours_required"],
+        )
         señal = False
     elif blocks:
         estado = f"🚫 BLOQUEADA {direction} — {len(blocks)} exclusión(es) automática"

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -40,15 +40,15 @@
     }
   },
   "symbol_overrides": {
-    "BTCUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 14, "max_participation_rate": 0.010 },
-    "ETHUSDT":    { "atr_sl_mult": 1.2, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 14, "max_participation_rate": 0.010 },
-    "ADAUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 5,  "max_participation_rate": 0.003 },
-    "AVAXUSDT":   { "atr_sl_mult": 1.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 8,  "max_participation_rate": 0.005 },
-    "DOGEUSDT":   { "atr_sl_mult": 0.7, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 5,  "max_participation_rate": 0.005 },
-    "UNIUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 3.0, "atr_be_mult": 1.5, "time_limit_hours": 5,  "max_participation_rate": 0.002 },
-    "XLMUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 5,  "max_participation_rate": 0.0015 },
-    "PENDLEUSDT": { "atr_sl_mult": 0.5, "atr_tp_mult": 3.0, "atr_be_mult": 2.0, "time_limit_hours": 5,  "max_participation_rate": 0.0015 },
-    "JUPUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 2.5, "time_limit_hours": 5,  "max_participation_rate": 0.005 },
-    "RUNEUSDT":   { "atr_sl_mult": 0.7, "atr_tp_mult": 6.0, "atr_be_mult": 2.5, "time_limit_hours": 5,  "max_participation_rate": 0.003 }
+    "BTCUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 14, "max_participation_rate": 0.010,  "cooldown_hours": 14 },
+    "ETHUSDT":    { "atr_sl_mult": 1.2, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 14, "max_participation_rate": 0.010,  "cooldown_hours": 14 },
+    "ADAUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 5,  "max_participation_rate": 0.003,  "cooldown_hours": 6 },
+    "AVAXUSDT":   { "atr_sl_mult": 1.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 8,  "max_participation_rate": 0.005,  "cooldown_hours": 8 },
+    "DOGEUSDT":   { "atr_sl_mult": 0.7, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 5,  "max_participation_rate": 0.005,  "cooldown_hours": 6 },
+    "UNIUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 3.0, "atr_be_mult": 1.5, "time_limit_hours": 5,  "max_participation_rate": 0.002,  "cooldown_hours": 6 },
+    "XLMUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 5,  "max_participation_rate": 0.0015, "cooldown_hours": 6 },
+    "PENDLEUSDT": { "atr_sl_mult": 0.5, "atr_tp_mult": 3.0, "atr_be_mult": 2.0, "time_limit_hours": 5,  "max_participation_rate": 0.0015, "cooldown_hours": 6 },
+    "JUPUSDT":    { "atr_sl_mult": 0.5, "atr_tp_mult": 4.0, "atr_be_mult": 2.5, "time_limit_hours": 5,  "max_participation_rate": 0.005,  "cooldown_hours": 6 },
+    "RUNEUSDT":   { "atr_sl_mult": 0.7, "atr_tp_mult": 6.0, "atr_be_mult": 2.5, "time_limit_hours": 5,  "max_participation_rate": 0.003,  "cooldown_hours": 6 }
   }
 }

--- a/db/positions.py
+++ b/db/positions.py
@@ -56,6 +56,29 @@ def db_create_position(data: dict) -> dict:
     return dict(row)
 
 
+def db_last_exit_ts(symbol: str) -> Optional[datetime]:
+    """Return last exit_ts (UTC, tz-aware) for symbol's closed positions, or None."""
+    # Naive ISO strings get tz=UTC attached so arithmetic vs
+    # datetime.now(timezone.utc) is well-defined; malformed ISO swallowed → None.
+    con = get_db()
+    row = con.execute(
+        "SELECT exit_ts FROM positions "
+        "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
+        "ORDER BY exit_ts DESC LIMIT 1",
+        (symbol.upper(),),
+    ).fetchone()
+    con.close()
+    if not row or not row[0]:
+        return None
+    try:
+        dt = datetime.fromisoformat(row[0])
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def db_get_positions(status: Optional[str] = None) -> list:
     con = get_db()
     if status and status != "all":

--- a/docs/superpowers/specs/es/2026-05-01-operational-model-manual-gating.md
+++ b/docs/superpowers/specs/es/2026-05-01-operational-model-manual-gating.md
@@ -1,8 +1,8 @@
 # Modelo operacional: gating manual de señales
 
-**Fecha:** 2026-05-01
+**Fecha:** 2026-05-01 (revisado post-PR3 cooldown parity)
 **Issue:** #283
-**Tono:** descriptivo (captura el estado al 2026-05-01, no propone cambios)
+**Tono:** descriptivo (captura el estado vigente, no propone cambios)
 
 ---
 
@@ -10,7 +10,9 @@
 
 El sistema genera señales de trading de forma automática (scanner → score → exclusiones → notificación), pero las decisiones de **entrada** y **cierre** de posiciones requieren aprobación manual del operador via CLI o frontend autenticado.
 
-Este spec materializa una decisión operacional que hasta ahora vivía implícita en el código (`btc_scanner.py:305-335`) y en convenciones no escritas. No introduce comportamiento nuevo: documenta el modelo vigente para que cualquier trabajo futuro sobre validación, automatización o comparación backtest-vs-live tenga una referencia explícita.
+Este spec materializa una decisión operacional que hasta ahora vivía implícita en el código (`btc_scanner.py: scan() exclusions dict (search `excl = {`)`) y en convenciones no escritas. No introduce comportamiento nuevo: documenta el modelo vigente para que cualquier trabajo futuro sobre validación, automatización o comparación backtest-vs-live tenga una referencia explícita.
+
+Post-PR3 (cooldown parity), E5_Cooldown se promovió de manual-check a auto-enforcement (scanner consulta `db_last_exit_ts` y reporta el `activo` como bool). E2/E3/E4 retienen status manual-check porque dependen de información externa al sistema.
 
 ## 2. Pipeline determinista vs gating manual
 
@@ -19,17 +21,15 @@ Este spec materializa una decisión operacional que hasta ahora vivía implícit
 - Cálculo de indicadores (LRC, RSI, BB, SMA100, ATR, ADX, divergencias, engulfings).
 - Regime detector (composite F&G + funding + price).
 - Score multi-timeframe (0–9).
-- Evaluación booleana de exclusiones automáticas (E1, E6) e informativas (E7).
+- Evaluación booleana de exclusiones automáticas (E1, E5, E6) e informativas (E7).
 - Persistencia a `signals.db` y emisión de notificación a Telegram.
 
 **Lo que requiere intervención humana:**
-- Verificación de las exclusiones marcadas `VERIFICAR_MANUAL` (E2, E3, E4, E5).
+- Verificación de las exclusiones marcadas `VERIFICAR_MANUAL` (E2, E3, E4).
 - Decisión final de abrir la posición.
 - Decisión de cerrar manualmente antes de SL/TP.
 
 ## 3. Exclusiones E1–E7 — clasificación auto vs manual
-
-Tabla extraída literal de `btc_scanner.py:305-335` (commit `4214ca8`):
 
 | ID | Campo `activo` | Tipo | Bloquea entrada |
 |----|---------------|------|-----------------|
@@ -37,11 +37,11 @@ Tabla extraída literal de `btc_scanner.py:305-335` (commit `4214ca8`):
 | E2_Noticias_Macro | `"VERIFICAR_MANUAL"` | Manual | Operador decide |
 | E3_RachaPerdedora | `"VERIFICAR_MANUAL"` | Manual | Operador decide |
 | E4_Capital_Min | `"VERIFICAR_MANUAL"` | Manual | Operador decide |
-| E5_Cooldown | `"VERIFICAR_MANUAL"` | Manual | Operador decide |
+| E5_Cooldown | `bool` (auto-evaluated, post-PR3) | Auto | Sí, si `True` |
 | E6_Divergencia_Bajista | `bear_div` (boolean) | Auto | Sí, si `True` |
 | E7_Tendencia_Fuerte | `"INFORMATIVO"` | Informativo | No |
 
-Resumen: 4 manual-check + 2 auto + 1 informativo.
+Resumen: 3 manual-check + 3 auto + 1 informativo.
 
 ## 4. Flujo de aprobación
 
@@ -49,57 +49,56 @@ Resumen: 4 manual-check + 2 auto + 1 informativo.
 2. Notificación sale por Telegram (push al chat configurado en `config.json`).
    - **Telegram es outbound only.** No hay bot de entrada que reciba aprobaciones. Las decisiones nunca se confirman vía Telegram.
 3. Operador revisa la señal en el frontend (`http://localhost:5173` en dev, `https://trading.sdar.dev` en prod) o vía la CLI.
-4. Operador resuelve manualmente las exclusiones marcadas `VERIFICAR_MANUAL` (E2–E5) consultando el contexto necesario (calendar de noticias para E2, historial de trades para E3, balance para E4, último exit para E5).
+4. Operador resuelve manualmente las exclusiones marcadas `VERIFICAR_MANUAL` (E2–E4) consultando el contexto necesario (calendar de noticias para E2, historial de trades para E3, balance para E4). E5 ya no requiere intervención: scanner reporta `activo: bool` derivado de `db_last_exit_ts(symbol)` vs `cooldown_hours_required`.
 5. Si las manual-checks pasan, operador ejecuta entrada via `POST /positions`.
 6. Cierre manual (cuando aplica) via `POST /positions/{id}/close`. SL/TP automáticos siguen activos en background y disparan cierres aun sin intervención.
 
 ## 5. Implicancias para validación (backtest vs live)
 
-El backtest enforcea **automáticamente** la exclusión E5_Cooldown porque es una simulación cerrada, sin operador. El código vive en `backtest.py:486-490`:
-
-```python
-# ── Cooldown check ────────────────────────────────────────────────
-if last_exit_time is not None:
-    hours_since = (bar_time - last_exit_time).total_seconds() / 3600
-    if hours_since < COOLDOWN_H:
-        continue
-```
-
-`COOLDOWN_H = 6` se importa desde `btc_scanner.py:131`. La constante es **idéntica** entre scanner y backtest; lo que cambia es **quién la enforcea**:
+Post-PR3, **ambos contextos enforcean automáticamente E5_Cooldown** con valores per-symbol (default-fallback al global `COOLDOWN_H=6` cuando el override no está configurado o es inválido). El backtest skipea la barra si `hours_since < effective_cooldown` (`backtest.py: cooldown enforcement block (search `Cooldown check`)`); el scanner consulta `db_last_exit_ts(symbol)` y reporta `E5_Cooldown.activo` como bool en cada tick.
 
 | Contexto | Quién enforcea E5 | Cómo |
 |----------|-------------------|------|
-| Backtest | Simulador | Skip de la barra si `hours_since < COOLDOWN_H` |
-| Live | Operador | Inspección manual del `nota` reportada por scanner |
+| Backtest | Simulador | Skip de la barra si `hours_since < effective_cooldown` |
+| Live | Scanner + frontend/CLI | `db_last_exit_ts` query en cada scan; bloqueo automático cuando `activo: True` |
 
-**Esto NO es drift.** Es la diferencia esperada entre simulación cerrada y operación supervisada. El `COOLDOWN_H = 6` es la misma fuente de verdad para ambos contextos; sólo el mecanismo de enforcement difiere.
+Las constantes per-symbol (BTC=14, ETH=14, AVAX=8, demás=6) viven en `config.json["symbol_overrides"]` y son fuente de verdad compartida entre scanner y backtest.
 
-**Implicancia para A.4 (#250) y cualquier evaluación holdout:** los resultados del backtest reflejan el comportamiento bajo enforce automático del cooldown. Trasladar conclusiones a producción asume que el operador es disciplinado en el manual-check de E5. Si en algún momento se observa divergencia material entre la densidad de trades del backtest y la real, este spec es el lugar a citar para encuadrar el análisis.
+**Implicancia para A.4 (#250) y cualquier evaluación holdout:** post-PR3, la densidad de trades de backtest y producción debería converger en este eje (ambos auto-enforcean). Cualquier divergencia material indica drift en otro eje (orderbook fills, slippage, regime cache, etc.) y debe investigarse contra los specs de PR2 (cap) o el cost model.
 
-El mismo razonamiento aplica a E2, E3 y E4: el backtest no las simula (no tiene calendar de noticias, no rastrea racha psicológica del operador, no modela balance externo). Cualquier comparación backtest-vs-live debe asumir que estas exclusiones operan asimétricamente.
+E2, E3 y E4 retienen status manual-check: el backtest no las simula (no tiene calendar de noticias, no rastrea racha psicológica del operador, no modela balance externo). Cualquier comparación backtest-vs-live debe asumir que estas tres exclusiones operan asimétricamente — sólo E5 alcanzó parity en PR3.
 
 ## 6. Lectura del diseño actual
 
-Las 4 exclusiones manual-check (E2–E5) están agrupadas en el mismo dict de `btc_scanner.py:305-335`, todas con `"activo": "VERIFICAR_MANUAL"` y un `nota` describiendo qué consultar. E5_Cooldown es técnicamente auto-enforceable (la información necesaria — timestamp del último exit — vive en `signals.db` y es accesible por el scanner), pero está al lado de E2–E4 que sí requieren información externa al sistema.
+Las 3 exclusiones manual-check restantes (E2–E4) están agrupadas en el mismo dict de `btc_scanner.py: scan() exclusions dict (search `excl = {`)`, todas con `"activo": "VERIFICAR_MANUAL"` y un `nota` describiendo qué consultar. Todas dependen de información externa al sistema (calendar, balance externo, racha psicológica) que el scanner no puede consultar autónomamente.
 
-Si esta agrupación fue decisión deliberada o evolución histórica no está documentado en código ni en commits previos. Este spec captura el **estado**, no infiere intent.
+E5_Cooldown se promovió a auto-evaluación en PR3 (epic #294) porque la información necesaria — timestamp del último exit — vive en `signals.db` y es accesible por el scanner via `db_last_exit_ts`. Esto eliminó la asimetría operacional con el backtest sin agregar dependencias externas.
 
-## 7. Promotion to auto-enforcement (open)
+## 7. Promotion to auto-enforcement
 
-No existen criterios definidos para migrar exclusiones manual-check a auto-enforcement. Cualquier propuesta — auto-enforce E5 leyendo `signals.db`, integrar un proveedor de calendar para E2, derivar E3 de la última racha en `positions`, leer balance via API de exchange para E4 — requiere ticket nuevo con:
+**Precedente: E5_Cooldown (PR3, epic #294).** Promovido cuando se cumplió:
+- La información necesaria estaba accesible localmente (`db_last_exit_ts` query a `signals.db`).
+- El backtest ya enforceaba auto, y la asimetría con producción era documentada como riesgo de divergencia (§5 pre-PR3).
+- Per-symbol values estaban derivados deterministically (rule `max(TL, NW=4, floor=6)` per spec D9 §2.1) — sin grado de libertad nuevo.
+
+Para promover E2/E3/E4 a auto-enforcement, cualquier propuesta debe satisfacer:
 
 - Scope explícito (qué exclusión, en qué condiciones).
+- Información accesible localmente (e.g., calendar API para E2, derivar E3 de `positions` table, balance via exchange API para E4).
 - Criterios de aceptación (cómo se valida que el auto-enforcement coincide con la decisión humana actual).
 - Plan de validación (backtest + paper trading + golden-path manual antes de promover a default).
 
-Este spec **no define esos criterios**. Su rol es servir de baseline contra el cual cualquier propuesta futura pueda compararse.
+Este spec captura el estado vigente — no define criterios genéricos para futuras promociones, solo documenta el patrón aplicado en E5.
 
 ## 8. Referencias
 
-- `btc_scanner.py:305-335` — tabla de exclusiones E1–E7.
-- `btc_scanner.py:131` — `COOLDOWN_H = 6` (constante compartida).
-- `backtest.py:486-490` — enforce automático de E5 en simulación.
-- `btc_api.py` — endpoints `POST /positions` y `POST /positions/{id}/close` que materializan la aprobación manual.
+- `btc_scanner.py: scan() exclusions dict (search `excl = {`)` — tabla de exclusiones E1–E7.
+- `btc_scanner.py`: `COOLDOWN_H` constant — global default-fallback (= 6).
+- `backtest.py: cooldown enforcement block (search `Cooldown check`)` — enforce automático de E5 en simulación con per-symbol resolution.
+- `db/positions.py` — `db_last_exit_ts(symbol)` helper consumido por scanner para E5.
+- `strategy/_validators.py` — `validated_cooldown_hours` (boundary `> 168` reject, default-fallback).
+- `btc_api.py` — endpoints `POST /positions` y `POST /positions/{id}/close` que materializan la aprobación manual de entrada/cierre (E5 ya no requiere aprobación).
 - Issue #283 — modelo operacional: producción manual vs backtest automático (cierra con este spec).
 - Issue #284 — análisis previo que confirmó que `COOLDOWN_H = 6` es consistente entre código y docs (cerrado como outdated).
+- `docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md` §2.1 — pre-registered cooldown per-symbol values (source of truth para PR3).
 - `docs/strategy-backtest-report.md` — reporte del backtest; menciona "6h cooldown" en §2 Methodology con referencia cruzada a este spec.

--- a/strategy/_validators.py
+++ b/strategy/_validators.py
@@ -2,13 +2,13 @@
 
 Both the live `api.positions.check_position_stops` path, the backtest's
 `simulate_strategy` resolver, and the production `btc_scanner.scan` path
-consume per-symbol `time_limit_hours` / `max_participation_rate` and the
-process-wide `scan_interval_sec` from cfg. Validation lives here so the same
-rules apply across paths and a single throttle prevents log spam from a
-long-running scanner that re-reads cfg every tick.
+consume per-symbol `time_limit_hours` / `max_participation_rate` /
+`cooldown_hours` and the process-wide `scan_interval_sec` from cfg.
+Validation lives here so the same rules apply across paths and a single
+throttle prevents log spam from a long-running scanner that re-reads cfg
+every tick.
 
 `_validator_warned` is a module-level set keyed by `(caller, symbol, error_kind)`.
-Tests reset it via `monkeypatch.setattr(strategy._validators, "_validator_warned", set())`.
 """
 from __future__ import annotations
 
@@ -36,19 +36,19 @@ def validated_time_limit_hours(
     msg: str | None = None
 
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-        error_kind = f"type:{type(value).__name__}"
+        error_kind = f"time_limit:type:{type(value).__name__}"
         msg = (
             f"{caller}: time_limit_hours for {symbol} has wrong type "
             f"({type(value).__name__}, value={value!r}) — ignoring"
         )
     elif not math.isfinite(value):
-        error_kind = "non-finite"
+        error_kind = "time_limit:non-finite"
         msg = (
             f"{caller}: time_limit_hours for {symbol} must be finite "
             f"(got {value!r}) — ignoring"
         )
     elif value <= 0:
-        error_kind = "non-positive"
+        error_kind = "time_limit:non-positive"
         msg = (
             f"{caller}: time_limit_hours for {symbol} must be > 0 "
             f"(got {value}) — ignoring"
@@ -82,25 +82,25 @@ def validated_max_participation_rate(
     msg: str | None = None
 
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-        error_kind = f"type:{type(value).__name__}"
+        error_kind = f"max_pov:type:{type(value).__name__}"
         msg = (
             f"{caller}: max_participation_rate for {symbol} has wrong type "
             f"({type(value).__name__}, value={value!r}) — ignoring"
         )
     elif not math.isfinite(value):
-        error_kind = "non-finite"
+        error_kind = "max_pov:non-finite"
         msg = (
             f"{caller}: max_participation_rate for {symbol} must be finite "
             f"(got {value!r}) — ignoring"
         )
     elif value <= 0:
-        error_kind = "non-positive"
+        error_kind = "max_pov:non-positive"
         msg = (
             f"{caller}: max_participation_rate for {symbol} must be > 0 "
             f"(got {value}) — ignoring"
         )
     elif value > 1.0:
-        error_kind = "above-one"
+        error_kind = "max_pov:above-one"
         msg = (
             f"{caller}: max_participation_rate for {symbol} must be ≤ 1.0 "
             f"(got {value}) — ignoring"
@@ -112,6 +112,56 @@ def validated_max_participation_rate(
             logger.warning(msg)
             _validator_warned.add(warn_key)
         return None
+
+    return float(value)
+
+
+def validated_cooldown_hours(
+    value,
+    *,
+    caller: str,
+    symbol: str,
+    logger: logging.Logger,
+    default: float = 6.0,
+) -> float:
+    """Return value as float if valid in (0, 168], else `default` (boundary > 168 = sanity reject)."""
+    if value is None:
+        return float(default)
+
+    error_kind: str | None = None
+    msg: str | None = None
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        error_kind = f"cooldown:type:{type(value).__name__}"
+        msg = (
+            f"{caller}: cooldown_hours for {symbol} has wrong type "
+            f"({type(value).__name__}, value={value!r}) — falling back to {default}"
+        )
+    elif not math.isfinite(value):
+        error_kind = "cooldown:non-finite"
+        msg = (
+            f"{caller}: cooldown_hours for {symbol} must be finite "
+            f"(got {value!r}) — falling back to {default}"
+        )
+    elif value <= 0:
+        error_kind = "cooldown:non-positive"
+        msg = (
+            f"{caller}: cooldown_hours for {symbol} must be > 0 "
+            f"(got {value}) — falling back to {default}"
+        )
+    elif value > 168:
+        error_kind = "cooldown:above-168"
+        msg = (
+            f"{caller}: cooldown_hours for {symbol} must be ≤ 168 "
+            f"(got {value}) — falling back to {default}"
+        )
+
+    if error_kind is not None:
+        warn_key = (caller, symbol, error_kind)
+        if warn_key not in _validator_warned:
+            logger.warning(msg)
+            _validator_warned.add(warn_key)
+        return float(default)
 
     return float(value)
 
@@ -131,19 +181,19 @@ def validated_scan_interval_sec(
     msg: str | None = None
 
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-        error_kind = f"type:{type(value).__name__}"
+        error_kind = f"scan_interval:type:{type(value).__name__}"
         msg = (
             f"{caller}: scan_interval_sec has wrong type "
             f"({type(value).__name__}, value={value!r}) — falling back to {default}"
         )
     elif not math.isfinite(value):
-        error_kind = "non-finite"
+        error_kind = "scan_interval:non-finite"
         msg = (
             f"{caller}: scan_interval_sec must be finite "
             f"(got {value!r}) — falling back to {default}"
         )
     elif value <= 0:
-        error_kind = "non-positive"
+        error_kind = "scan_interval:non-positive"
         msg = (
             f"{caller}: scan_interval_sec must be > 0 "
             f"(got {value}) — falling back to {default}"

--- a/tests/_baselines/scan_btcusdt.json
+++ b/tests/_baselines/scan_btcusdt.json
@@ -72,8 +72,10 @@
       "nota": "Capital disponible > $100 (o > 10% del capital inicial)"
     },
     "E5_Cooldown": {
-      "activo": "VERIFICAR_MANUAL",
-      "nota": "\u00bfHan pasado \u2265 6h desde el \u00faltimo trade?"
+      "activo": false,
+      "cooldown_hours_required": 6.0,
+      "hours_since_last_exit": null,
+      "nota": "Sin trades previos \u2014 cooldown libre"
     },
     "E6_Divergencia_Bajista": {
       "activo": false,

--- a/tests/_baselines/signals.json
+++ b/tests/_baselines/signals.json
@@ -56,7 +56,7 @@
       "setup": 0,
       "se\u00f1al": 1,
       "symbol": "BTCUSDT",
-      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, cooldown 6h, DXY\n_BTCUSDT Spot 1H V6_",
+      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
       "ts": "2026-01-15T10:05:00Z"
     },
     "status": 200
@@ -74,14 +74,14 @@
       "score_label": "premium",
       "sizing": {},
       "symbol": "BTCUSDT",
-      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, cooldown 6h, DXY\n_BTCUSDT Spot 1H V6_",
+      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
       "ts": "2026-01-15T10:05:00Z"
     },
     "status": 200
   },
   "GET /signals/latest/message": {
     "body": {
-      "message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, cooldown 6h, DXY\n_BTCUSDT Spot 1H V6_",
+      "message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
       "scan_id": 2,
       "symbol": "BTCUSDT",
       "ts": "2026-01-15T10:05:00Z"
@@ -101,7 +101,7 @@
       "score_label": "premium",
       "sizing": {},
       "symbol": "BTCUSDT",
-      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, cooldown 6h, DXY\n_BTCUSDT Spot 1H V6_",
+      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
       "ts": "2026-01-15T10:05:00Z"
     },
     "status": 200

--- a/tests/_fixtures/scanner_frozen.py
+++ b/tests/_fixtures/scanner_frozen.py
@@ -116,4 +116,15 @@ def frozen_scan(monkeypatch, tmp_path):
     monkeypatch.setattr("observability.record_decision", lambda **kw: None)
     monkeypatch.setattr(
         "strategy.kill_switch_v2_shadow.emit_shadow_decision", lambda **kw: None)
+    # scan() reads `db_last_exit_ts(symbol)` to build E5_Cooldown. The snapshot
+    # tests scanner determinism, not end-to-end DB state — mock to "no prior
+    # exits" so snapshot doesn't drift with whatever the runner's signals.db
+    # happens to contain. The defensive assert catches future regressions
+    # where the helper is called without a symbol argument.
+    def _no_prior_exits(symbol, *args, **kwargs):
+        assert isinstance(symbol, str) and symbol, (
+            f"db_last_exit_ts called with bad symbol: {symbol!r}"
+        )
+        return None
+    monkeypatch.setattr("db.positions.db_last_exit_ts", _no_prior_exits)
     yield

--- a/tests/test_backtest_generate_report.py
+++ b/tests/test_backtest_generate_report.py
@@ -1,0 +1,79 @@
+"""generate_report — disabled-symbol guard for cooldown resolution."""
+from __future__ import annotations
+
+
+def _minimal_metrics() -> dict:
+    """Smallest dict shape that satisfies generate_report's f-string interpolation."""
+    return {
+        "total_trades": 0, "wins": 0, "losses": 0, "win_rate": 0.0,
+        "gross_profit": 0.0, "gross_loss": 0.0, "net_pnl": 0.0,
+        "profit_factor": 0.0, "total_return_pct": 0.0, "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0, "sortino_ratio": 0.0,
+        "avg_duration_hours": 0.0, "avg_win_duration_hours": 0.0,
+        "avg_loss_duration_hours": 0.0,
+        "max_consecutive_wins": 0, "max_consecutive_losses": 0,
+        "trades_per_month": 0.0,
+        "best_trade_pct": 0.0, "worst_trade_pct": 0.0, "median_trade_pct": 0.0,
+        "final_equity": 10000.0, "score_tiers": {},
+    }
+
+
+def _minimal_regimes() -> dict:
+    """Shape required by generate_report's regime table — dict-of-dicts."""
+    empty = {"trades": 0, "win_rate": 0.0, "avg_pnl_pct": 0.0, "total_pnl_usd": 0.0}
+    return {"bull": dict(empty), "bear": dict(empty), "sideways": dict(empty)}
+
+
+def test_generate_report_handles_disabled_symbol():
+    """generate_report must not crash when symbol_overrides[sym] = False.
+
+    Regression net for C-R2-1: the cooldown-resolution helper was added in PR3
+    R1 without a `False`-value guard, leaving an unmasked crash if any caller
+    invokes generate_report with a disabled symbol entry. Today the upstream
+    `if not trades: return` short-circuits this path, but any refactor that
+    drops the early return would unmask the bug.
+    """
+    from backtest import generate_report
+
+    so = {"BTCUSDT": False}
+    rep = generate_report(
+        "BTCUSDT",
+        _minimal_metrics(),
+        _minimal_regimes(),
+        trades=[],
+        symbol_overrides=so,
+    )
+    # Template resolved (no AttributeError, no f-string placeholders left).
+    assert isinstance(rep, str) and len(rep) > 0
+    assert "{COOLDOWN_H}h" not in rep
+    assert "{_eff_cd" not in rep
+
+
+def test_generate_report_handles_dict_override():
+    """Sanity: with a normal dict override the resolution still works."""
+    from backtest import generate_report
+
+    so = {"BTCUSDT": {"cooldown_hours": 14}}
+    rep = generate_report(
+        "BTCUSDT",
+        _minimal_metrics(),
+        _minimal_regimes(),
+        trades=[],
+        symbol_overrides=so,
+    )
+    # Effective cooldown for BTC should be 14 (the override).
+    assert "14h cooldown" in rep
+
+
+def test_generate_report_handles_no_overrides():
+    """`symbol_overrides=None` falls back to COOLDOWN_H global."""
+    from backtest import generate_report, COOLDOWN_H
+
+    rep = generate_report(
+        "BTCUSDT",
+        _minimal_metrics(),
+        _minimal_regimes(),
+        trades=[],
+        symbol_overrides=None,
+    )
+    assert f"{COOLDOWN_H}h cooldown" in rep

--- a/tests/test_backtest_refactor_parity.py
+++ b/tests/test_backtest_refactor_parity.py
@@ -205,11 +205,12 @@ def test_simulate_strategy_parity_doge_2024_h1(tmp_path, monkeypatch):
 
     cfg = _btc_api.load_config()
     symbol_overrides = cfg.get("symbol_overrides", {}) if isinstance(cfg, dict) else {}
-    # Strip time_limit_hours and max_participation_rate so the pin (precision-fix
-    # invariant: no phantom SL profits) stays valid independent of the structural
-    # exit + sizing barriers. Those are exercised separately in their own smoke tests.
+    # Strip time_limit_hours, max_participation_rate, and cooldown_hours so the pin
+    # (precision-fix invariant: no phantom SL profits) stays valid independent of
+    # the structural exit + sizing + cooldown barriers. Those are exercised
+    # separately in their own smoke tests.
     cfg = {**cfg, "symbol_overrides": {
-        sym: {k: v for k, v in ov.items() if k not in ("time_limit_hours", "max_participation_rate")}
+        sym: {k: v for k, v in ov.items() if k not in ("time_limit_hours", "max_participation_rate", "cooldown_hours")}
         for sym, ov in symbol_overrides.items()
     }}
     symbol_overrides = cfg["symbol_overrides"]
@@ -276,9 +277,9 @@ def test_simulate_strategy_parity_xlm_2024_h1(tmp_path, monkeypatch):
 
     cfg = _btc_api.load_config()
     symbol_overrides = cfg.get("symbol_overrides", {}) if isinstance(cfg, dict) else {}
-    # Strip time_limit_hours and max_participation_rate — see DOGE test above for the rationale.
+    # Strip time_limit_hours, max_participation_rate, and cooldown_hours — see DOGE test above for the rationale.
     cfg = {**cfg, "symbol_overrides": {
-        sym: {k: v for k, v in ov.items() if k not in ("time_limit_hours", "max_participation_rate")}
+        sym: {k: v for k, v in ov.items() if k not in ("time_limit_hours", "max_participation_rate", "cooldown_hours")}
         for sym, ov in symbol_overrides.items()
     }}
     symbol_overrides = cfg["symbol_overrides"]

--- a/tests/test_backtest_smoke_cooldown.py
+++ b/tests/test_backtest_smoke_cooldown.py
@@ -1,0 +1,154 @@
+"""End-to-end smoke for per-symbol cooldown across the curated basket."""
+from __future__ import annotations
+
+import json
+import math
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OHLCV_DB = os.path.join(REPO_ROOT, "data", "ohlcv.db")
+CONFIG_DEFAULTS_PATH = os.path.join(REPO_ROOT, "config.defaults.json")
+
+
+CURATED_SYMBOLS = [
+    "BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT",
+    "UNIUSDT", "XLMUSDT", "PENDLEUSDT", "JUPUSDT", "RUNEUSDT",
+]
+
+
+# Baseline post-cap, pre-cooldown trade counts (TL active + cap active, costs
+# OFF, train segment 2023-10-01 → 2025-03-31). Captured against commit
+# ec0a586 (post-cap-merge, pre-cooldown). Hard-pinned: a future increase in
+# any per-symbol count means the cooldown stopped firing for that symbol —
+# surface as regression.
+BASELINE_CLOSED_POST_CAP_PRE_COOLDOWN: dict[str, int] = {
+    "BTCUSDT": 206, "ETHUSDT": 169, "ADAUSDT":   79, "AVAXUSDT": 145,
+    "DOGEUSDT": 170, "UNIUSDT":   40, "XLMUSDT":  23, "PENDLEUSDT": 10,
+    "JUPUSDT":   55, "RUNEUSDT":  67,
+}
+BASELINE_TOTAL = sum(BASELINE_CLOSED_POST_CAP_PRE_COOLDOWN.values())  # = 964
+
+# Symbols whose cooldown changed from the legacy global 6h:
+# BTC/ETH 6→14, AVAX 6→8. These MUST show some retention drop (cooldown
+# binding at least once in 18 months); otherwise the per-symbol resolution
+# silently fell back to the global default.
+COOLDOWN_INCREASED_SYMBOLS = {"BTCUSDT", "ETHUSDT", "AVAXUSDT"}
+
+
+@pytest.mark.skipif(
+    not os.path.exists(OHLCV_DB),
+    reason="requires cached market data (data/ohlcv.db)",
+)
+def test_smoke_cooldown_across_curated_symbols(tmp_path, monkeypatch):
+    """Per-symbol cooldown smoke: counts ≤ baseline, BTC/ETH/AVAX retention < 100%."""
+    from backtest import simulate_strategy, get_cached_data
+    import btc_api
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    with open(CONFIG_DEFAULTS_PATH) as f:
+        cfg = json.load(f)
+
+    symbol_overrides = cfg.get("symbol_overrides", {})
+    for sym in CURATED_SYMBOLS:
+        assert "cooldown_hours" in symbol_overrides.get(sym, {}), (
+            f"{sym} must have cooldown_hours in config.defaults.json"
+        )
+
+    sim_start = datetime(2023, 10, 1, tzinfo=timezone.utc)
+    sim_end = datetime(2025, 3, 31, tzinfo=timezone.utc)
+    data_start = datetime(2022, 1, 1, tzinfo=timezone.utc)
+
+    df1d_btc = get_cached_data("BTCUSDT", "1d", start_date=data_start)
+    if df1d_btc.empty:
+        pytest.skip("BTCUSDT 1d not cached")
+
+    summary: dict[str, dict] = {}
+
+    for symbol in CURATED_SYMBOLS:
+        df1h = get_cached_data(symbol, "1h", start_date=data_start)
+        df4h = get_cached_data(symbol, "4h", start_date=data_start)
+        df5m = get_cached_data(symbol, "5m", start_date=data_start)
+        df1d = get_cached_data(symbol, "1d", start_date=data_start)
+        if df1h.empty or df4h.empty or df5m.empty:
+            pytest.skip(f"{symbol} market data not cached")
+
+        trades, _equity = simulate_strategy(
+            df1h, df4h, df5m, symbol,
+            sim_start=sim_start, sim_end=sim_end,
+            df1d=df1d, df1d_btc=df1d_btc,
+            cfg=cfg, symbol_overrides=symbol_overrides,
+            enable_slippage=False, enable_spread=False, enable_fees=False,
+        )
+
+        assert isinstance(trades, list)
+
+        for t in trades:
+            assert t["pnl_usd"] is not None and not math.isnan(t["pnl_usd"]), (
+                f"NaN pnl_usd for {symbol}: {t}"
+            )
+            assert t["pnl_pct"] is not None and not math.isnan(t["pnl_pct"]), (
+                f"NaN pnl_pct for {symbol}: {t}"
+            )
+
+        closed = [t for t in trades if t["exit_reason"] != "OPEN"]
+        summary[symbol] = {"closed": len(closed)}
+
+    # ── Per-symbol monotonic regression: cooldown can only reduce ───────────
+    for symbol in CURATED_SYMBOLS:
+        post_cooldown = summary[symbol]["closed"]
+        baseline = BASELINE_CLOSED_POST_CAP_PRE_COOLDOWN[symbol]
+        assert 0 <= post_cooldown <= baseline, (
+            f"{symbol}: post_cooldown_count={post_cooldown} must be in [0, {baseline}] "
+            f"(cooldown can only equal or reduce, never add)"
+        )
+
+    # ── Aggregate monotonic ─────────────────────────────────────────────────
+    total_post_cooldown = sum(s["closed"] for s in summary.values())
+    assert total_post_cooldown <= BASELINE_TOTAL, (
+        f"aggregate post_cooldown={total_post_cooldown} must be ≤ baseline={BASELINE_TOTAL}; "
+        f"larger means cooldown logic broke (or per-symbol resolution leaked into "
+        f"a faster path than the legacy global)"
+    )
+
+    # ── Cooldown-increased symbols MUST show binding ────────────────────────
+    # BTC/ETH 6h→14h, AVAX 6h→8h. Over 18 months, the new cooldown MUST bind
+    # at least once for each — else per-symbol resolution silently no-op'd.
+    for symbol in COOLDOWN_INCREASED_SYMBOLS:
+        post = summary[symbol]["closed"]
+        baseline = BASELINE_CLOSED_POST_CAP_PRE_COOLDOWN[symbol]
+        assert post < baseline, (
+            f"{symbol}: cooldown increased from 6h to "
+            f"{symbol_overrides[symbol]['cooldown_hours']}h but trade count did "
+            f"not drop ({post} == {baseline}). Per-symbol resolution may be "
+            f"silently falling back to the global default. Investigate."
+        )
+        # Soft floor: cooldown can bind but not annihilate. Catches an
+        # "always-blocks" regression (e.g., TZ bug → hours_since negative →
+        # activo always True) that would dump trade count to ~0 silently.
+        assert post >= baseline * 0.5, (
+            f"{symbol}: post-cooldown count {post} below {baseline * 0.5:.0f} "
+            f"(50% baseline floor). Cooldown is binding too aggressively — "
+            f"investigate for an always-blocks regression (TZ sign flip, "
+            f"future-dated last_exit_ts)."
+        )
+
+    # ── Print summary so post-merge readers can compare ─────────────────────
+    print("\n=== SMOKE COOLDOWN PER-SYMBOL SUMMARY ===")
+    print(f"{'Symbol':<14} {'Post-CD':>9} {'Baseline':>9} {'Retention':>10} {'CD':>4}")
+    for sym in CURATED_SYMBOLS:
+        post = summary[sym]["closed"]
+        base = BASELINE_CLOSED_POST_CAP_PRE_COOLDOWN[sym]
+        ret = (post / base) if base > 0 else 0.0
+        cd_h = symbol_overrides[sym]["cooldown_hours"]
+        print(f"  {sym:<12} {post:>9d} {base:>9d} {ret:>9.1%} {cd_h:>4}h")
+    print(f"  {'TOTAL':<12} {total_post_cooldown:>9d} {BASELINE_TOTAL:>9d} "
+          f"{total_post_cooldown/BASELINE_TOTAL:>9.1%}")
+    print(f"  Reduction: {BASELINE_TOTAL - total_post_cooldown} trades "
+          f"({(1 - total_post_cooldown/BASELINE_TOTAL):.1%})")

--- a/tests/test_backtest_smoke_sizing_cap.py
+++ b/tests/test_backtest_smoke_sizing_cap.py
@@ -74,6 +74,16 @@ def test_smoke_sizing_cap_across_curated_symbols(tmp_path, monkeypatch):
             f"{sym} must have max_participation_rate in config.defaults.json"
         )
 
+    # Strip cooldown_hours so this smoke isolates cap-only delta. The pinned
+    # BASELINE_CLOSED_PRE_CAP was captured when cooldown was global (6h via
+    # COOLDOWN_H); per-symbol cooldown shifts BTC/ETH/AVAX baselines and would
+    # confound the cap-only retention assertion.
+    symbol_overrides = {
+        sym: {k: v for k, v in ov.items() if k != "cooldown_hours"}
+        for sym, ov in symbol_overrides.items()
+    }
+    cfg = {**cfg, "symbol_overrides": symbol_overrides}
+
     # Same window as the time-limit smoke for direct comparability.
     sim_start = datetime(2023, 10, 1, tzinfo=timezone.utc)
     sim_end = datetime(2025, 3, 31, tzinfo=timezone.utc)

--- a/tests/test_db_positions_last_exit.py
+++ b/tests/test_db_positions_last_exit.py
@@ -1,0 +1,126 @@
+"""db_last_exit_ts(symbol) — direct unit coverage."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from db.positions import db_last_exit_ts
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh schema'd DB per test."""
+    import btc_api
+    db_path = str(tmp_path / "test_last_exit.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+    return btc_api  # for convenience callers
+
+
+def _insert_position(
+    btc_api,
+    *,
+    symbol: str = "BTCUSDT",
+    status: str = "closed",
+    entry_price: float = 100.0,
+    entry_ts: str = "2026-01-01T00:00:00+00:00",
+    exit_ts: str | None = "2026-01-02T00:00:00+00:00",
+    direction: str = "LONG",
+):
+    """Insert a position row directly via db helper."""
+    pos = btc_api.db_create_position({
+        "symbol": symbol,
+        "entry_price": entry_price,
+        "direction": direction,
+        "entry_ts": entry_ts,
+    })
+    if status == "closed":
+        from db.connection import get_db
+        con = get_db()
+        con.execute(
+            "UPDATE positions SET status=?, exit_ts=? WHERE id=?",
+            (status, exit_ts, pos["id"]),
+        )
+        con.commit()
+        con.close()
+    return pos
+
+
+# ── Path A: empty DB / no closed positions ─────────────────────────────────
+
+
+def test_no_positions_returns_none(tmp_db):
+    """Fresh DB → None (cooldown free for first signal of every symbol)."""
+    assert db_last_exit_ts("BTCUSDT") is None
+
+
+def test_only_open_position_returns_none(tmp_db):
+    """Open positions don't count — cooldown only respects closed exits."""
+    _insert_position(tmp_db, status="open", exit_ts=None)
+    assert db_last_exit_ts("BTCUSDT") is None
+
+
+# ── Path B: single closed position ─────────────────────────────────────────
+
+
+def test_single_closed_returns_its_exit_ts(tmp_db):
+    """Returns tz-aware UTC datetime."""
+    _insert_position(tmp_db, exit_ts="2026-01-02T15:30:00+00:00")
+    result = db_last_exit_ts("BTCUSDT")
+    assert isinstance(result, datetime)
+    assert result == datetime(2026, 1, 2, 15, 30, 0, tzinfo=timezone.utc)
+    assert result.tzinfo is not None
+
+
+# ── Path C: multiple closed → most recent ──────────────────────────────────
+
+
+def test_multiple_closed_returns_most_recent(tmp_db):
+    """ORDER BY exit_ts DESC LIMIT 1 — newest wins."""
+    _insert_position(tmp_db, exit_ts="2026-01-01T10:00:00+00:00")
+    _insert_position(tmp_db, exit_ts="2026-01-03T10:00:00+00:00")  # most recent
+    _insert_position(tmp_db, exit_ts="2026-01-02T10:00:00+00:00")
+    result = db_last_exit_ts("BTCUSDT")
+    assert result == datetime(2026, 1, 3, 10, 0, 0, tzinfo=timezone.utc)
+
+
+# ── Path D: NULL exit_ts ─────────────────────────────────────────────────
+
+
+def test_closed_with_null_exit_ts_returns_none(tmp_db):
+    """NULL exit_ts on a 'closed' row is malformed — treat as no exit."""
+    _insert_position(tmp_db, exit_ts=None)  # status will still get set to closed
+    assert db_last_exit_ts("BTCUSDT") is None
+
+
+# ── Path E: symbol case ────────────────────────────────────────────────────
+
+
+def test_lowercase_symbol_normalized_to_upper(tmp_db):
+    """`symbol.upper()` so 'btc' / 'BtcUsdT' all hit 'BTCUSDT' rows."""
+    _insert_position(tmp_db, symbol="BTCUSDT", exit_ts="2026-01-02T00:00:00+00:00")
+    assert db_last_exit_ts("btcusdt") == datetime(2026, 1, 2, tzinfo=timezone.utc)
+    assert db_last_exit_ts("BtcUsdT") == datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+
+# ── Path F: tz-naive ISO strings ───────────────────────────────────────────
+
+
+def test_naive_iso_promoted_to_utc(tmp_db):
+    """Legacy naive ISO rows get tz=UTC attached for safe arithmetic."""
+    _insert_position(tmp_db, exit_ts="2026-01-02T15:30:00")  # NO tz
+    result = db_last_exit_ts("BTCUSDT")
+    assert isinstance(result, datetime)
+    assert result.tzinfo is not None
+    # Check value preserved (tz attached, not converted from another zone)
+    assert result.replace(tzinfo=None) == datetime(2026, 1, 2, 15, 30, 0)
+
+
+# ── Path G: malformed ISO ──────────────────────────────────────────────────
+
+
+def test_malformed_exit_ts_returns_none(tmp_db):
+    """ValueError from datetime.fromisoformat must be caught — no crash."""
+    _insert_position(tmp_db, exit_ts="not-a-real-iso-string")
+    assert db_last_exit_ts("BTCUSDT") is None

--- a/tests/test_scanner_cooldown.py
+++ b/tests/test_scanner_cooldown.py
@@ -1,0 +1,309 @@
+"""btc_scanner cooldown — _build_e5_cooldown paths A-E + scan() verdict integration."""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import btc_scanner as scanner
+from strategy.core import SignalDecision
+
+
+@pytest.fixture(autouse=True)
+def _reset_throttles(monkeypatch):
+    """Reset both the validator-warning throttle and the scanner's
+    DB-failure throttle so each test starts clean."""
+    from strategy import _validators
+    monkeypatch.setattr(_validators, "_validator_warned", set())
+    monkeypatch.setattr(scanner, "_db_fail_warned", set())
+
+
+@pytest.fixture
+def fake_cfg(tmp_path, monkeypatch):
+    def _set(cfg: dict):
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        monkeypatch.setattr(scanner, "SCRIPT_DIR", str(tmp_path))
+    return _set
+
+
+@pytest.fixture(autouse=True)
+def _stub_external(monkeypatch):
+    monkeypatch.setattr(scanner, "get_cached_regime",
+                        lambda: {"regime": "BULL", "score": 75.0, "details": {}})
+    monkeypatch.setattr(scanner, "detect_regime_for_symbol",
+                        lambda sym, mode: {"regime": "BULL", "score": 75.0, "details": {}})
+    import health as _h
+    monkeypatch.setattr(_h, "apply_reduce_factor", lambda size, sym, cfg: size)
+    monkeypatch.setattr(_h, "get_symbol_state", lambda sym: "NORMAL")
+
+
+def _make_ohlcv(n=210, base=100.0, volume=1000.0, seed=42):
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2025-01-01", periods=n, freq="1h")
+    closes = base + rng.normal(0, 0.5, n)
+    closes = np.maximum(closes, 1.0)
+    return pd.DataFrame({
+        "open":  closes + rng.normal(0, 0.1, n),
+        "high":  closes + rng.uniform(0.1, 0.5, n),
+        "low":   np.maximum(closes - rng.uniform(0.1, 0.5, n), 0.5),
+        "close": closes,
+        "volume": [volume] * n,
+        "taker_buy_base":  [volume * 0.5] * n,
+        "taker_buy_quote": [volume * 0.5 * base] * n,
+    }, index=idx)
+
+
+def _make_scan_klines(volume=1000.0, base=100.0):
+    df1h = _make_ohlcv(n=210, base=base, volume=volume)
+    df4h = _make_ohlcv(n=150, base=base, volume=volume)
+    df5m = _make_ohlcv(n=210, base=base, volume=volume)
+    return df5m, df1h, df4h, df1h
+
+
+# ── Direct unit tests for _build_e5_cooldown (paths A-E) ───────────────────
+
+
+def test_e5_path_a_no_prior_exits_returns_activo_false_with_null_hours(monkeypatch):
+    """Path A: db_last_exit_ts → None. activo=False, hours_since_last_exit=None."""
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["activo"] is False
+    assert e5["hours_since_last_exit"] is None
+    assert e5["cooldown_hours_required"] == 6.0
+    assert "Sin trades previos" in e5["nota"]
+
+
+def test_e5_path_b_hours_since_exceeds_cooldown_returns_activo_false(monkeypatch):
+    """Path B: 10h since exit, 6h required → activo=False."""
+    last_exit = datetime.now(timezone.utc) - timedelta(hours=10)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["activo"] is False
+    assert e5["hours_since_last_exit"] is not None
+    assert e5["hours_since_last_exit"] >= 9.99  # ~10
+    assert e5["cooldown_hours_required"] == 6.0
+
+
+def test_e5_path_c_hours_since_below_cooldown_returns_activo_true(monkeypatch):
+    """Path C: 1h since exit, 6h required → activo=True (the core blocking path)."""
+    last_exit = datetime.now(timezone.utc) - timedelta(hours=1)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["activo"] is True
+    assert e5["hours_since_last_exit"] < 6.0
+    assert e5["cooldown_hours_required"] == 6.0
+
+
+def test_e5_path_c_uses_per_symbol_override_not_global(monkeypatch):
+    """Per-symbol override binds when global cd would not (8h since exit, cd=14)."""
+    last_exit = datetime.now(timezone.utc) - timedelta(hours=8)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 14}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["activo"] is True
+    assert e5["cooldown_hours_required"] == 14.0
+
+
+def test_e5_path_d_invalid_override_falls_back_to_global_cooldown_h(monkeypatch, caplog):
+    """Path D: invalid override → fallback to COOLDOWN_H. Validator emits 1 warn."""
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    caplog.set_level(logging.WARNING)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": -5}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["cooldown_hours_required"] == float(scanner.COOLDOWN_H)
+    matching = [r for r in caplog.records if "cooldown_hours" in r.getMessage()]
+    assert len(matching) >= 1
+
+
+def test_e5_path_d_invalid_override_fallback_USED_in_comparison(monkeypatch, caplog):
+    """Combo: invalid override AND last_exit 1h ago → activo=True from fallback.
+
+    Catches a regression where the fallback COOLDOWN_H is only stored in the
+    dict but not actually used in the `hours_since < cd` comparison. Without
+    this test, a refactor that resolved the value via a different path could
+    return cooldown_hours_required=6.0 in the dict yet compare against 0
+    (missing/None) and let the trade through.
+    """
+    last_exit = datetime.now(timezone.utc) - timedelta(hours=1)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    caplog.set_level(logging.WARNING)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": -5}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["cooldown_hours_required"] == float(scanner.COOLDOWN_H)
+    # 1h since exit < 6h fallback → activo MUST be True.
+    assert e5["activo"] is True, (
+        "fallback value must be USED in comparison, not just stored in the dict"
+    )
+
+
+def test_e5_path_e_db_exception_fail_open_logs_warning(monkeypatch, caplog):
+    """DB query raises → activo=False (fail-open), warning logged."""
+    def _boom(sym):
+        raise RuntimeError("DB connection lost")
+    monkeypatch.setattr("db.positions.db_last_exit_ts", _boom)
+    caplog.set_level(logging.WARNING)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["activo"] is False
+    assert e5["hours_since_last_exit"] is None
+    matching = [r for r in caplog.records if "db_last_exit_ts" in r.getMessage()]
+    assert len(matching) >= 1, "fail-open path must log a warning"
+
+
+def test_e5_path_e_sqlite_operational_error_logs_at_error_level(monkeypatch, caplog):
+    """SQLite OperationalError escalates to log.error (not warning)."""
+    import sqlite3
+    def _boom(sym):
+        raise sqlite3.OperationalError("database is locked")
+    monkeypatch.setattr("db.positions.db_last_exit_ts", _boom)
+    caplog.set_level(logging.WARNING)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["activo"] is False  # fail-open behavior unchanged
+    error_records = [
+        r for r in caplog.records
+        if r.levelname == "ERROR" and "db_last_exit_ts" in r.getMessage()
+    ]
+    assert len(error_records) >= 1, "SQLite OperationalError must escalate to ERROR level"
+
+
+def test_e5_path_e_oserror_logs_at_error_level(monkeypatch, caplog):
+    """OSError (disk-full, permission-denied, missing parent dir) escalates to error."""
+    def _boom(sym):
+        raise OSError("disk full")
+    monkeypatch.setattr("db.positions.db_last_exit_ts", _boom)
+    caplog.set_level(logging.WARNING)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["activo"] is False
+    error_records = [
+        r for r in caplog.records
+        if r.levelname == "ERROR" and "db_last_exit_ts" in r.getMessage()
+    ]
+    assert len(error_records) >= 1, "OSError must escalate to ERROR level"
+
+
+# ── Schema invariants ──────────────────────────────────────────────────────
+
+
+def test_e5_dict_always_present_keys_match_baseline_shape(monkeypatch):
+    """Frontend pin: 4 keys, types correct. Drift here breaks downstream consumers."""
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+
+    expected_keys = {"activo", "nota", "hours_since_last_exit", "cooldown_hours_required"}
+    assert set(e5.keys()) == expected_keys
+    assert isinstance(e5["activo"], bool)
+    assert isinstance(e5["nota"], str)
+    assert e5["hours_since_last_exit"] is None or isinstance(e5["hours_since_last_exit"], (int, float))
+    assert isinstance(e5["cooldown_hours_required"], float)
+
+
+def test_e5_hours_since_rounded_to_2_decimals(monkeypatch):
+    """Round contract: hours_since_last_exit must be limited to 2 decimals."""
+    last_exit = datetime.now(timezone.utc) - timedelta(hours=2, minutes=37, seconds=18)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    h = e5["hours_since_last_exit"]
+    # Verify at most 2 decimal places (round(x, 2) yields finite resolution)
+    assert h == round(h, 2)
+
+
+def test_e5_cooldown_hours_required_reflects_per_symbol_when_present(monkeypatch):
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    cfg = {"symbol_overrides": {"ETHUSDT": {"cooldown_hours": 14}}}
+    e5 = scanner._build_e5_cooldown("ETHUSDT", cfg)
+    assert e5["cooldown_hours_required"] == 14.0
+
+
+def test_e5_cooldown_hours_required_reflects_global_when_overrides_missing(monkeypatch):
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    cfg = {"symbol_overrides": {}}  # no per-symbol entry
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["cooldown_hours_required"] == float(scanner.COOLDOWN_H)
+
+
+def test_e5_payload_json_serializable(monkeypatch):
+    """The dict ends up in scan() report which is JSON-serialized for /symbols."""
+    last_exit = datetime.now(timezone.utc) - timedelta(hours=3)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    # Must not raise.
+    s = json.dumps(e5, ensure_ascii=False)
+    assert len(s) > 0
+
+
+# ── C2 disabled-symbol guard (cfg=False) ───────────────────────────────────
+
+
+def test_e5_disabled_symbol_does_not_crash(monkeypatch):
+    """cfg.symbol_overrides[BTC] = False → no AttributeError on .get('cooldown_hours')."""
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    cfg = {"symbol_overrides": {"BTCUSDT": False}}
+    e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
+    assert e5["cooldown_hours_required"] == float(scanner.COOLDOWN_H)
+    assert e5["activo"] is False
+
+
+# ── End-to-end scan() integration: verdict ladder must read E5 ────────────
+
+
+def _full_long_indicators(price=100.0):
+    return {
+        "atr_1h": 0.5, "lrc_pct": 15.0, "lrc_upper": 110, "lrc_lower": 90,
+        "lrc_mid": 100, "rsi_1h": 30, "adx_1h": 20, "sma100_4h": 100,
+        "price_above_sma100_4h": True,
+        "vol_1h": 100.0, "vol_avg_1h": 100.0, "cvd_1h": 0.5,
+        "sma10_1h": price, "sma20_1h": price,
+        "bb_upper_1h": price + 2.0, "bb_lower_1h": price - 2.0,
+        "bull_div_1h": False, "bear_div_1h": False,
+    }
+
+
+def _make_long_signal(price=100.0):
+    return SignalDecision(
+        direction="LONG", score=5, score_label="PREMIUM", is_signal=True,
+        entry_price=price, sl_price=price * 0.5, tp_price=price * 2.0,
+        reasons={"atr_sl_mult": 1.0, "atr_tp_mult": 2.0, "atr_be_mult": 1.5},
+        indicators=_full_long_indicators(price),
+    )
+
+
+def test_scan_blocks_signal_when_cooldown_active(fake_cfg, monkeypatch):
+    """When E5_Cooldown.activo=True, scan() sets señal_activa=False with a 'BLOQUEADA' estado containing 'cooldown'."""
+    fake_cfg({"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 14}}})
+
+    # Last exit 1h ago — cooldown 14h NOT elapsed → activo=True
+    last_exit = datetime.now(timezone.utc) - timedelta(hours=1)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+
+    fake_decision = _make_long_signal()
+
+    with patch("btc_scanner.md.get_klines") as mock_klines, \
+         patch("strategy.core.evaluate_signal", return_value=fake_decision), \
+         patch("btc_scanner.detect_bull_engulfing", return_value=False), \
+         patch("btc_scanner.detect_bear_engulfing", return_value=False), \
+         patch("btc_scanner.check_trigger_5m", return_value=(True, {})):
+        mock_klines.side_effect = _make_scan_klines(volume=1000.0)
+        rep = scanner.scan("BTCUSDT")
+
+    assert rep["señal_activa"] is False, (
+        f"cooldown active must block signal; got estado={rep['estado']}"
+    )
+    assert "BLOQUEADA" in rep["estado"]
+    assert "cooldown" in rep["estado"].lower()
+    # E5 also surfaced in blocks_auto for CLI/frontend visibility.
+    assert any("E5: cooldown activo" in b for b in rep["blocks_auto"]), (
+        f"E5 must surface in blocks_auto; got {rep['blocks_auto']}"
+    )

--- a/tests/test_strategy_validators_cooldown.py
+++ b/tests/test_strategy_validators_cooldown.py
@@ -1,0 +1,192 @@
+"""validated_cooldown_hours — boundary, throttle, default-fallback unit tests."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from strategy._validators import validated_cooldown_hours
+
+
+@pytest.fixture(autouse=True)
+def _reset_validator_throttle(monkeypatch):
+    """Fresh shared throttle state per test — avoids cross-test bleed."""
+    from strategy import _validators
+    monkeypatch.setattr(_validators, "_validator_warned", set())
+
+
+def _logger():
+    return logging.getLogger("test_validator_cooldown")
+
+
+# ── Pass-through for valid values ───────────────────────────────────────────
+
+
+def test_none_returns_default_silent(caplog):
+    """None → default fallback silently (caller decides default per-call)."""
+    caplog.set_level(logging.WARNING)
+    assert validated_cooldown_hours(None, caller="test", symbol="BTC", logger=_logger()) == 6.0
+    assert validated_cooldown_hours(
+        None, caller="test", symbol="BTC", logger=_logger(), default=10.0
+    ) == 10.0
+    assert len(caplog.records) == 0, "None passthrough must not log"
+
+
+def test_valid_floats_passthrough():
+    log = _logger()
+    assert validated_cooldown_hours(1.0, caller="test", symbol="BTC", logger=log) == 1.0
+    assert validated_cooldown_hours(6.0, caller="test", symbol="BTC", logger=log) == 6.0
+    assert validated_cooldown_hours(14.0, caller="test", symbol="BTC", logger=log) == 14.0
+    assert validated_cooldown_hours(48.5, caller="test", symbol="FOO", logger=log) == 48.5
+
+
+def test_valid_int_returns_float():
+    """int values get coerced to float."""
+    assert validated_cooldown_hours(6, caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+def test_boundary_168_inclusive():
+    """168 is the inclusive upper bound — exactly 168 passes."""
+    assert validated_cooldown_hours(168, caller="test", symbol="FOO", logger=_logger()) == 168.0
+    assert validated_cooldown_hours(168.0, caller="test", symbol="FOO", logger=_logger()) == 168.0
+
+
+def test_just_below_168_passes():
+    assert validated_cooldown_hours(167.999, caller="test", symbol="BTC", logger=_logger()) == 167.999
+
+
+# ── Type rejections — return default + warn ─────────────────────────────────
+
+
+def test_bool_rejected_returns_default(caplog):
+    """bool subclasses int but is never a valid hour count."""
+    caplog.set_level(logging.WARNING)
+    log = _logger()
+    assert validated_cooldown_hours(True, caller="test", symbol="BTC", logger=log) == 6.0
+    assert validated_cooldown_hours(False, caller="test", symbol="BTC", logger=log) == 6.0
+    matching = [r for r in caplog.records if "cooldown_hours" in r.getMessage()]
+    assert len(matching) >= 1
+
+
+def test_string_rejected_returns_default(caplog):
+    caplog.set_level(logging.WARNING)
+    assert validated_cooldown_hours("6", caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+def test_dict_rejected_returns_default():
+    assert validated_cooldown_hours({"value": 6}, caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+def test_custom_default_used_on_rejection():
+    """Passing default=10 → invalid input returns 10, not the spec default 6."""
+    assert validated_cooldown_hours(
+        "bogus", caller="test", symbol="BTC", logger=_logger(), default=10.0
+    ) == 10.0
+    assert validated_cooldown_hours(
+        -5, caller="test", symbol="BTC", logger=_logger(), default=10.0
+    ) == 10.0
+
+
+# ── Numeric edge cases ─────────────────────────────────────────────────────
+
+
+def test_nan_rejected_returns_default():
+    assert validated_cooldown_hours(float("nan"), caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+def test_inf_rejected_returns_default():
+    assert validated_cooldown_hours(float("inf"), caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+def test_neg_inf_rejected_returns_default():
+    assert validated_cooldown_hours(float("-inf"), caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+def test_zero_rejected_returns_default():
+    assert validated_cooldown_hours(0, caller="test", symbol="BTC", logger=_logger()) == 6.0
+    assert validated_cooldown_hours(0.0, caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+def test_negative_rejected_returns_default():
+    assert validated_cooldown_hours(-1, caller="test", symbol="BTC", logger=_logger()) == 6.0
+    assert validated_cooldown_hours(-6.0, caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+# ── Boundary > 168 ──────────────────────────────────────────────────────────
+
+
+def test_above_168_rejected_just_above():
+    """168.001 is just above the boundary — must reject."""
+    assert validated_cooldown_hours(168.001, caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+def test_above_168_rejected_realistic_misconfig():
+    """Operator typing 168 hours when meaning days → must reject."""
+    assert validated_cooldown_hours(720, caller="test", symbol="BTC", logger=_logger()) == 6.0  # 30 days
+
+
+def test_above_168_rejected_extreme():
+    assert validated_cooldown_hours(1e9, caller="test", symbol="BTC", logger=_logger()) == 6.0
+
+
+# ── Throttling — same misconfig must warn at most once per (caller, symbol, kind)
+
+
+def test_throttle_one_warning_per_caller_symbol_kind(caplog):
+    """5 calls with same misconfig → 1 warning."""
+    caplog.set_level(logging.WARNING)
+    log = _logger()
+
+    for _ in range(5):
+        validated_cooldown_hours(-5, caller="scan", symbol="BTCUSDT", logger=log)
+
+    matching = [r for r in caplog.records if "cooldown_hours" in r.getMessage()]
+    assert len(matching) == 1, f"throttle broken: got {len(matching)} warnings for 5 same-key calls"
+
+
+def test_throttle_separates_by_caller(caplog):
+    caplog.set_level(logging.WARNING)
+    log = _logger()
+
+    validated_cooldown_hours(-5, caller="scan", symbol="BTCUSDT", logger=log)
+    validated_cooldown_hours(-5, caller="simulate_strategy", symbol="BTCUSDT", logger=log)
+
+    matching = [r for r in caplog.records if "cooldown_hours" in r.getMessage()]
+    assert len(matching) == 2
+
+
+def test_throttle_separates_by_symbol(caplog):
+    caplog.set_level(logging.WARNING)
+    log = _logger()
+
+    validated_cooldown_hours(-5, caller="scan", symbol="BTCUSDT", logger=log)
+    validated_cooldown_hours(-5, caller="scan", symbol="ETHUSDT", logger=log)
+
+    matching = [r for r in caplog.records if "cooldown_hours" in r.getMessage()]
+    assert len(matching) == 2
+
+
+def test_throttle_separates_by_error_kind(caplog):
+    """Same (caller, symbol) but different error categories → separate warnings."""
+    caplog.set_level(logging.WARNING)
+    log = _logger()
+
+    validated_cooldown_hours(-5, caller="scan", symbol="BTCUSDT", logger=log)              # non-positive
+    validated_cooldown_hours(float("nan"), caller="scan", symbol="BTCUSDT", logger=log)    # non-finite
+    validated_cooldown_hours(200, caller="scan", symbol="BTCUSDT", logger=log)             # above-168
+    validated_cooldown_hours("6", caller="scan", symbol="BTCUSDT", logger=log)             # type:str
+
+    matching = [r for r in caplog.records if "cooldown_hours" in r.getMessage()]
+    assert len(matching) == 4
+
+
+def test_throttle_does_not_emit_for_valid_values(caplog):
+    """Successful validation must not warn."""
+    caplog.set_level(logging.WARNING)
+    log = _logger()
+
+    for _ in range(5):
+        validated_cooldown_hours(6.0, caller="scan", symbol="BTCUSDT", logger=log)
+
+    matching = [r for r in caplog.records if "cooldown_hours" in r.getMessage()]
+    assert len(matching) == 0


### PR DESCRIPTION
## Summary

Tercer PR estructural del epic #294 (Triple Barrier exit logic). Promueve `E5_Cooldown` de manual-check + global enforce a per-symbol auto-enforce en BOTH scanner y backtest.

## Cambios

- **Per-symbol `cooldown_hours`** en `config.json["symbol_overrides"]`: BTC/ETH=14h, AVAX=8h, demás=6h. Valores derivados deterministicamente de time-limits (rule: max(TL, NW=4, floor=6)) — NO new DOFs.
- **`strategy/_validators.py`** — `validated_cooldown_hours` con sanity boundary >168, namespace prefix `cooldown:*` para evitar throttle collision con PR1/PR2.
- **Scanner** — `_build_e5_cooldown(symbol, cfg)` lazy-imports `db_last_exit_ts(symbol)`, fail-open en DB failure (con throttled log warn/error por severity tier).
- **Backtest** — stateless per-symbol resolution en cooldown check site. Legacy `atr_*` kwargs path uses `COOLDOWN_H` global default-fallback (no bypass).
- **Operational model spec** updated: E5 promoted to auto-enforce. E2/E3/E4 retain manual-check.
- **Notifier templates refreshed:** `backtest.py` report uses `{_eff_cd:g}h` per-symbol; Telegram template removes "cooldown 6h" from manual-check listing.

## Smoke results (per-symbol cooldown impact)

| Symbol | Cooldown | Post / Baseline | Retention |
|---|---|---|---|
| BTC | 14h | 144 / 206 | 69.9% |
| ETH | 14h | 128 / 169 | 75.7% |
| AVAX | 8h | 133 / 145 | 91.7% |
| ADA, DOGE, UNI, XLM, PENDLE, JUP, RUNE | 6h | unchanged | 100% |
| **Total** | | **849 / 964** | **88.1%** |

Soft-floor assertion `>= baseline * 0.5` per binding symbol catches "always-blocks" regression (TZ sign flip).

## Tests

1254/1254 passing (1248 prior + 6 new):
- 22 validator unit (`test_strategy_validators_cooldown.py`)
- 8 db helper (`test_db_positions_last_exit.py`)
- 16 scanner (`test_scanner_cooldown.py`) incl. e2e blocking + Path A-E + sqlite/OSError severity tiers
- 3 generate_report (`test_backtest_generate_report.py`) — disabled-symbol guard
- 1 PR3 smoke (`test_backtest_smoke_cooldown.py`)
- PR2 smoke `cooldown_hours` strip pattern preserves 964/1866 cap-only baseline

## References (this PR closes nothing)

- #294 (epic estructural — open until A.4 holdout eval per strategic pivot plan)
- #281 (diagnostic)
- #249 (Gate 3 / DSR threshold)
- #250 (A.4 holdout evaluation epic)
- Spec D9 (`docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md`) — pre-registered N=2 effective DSR commitment

## Review iterations

- Round 1: 5 critical + 8 important issues found across 4 specialized agents
- Round 2: 1 R1-introduced regression (generate_report guard) + 1 spec doc rot + minor tier
- All 17 R2 items applied cleanly + 6 new tests for R2 coverage gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
