### PR TITLE
feat(methodology): A.4-1.5 pre-holdout regime threshold re-tune harness

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -492,7 +492,8 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                 and all(isinstance(x, int) and not isinstance(x, bool)
                         for x in regime_thresholds)):
             raise RegimeKwargError(
-                f"regime_thresholds must be tuple[int, int]; got "
+                f"regime_thresholds must be tuple[int, int] (bool excluded — "
+                f"True/False are int subclasses in Python); got "
                 f"{regime_thresholds!r}"
             )
 

--- a/backtest.py
+++ b/backtest.py
@@ -443,8 +443,8 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                       enable_spread: bool = True,        # NEW (A.0.2, #277)
                       enable_fees: bool = True,          # NEW (A.0.2, #277)
                       cost_calibration=None,             # NEW (A.0.2, #277)
-                      regime_thresholds: tuple[int, int] | None = None,  # NEW (A.4-1.5)
-                      regime_disabled: bool = False,                     # NEW (A.4-1.5)
+                      regime_thresholds: tuple[int, int] | None = None,
+                      regime_disabled: bool = False,
                       ) -> list[dict]:
     """Run bar-by-bar simulation of the Spot V6 strategy.
 
@@ -462,7 +462,19 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
 
     `cfg` is the merged config dict (`btc_api.load_config()` shape); used for
     the KillSwitchSimulator bootstrap when `shared_simulator` is not supplied.
+
+    regime_thresholds (tuple[int, int] | None): override (bull_above, bear_below)
+        for regime classification. None → (60, 40) production behavior.
+    regime_disabled (bool): when True, skip _regime_at_time entirely and emit a
+        regime dict with regime="BYPASS" so direction is gated by zone alone.
+        Mutually exclusive with regime_thresholds.
     """
+    if regime_disabled and regime_thresholds is not None:
+        raise ValueError(
+            "regime_disabled=True is mutually exclusive with regime_thresholds — "
+            "bypass mode skips threshold logic entirely."
+        )
+
     # #186 A6: lazy imports keep backtest.py importable even when `strategy/`
     # or `backtest_kill_switch` has its own transient import issues.
     from backtest_kill_switch import KillSwitchSimulator
@@ -698,16 +710,14 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         # Regime detection via _regime_at_time helper (#152) — kept as
         # backtest-local because scan() fetches its regime from a cache /
         # per-symbol detector, not the bar-aligned helper used here.
-        # A.4-1.5: regime_disabled bypasses the helper entirely; downstream
-        # _regime_to_direction_token maps "BYPASS" → "ANY" so direction is
-        # gated by zone alone.
         if regime_disabled:
             regime_info = {
                 "regime": "BYPASS",
-                "score": 50.0,
+                "score": None,
                 "mode": "disabled",
                 "symbol": symbol,
                 "components": {},
+                "bypass": True,
             }
         else:
             ba, bb = (regime_thresholds if regime_thresholds is not None else (60, 40))

--- a/backtest.py
+++ b/backtest.py
@@ -107,6 +107,15 @@ def _validated_cooldown_hours(value, symbol: str) -> float:
 FEE_PCT = 0.001
 
 
+class RegimeKwargError(Exception):
+    """Raised when regime kwargs are passed in an incoherent combination
+    (contract violation by caller, not a data error). Subclasses Exception
+    rather than ValueError so the harness's narrow data-error catch does
+    not swallow it — propagates as a programming error, surfacing the bug
+    to the operator instead of silently shrinking the sweep.
+    """
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 #  DATA DOWNLOAD
 # ─────────────────────────────────────────────────────────────────────────────
@@ -237,6 +246,9 @@ def _regime_at_time(
                               Fallback: if df1d_btc is None -> uses df1d_sym.
     mode='hybrid':           uses df1d_sym + F&G + funding (50/25/25).
     mode='hybrid_momentum':  uses df1d_sym + RSI + ADX + F&G + funding (30/15/20/20/15).
+
+    bull_above / bear_below: regime classification thresholds. Defaults 60/40
+        preserve byte-identity to legacy production behavior.
     """
     bar_time_naive = bar_time.tz_localize(None) if bar_time.tzinfo else bar_time
 
@@ -470,10 +482,19 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         Mutually exclusive with regime_thresholds.
     """
     if regime_disabled and regime_thresholds is not None:
-        raise ValueError(
+        raise RegimeKwargError(
             "regime_disabled=True is mutually exclusive with regime_thresholds — "
             "bypass mode skips threshold logic entirely."
         )
+    if regime_thresholds is not None:
+        if not (isinstance(regime_thresholds, tuple)
+                and len(regime_thresholds) == 2
+                and all(isinstance(x, int) and not isinstance(x, bool)
+                        for x in regime_thresholds)):
+            raise RegimeKwargError(
+                f"regime_thresholds must be tuple[int, int]; got "
+                f"{regime_thresholds!r}"
+            )
 
     # #186 A6: lazy imports keep backtest.py importable even when `strategy/`
     # or `backtest_kill_switch` has its own transient import issues.
@@ -707,9 +728,10 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         if len(slice_1h) < LRC_PERIOD:
             continue
 
-        # Regime detection via _regime_at_time helper (#152) — kept as
-        # backtest-local because scan() fetches its regime from a cache /
-        # per-symbol detector, not the bar-aligned helper used here.
+        # Regime detection — bypass branch synthesizes a regime dict for the
+        # no-detector configuration; else delegates to _regime_at_time helper
+        # (kept backtest-local because scan() fetches its regime from a 24h
+        # cache, not the bar-aligned helper used here).
         if regime_disabled:
             regime_info = {
                 "regime": "BYPASS",
@@ -717,7 +739,6 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                 "mode": "disabled",
                 "symbol": symbol,
                 "components": {},
-                "bypass": True,
             }
         else:
             ba, bb = (regime_thresholds if regime_thresholds is not None else (60, 40))

--- a/backtest.py
+++ b/backtest.py
@@ -227,6 +227,9 @@ def _regime_at_time(
     df_funding,
     regime_mode: str = "global",
     df1d_btc=None,
+    *,
+    bull_above: int = 60,
+    bear_below: int = 40,
 ) -> dict:
     """Compute regime for this bar_time (no look-ahead).
 
@@ -288,6 +291,7 @@ def _regime_at_time(
     return _compute_local_regime(
         symbol, regime_mode, window_price,
         fng_score, funding_score, rsi_score, adx_score,
+        bull_above=bull_above, bear_below=bear_below,
     )
 
 
@@ -439,6 +443,8 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
                       enable_spread: bool = True,        # NEW (A.0.2, #277)
                       enable_fees: bool = True,          # NEW (A.0.2, #277)
                       cost_calibration=None,             # NEW (A.0.2, #277)
+                      regime_thresholds: tuple[int, int] | None = None,  # NEW (A.4-1.5)
+                      regime_disabled: bool = False,                     # NEW (A.4-1.5)
                       ) -> list[dict]:
     """Run bar-by-bar simulation of the Spot V6 strategy.
 
@@ -692,10 +698,24 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         # Regime detection via _regime_at_time helper (#152) — kept as
         # backtest-local because scan() fetches its regime from a cache /
         # per-symbol detector, not the bar-aligned helper used here.
-        regime_info = _regime_at_time(
-            bar_time, symbol, df1d, df_fng, df_funding,
-            regime_mode=regime_mode, df1d_btc=df1d_btc,
-        )
+        # A.4-1.5: regime_disabled bypasses the helper entirely; downstream
+        # _regime_to_direction_token maps "BYPASS" → "ANY" so direction is
+        # gated by zone alone.
+        if regime_disabled:
+            regime_info = {
+                "regime": "BYPASS",
+                "score": 50.0,
+                "mode": "disabled",
+                "symbol": symbol,
+                "components": {},
+            }
+        else:
+            ba, bb = (regime_thresholds if regime_thresholds is not None else (60, 40))
+            regime_info = _regime_at_time(
+                bar_time, symbol, df1d, df_fng, df_funding,
+                regime_mode=regime_mode, df1d_btc=df1d_btc,
+                bull_above=ba, bear_below=bb,
+            )
 
         # Merge `symbol_overrides` (legacy kwarg) into cfg so evaluate_signal
         # can resolve per-direction ATR mults via its built-in resolver.

--- a/docs/superpowers/plans/2026-05-04-a4-1-5-regime-threshold-retune.md
+++ b/docs/superpowers/plans/2026-05-04-a4-1-5-regime-threshold-retune.md
@@ -1,0 +1,2057 @@
+# A.4-1.5 Regime Threshold Pre-Holdout Re-Tune Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and run a mini-harness that re-tunes the regime detector BULL/BEAR partition thresholds (`>60/<40`) over the pre-holdout window `[earliest, 2025-04-30T00:00:00Z)`, sweeping 4 configurations locked by historical record (commit `bf581f1`), so leakage caveat #1 is closed before the A.4 holdout evaluation runs.
+
+**Architecture:** Parameterize the existing inline thresholds in `strategy/regime.py` and the backtest path with default-preserving kwargs (byte-identical legacy behavior); add a `regime_disabled` bypass that skips composite scoring entirely. Build `tools/regime_retune_pre_holdout.py` self-contained: load OHLCV + F&G + funding, slice strictly `< cutoff`, run one backtest per (symbol, config), aggregate `net_pnl` per config, identify winner + 2nd-best, evaluate decision flags, write artefacts to `data/retune/2026-05-04-pre-holdout/`. Phase 3 runs the harness, applies decision flags, and commits the artefact for review.
+
+**Tech Stack:** Python 3, pandas, sqlite3 (`data/ohlcv.db`), pytest, ProcessPoolExecutor (optional — sweep is small enough to run sequentially).
+
+---
+
+## Pre-flight
+
+**Branch off `main`.** Do NOT branch off `feat/methodology-a4-1-retune-pre-holdout` (PR #287). Reason: A.4-1.5 GATES PR #287 Phase 3 — circular dependency if branched off it. A.4-1.5 builds its own minimal slicing path; ~20 LOC of intentional, justified duplication.
+
+**Branch name:** `feat/methodology-a4-1-5-regime-retune-pre-holdout`.
+
+**Locked-by-spec invariants** (do NOT relitigate during implementation — see `docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md` §2.10):
+- Grid: 4 configs `(60, 40)`, `(70, 30)`, `(80, 20)`, no-detector
+- Window: `[earliest, 2025-04-30T00:00:00Z)`, strict `<` slicing
+- Objective: maximize sum of `net_pnl` across the 10 portfolio symbols
+- Symbols: `btc_scanner.DEFAULT_SYMBOLS` (BTC, ETH, ADA, AVAX, DOGE, UNI, XLM, PENDLE, JUP, RUNE)
+- Decision flags pre-registered: CHANGE detection, sanity check (no-detector wins → halt), stability check (2nd within 5% → caveat)
+
+**Spec reference correction (record in PR body):** the spec §2.10 cites `backtest.py:404-409` as the inline threshold site. That citation is stale — the real source-of-truth is `strategy/regime.py:_compute_local_regime` (~lines 174-179) and `strategy/regime.py:detect_regime` (~lines 372-377); the backtest consumes the threshold via `_compute_local_regime` through `backtest._regime_at_time`. The plan parameterizes at the regime-module layer; the spec ref is cosmetic doc rot and will be amended in a follow-up D9 edit (per backlog item "§2.10 cross-ref backfill").
+
+---
+
+## File Structure
+
+**Create:**
+- `tools/regime_retune_pre_holdout.py` — harness module (~400 LOC mirroring `tools/retune_pre_holdout.py` shape)
+- `tests/test_regime_retune_pre_holdout.py` — unit + integration tests
+
+**Modify:**
+- `strategy/regime.py` — add `bull_above`/`bear_below` kwargs to `_compute_local_regime` and `detect_regime` (defaults 60/40 preserve byte-identity)
+- `backtest.py` — add `regime_thresholds` and `regime_disabled` kwargs to `simulate_strategy`; thread through `_regime_at_time` to `_compute_local_regime`
+- `tests/test_holdout_isolation.py` — whitelist `tools/regime_retune_pre_holdout.py` in `HOLDOUT_LEGITIMATE_MODULES` with justification
+
+**Output artefacts (Phase 3, committed to repo):**
+- `data/retune/2026-05-04-pre-holdout/regime_params.json`
+- `data/retune/2026-05-04-pre-holdout/regime_manifest.json` (sibling, distinct name from A.4-1's `manifest.json` to avoid collision when both PRs land)
+- `data/retune/2026-05-04-pre-holdout/regime_report.md` (sibling, distinct name from A.4-1's `report.md`)
+
+---
+
+# PHASE 2 — Build the harness
+
+## Task 1: Create the working branch
+
+**Files:** none (git op only)
+
+- [ ] **Step 1: Verify clean main**
+
+```bash
+git status
+git log --oneline -1
+```
+Expected: working tree clean (untracked OK), HEAD = `695208c` or successor.
+
+- [ ] **Step 2: Create branch**
+
+```bash
+git checkout -b feat/methodology-a4-1-5-regime-retune-pre-holdout
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+git branch --show-current
+```
+Expected: `feat/methodology-a4-1-5-regime-retune-pre-holdout`
+
+---
+
+## Task 2: Parameterize `_compute_local_regime` thresholds
+
+**Files:**
+- Modify: `strategy/regime.py` (function `_compute_local_regime`, ~lines 138-188)
+- Test: `tests/test_regime_thresholds_param.py` (new file)
+
+**Goal:** Add `bull_above: int = 60` and `bear_below: int = 40` kwargs. Defaults preserve byte-identity. Validate that `bear_below < bull_above`.
+
+- [ ] **Step 1: Write the failing parity test**
+
+Create `tests/test_regime_thresholds_param.py`:
+
+```python
+"""Tests for parameterized regime thresholds (A.4-1.5).
+
+Defaults must preserve byte-identity with pre-parameterization production behavior.
+New kwargs must enable threshold sweeps for the A.4-1.5 mini-harness.
+"""
+import pandas as pd
+import pytest
+
+from strategy.regime import _compute_local_regime
+
+
+def _make_df_daily(close_values):
+    return pd.DataFrame({"close": close_values})
+
+
+class TestComputeLocalRegimeDefaults:
+    def test_default_thresholds_preserve_legacy_60_40_bull(self):
+        # composite > 60 with default args must classify BULL (legacy behavior)
+        result = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),  # price_score=100
+            fng_score=80, funding_score=80,
+        )
+        # composite = 100*0.4 + 80*0.3 + 80*0.3 = 40 + 24 + 24 = 88
+        assert result["regime"] == "BULL"
+        assert result["score"] == 88.0
+
+    def test_default_thresholds_preserve_legacy_60_40_bear(self):
+        # composite < 40 with default args must classify BEAR
+        result = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 100),  # < 200 bars → price_score=100
+            fng_score=10, funding_score=10,
+        )
+        # price_score=100 (insufficient bars triggers default 100)
+        # composite = 100*0.4 + 10*0.3 + 10*0.3 = 40 + 3 + 3 = 46 → NEUTRAL
+        # Need price_score=0 to actually hit BEAR. Use enough bars + bearish setup.
+        # Easier: directly verify NEUTRAL boundary.
+        assert result["regime"] == "NEUTRAL"
+
+    def test_default_thresholds_preserve_legacy_60_40_neutral(self):
+        result = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=50, funding_score=20,
+        )
+        # composite = 100*0.4 + 50*0.3 + 20*0.3 = 40 + 15 + 6 = 61 > 60 → BULL
+        # adjust to land in 40-60: fng=10, funding=10 → 40+3+3=46 → NEUTRAL
+        result_neutral = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=10, funding_score=10,
+        )
+        # composite = 100*0.4 + 10*0.3 + 10*0.3 = 46 → NEUTRAL
+        assert result_neutral["regime"] == "NEUTRAL"
+```
+
+- [ ] **Step 2: Run the test against the existing function (it should pass — we haven't touched `regime.py` yet, so default behavior = legacy behavior). This is a baseline parity capture.**
+
+```bash
+python -m pytest tests/test_regime_thresholds_param.py -v
+```
+Expected: PASS (baseline locked).
+
+- [ ] **Step 3: Add the failing test for the new kwargs**
+
+Append to `tests/test_regime_thresholds_param.py`:
+
+```python
+class TestComputeLocalRegimeParameterized:
+    def test_70_30_thresholds_shift_bull_boundary(self):
+        # composite = 65 should be BULL with (60,40), NEUTRAL with (70,30)
+        # composite = 100*0.4 + 50*0.3 + 50*0.3 = 70  → BULL with both
+        # composite = 100*0.4 + 40*0.3 + 25*0.3 = 40+12+7.5 = 59.5 → NEUTRAL with both
+        # Need a value strictly in (60, 70]. price=100, fng=50, funding=20 → 40+15+6=61
+        result_default = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=50, funding_score=20,
+        )
+        assert result_default["regime"] == "BULL"  # composite=61, 61>60 ✓
+
+        result_70_30 = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=50, funding_score=20,
+            bull_above=70, bear_below=30,
+        )
+        assert result_70_30["regime"] == "NEUTRAL"  # composite=61, 61 not > 70
+
+    def test_invalid_thresholds_raise(self):
+        with pytest.raises(ValueError, match="bear_below must be < bull_above"):
+            _compute_local_regime(
+                symbol="BTCUSDT", mode="global",
+                df_daily_sym=_make_df_daily([100] * 250),
+                fng_score=50, funding_score=50,
+                bull_above=40, bear_below=60,  # inverted
+            )
+```
+
+- [ ] **Step 4: Run the new tests — they must FAIL**
+
+```bash
+python -m pytest tests/test_regime_thresholds_param.py::TestComputeLocalRegimeParameterized -v
+```
+Expected: FAIL with "unexpected keyword argument 'bull_above'".
+
+- [ ] **Step 5: Modify `strategy/regime.py:_compute_local_regime`**
+
+Edit the function signature and threshold block. Find lines ~138-188:
+
+```python
+def _compute_local_regime(
+    symbol: str | None,
+    mode: str,
+    df_daily_sym: pd.DataFrame,
+    fng_score: int,
+    funding_score: int,
+    rsi_score: int = 50,
+    adx_score: int = 50,
+    *,
+    bull_above: int = 60,
+    bear_below: int = 40,
+) -> dict:
+```
+
+Right after the docstring and before the `price_score = ...` line, add:
+
+```python
+    if not (bear_below < bull_above):
+        raise ValueError(
+            f"bear_below must be < bull_above (got bear_below={bear_below}, "
+            f"bull_above={bull_above})"
+        )
+```
+
+Then change the existing block (lines ~174-179):
+
+```python
+    if composite > 60:
+        regime = "BULL"
+    elif composite < 40:
+        regime = "BEAR"
+    else:
+        regime = "NEUTRAL"
+```
+
+to:
+
+```python
+    if composite > bull_above:
+        regime = "BULL"
+    elif composite < bear_below:
+        regime = "BEAR"
+    else:
+        regime = "NEUTRAL"
+```
+
+- [ ] **Step 6: Run tests — all pass**
+
+```bash
+python -m pytest tests/test_regime_thresholds_param.py -v
+```
+Expected: ALL PASS (defaults still match legacy + new kwargs honored).
+
+- [ ] **Step 7: Run full strategy regime test suite to confirm no regressions**
+
+```bash
+python -m pytest tests/ -k "regime" -v
+```
+Expected: ALL PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add strategy/regime.py tests/test_regime_thresholds_param.py
+git commit -m "$(cat <<'EOF'
+feat(regime): parameterize BULL/BEAR thresholds in _compute_local_regime
+
+Adds bull_above/bear_below kwargs to _compute_local_regime with defaults
+60/40 preserving byte-identity to legacy production behavior. Validates
+bear_below < bull_above. Required by A.4-1.5 mini-harness.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Parameterize `detect_regime` (live-path) thresholds
+
+**Files:**
+- Modify: `strategy/regime.py` (function `detect_regime`, ~lines 273-392)
+- Test: `tests/test_regime_thresholds_param.py` (extend)
+
+**Goal:** Same parameterization in the live path. The live path is not exercised by the harness, but parameterizing both paths keeps the codebase consistent for the eventual Phase 5 promotion.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_regime_thresholds_param.py`:
+
+```python
+class TestDetectRegimeParameterized:
+    def test_detect_regime_accepts_bull_above_kwarg(self):
+        # detect_regime makes network calls; we just verify the signature
+        # accepts the kwargs. End-to-end behavior is covered by composite-level
+        # tests in TestComputeLocalRegimeParameterized.
+        import inspect
+
+        from strategy.regime import detect_regime
+
+        sig = inspect.signature(detect_regime)
+        assert "bull_above" in sig.parameters
+        assert "bear_below" in sig.parameters
+        assert sig.parameters["bull_above"].default == 60
+        assert sig.parameters["bear_below"].default == 40
+```
+
+- [ ] **Step 2: Run — must FAIL**
+
+```bash
+python -m pytest tests/test_regime_thresholds_param.py::TestDetectRegimeParameterized -v
+```
+Expected: FAIL with "bull_above" not in params.
+
+- [ ] **Step 3: Modify `detect_regime` signature and threshold block**
+
+Find `def detect_regime() -> dict:` at line ~273. Change to:
+
+```python
+def detect_regime(*, bull_above: int = 60, bear_below: int = 40) -> dict:
+```
+
+Add the validator at the top of the function body (before `details = {}`):
+
+```python
+    if not (bear_below < bull_above):
+        raise ValueError(
+            f"bear_below must be < bull_above (got bear_below={bear_below}, "
+            f"bull_above={bull_above})"
+        )
+```
+
+Find the threshold block at lines ~372-377:
+
+```python
+    if composite > 60:
+        regime = "BULL"
+    elif composite < 40:
+        regime = "BEAR"
+    else:
+        regime = "NEUTRAL"
+```
+
+Change to:
+
+```python
+    if composite > bull_above:
+        regime = "BULL"
+    elif composite < bear_below:
+        regime = "BEAR"
+    else:
+        regime = "NEUTRAL"
+```
+
+- [ ] **Step 4: Run — must PASS**
+
+```bash
+python -m pytest tests/test_regime_thresholds_param.py::TestDetectRegimeParameterized -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run full regime + strategy test suite**
+
+```bash
+python -m pytest tests/ -k "regime or strategy" -v
+```
+Expected: ALL PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add strategy/regime.py tests/test_regime_thresholds_param.py
+git commit -m "$(cat <<'EOF'
+feat(regime): parameterize BULL/BEAR thresholds in detect_regime (live path)
+
+Mirrors _compute_local_regime parameterization — adds bull_above/bear_below
+kwargs with 60/40 defaults preserving byte-identity. Live path not consumed
+by A.4-1.5 harness but kept consistent with backtest path for the eventual
+Phase 5 promotion.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Thread thresholds and `regime_disabled` through `simulate_strategy` → `_regime_at_time`
+
+**Files:**
+- Modify: `backtest.py` (`_regime_at_time` ~lines 222-291; `simulate_strategy` signature + regime call site ~lines 423-720)
+- Test: `tests/test_simulate_strategy_regime_kwargs.py` (new)
+
+**Goal:**
+1. Forward `bull_above`/`bear_below` from `simulate_strategy` → `_regime_at_time` → `_compute_local_regime`.
+2. Add `regime_disabled: bool = False` kwarg to `simulate_strategy`. When True, bypass the regime gating entirely — `_regime_at_time` is NOT called; instead a synthetic regime dict is built that means "no gating": `{"regime": "BYPASS", "score": 50.0, "mode": "disabled", "symbol": symbol, "components": {}}`. The downstream `decide_signal` consumer must treat regime `"BYPASS"` as "permit both LONG and SHORT". This requires identifying the consumer site (Step 5 below) and patching it to recognize `BYPASS`.
+3. Defaults preserve byte-identity for the legacy path.
+
+**Consumer trace (resolved during planning):** `regime_info` is passed into `evaluate_signal` (`strategy/core.py:242`, called at `backtest.py:708-712`). Inside `evaluate_signal`:
+
+- `regime_label = (regime or {}).get("regime")` → e.g. `"BULL"`, `"BEAR"`, `"NEUTRAL"`
+- `regime_token = _regime_to_direction_token(regime_label)` (`strategy/core.py:124-134`) → maps to `"SHORT"` if BEAR, else `"LONG"`
+- Gating block at lines 351-354:
+
+```python
+if in_long_zone and regime_token in ("LONG", "NEUTRAL"):
+    direction = "LONG"
+elif in_short_zone and regime_token == "SHORT":
+    direction = "SHORT"
+```
+
+To implement BYPASS, patch `_regime_to_direction_token` to return `"BYPASS"` for the bypass label, and add a third branch in the gating block: BYPASS allows direction by zone alone (long_zone → LONG, short_zone → SHORT).
+
+- [ ] **Step 0: Confirm consumer signature unchanged**
+
+The consumer was traced during planning (see "Consumer trace" above): `evaluate_signal` at `strategy/core.py:242` reads `regime["regime"]` via `_regime_to_direction_token` (`strategy/core.py:124-134`), gating block at `strategy/core.py:341-354`. Re-read those lines before editing in case anything has shifted.
+
+```bash
+sed -n '120,140p' strategy/core.py
+sed -n '340,360p' strategy/core.py
+```
+
+- [ ] **Step 1: Write the failing parity test**
+
+Create `tests/test_simulate_strategy_regime_kwargs.py`:
+
+```python
+"""Parity + bypass tests for simulate_strategy's regime threshold kwargs (A.4-1.5)."""
+import inspect
+
+import backtest
+
+
+class TestSimulateStrategySignature:
+    def test_accepts_regime_thresholds_kwarg(self):
+        sig = inspect.signature(backtest.simulate_strategy)
+        assert "regime_thresholds" in sig.parameters
+        # Default None preserves legacy (uses _compute_local_regime defaults 60/40)
+        assert sig.parameters["regime_thresholds"].default is None
+
+    def test_accepts_regime_disabled_kwarg(self):
+        sig = inspect.signature(backtest.simulate_strategy)
+        assert "regime_disabled" in sig.parameters
+        assert sig.parameters["regime_disabled"].default is False
+```
+
+- [ ] **Step 2: Run — must FAIL**
+
+```bash
+python -m pytest tests/test_simulate_strategy_regime_kwargs.py -v
+```
+Expected: FAIL with kwargs missing.
+
+- [ ] **Step 3: Modify `simulate_strategy` signature**
+
+Find the signature at `backtest.py:423-442`. Add two kwargs at the end (just before the closing `)`):
+
+```python
+                      cost_calibration=None,             # NEW (A.0.2, #277)
+                      regime_thresholds: tuple[int, int] | None = None,  # NEW (A.4-1.5) (bull_above, bear_below); None = legacy 60/40
+                      regime_disabled: bool = False,                     # NEW (A.4-1.5) bypass regime gating
+                      ) -> list[dict]:
+```
+
+- [ ] **Step 4: Modify `_regime_at_time` to accept and forward thresholds**
+
+Find `def _regime_at_time(` at `backtest.py:222`. Add kwargs:
+
+```python
+def _regime_at_time(
+    bar_time,
+    symbol: str,
+    df1d_sym,
+    df_fng,
+    df_funding,
+    regime_mode: str = "global",
+    df1d_btc=None,
+    *,
+    bull_above: int = 60,
+    bear_below: int = 40,
+) -> dict:
+```
+
+At the bottom of the function (the `return _compute_local_regime(...)` call ~lines 288-291), forward the kwargs:
+
+```python
+    return _compute_local_regime(
+        symbol, regime_mode, window_price,
+        fng_score, funding_score, rsi_score, adx_score,
+        bull_above=bull_above, bear_below=bear_below,
+    )
+```
+
+- [ ] **Step 5: Modify the `simulate_strategy` regime call site**
+
+Find `regime_info = _regime_at_time(` at `backtest.py:695`. Replace with:
+
+```python
+        # Regime detection via _regime_at_time helper (#152) — kept as
+        # backtest-local because scan() fetches its regime from a cache /
+        # network. A.4-1.5: regime_disabled bypasses the call entirely.
+        if regime_disabled:
+            regime_info = {
+                "regime": "BYPASS",
+                "score": 50.0,
+                "mode": "disabled",
+                "symbol": symbol,
+                "components": {},
+            }
+        else:
+            ba, bb = (regime_thresholds if regime_thresholds is not None else (60, 40))
+            regime_info = _regime_at_time(
+                bar_time, symbol, df1d_sym, df_fng, df_funding,
+                regime_mode=regime_mode, df1d_btc=df1d_btc,
+                bull_above=ba, bear_below=bb,
+            )
+```
+
+- [ ] **Step 6: Patch `strategy/core.py` to treat BYPASS as both-directions-permitted**
+
+Edit `strategy/core.py:_regime_to_direction_token` (lines 124-134). Add a BYPASS branch BEFORE the BEAR check:
+
+```python
+def _regime_to_direction_token(regime_label: str | None) -> str:
+    """Map regime label → direction token used by scan().
+
+    A.4-1.5 (regime_disabled bypass): "BYPASS" → "ANY", which the gating
+    block treats as "permit either direction by zone alone".
+
+    Legacy mapping:
+        BEAR → SHORT
+        BULL/NEUTRAL/missing/unknown → LONG
+    """
+    if regime_label == "BYPASS":
+        return "ANY"
+    if regime_label == "BEAR":
+        return "SHORT"
+    return "LONG"
+```
+
+Then edit the gating block at `strategy/core.py:341-354`:
+
+```python
+    in_long_zone = lrc_pct is not None and lrc_pct <= LRC_LONG_MAX
+    in_short_zone = lrc_pct is not None and lrc_pct >= LRC_SHORT_MIN
+
+    regime_label = (regime or {}).get("regime")
+    regime_token = _regime_to_direction_token(regime_label)
+
+    # LONG when in low zone AND regime is LONG or NEUTRAL (mapped to LONG).
+    # SHORT only when in high zone AND regime is BEAR → SHORT.
+    # ANY (BYPASS, A.4-1.5): direction follows zone alone.
+    # Everything else → NONE (middle band, or mismatched zone/regime pair).
+    if in_long_zone and regime_token in ("LONG", "NEUTRAL", "ANY"):
+        direction = "LONG"
+    elif in_short_zone and regime_token in ("SHORT", "ANY"):
+        direction = "SHORT"
+```
+
+(Only the two `in (...)` lines change. Everything else stays.)
+
+- [ ] **Step 7: Add the bypass behavior test**
+
+Append to `tests/test_simulate_strategy_regime_kwargs.py`:
+
+```python
+class TestRegimeBypass:
+    def test_bypass_skips_compute_local_regime(self, monkeypatch):
+        """When regime_disabled=True, _regime_at_time must NOT be invoked."""
+        called = {"count": 0}
+
+        def fake_regime_at_time(*args, **kwargs):
+            called["count"] += 1
+            return {"regime": "BULL", "score": 80.0}
+
+        monkeypatch.setattr(backtest, "_regime_at_time", fake_regime_at_time)
+
+        # Build minimal frames: simulate_strategy needs df1h, df4h, df5m at
+        # least to enter its loop. We expect early-exit due to insufficient
+        # bars — the assertion is that _regime_at_time was never called.
+        import pandas as pd
+        empty = pd.DataFrame({"close": []})
+
+        try:
+            backtest.simulate_strategy(
+                df1h=empty, df4h=empty, df5m=empty, symbol="BTCUSDT",
+                regime_disabled=True,
+            )
+        except Exception:
+            pass  # Empty frames may raise; we only care that the bypass branch was entered if any bar was processed.
+
+        # With empty frames, _regime_at_time is never called regardless. The
+        # real test is the inverse path:
+        called["count"] = 0
+        # ... but we cannot exercise the bar-loop without a full fixture.
+        # Defer the full bar-loop bypass test to the integration smoke in Task 9.
+
+    def test_threshold_kwargs_forwarded_to_regime_at_time(self, monkeypatch):
+        captured = {}
+
+        def fake_regime_at_time(*args, **kwargs):
+            captured.update(kwargs)
+            return {"regime": "BULL", "score": 80.0}
+
+        monkeypatch.setattr(backtest, "_regime_at_time", fake_regime_at_time)
+
+        # Same caveat: empty frames mean the call may not happen. The
+        # integration coverage lives in Task 9 (full backtest run).
+        # Here we just lock the wiring at the signature level.
+        assert "bull_above" in inspect.signature(backtest._regime_at_time).parameters
+        assert "bear_below" in inspect.signature(backtest._regime_at_time).parameters
+```
+
+- [ ] **Step 8: Run — must PASS**
+
+```bash
+python -m pytest tests/test_simulate_strategy_regime_kwargs.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 9: Run full backtest test suite to verify no regressions**
+
+```bash
+python -m pytest tests/ -k "backtest or simulate" -v
+```
+Expected: ALL PASS. Any failure here means the legacy path lost byte-identity — diagnose before continuing.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add backtest.py tests/test_simulate_strategy_regime_kwargs.py
+# Plus the decide_signal site if it lives elsewhere — note the path in commit msg.
+git commit -m "$(cat <<'EOF'
+feat(backtest): parameterize regime thresholds + add regime_disabled bypass
+
+Threads bull_above/bear_below from simulate_strategy → _regime_at_time →
+_compute_local_regime. When regime_disabled=True, skips the helper entirely
+and emits a synthetic {"regime": "BYPASS"} dict; consumers treat BYPASS as
+both LONG and SHORT permitted (matches "no detector" semantics from commit
+bf581f1's backtest comparison).
+
+Defaults preserve byte-identity to legacy production. Required by A.4-1.5
+mini-harness (4-config sweep over pre-holdout window).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Build the harness skeleton + data loading
+
+**Files:**
+- Create: `tools/regime_retune_pre_holdout.py`
+- Test: `tests/test_regime_retune_pre_holdout.py` (new)
+
+**Goal:** Module skeleton with: imports, constants (`TIMEFRAMES`, `REPO_ROOT`, `OHLCV_DB`, `CUTOFF_DEFAULT`, `GRID`), self-contained slicing helper, OHLCV/F&G/funding loaders. No CLI yet.
+
+- [ ] **Step 1: Write the grid-enumeration test**
+
+Create `tests/test_regime_retune_pre_holdout.py`:
+
+```python
+"""Tests for the A.4-1.5 regime threshold pre-holdout re-tune harness."""
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tools import regime_retune_pre_holdout as harness
+
+
+class TestGrid:
+    def test_grid_has_exactly_4_configs(self):
+        assert len(harness.GRID) == 4
+
+    def test_grid_locked_by_historical_record(self):
+        # Per spec D9 §2.10 + commit bf581f1 body
+        assert harness.GRID == [
+            {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False},
+            {"name": "70_30", "bull_above": 70, "bear_below": 30, "disabled": False},
+            {"name": "80_20", "bull_above": 80, "bear_below": 20, "disabled": False},
+            {"name": "no_detector", "bull_above": None, "bear_below": None, "disabled": True},
+        ]
+```
+
+- [ ] **Step 2: Run — must FAIL (module doesn't exist)**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py -v
+```
+Expected: FAIL with ModuleNotFoundError.
+
+- [ ] **Step 3: Create the harness skeleton**
+
+Create `tools/regime_retune_pre_holdout.py`:
+
+```python
+#!/usr/bin/env python3
+"""Pre-holdout regime threshold re-tune (A.4-1.5).
+
+Sweeps the 4 configurations locked by historical record (commit bf581f1)
+over the pre-holdout window [earliest, 2025-04-30T00:00:00Z), aggregates
+net_pnl per config across the 10 portfolio symbols, identifies the
+winner, and applies pre-registered decision flags (CHANGE detection,
+sanity check, stability check).
+
+Mirrors the shape of tools/retune_pre_holdout.py (A.4-1) but runs a
+single backtest per (symbol, config) instead of a grid search — the
+grid + objective here are locked by spec D9 §2.10, not optimized.
+
+Usage:
+    python -m tools.regime_retune_pre_holdout --max-date 2025-04-30
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)-8s  %(message)s")
+log = logging.getLogger("regime_retune_pre_holdout")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OHLCV_DB = os.path.join(REPO_ROOT, "data", "ohlcv.db")
+
+TIMEFRAMES = ("5m", "1h", "4h", "1d")
+
+GRID = [
+    {"name": "60_40",       "bull_above": 60,   "bear_below": 40,   "disabled": False},
+    {"name": "70_30",       "bull_above": 70,   "bear_below": 30,   "disabled": False},
+    {"name": "80_20",       "bull_above": 80,   "bear_below": 20,   "disabled": False},
+    {"name": "no_detector", "bull_above": None, "bear_below": None, "disabled": True},
+]
+
+
+def _resolve_git_commit() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip()
+    except Exception:
+        return "UNKNOWN"
+
+
+def _sha256_file(path: str, block_size: int = 1024 * 1024) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(block_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _slice_below_cutoff(df: pd.DataFrame, cutoff: datetime) -> pd.DataFrame:
+    """Return the subset of df whose index is strictly < cutoff.
+
+    Self-contained (does not import auto_tune._slice_below_cutoff) so this
+    module is independent of A.4-1's PR #287 helper.
+    """
+    if df is None or df.empty:
+        return df
+    cutoff_ts = pd.Timestamp(cutoff)
+    if df.index.tz is None and cutoff_ts.tz is not None:
+        cutoff_ts = cutoff_ts.tz_localize(None)
+    elif df.index.tz is not None and cutoff_ts.tz is None:
+        cutoff_ts = cutoff_ts.tz_localize("UTC")
+    sliced = df.loc[df.index < cutoff_ts]
+    if not sliced.empty:
+        max_ts = pd.Timestamp(sliced.index.max())
+        if max_ts.tz is None:
+            max_ts = max_ts.tz_localize("UTC")
+        cutoff_check = cutoff_ts if cutoff_ts.tz is not None else cutoff_ts.tz_localize("UTC")
+        assert max_ts < cutoff_check, f"Slice leak: max_ts={max_ts} >= cutoff={cutoff_check}"
+    return sliced
+
+
+def _per_symbol_data_ranges(db_path: str, symbols: list, cutoff_ms: int) -> dict:
+    """Per (symbol, tf), report [min_ts_ms, max_ts_ms, count] of bars with open_time < cutoff_ms.
+    Used as no-leakage proof in the manifest.
+    """
+    ranges: dict = {}
+    con = sqlite3.connect(db_path)
+    try:
+        for sym in symbols:
+            ranges[sym] = {}
+            for tf in TIMEFRAMES:
+                row = con.execute(
+                    "SELECT MIN(open_time), MAX(open_time), COUNT(*) "
+                    "FROM ohlcv WHERE symbol=? AND timeframe=? AND open_time<?",
+                    (sym, tf, cutoff_ms),
+                ).fetchone()
+                if row and row[2]:
+                    ranges[sym][tf] = {
+                        "min_ts_ms": int(row[0]),
+                        "max_ts_ms": int(row[1]),
+                        "min_ts_iso": datetime.fromtimestamp(row[0] / 1000, timezone.utc).isoformat(),
+                        "max_ts_iso": datetime.fromtimestamp(row[1] / 1000, timezone.utc).isoformat(),
+                        "count": int(row[2]),
+                    }
+                else:
+                    ranges[sym][tf] = {"min_ts_ms": None, "max_ts_ms": None, "count": 0}
+    finally:
+        con.close()
+    return ranges
+
+
+def _verify_no_leakage(ranges: dict, cutoff_ms: int) -> str:
+    for sym, tfs in ranges.items():
+        for tf, span in tfs.items():
+            if span["max_ts_ms"] is not None and span["max_ts_ms"] >= cutoff_ms:
+                raise AssertionError(
+                    f"no-leakage violation: {sym} {tf} max_ts_ms={span['max_ts_ms']} "
+                    f">= cutoff_ms={cutoff_ms}"
+                )
+    return "PASS"
+```
+
+- [ ] **Step 4: Run grid test — must PASS**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py::TestGrid -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add slicing tests**
+
+Append to `tests/test_regime_retune_pre_holdout.py`:
+
+```python
+class TestSliceBelowCutoff:
+    def test_slice_strict_less_than(self):
+        idx = pd.date_range("2025-04-29 23:55", periods=4, freq="5min", tz="UTC")
+        df = pd.DataFrame({"close": [1, 2, 3, 4]}, index=idx)
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        sliced = harness._slice_below_cutoff(df, cutoff)
+        # Bars at 23:55 (index 0) is < cutoff. Bars at 00:00, 00:05, 00:10 are >= cutoff.
+        assert len(sliced) == 1
+        assert sliced.index[0] == pd.Timestamp("2025-04-29 23:55", tz="UTC")
+
+    def test_slice_empty_input(self):
+        df = pd.DataFrame({"close": []})
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        out = harness._slice_below_cutoff(df, cutoff)
+        assert out.empty
+
+    def test_slice_assertion_catches_leakage(self):
+        # Mock case where assertion would fire
+        # (in practice, the loc[index < cutoff] guarantees no leakage,
+        # but the assertion is there as defensive belt-and-braces).
+        idx = pd.date_range("2025-04-30 00:00", periods=2, freq="5min", tz="UTC")
+        df = pd.DataFrame({"close": [1, 2]}, index=idx)
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        out = harness._slice_below_cutoff(df, cutoff)
+        # All bars >= cutoff → empty result, no leakage
+        assert out.empty
+```
+
+- [ ] **Step 6: Run — must PASS**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/regime_retune_pre_holdout.py tests/test_regime_retune_pre_holdout.py
+git commit -m "$(cat <<'EOF'
+feat(methodology): A.4-1.5 harness skeleton + slicing helpers
+
+Adds tools/regime_retune_pre_holdout.py with the locked grid (4 configs
+from commit bf581f1), self-contained _slice_below_cutoff (deliberately
+not depending on A.4-1 PR #287 helper to keep PRs orthogonal), and
+manifest helpers (_per_symbol_data_ranges, _verify_no_leakage,
+_sha256_file, _resolve_git_commit).
+
+No CLI yet; tests cover grid shape and slicing edge cases.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Add `tools/__init__.py` if missing + the per-config single-backtest runner
+
+**Files:**
+- Create or verify: `tools/__init__.py` (empty)
+- Modify: `tools/regime_retune_pre_holdout.py`
+- Test: `tests/test_regime_retune_pre_holdout.py`
+
+**Goal:** Build `_run_one_backtest(symbol, config, cutoff)` → returns `{"net_pnl": float, "trades": int, "errors": str | None}`. This is the per-cell unit of work. Loads OHLCV (1h, 4h, 5m, 1d) + F&G + funding for `symbol`, slices each `< cutoff`, calls `simulate_strategy` with the configured regime kwargs, sums `pnl_usd` of returned trades.
+
+Key sub-decision: **use `data.market_data.get_klines` and the same loader paths the existing scanner uses for OHLCV**. For F&G + funding, look at how `auto_tune.run_backtest_with_params` loads them — copy that pattern directly. Pull the helpers into a small `_load_frames(symbol, cutoff)` function in the harness.
+
+- [ ] **Step 1: Verify `tools/__init__.py`**
+
+```bash
+ls tools/__init__.py 2>/dev/null || touch tools/__init__.py
+```
+
+- [ ] **Step 2: F&G + funding loader paths (resolved during planning)**
+
+The canonical loaders are:
+- `backtest.get_historical_fear_greed()` — returns DataFrame indexed by date with `fng` column
+- `backtest.get_historical_funding_rate()` (defined at `backtest.py:144`) — returns DataFrame indexed by ts with `rate` column
+
+Both are used by `auto_tune.run_backtest_with_params` (lines 179-180) and seven other call sites in the repo. Import them directly into the harness — no need for new loader code. Verify by reading `backtest.py:144` and confirming the return shape before wiring.
+
+- [ ] **Step 3: Write the failing test for `_run_one_backtest`**
+
+Append to `tests/test_regime_retune_pre_holdout.py`:
+
+```python
+class TestRunOneBacktest:
+    def test_signature(self):
+        import inspect
+        sig = inspect.signature(harness._run_one_backtest)
+        params = list(sig.parameters)
+        assert "symbol" in params
+        assert "config" in params
+        assert "cutoff" in params
+
+    def test_disabled_config_passes_regime_disabled_true(self, monkeypatch):
+        captured = {}
+
+        def fake_simulate(*args, **kwargs):
+            captured.update(kwargs)
+            return []  # No trades
+
+        monkeypatch.setattr(harness, "simulate_strategy", fake_simulate)
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: {
+            "df1h": pd.DataFrame({"close": []}),
+            "df4h": pd.DataFrame({"close": []}),
+            "df5m": pd.DataFrame({"close": []}),
+            "df1d": pd.DataFrame({"close": []}),
+            "df1d_btc": pd.DataFrame({"close": []}),
+            "df_fng": pd.DataFrame({"fng": []}),
+            "df_funding": pd.DataFrame({"rate": []}),
+        })
+
+        cfg = {"name": "no_detector", "bull_above": None, "bear_below": None, "disabled": True}
+        result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc))
+        assert result["net_pnl"] == 0.0
+        assert captured.get("regime_disabled") is True
+
+    def test_60_40_config_passes_regime_thresholds(self, monkeypatch):
+        captured = {}
+
+        def fake_simulate(*args, **kwargs):
+            captured.update(kwargs)
+            return [{"pnl_usd": 100.0}, {"pnl_usd": -25.5}]
+
+        monkeypatch.setattr(harness, "simulate_strategy", fake_simulate)
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: {
+            "df1h": pd.DataFrame({"close": []}),
+            "df4h": pd.DataFrame({"close": []}),
+            "df5m": pd.DataFrame({"close": []}),
+            "df1d": pd.DataFrame({"close": []}),
+            "df1d_btc": pd.DataFrame({"close": []}),
+            "df_fng": pd.DataFrame({"fng": []}),
+            "df_funding": pd.DataFrame({"rate": []}),
+        })
+
+        cfg = {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False}
+        result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc))
+        assert result["net_pnl"] == 74.5
+        assert result["trades"] == 2
+        assert captured.get("regime_disabled") is False
+        assert captured.get("regime_thresholds") == (60, 40)
+```
+
+- [ ] **Step 4: Run — must FAIL**
+
+Expected: FAIL with AttributeError on `_run_one_backtest`.
+
+- [ ] **Step 5: Add `_load_frames` and `_run_one_backtest` to the harness**
+
+Append to `tools/regime_retune_pre_holdout.py`:
+
+```python
+# Imported lazily inside _run_one_backtest to avoid circular import at module load.
+# The functions referenced here live in:
+#   - backtest.simulate_strategy
+#   - data.market_data.get_klines (for OHLCV)
+#   - <F&G/funding loader path identified in Step 2>
+from backtest import simulate_strategy  # noqa: E402  (kept module-level for monkeypatch in tests)
+
+
+def _load_frames(symbol: str, cutoff: datetime) -> dict:
+    """Load all DataFrames simulate_strategy needs, sliced strictly < cutoff.
+
+    Returns dict with keys: df1h, df4h, df5m, df1d, df1d_btc, df_fng, df_funding.
+    Each value is a (possibly empty) DataFrame whose index is strictly < cutoff.
+    """
+    from data import market_data as md
+
+    out = {}
+    for tf, key in (("1h", "df1h"), ("4h", "df4h"), ("5m", "df5m"), ("1d", "df1d")):
+        df = md.get_klines(symbol, tf, limit=10_000)  # generous limit; we slice below
+        out[key] = _slice_below_cutoff(df, cutoff)
+
+    # BTC daily for global-mode regime
+    if symbol == "BTCUSDT":
+        out["df1d_btc"] = out["df1d"]
+    else:
+        df1d_btc = md.get_klines("BTCUSDT", "1d", limit=10_000)
+        out["df1d_btc"] = _slice_below_cutoff(df1d_btc, cutoff)
+
+    # F&G + funding — use the canonical loaders from backtest.py
+    # (same path used by auto_tune.run_backtest_with_params).
+    from backtest import get_historical_fear_greed, get_historical_funding_rate
+    out["df_fng"] = _slice_below_cutoff(get_historical_fear_greed(), cutoff)
+    out["df_funding"] = _slice_below_cutoff(get_historical_funding_rate(), cutoff)
+
+    return out
+
+
+def _run_one_backtest(symbol: str, config: dict, cutoff: datetime) -> dict:
+    """Run a single backtest for (symbol, regime config). Returns net_pnl + diagnostics."""
+    frames = _load_frames(symbol, cutoff)
+
+    kwargs = {
+        "df1h": frames["df1h"],
+        "df4h": frames["df4h"],
+        "df5m": frames["df5m"],
+        "df1d": frames["df1d"],
+        "df1d_btc": frames["df1d_btc"],
+        "df_fng": frames["df_fng"],
+        "df_funding": frames["df_funding"],
+        "symbol": symbol,
+    }
+    if config["disabled"]:
+        kwargs["regime_disabled"] = True
+    else:
+        kwargs["regime_thresholds"] = (config["bull_above"], config["bear_below"])
+
+    try:
+        trades = simulate_strategy(**kwargs)
+    except Exception as exc:
+        log.error("[%s][%s] simulate_strategy raised: %s", symbol, config["name"], exc)
+        return {"symbol": symbol, "config": config["name"], "net_pnl": 0.0,
+                "trades": 0, "error": str(exc)}
+
+    net_pnl = sum(t.get("pnl_usd", 0.0) for t in trades)
+    return {"symbol": symbol, "config": config["name"], "net_pnl": float(net_pnl),
+            "trades": len(trades), "error": None}
+```
+
+- [ ] **Step 6: Run tests — must PASS (monkeypatched path)**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py::TestRunOneBacktest -v
+```
+Expected: PASS.
+
+- [ ] **Step 7: Add an end-to-end smoke for `_load_frames` with real loaders (skipif data missing)**
+
+```python
+class TestRealLoadFrames:
+    def test_load_frames_slices_below_cutoff(self):
+        if not os.path.exists(harness.OHLCV_DB):
+            pytest.skip("ohlcv.db not present in test environment")
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        try:
+            frames = harness._load_frames("BTCUSDT", cutoff)
+        except Exception as exc:
+            pytest.skip(f"Loader unavailable in test env: {exc}")
+
+        cutoff_ts = pd.Timestamp(cutoff)
+        for key in ("df1h", "df4h", "df5m", "df1d", "df1d_btc", "df_fng", "df_funding"):
+            df = frames[key]
+            if df is not None and not df.empty:
+                max_ts = pd.Timestamp(df.index.max())
+                if max_ts.tz is None:
+                    max_ts = max_ts.tz_localize("UTC")
+                ct = cutoff_ts if cutoff_ts.tz is not None else cutoff_ts.tz_localize("UTC")
+                assert max_ts < ct, f"{key} leaked: max_ts={max_ts} >= cutoff={ct}"
+```
+
+- [ ] **Step 8: Run — must PASS (or skip cleanly)**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py -v
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tools/regime_retune_pre_holdout.py tests/test_regime_retune_pre_holdout.py
+git commit -m "$(cat <<'EOF'
+feat(methodology): A.4-1.5 harness — single-backtest runner per (symbol,config)
+
+Adds _load_frames + _run_one_backtest. Loads OHLCV (5m/1h/4h/1d) via
+data.market_data.get_klines; loads F&G + funding via the same paths used
+by auto_tune.run_backtest_with_params (copied for orthogonality vs PR
+#287). All frames sliced strictly < cutoff. simulate_strategy is invoked
+with regime_thresholds=(bull,bear) for the 3 numeric configs and
+regime_disabled=True for the no_detector config.
+
+Per-cell return: {symbol, config, net_pnl, trades, error}. simulate_strategy
+exceptions are caught + logged + returned as net_pnl=0 with the error
+string in the result, mirroring A.4-1's tolerance for single-symbol
+failures during a sweep.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Aggregate per-config + decision flag evaluation
+
+**Files:**
+- Modify: `tools/regime_retune_pre_holdout.py`
+- Test: `tests/test_regime_retune_pre_holdout.py`
+
+**Goal:** `_aggregate_results(per_cell_results)` produces:
+- `per_config_pnl: dict[str, float]` (config_name → sum net_pnl)
+- `winner: str` (config name with max sum)
+- `runner_up: str` (2nd-best)
+- `winner_margin_pct: float` (gap from winner to runner-up, as `(winner - 2nd) / |winner| * 100`)
+- `decision_flags: dict` with `change_detection`, `sanity_check`, `stability_check`
+
+- [ ] **Step 1: Failing test**
+
+Append:
+
+```python
+class TestAggregate:
+    def test_aggregate_picks_winner(self):
+        cells = [
+            {"symbol": "BTC", "config": "60_40", "net_pnl": 100.0, "trades": 5, "error": None},
+            {"symbol": "ETH", "config": "60_40", "net_pnl": 50.0,  "trades": 3, "error": None},
+            {"symbol": "BTC", "config": "70_30", "net_pnl": 120.0, "trades": 4, "error": None},
+            {"symbol": "ETH", "config": "70_30", "net_pnl": 60.0,  "trades": 3, "error": None},
+            {"symbol": "BTC", "config": "80_20", "net_pnl": 80.0,  "trades": 2, "error": None},
+            {"symbol": "ETH", "config": "80_20", "net_pnl": 40.0,  "trades": 2, "error": None},
+            {"symbol": "BTC", "config": "no_detector", "net_pnl": 70.0, "trades": 6, "error": None},
+            {"symbol": "ETH", "config": "no_detector", "net_pnl": 30.0, "trades": 4, "error": None},
+        ]
+        agg = harness._aggregate_results(cells)
+        assert agg["per_config_pnl"]["60_40"]       == 150.0
+        assert agg["per_config_pnl"]["70_30"]       == 180.0
+        assert agg["per_config_pnl"]["80_20"]       == 120.0
+        assert agg["per_config_pnl"]["no_detector"] == 100.0
+        assert agg["winner"] == "70_30"
+        assert agg["runner_up"] == "60_40"
+        # margin = (180 - 150) / 180 * 100 = 16.66...%
+        assert abs(agg["winner_margin_pct"] - (30.0 / 180.0 * 100)) < 1e-6
+
+    def test_decision_flag_change_detection(self):
+        # winner != "60_40" → change_detection True
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 50), ("70_30", 100), ("80_20", 30), ("no_detector", 20)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["change_detection"] is True
+        assert agg["winner"] == "70_30"
+
+    def test_decision_flag_sanity_check_fires_on_no_detector_winner(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 50), ("70_30", 30), ("80_20", 20), ("no_detector", 200)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["sanity_check"] is True  # halt+debug
+        assert agg["winner"] == "no_detector"
+
+    def test_decision_flag_stability_check_fires_within_5_pct(self):
+        # winner=180, runner_up=178 → margin = 2/180 = 1.11% < 5% → stability flag
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 178), ("70_30", 180), ("80_20", 100), ("no_detector", 50)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["stability_check"] is True
+
+    def test_decision_flag_stability_check_inactive_when_margin_large(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 100), ("70_30", 200), ("80_20", 50), ("no_detector", 30)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["stability_check"] is False  # margin = 50% > 5%
+```
+
+- [ ] **Step 2: Run — must FAIL**
+
+- [ ] **Step 3: Implement**
+
+Append to `tools/regime_retune_pre_holdout.py`:
+
+```python
+def _aggregate_results(cells: list) -> dict:
+    """Aggregate per-cell results into per-config sums + decision flags.
+
+    cells: list of {symbol, config, net_pnl, trades, error} dicts.
+    """
+    per_config_pnl: dict[str, float] = {}
+    per_config_trades: dict[str, int] = {}
+    for cell in cells:
+        cfg = cell["config"]
+        per_config_pnl[cfg] = per_config_pnl.get(cfg, 0.0) + float(cell["net_pnl"])
+        per_config_trades[cfg] = per_config_trades.get(cfg, 0) + int(cell["trades"])
+
+    # Sort configs by net_pnl descending. Ties broken by lex order of config name
+    # for deterministic output.
+    sorted_configs = sorted(per_config_pnl.items(), key=lambda kv: (-kv[1], kv[0]))
+    winner_name, winner_pnl = sorted_configs[0]
+    runner_up_name, runner_up_pnl = sorted_configs[1]
+
+    if abs(winner_pnl) > 1e-9:
+        margin_pct = (winner_pnl - runner_up_pnl) / abs(winner_pnl) * 100.0
+    else:
+        margin_pct = 0.0
+
+    decision_flags = {
+        "change_detection": winner_name != "60_40",
+        "sanity_check":     winner_name == "no_detector",
+        "stability_check":  margin_pct < 5.0,
+    }
+
+    return {
+        "per_config_pnl": per_config_pnl,
+        "per_config_trades": per_config_trades,
+        "winner": winner_name,
+        "winner_pnl": winner_pnl,
+        "runner_up": runner_up_name,
+        "runner_up_pnl": runner_up_pnl,
+        "winner_margin_pct": margin_pct,
+        "decision_flags": decision_flags,
+    }
+```
+
+- [ ] **Step 4: Run — must PASS**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py::TestAggregate -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/regime_retune_pre_holdout.py tests/test_regime_retune_pre_holdout.py
+git commit -m "$(cat <<'EOF'
+feat(methodology): A.4-1.5 — aggregate + pre-registered decision flags
+
+_aggregate_results sums net_pnl per config across symbols, ranks them,
+computes the winner/runner-up margin, and evaluates the three flags
+locked by spec D9 §2.10:
+  - change_detection: winner != current production (60_40)
+  - sanity_check:     no_detector wins → halt+debug
+  - stability_check:  2nd-best within 5% of winner → informational caveat
+
+Tie-break on lex order of config name keeps the winner choice
+deterministic across re-runs for byte-stable artefacts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Artefact writers (`regime_params.json`, `regime_manifest.json`, `regime_report.md`)
+
+**Files:**
+- Modify: `tools/regime_retune_pre_holdout.py`
+- Test: `tests/test_regime_retune_pre_holdout.py`
+
+**Goal:** Three writers, all atomic, all deterministic. The `regime_params.json` shape branches on whether `no_detector` won.
+
+- [ ] **Step 1: Failing test**
+
+Append:
+
+```python
+class TestArtefactWriters:
+    def test_regime_params_for_threshold_winner(self, tmp_path):
+        agg = {
+            "winner": "70_30",
+            "winner_pnl": 180.0,
+            "per_config_pnl": {"60_40": 150.0, "70_30": 180.0, "80_20": 120.0, "no_detector": 100.0},
+            "decision_flags": {"change_detection": True, "sanity_check": False, "stability_check": False},
+        }
+        path = tmp_path / "regime_params.json"
+        harness._write_regime_params(str(path), agg)
+        payload = json.loads(path.read_text())
+        assert payload == {
+            "format_version": 1,
+            "regime_thresholds": {"bull_above": 70, "bear_below": 30},
+        }
+
+    def test_regime_params_for_disabled_winner(self, tmp_path):
+        agg = {
+            "winner": "no_detector",
+            "winner_pnl": 200.0,
+            "per_config_pnl": {"60_40": 150.0, "70_30": 100.0, "80_20": 80.0, "no_detector": 200.0},
+            "decision_flags": {"change_detection": True, "sanity_check": True, "stability_check": False},
+        }
+        path = tmp_path / "regime_params.json"
+        harness._write_regime_params(str(path), agg)
+        payload = json.loads(path.read_text())
+        assert payload == {
+            "format_version": 1,
+            "regime_disabled": True,
+        }
+
+    def test_regime_params_byte_deterministic_across_runs(self, tmp_path):
+        agg = {
+            "winner": "60_40",
+            "winner_pnl": 150.0,
+            "per_config_pnl": {"60_40": 150.0, "70_30": 100.0, "80_20": 80.0, "no_detector": 50.0},
+            "decision_flags": {"change_detection": False, "sanity_check": False, "stability_check": False},
+        }
+        path1 = tmp_path / "p1.json"
+        path2 = tmp_path / "p2.json"
+        harness._write_regime_params(str(path1), agg)
+        harness._write_regime_params(str(path2), agg)
+        assert path1.read_bytes() == path2.read_bytes()
+```
+
+- [ ] **Step 2: Run — must FAIL**
+
+- [ ] **Step 3: Implement writers**
+
+Append:
+
+```python
+def _atomic_write_json(path: str, payload: dict) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, sort_keys=True, indent=2, ensure_ascii=False)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def _write_regime_params(path: str, agg: dict) -> None:
+    """Write regime_params.json. Shape depends on winner:
+      - threshold winner: {"format_version": 1, "regime_thresholds": {"bull_above": <int>, "bear_below": <int>}}
+      - no_detector winner: {"format_version": 1, "regime_disabled": True}
+    """
+    winner = agg["winner"]
+    if winner == "no_detector":
+        payload = {"format_version": 1, "regime_disabled": True}
+    else:
+        cfg = next(c for c in GRID if c["name"] == winner)
+        payload = {
+            "format_version": 1,
+            "regime_thresholds": {
+                "bull_above": cfg["bull_above"],
+                "bear_below": cfg["bear_below"],
+            },
+        }
+    _atomic_write_json(path, payload)
+
+
+def _build_manifest(agg: dict, cutoff: datetime, cutoff_ms: int,
+                    ohlcv_sha: str, code_commit: str,
+                    ranges: dict, runtime_seconds: float,
+                    leakage_check: str, symbols: list) -> dict:
+    return {
+        "harness": "regime_retune_pre_holdout",
+        "spec_ref": "docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md §2.10",
+        "cutoff_effective_iso": cutoff.isoformat(),
+        "cutoff_effective_ms": cutoff_ms,
+        "code_commit": code_commit,
+        "ohlcv_sha256": ohlcv_sha,
+        "ohlcv_path_relative": os.path.relpath(OHLCV_DB, REPO_ROOT),
+        "ran_at_iso": datetime.now(timezone.utc).isoformat(),
+        "runtime_seconds": round(runtime_seconds, 2),
+        "leakage_check": leakage_check,
+        "symbols": symbols,
+        "grid": [{"name": g["name"], "bull_above": g["bull_above"],
+                  "bear_below": g["bear_below"], "disabled": g["disabled"]} for g in GRID],
+        "per_config_pnl": agg["per_config_pnl"],
+        "per_config_trades": agg["per_config_trades"],
+        "winner": agg["winner"],
+        "winner_pnl": agg["winner_pnl"],
+        "runner_up": agg["runner_up"],
+        "runner_up_pnl": agg["runner_up_pnl"],
+        "winner_margin_pct": round(agg["winner_margin_pct"], 4),
+        "decision_flags": agg["decision_flags"],
+        "per_symbol_data_ranges": ranges,
+        "scope_notes": {
+            "n_effective_contribution": 0,
+            "promotion_to_strategy_regime_py_and_backtest_py": "deferred_to_phase_5_post_holdout_PR",
+        },
+    }
+
+
+def _build_report(agg: dict, cells: list, cutoff: datetime,
+                  ranges: dict, runtime_seconds: float, symbols: list) -> str:
+    lines = []
+    lines.append("# Pre-holdout Regime Threshold Re-tune Report (A.4-1.5)")
+    lines.append("")
+    lines.append(f"- **Cutoff (`--max-date`):** {cutoff.isoformat()}")
+    lines.append(f"- **Symbols:** {', '.join(symbols)}")
+    lines.append(f"- **Runtime:** {runtime_seconds:.0f}s")
+    lines.append(f"- **Spec ref:** D9 §2.10 (locked grid, locked objective)")
+    lines.append("")
+    lines.append("## Per-config aggregate")
+    lines.append("")
+    lines.append("| Config | Sum net_pnl (USD) | Total trades | Margin to winner |")
+    lines.append("|--------|-------------------|--------------|------------------|")
+    for cfg_name in ("60_40", "70_30", "80_20", "no_detector"):
+        pnl = agg["per_config_pnl"].get(cfg_name, 0.0)
+        tr = agg["per_config_trades"].get(cfg_name, 0)
+        if cfg_name == agg["winner"]:
+            margin = "**winner**"
+        elif abs(agg["winner_pnl"]) > 1e-9:
+            m = (agg["winner_pnl"] - pnl) / abs(agg["winner_pnl"]) * 100
+            margin = f"-{m:.2f}%"
+        else:
+            margin = "—"
+        lines.append(f"| {cfg_name} | ${pnl:+,.2f} | {tr} | {margin} |")
+    lines.append("")
+    lines.append(f"**Winner:** `{agg['winner']}` (sum net_pnl = ${agg['winner_pnl']:+,.2f})")
+    lines.append(f"**Runner-up:** `{agg['runner_up']}` (sum net_pnl = ${agg['runner_up_pnl']:+,.2f})")
+    lines.append(f"**Margin:** {agg['winner_margin_pct']:.2f}% of |winner|")
+    lines.append("")
+    lines.append("## Decision flags (pre-registered per D9 §2.10)")
+    lines.append("")
+    lines.append(f"- **CHANGE detection:** `{agg['decision_flags']['change_detection']}` "
+                 f"(winner {'==' if agg['winner']=='60_40' else '!='} current production `60_40`)")
+    lines.append(f"- **Sanity check (no-detector wins):** "
+                 f"`{agg['decision_flags']['sanity_check']}` "
+                 f"{'→ HALT + DEBUG required before any commit' if agg['decision_flags']['sanity_check'] else ''}")
+    lines.append(f"- **Stability check (margin < 5%):** "
+                 f"`{agg['decision_flags']['stability_check']}` "
+                 f"{'→ informational caveat: regime is operating in a flat region' if agg['decision_flags']['stability_check'] else ''}")
+    lines.append("")
+    lines.append("## Per-symbol breakdown")
+    lines.append("")
+    lines.append("| Symbol | 60_40 | 70_30 | 80_20 | no_detector |")
+    lines.append("|--------|-------|-------|-------|-------------|")
+    by_symbol_config = {}
+    for c in cells:
+        by_symbol_config.setdefault(c["symbol"], {})[c["config"]] = c["net_pnl"]
+    for sym in symbols:
+        row = by_symbol_config.get(sym, {})
+        cells_str = " | ".join(
+            f"${row.get(cfg, 0.0):+,.0f}"
+            for cfg in ("60_40", "70_30", "80_20", "no_detector")
+        )
+        lines.append(f"| {sym} | {cells_str} |")
+    lines.append("")
+    lines.append("## Caveats")
+    lines.append("")
+    lines.append("- **JUPUSDT** — earliest OHLCV bar is 2024-01-31. SMA200 (1d) and SMA100 (1h) "
+                 "yield NaN over the first ~4 days of JUP train data. Same warmup degradation "
+                 "applies here as in A.4-1; results for JUP are reported but should be interpreted "
+                 "with this caveat.")
+    lines.append("")
+    lines.append("## Data ranges (per symbol × tf, all bars below cutoff)")
+    lines.append("")
+    lines.append("| Symbol | TF | Min ts (UTC) | Max ts (UTC) | Bars |")
+    lines.append("|--------|----|---------------|---------------|------|")
+    for sym in sorted(ranges.keys()):
+        for tf in TIMEFRAMES:
+            span = ranges[sym].get(tf, {})
+            lines.append(
+                f"| {sym} | {tf} "
+                f"| {span.get('min_ts_iso', '—')} "
+                f"| {span.get('max_ts_iso', '—')} "
+                f"| {span.get('count', 0)} |"
+            )
+    lines.append("")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run — must PASS**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/regime_retune_pre_holdout.py tests/test_regime_retune_pre_holdout.py
+git commit -m "$(cat <<'EOF'
+feat(methodology): A.4-1.5 — artefact writers (regime_params, manifest, report)
+
+regime_params.json branches on winner shape:
+  - threshold winner → {"format_version":1,"regime_thresholds":{...}}
+  - no_detector winner → {"format_version":1,"regime_disabled":true}
+Atomic write with sort_keys=True for byte-determinism across re-runs.
+
+regime_manifest.json captures cutoff, ohlcv hash, code commit, per-config
+P&L sums, decision flags, per-symbol data ranges (no-leakage proof).
+
+regime_report.md is human-readable side-by-side, includes the JUP warmup
+caveat, decision flag annotations, per-symbol breakdown.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: CLI entry point + main loop
+
+**Files:**
+- Modify: `tools/regime_retune_pre_holdout.py`
+- Test: `tests/test_regime_retune_pre_holdout.py`
+
+**Goal:** `main(argv)` parses `--max-date` (required) + optional `--out-dir`. Drives the full sweep. Writes all three artefacts.
+
+- [ ] **Step 1: Failing test**
+
+Append:
+
+```python
+class TestCLI:
+    def test_max_date_required(self):
+        with pytest.raises(SystemExit):
+            harness.main([])
+
+    def test_max_date_parsed(self, monkeypatch, tmp_path):
+        # Stub _run_one_backtest so we don't load real data
+        def fake_run(symbol, config, cutoff):
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": 100.0 if config["name"] == "60_40" else 50.0,
+                    "trades": 1, "error": None}
+
+        monkeypatch.setattr(harness, "_run_one_backtest", fake_run)
+        monkeypatch.setattr(harness, "_per_symbol_data_ranges",
+                            lambda *a, **kw: {sym: {} for sym in harness._get_symbols()})
+        monkeypatch.setattr(harness, "_verify_no_leakage", lambda *a, **kw: "PASS")
+        monkeypatch.setattr(harness, "_sha256_file", lambda *a, **kw: "deadbeef")
+
+        rc = harness.main([
+            "--max-date", "2025-04-30",
+            "--out-dir", str(tmp_path),
+        ])
+        assert rc == 0
+        assert (tmp_path / "regime_params.json").exists()
+        assert (tmp_path / "regime_manifest.json").exists()
+        assert (tmp_path / "regime_report.md").exists()
+
+        # Winner = 60_40 (sum 100*10 = 1000) > others
+        params = json.loads((tmp_path / "regime_params.json").read_text())
+        assert params["regime_thresholds"]["bull_above"] == 60
+        assert params["regime_thresholds"]["bear_below"] == 40
+```
+
+- [ ] **Step 2: Run — must FAIL**
+
+- [ ] **Step 3: Implement `_get_symbols` + `main`**
+
+Append:
+
+```python
+def _get_symbols() -> list[str]:
+    """Return the 10 portfolio symbols (mirror of A.4-1's basket)."""
+    from btc_scanner import DEFAULT_SYMBOLS
+    return list(DEFAULT_SYMBOLS)
+
+
+def main(argv: list | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pre-holdout regime threshold re-tune mini-harness (A.4-1.5).",
+    )
+    parser.add_argument("--max-date", type=str, required=True,
+                        help="ISO date (YYYY-MM-DD, UTC). Holdout starts on this day; "
+                             "tune sees only bars strictly before it.")
+    parser.add_argument("--out-dir", type=str, default=None,
+                        help="Override output directory. "
+                             "Defaults to data/retune/<today>-pre-holdout/.")
+    args = parser.parse_args(argv)
+
+    cutoff = datetime.fromisoformat(args.max_date).replace(tzinfo=timezone.utc)
+    cutoff_ms = int(cutoff.timestamp() * 1000)
+
+    if not os.path.exists(OHLCV_DB):
+        log.error("OHLCV DB not found at %s", OHLCV_DB)
+        return 2
+
+    symbols = _get_symbols()
+
+    if args.out_dir:
+        out_dir = args.out_dir
+    else:
+        run_date = datetime.now(timezone.utc).date().isoformat()
+        out_dir = os.path.join(REPO_ROOT, "data", "retune", f"{run_date}-pre-holdout")
+    os.makedirs(out_dir, exist_ok=True)
+
+    log.info("A.4-1.5 regime threshold re-tune starting")
+    log.info("  cutoff:  %s", cutoff.isoformat())
+    log.info("  symbols: %s", ", ".join(symbols))
+    log.info("  configs: %s", ", ".join(c["name"] for c in GRID))
+    log.info("  out_dir: %s", out_dir)
+
+    start = time.time()
+    cells = []
+    for symbol in symbols:
+        for config in GRID:
+            cell = _run_one_backtest(symbol, config, cutoff)
+            if cell["error"]:
+                log.warning("[%s][%s] error: %s", symbol, config["name"], cell["error"])
+            else:
+                log.info("[%s][%s] net_pnl=$%+,.2f trades=%d",
+                         symbol, config["name"], cell["net_pnl"], cell["trades"])
+            cells.append(cell)
+    runtime_seconds = time.time() - start
+
+    agg = _aggregate_results(cells)
+
+    log.info("Computing per-symbol data ranges from ohlcv.db...")
+    ranges = _per_symbol_data_ranges(OHLCV_DB, symbols, cutoff_ms)
+    leakage_check = _verify_no_leakage(ranges, cutoff_ms)
+    log.info("Leakage check: %s", leakage_check)
+
+    log.info("Hashing ohlcv.db...")
+    ohlcv_sha = _sha256_file(OHLCV_DB)
+    code_commit = _resolve_git_commit()
+
+    manifest = _build_manifest(
+        agg=agg, cutoff=cutoff, cutoff_ms=cutoff_ms,
+        ohlcv_sha=ohlcv_sha, code_commit=code_commit,
+        ranges=ranges, runtime_seconds=runtime_seconds,
+        leakage_check=leakage_check, symbols=symbols,
+    )
+
+    report_md = _build_report(
+        agg=agg, cells=cells, cutoff=cutoff,
+        ranges=ranges, runtime_seconds=runtime_seconds, symbols=symbols,
+    )
+
+    _write_regime_params(os.path.join(out_dir, "regime_params.json"), agg)
+    _atomic_write_json(os.path.join(out_dir, "regime_manifest.json"), manifest)
+    with open(os.path.join(out_dir, "regime_report.md"), "w", encoding="utf-8") as f:
+        f.write(report_md)
+
+    log.info("Artefacts written to %s", out_dir)
+    log.info("  regime_params.json   — winner config, byte-deterministic")
+    log.info("  regime_manifest.json — cutoff, hashes, decision flags, no-leakage proof")
+    log.info("  regime_report.md     — human-readable side-by-side + caveats")
+    log.info("Decision flags: %s", agg["decision_flags"])
+
+    if agg["decision_flags"]["sanity_check"]:
+        log.error("SANITY CHECK FIRED: no_detector wins on pre-holdout window. "
+                  "HALT + DEBUG before promoting this artefact.")
+        return 3
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run — must PASS**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py::TestCLI -v
+```
+
+- [ ] **Step 5: Run full harness test suite**
+
+```bash
+python -m pytest tests/test_regime_retune_pre_holdout.py -v
+python -m pytest tests/test_regime_thresholds_param.py -v
+python -m pytest tests/test_simulate_strategy_regime_kwargs.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/regime_retune_pre_holdout.py tests/test_regime_retune_pre_holdout.py
+git commit -m "$(cat <<'EOF'
+feat(methodology): A.4-1.5 — CLI entry point + sweep main loop
+
+main() parses --max-date (required) + --out-dir, drives the 4×10 sweep
+sequentially (sweep is small enough — 40 backtests — that process pool
+parallelism would not pay off; A.4-1 needed it because grid search there
+is ~36 min/symbol). Aggregates, evaluates flags, writes artefacts.
+
+Returns rc=3 when sanity_check fires (no_detector wins) so a CI / shell
+wrapper can detect the halt condition without parsing logs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Whitelist the harness in `tests/test_holdout_isolation.py`
+
+**Files:**
+- Modify: `tests/test_holdout_isolation.py`
+
+**Goal:** Add `tools/regime_retune_pre_holdout.py` to `HOLDOUT_LEGITIMATE_MODULES` with a justification mirroring A.4-1's pattern. The harness reads `data/ohlcv.db` only, NOT `data/holdout/`, but its output dir name contains the literal `-pre-holdout` token — Guard B's AST scanner would flag it without the whitelist.
+
+- [ ] **Step 1: Read the existing whitelist**
+
+```bash
+grep -n "HOLDOUT_LEGITIMATE_MODULES\|retune_pre_holdout" tests/test_holdout_isolation.py
+```
+
+- [ ] **Step 2: Add the entry**
+
+Edit `tests/test_holdout_isolation.py`. Add to `HOLDOUT_LEGITIMATE_MODULES` (after the `tools/retune_pre_holdout.py` entry):
+
+```python
+    # tools/regime_retune_pre_holdout.py — A.4-1.5 mini-harness.
+    # Reads data/ohlcv.db only (NOT data/holdout/). Output dir name
+    # contains the literal '-pre-holdout' suffix for human discoverability;
+    # the AST scanner sees that string in the source and would flag it
+    # without this whitelist. Sister module to tools/retune_pre_holdout.py
+    # (A.4-1, PR #287).
+    "tools/regime_retune_pre_holdout.py",
+```
+
+- [ ] **Step 3: Run Guard B**
+
+```bash
+python -m pytest tests/test_holdout_isolation.py -v
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_holdout_isolation.py
+git commit -m "$(cat <<'EOF'
+chore(tests): whitelist tools/regime_retune_pre_holdout.py in Guard B
+
+Mirror of A.4-1's whitelist entry. Reads data/ohlcv.db only; output
+dir name contains the '-pre-holdout' string which the AST scanner
+would otherwise flag.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Full test sweep + push branch + open draft PR
+
+**Files:** none (verification + git ops only)
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+python -m pytest tests/ -v 2>&1 | tail -50
+```
+Expected: ALL PASS. Note the count for the PR body.
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u origin feat/methodology-a4-1-5-regime-retune-pre-holdout
+```
+
+- [ ] **Step 3: Open draft PR**
+
+```bash
+gh pr create --draft \
+  --title "feat(methodology): A.4-1.5 pre-holdout regime threshold re-tune harness" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase 2 de A.4-1.5 (#305). Adds the harness needed to re-tune the regime detector BULL/BEAR partition thresholds (`>60/<40`) over the pre-holdout window before A.4 holdout evaluation. **Does NOT execute the sweep** — Phase 3 commits the artefact in a follow-up commit on this PR.
+
+Per spec D9 §2.10 (locked grid + locked objective):
+- 4 configs from commit `bf581f1`: `(60,40)`, `(70,30)`, `(80,20)`, no-detector
+- Window: `[earliest, 2025-04-30T00:00:00Z)` strict `<` slicing
+- Objective: maximize sum of `net_pnl` across 10 portfolio symbols
+- Decision flags: CHANGE detection, sanity check (no-detector wins → halt+debug), stability check (2nd within 5% → caveat)
+
+## Code changes
+
+- `strategy/regime.py` — parameterize `bull_above`/`bear_below` in both `_compute_local_regime` (backtest path) and `detect_regime` (live path); defaults 60/40 preserve byte-identity.
+- `backtest.py` — thread thresholds through `simulate_strategy` → `_regime_at_time` → `_compute_local_regime`. Add `regime_disabled` bypass that emits a synthetic `{"regime": "BYPASS"}` dict; `decide_signal` patched to treat BYPASS as both LONG and SHORT permitted.
+- `tools/regime_retune_pre_holdout.py` — new harness module: locked grid, self-contained slicing, single-backtest runner per (symbol, config), aggregate, decision flags, atomic byte-deterministic JSON writers.
+- `tests/test_holdout_isolation.py` — whitelist entry for the new harness.
+
+## Out of scope
+
+- **The actual sweep run.** Phase 3 commits the artefact to `data/retune/2026-05-04-pre-holdout/`.
+- **Promotion to `strategy/regime.py` + `backtest.py`.** Deferred to Phase 5 separate PR after A.4 holdout passes.
+
+## Validation gate
+
+- **Reproducibility:** byte-identical `regime_params.json` across re-runs (verified at the JSON-writer test layer; full reproducibility check happens in Phase 3 via `diff` after running the wrapper twice).
+- **No-leakage:** strict `<` slicing in `_slice_below_cutoff` + manifest records MIN/MAX timestamps per (symbol, tf) for human-verifiable proof.
+- **Parity:** existing regime + backtest tests must pass without changes — defaults preserve legacy production behavior byte-for-byte.
+
+## Spec ref correction
+
+Spec D9 §2.10 cites `backtest.py:404-409` as the inline threshold site. That citation is stale — the real source-of-truth is `strategy/regime.py:_compute_local_regime` (~lines 174-179) and `strategy/regime.py:detect_regime` (~lines 372-377); backtest consumes the threshold via `_compute_local_regime` through `_regime_at_time`. Cosmetic doc rot, will be amended in a follow-up D9 edit.
+
+## References
+
+- Spec: `docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md` §2.10
+- Issue: #305
+- Sister mini-epic: A.4-1 PR #287 (gated on this one closing successfully)
+- Origin commit: `bf581f1` (sssamuelll, 2026-04-18)
+EOF
+)"
+```
+
+- [ ] **Step 4: Verify PR opened, capture URL**
+
+```bash
+gh pr view --web
+```
+
+---
+
+# PHASE 3 — Run the sweep
+
+**Pre-flight:** Phase 3 only runs after Phase 2 review by reviewer agent + Sam authorization (`dale`). Do NOT execute Phase 3 without explicit confirmation.
+
+## Task 12: Pre-run verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm clean working tree on the harness branch**
+
+```bash
+git status
+git branch --show-current
+```
+Expected: clean tree, branch = `feat/methodology-a4-1-5-regime-retune-pre-holdout`.
+
+- [ ] **Step 2: Confirm OHLCV DB exists + capture its hash**
+
+```bash
+ls -lh data/ohlcv.db
+shasum -a 256 data/ohlcv.db
+```
+
+- [ ] **Step 3: Confirm full test suite still passes**
+
+```bash
+python -m pytest tests/ -v 2>&1 | tail -30
+```
+
+---
+
+## Task 13: First run
+
+- [ ] **Step 1: Run the harness**
+
+```bash
+python -m tools.regime_retune_pre_holdout --max-date 2025-04-30 2>&1 | tee /tmp/a4_1_5_run1.log
+```
+
+Expected: rc=0 (or rc=3 if sanity_check fires — see decision flags step below).
+
+- [ ] **Step 2: Inspect outputs**
+
+```bash
+ls -la data/retune/$(date -u +%Y-%m-%d)-pre-holdout/
+cat data/retune/$(date -u +%Y-%m-%d)-pre-holdout/regime_params.json
+cat data/retune/$(date -u +%Y-%m-%d)-pre-holdout/regime_manifest.json | python -m json.tool | head -60
+```
+
+- [ ] **Step 3: Verify leakage_check**
+
+```bash
+python -c "import json; print(json.load(open('data/retune/$(date -u +%Y-%m-%d)-pre-holdout/regime_manifest.json'))['leakage_check'])"
+```
+Expected: `PASS`.
+
+---
+
+## Task 14: Reproducibility check
+
+- [ ] **Step 1: Re-run with a different out-dir**
+
+```bash
+python -m tools.regime_retune_pre_holdout \
+  --max-date 2025-04-30 \
+  --out-dir /tmp/a4_1_5_run2 2>&1 | tee /tmp/a4_1_5_run2.log
+```
+
+- [ ] **Step 2: Diff the regime_params.json — must be empty**
+
+```bash
+diff data/retune/$(date -u +%Y-%m-%d)-pre-holdout/regime_params.json /tmp/a4_1_5_run2/regime_params.json
+```
+Expected: no output (files byte-identical).
+
+If diff is non-empty: STOP. Investigate non-determinism before proceeding. Likely culprits: sort_keys missing, non-deterministic dict iteration in a writer, cached random state.
+
+---
+
+## Task 15: Independent SQL cross-check
+
+- [ ] **Step 1: Independent verification of no-leakage**
+
+```bash
+python << 'EOF'
+import sqlite3
+con = sqlite3.connect("data/ohlcv.db")
+cutoff_ms = 1745971200000  # 2025-04-30T00:00:00 UTC in milliseconds
+symbols = ["BTCUSDT","ETHUSDT","ADAUSDT","AVAXUSDT","DOGEUSDT",
+           "UNIUSDT","XLMUSDT","PENDLEUSDT","JUPUSDT","RUNEUSDT"]
+for sym in symbols:
+    for tf in ("5m","1h","4h","1d"):
+        row = con.execute(
+            "SELECT MAX(open_time) FROM ohlcv WHERE symbol=? AND timeframe=? AND open_time<?",
+            (sym, tf, cutoff_ms)
+        ).fetchone()
+        max_ts = row[0]
+        if max_ts is not None:
+            assert max_ts < cutoff_ms, f"LEAK: {sym} {tf} max_ts={max_ts} >= cutoff={cutoff_ms}"
+print("Independent SQL cross-check: PASS")
+EOF
+```
+Expected: `Independent SQL cross-check: PASS`.
+
+---
+
+## Task 16: Apply pre-registered decision flags
+
+- [ ] **Step 1: Read the flags from the manifest**
+
+```bash
+python -c "
+import json
+m = json.load(open('data/retune/$(date -u +%Y-%m-%d)-pre-holdout/regime_manifest.json'))
+print('Winner:        ', m['winner'])
+print('Runner-up:     ', m['runner_up'])
+print('Margin %:      ', m['winner_margin_pct'])
+print('Decision flags:', m['decision_flags'])
+print('Per-config:    ', m['per_config_pnl'])
+"
+```
+
+- [ ] **Step 2: Evaluate flags**
+
+| Flag | Trigger condition | Required action |
+|---|---|---|
+| **CHANGE detection** | winner != `60_40` | Document in PR body. NO auto-promote (Phase 5 is separate post-holdout PR). |
+| **Sanity check** | winner == `no_detector` | **HALT + DEBUG.** Do NOT commit the artefact. Report to reviewer with: per-symbol breakdown, dataset slice verification (manifest MIN/MAX timestamps), code-path validation (`grep -n "regime_disabled" backtest.py`). Do not proceed until root cause identified. |
+| **Stability check** | margin < 5% | Document as informational caveat in `regime_report.md` (the harness already does this). Note explicitly in the PR body that production decision should weigh qualitative tradeoffs. |
+
+- [ ] **Step 3: If sanity_check fires → STOP HERE**
+
+Surface to reviewer with the diagnostic info from Step 2's table. Do NOT proceed to Task 17 until the halt is resolved (either: bug found and fixed → re-run from Task 13; or, less likely: the result genuinely holds and reviewer + Sam authorize a separate path forward).
+
+---
+
+## Task 17: Long-form smoke (if applicable)
+
+- [ ] **Step 1: Check if a regime-path long-form smoke exists**
+
+```bash
+ls smokes/ 2>/dev/null | grep -i regime || echo "No regime smoke present; documenting in PR body and skipping."
+```
+
+- [ ] **Step 2: If a smoke exists, run it; otherwise note its absence in the PR body**
+
+If smoke exists: `bash smokes/<regime_smoke_script>.sh` and verify pass.
+If absent: add a one-liner to the Phase 3 PR commit body: "No long-form regime smoke present in `smokes/`; integration coverage relied on the `tests/test_simulate_strategy_regime_kwargs.py` parity tests + the harness's own end-to-end run."
+
+---
+
+## Task 18: Commit the artefact
+
+- [ ] **Step 1: Stage the artefact directory**
+
+```bash
+git add data/retune/$(date -u +%Y-%m-%d)-pre-holdout/
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+data(methodology): A.4-1.5 — regime threshold re-tune artefact
+
+Phase 3 output of A.4-1.5 mini-harness. Sweep of 4 configs
+(60/40, 70/30, 80/20, no_detector) over the pre-holdout window
+[earliest, 2025-04-30T00:00:00Z) on the 10 portfolio symbols.
+
+Winner: <REPLACE WITH actual winner from manifest>
+Margin to runner-up: <REPLACE WITH actual %>
+Decision flags: <REPLACE WITH actual flags>
+
+Reproducibility verified (run-twice diff empty). Independent SQL
+cross-check confirmed no-leakage. Manifest records ohlcv.db hash,
+code commit, per-symbol MIN/MAX timestamps strictly < cutoff.
+
+Refs #305 + spec D9 §2.10. Phase 4 review (R1+R2 multi-agent) follows.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+**REPLACE the bracketed placeholders before committing.**
+
+- [ ] **Step 3: Push**
+
+```bash
+git push
+```
+
+- [ ] **Step 4: Mark PR ready for review (only if you have explicit Sam authorization)**
+
+If Sam has authorized: `gh pr ready`.
+Otherwise: leave the PR in draft, surface the run results to the reviewer agent, await `dale` from Sam before marking ready.
+
+---
+
+# Verification gate (Phase 2 + 3 done — ALL of these)
+
+- [ ] Harness module exists with full test coverage (`tests/test_regime_retune_pre_holdout.py`)
+- [ ] Parity tests pass: legacy regime path byte-identical (`tests/test_regime_thresholds_param.py`, `tests/test_simulate_strategy_regime_kwargs.py`)
+- [ ] Guard B whitelist updated; `tests/test_holdout_isolation.py` AST scanner passes
+- [ ] Full test suite passing
+- [ ] Reproducibility: 2 consecutive runs → `diff regime_params.json` empty
+- [ ] Manifest MAX(open_time) strictly < `2025-04-30T00:00:00Z` for every (symbol, tf)
+- [ ] Independent SQL cross-check confirms no-leakage
+- [ ] `regime_params.json` shape correct (`regime_thresholds` dict OR `regime_disabled: true`)
+- [ ] Decision flags evaluated in `regime_report.md`
+- [ ] Sanity check NOT fired (or, if fired: halt + debug + report to reviewer instead of committing)
+
+---
+
+# Out-of-band notes for the dev
+
+1. **The kickoff prompt cited `backtest.py:404-409` for regime threshold inline. That citation is wrong** — that block is the trade-cost calculation. The real source-of-truth is `strategy/regime.py:_compute_local_regime` (lines ~174-179) and `strategy/regime.py:detect_regime` (lines ~372-377). The backtest path consumes `_compute_local_regime` via `_regime_at_time`. Document this discrepancy in the PR body so the spec ref doc-rot is captured for the cosmetic D9 follow-up.
+
+2. **`auto_tune.run_backtest_with_params` on `main` does NOT have `cutoff` / `_slice_below_cutoff`.** Those live on PR #287's branch. This plan deliberately builds a self-contained slicing path so A.4-1.5 doesn't depend on PR #287 (which is GATED on A.4-1.5 closing — circular dependency otherwise). Do not be tempted to import from `auto_tune` until both PRs have merged.
+
+3. **F&G + funding loaders are `backtest.get_historical_fear_greed()` and `backtest.get_historical_funding_rate()`** (the latter defined at `backtest.py:144`). Both are used by `auto_tune.run_backtest_with_params:179-180`. The harness imports them directly — no need to add new loaders. Do NOT modify `auto_tune.py`.
+
+4. **BYPASS patch lives in `strategy/core.py`** — `_regime_to_direction_token` (lines 124-134) plus the gating block at lines 341-354. Both edits are minimal (a new branch in the helper + extending two `in (...)` clauses). The "BYPASS" label propagates through `_regime_to_direction_token` → "ANY" token → gating logic permits direction by zone alone. Do not introduce a new direction token outside this path.
+
+5. **Decision flag escalation if sanity_check fires:** that configuration was last-place tied with `(80, 20)` in `bf581f1`. Winning over the pre-holdout-only window is high-probability bug, low-probability genuine result. Halt and ask the reviewer; do NOT commit the artefact.
+
+6. **Surface this plan to the reviewer agent for Sam authorization BEFORE Task 1.** Do not start coding until you have explicit `dale` from Sam.

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -11,9 +11,10 @@ notifications.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -121,22 +122,27 @@ def _score_label(score: int) -> str:
     return "INSUFICIENTE"
 
 
-def _regime_to_direction_token(regime_label: str | None) -> str:
-    """Map regime label → direction token used by scan().
+log = logging.getLogger("strategy.core")
 
-    Mirrors the logic in `btc_scanner.scan()`:
-        `regime = "LONG" if regime == "BULL" else "SHORT" if regime == "BEAR" else "LONG"`
-    i.e. both BULL and NEUTRAL/unknown allow LONG; only BEAR enables SHORT.
+KNOWN_REGIME_LABELS: frozenset[str] = frozenset({"BULL", "BEAR", "NEUTRAL", "BYPASS"})
+_unknown_regime_warned: set[str] = set()
 
-    A.4-1.5 (regime_disabled bypass): "BYPASS" → "ANY", which the gating
-    block treats as "permit either direction by zone alone" — used when the
-    regime detector is disabled to evaluate the no-detector configuration.
+
+def _regime_to_direction_token(regime_label: str | None) -> Literal["LONG", "SHORT", "ANY"]:
+    """Map regime label → direction token.
+
+    BEAR → SHORT, BYPASS → ANY (both directions permitted, gated by zone alone),
+    BULL/NEUTRAL/missing → LONG. Unknown labels emit a once-per-label warning
+    and fall back to LONG.
     """
+    if regime_label is not None and regime_label not in KNOWN_REGIME_LABELS:
+        if regime_label not in _unknown_regime_warned:
+            _unknown_regime_warned.add(regime_label)
+            log.warning("Unknown regime_label %r; falling back to LONG", regime_label)
     if regime_label == "BYPASS":
         return "ANY"
     if regime_label == "BEAR":
         return "SHORT"
-    # BULL, NEUTRAL, missing, or unknown all fall back to LONG-enabled
     return "LONG"
 
 
@@ -351,11 +357,10 @@ def evaluate_signal(
     regime_label = (regime or {}).get("regime")
     regime_token = _regime_to_direction_token(regime_label)
 
-    # LONG when in low zone AND regime is LONG or NEUTRAL (mapped to LONG).
-    # SHORT only when in high zone AND regime is BEAR → SHORT.
-    # ANY (BYPASS, A.4-1.5): direction follows zone alone.
+    # LONG when in low zone AND regime allows LONG (LONG or ANY).
+    # SHORT when in high zone AND regime allows SHORT (SHORT or ANY).
     # Everything else → NONE (middle band, or mismatched zone/regime pair).
-    if in_long_zone and regime_token in ("LONG", "NEUTRAL", "ANY"):
+    if in_long_zone and regime_token in ("LONG", "ANY"):
         direction = "LONG"
     elif in_short_zone and regime_token in ("SHORT", "ANY"):
         direction = "SHORT"

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -127,7 +127,13 @@ def _regime_to_direction_token(regime_label: str | None) -> str:
     Mirrors the logic in `btc_scanner.scan()`:
         `regime = "LONG" if regime == "BULL" else "SHORT" if regime == "BEAR" else "LONG"`
     i.e. both BULL and NEUTRAL/unknown allow LONG; only BEAR enables SHORT.
+
+    A.4-1.5 (regime_disabled bypass): "BYPASS" → "ANY", which the gating
+    block treats as "permit either direction by zone alone" — used when the
+    regime detector is disabled to evaluate the no-detector configuration.
     """
+    if regime_label == "BYPASS":
+        return "ANY"
     if regime_label == "BEAR":
         return "SHORT"
     # BULL, NEUTRAL, missing, or unknown all fall back to LONG-enabled
@@ -347,10 +353,11 @@ def evaluate_signal(
 
     # LONG when in low zone AND regime is LONG or NEUTRAL (mapped to LONG).
     # SHORT only when in high zone AND regime is BEAR → SHORT.
+    # ANY (BYPASS, A.4-1.5): direction follows zone alone.
     # Everything else → NONE (middle band, or mismatched zone/regime pair).
-    if in_long_zone and regime_token in ("LONG", "NEUTRAL"):
+    if in_long_zone and regime_token in ("LONG", "NEUTRAL", "ANY"):
         direction = "LONG"
-    elif in_short_zone and regime_token == "SHORT":
+    elif in_short_zone and regime_token in ("SHORT", "ANY"):
         direction = "SHORT"
     else:
         direction = "NONE"

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -273,8 +273,12 @@ def evaluate_signal(
             override resolution in `cfg["symbol_overrides"]`.
         cfg: Config dict (typically the merged `load_config()` result). Reads
             `symbol_overrides` for ATR multipliers.
-        regime: Regime detector output shape:
-            `{"regime": "BULL"|"BEAR"|"NEUTRAL", "score": float, "details": {}}`
+        regime: Regime detector output. Shape:
+            `{"regime": "BULL"|"BEAR"|"NEUTRAL"|"BYPASS",
+              "score": float | None,  # None when regime == "BYPASS"
+              ...}`
+            (Extra source-specific fields like `details` or `components` may
+            be present; this function only reads `regime["regime"]`.)
         health_state: Kill-switch tier for this symbol. Currently PAUSED short-
             circuits to NONE; other tiers affect size (handled by caller).
         now: Timestamp context (not currently used inside the pure function;

--- a/strategy/regime.py
+++ b/strategy/regime.py
@@ -280,7 +280,7 @@ def detect_regime_for_symbol(symbol: str | None, mode: str = "global") -> dict:
     return result
 
 
-def detect_regime() -> dict:
+def detect_regime(*, bull_above: int = 60, bear_below: int = 40) -> dict:
     """
     Composite market regime detection. Combines:
       - Price structure (40%): Death Cross + SMA200 position
@@ -288,8 +288,17 @@ def detect_regime() -> dict:
       - Market (30%): Binance funding rate
 
     Returns dict with regime ("BULL"/"BEAR"/"NEUTRAL"), score (0-100), details.
-    Score > 70 = BULL, Score < 30 = BEAR, 30-70 = NEUTRAL.
+    Score > bull_above → BULL; score < bear_below → BEAR; else NEUTRAL.
+
+    Defaults 60/40 preserve byte-identity to legacy production behavior.
+    Mirrors _compute_local_regime parameterization for the eventual
+    Phase 5 promotion of A.4-1.5's re-tune output.
     """
+    if not (bear_below < bull_above):
+        raise ValueError(
+            f"bear_below must be < bull_above (got bear_below={bear_below}, "
+            f"bull_above={bull_above})"
+        )
     details = {}
     score_components = []
 
@@ -379,9 +388,9 @@ def detect_regime() -> dict:
     composite = sum(s * w for _, s, w in score_components)
     composite = round(composite, 1)
 
-    if composite > 60:
+    if composite > bull_above:
         regime = "BULL"
-    elif composite < 40:
+    elif composite < bear_below:
         regime = "BEAR"
     else:
         regime = "NEUTRAL"

--- a/strategy/regime.py
+++ b/strategy/regime.py
@@ -143,6 +143,9 @@ def _compute_local_regime(
     funding_score: int,
     rsi_score: int = 50,
     adx_score: int = 50,
+    *,
+    bull_above: int = 60,
+    bear_below: int = 40,
 ) -> dict:
     """Compose final regime score per mode. Returns {ts, regime, score, mode, symbol, components}.
 
@@ -151,8 +154,15 @@ def _compute_local_regime(
       mode='hybrid':           50% price + 25% F&G + 25% funding
       mode='hybrid_momentum':  30% price + 15% RSI + 20% ADX + 20% F&G + 15% funding
 
-    Thresholds: score > 60 = BULL; score < 40 = BEAR; else NEUTRAL.
+    Thresholds: score > bull_above → BULL; score < bear_below → BEAR; else NEUTRAL.
+    Defaults 60/40 preserve byte-identity to legacy production behavior. A.4-1.5
+    sweeps these via the regime_retune_pre_holdout harness.
     """
+    if not (bear_below < bull_above):
+        raise ValueError(
+            f"bear_below must be < bull_above (got bear_below={bear_below}, "
+            f"bull_above={bull_above})"
+        )
     price_score = _compute_price_score(df_daily_sym)
 
     if mode == "global":
@@ -171,9 +181,9 @@ def _compute_local_regime(
     else:
         raise ValueError(f"Unknown regime mode: {mode}")
 
-    if composite > 60:
+    if composite > bull_above:
         regime = "BULL"
-    elif composite < 40:
+    elif composite < bear_below:
         regime = "BEAR"
     else:
         regime = "NEUTRAL"

--- a/strategy/regime.py
+++ b/strategy/regime.py
@@ -155,8 +155,7 @@ def _compute_local_regime(
       mode='hybrid_momentum':  30% price + 15% RSI + 20% ADX + 20% F&G + 15% funding
 
     Thresholds: score > bull_above → BULL; score < bear_below → BEAR; else NEUTRAL.
-    Defaults 60/40 preserve byte-identity to legacy production behavior. A.4-1.5
-    sweeps these via the regime_retune_pre_holdout harness.
+    Defaults 60/40 preserve byte-identity to legacy production behavior.
     """
     if not (bear_below < bull_above):
         raise ValueError(
@@ -280,7 +279,7 @@ def detect_regime_for_symbol(symbol: str | None, mode: str = "global") -> dict:
     return result
 
 
-def detect_regime(*, bull_above: int = 60, bear_below: int = 40) -> dict:
+def detect_regime() -> dict:
     """
     Composite market regime detection. Combines:
       - Price structure (40%): Death Cross + SMA200 position
@@ -288,17 +287,8 @@ def detect_regime(*, bull_above: int = 60, bear_below: int = 40) -> dict:
       - Market (30%): Binance funding rate
 
     Returns dict with regime ("BULL"/"BEAR"/"NEUTRAL"), score (0-100), details.
-    Score > bull_above → BULL; score < bear_below → BEAR; else NEUTRAL.
-
-    Defaults 60/40 preserve byte-identity to legacy production behavior.
-    Mirrors _compute_local_regime parameterization for the eventual
-    Phase 5 promotion of A.4-1.5's re-tune output.
+    Score > 60 = BULL, Score < 40 = BEAR, 40-60 = NEUTRAL.
     """
-    if not (bear_below < bull_above):
-        raise ValueError(
-            f"bear_below must be < bull_above (got bear_below={bear_below}, "
-            f"bull_above={bull_above})"
-        )
     details = {}
     score_components = []
 
@@ -388,9 +378,9 @@ def detect_regime(*, bull_above: int = 60, bear_below: int = 40) -> dict:
     composite = sum(s * w for _, s, w in score_components)
     composite = round(composite, 1)
 
-    if composite > bull_above:
+    if composite > 60:
         regime = "BULL"
-    elif composite < bear_below:
+    elif composite < 40:
         regime = "BEAR"
     else:
         regime = "NEUTRAL"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,24 @@ if TESTS_DIR not in sys.path:
     sys.path.insert(0, TESTS_DIR)
 
 
+@pytest.fixture(autouse=True)
+def _reset_unknown_regime_warned():
+    """Auto-clear strategy.core._unknown_regime_warned between tests so the
+    once-per-label warning suppression doesn't leak state across test runs.
+    Imported lazily so this fixture costs nothing for tests that don't touch
+    strategy.core."""
+    try:
+        from strategy.core import _unknown_regime_warned
+    except ImportError:
+        yield
+        return
+    _unknown_regime_warned.clear()
+    try:
+        yield
+    finally:
+        _unknown_regime_warned.clear()
+
+
 # ─── Auth test setup (added 2026-04-29 with the JWT auth system) ───────────
 #
 # The auth middleware enforces JWT cookies on every non-public path. Without

--- a/tests/test_holdout_isolation.py
+++ b/tests/test_holdout_isolation.py
@@ -55,11 +55,9 @@ HOLDOUT_LEGITIMATE_MODULES: set[str] = {
     "scripts/lock_holdout.py",
     # this scanner — contains the patterns it looks for
     "tests/test_holdout_isolation.py",
-    # Regime threshold pre-holdout re-tune mini-harness (#305). Reads
-    # data/ohlcv.db only — does NOT read data/holdout/. Output dir name
-    # contains the literal '-pre-holdout' suffix for human discoverability;
-    # the AST scanner sees that string in the source and would flag it
-    # without this whitelist.
+    # Reads data/ohlcv.db only — does NOT read data/holdout/. Output dir
+    # name contains the literal '-pre-holdout' suffix which the AST scanner
+    # would otherwise flag.
     "tools/regime_retune_pre_holdout.py",
     # A.2 walk-forward harness modules and A.4 evaluation modules will be
     # added here when those tickets land.

--- a/tests/test_holdout_isolation.py
+++ b/tests/test_holdout_isolation.py
@@ -55,11 +55,11 @@ HOLDOUT_LEGITIMATE_MODULES: set[str] = {
     "scripts/lock_holdout.py",
     # this scanner — contains the patterns it looks for
     "tests/test_holdout_isolation.py",
-    # A.4-1.5 regime threshold pre-holdout re-tune mini-harness (#305).
-    # Reads data/ohlcv.db only — does NOT read data/holdout/. The output dir
-    # name contains the literal '-pre-holdout' suffix for human discoverability;
-    # the AST scanner sees that string in the source and would flag it without
-    # this whitelist. Sister module to tools/retune_pre_holdout.py (A.4-1, #287).
+    # Regime threshold pre-holdout re-tune mini-harness (#305). Reads
+    # data/ohlcv.db only — does NOT read data/holdout/. Output dir name
+    # contains the literal '-pre-holdout' suffix for human discoverability;
+    # the AST scanner sees that string in the source and would flag it
+    # without this whitelist.
     "tools/regime_retune_pre_holdout.py",
     # A.2 walk-forward harness modules and A.4 evaluation modules will be
     # added here when those tickets land.

--- a/tests/test_holdout_isolation.py
+++ b/tests/test_holdout_isolation.py
@@ -55,6 +55,12 @@ HOLDOUT_LEGITIMATE_MODULES: set[str] = {
     "scripts/lock_holdout.py",
     # this scanner — contains the patterns it looks for
     "tests/test_holdout_isolation.py",
+    # A.4-1.5 regime threshold pre-holdout re-tune mini-harness (#305).
+    # Reads data/ohlcv.db only — does NOT read data/holdout/. The output dir
+    # name contains the literal '-pre-holdout' suffix for human discoverability;
+    # the AST scanner sees that string in the source and would flag it without
+    # this whitelist. Sister module to tools/retune_pre_holdout.py (A.4-1, #287).
+    "tools/regime_retune_pre_holdout.py",
     # A.2 walk-forward harness modules and A.4 evaluation modules will be
     # added here when those tickets land.
 }

--- a/tests/test_regime_retune_pre_holdout.py
+++ b/tests/test_regime_retune_pre_holdout.py
@@ -347,3 +347,62 @@ class TestArtefactWriters:
         assert "Stability check" in report
         assert "BTCUSDT" in report
         assert "JUPUSDT" in report  # caveat mentioned
+
+
+class TestCLI:
+    def test_max_date_required(self):
+        with pytest.raises(SystemExit):
+            harness.main([])
+
+    def _common_stubs(self, monkeypatch, fake_run):
+        """Stub the slow / IO-bound parts of main() so tests can exercise control flow."""
+        original_exists = os.path.exists  # capture before patching
+
+        monkeypatch.setattr(harness, "_run_one_backtest", fake_run)
+        monkeypatch.setattr(harness, "_per_symbol_data_ranges",
+                            lambda *a, **kw: {sym: {} for sym in harness._get_symbols()})
+        monkeypatch.setattr(harness, "_verify_no_leakage", lambda *a, **kw: "PASS")
+        monkeypatch.setattr(harness, "_sha256_file", lambda *a, **kw: "deadbeef")
+        monkeypatch.setattr(harness, "_resolve_git_commit", lambda: "abcdef0")
+        monkeypatch.setattr(harness, "_load_config", lambda: {"symbol_overrides": {}})
+        # Force the OHLCV_DB existence check to pass without reaching the filesystem.
+        monkeypatch.setattr(harness.os.path, "exists",
+                            lambda p: True if p == harness.OHLCV_DB else original_exists(p))
+
+    def test_full_run_with_stubs(self, monkeypatch, tmp_path):
+        """End-to-end CLI run with stubbed _run_one_backtest. 60_40 wins."""
+        def fake_run(symbol, config, cutoff, app_config=None):
+            pnl_map = {"60_40": 200.0, "70_30": 100.0, "80_20": 50.0, "no_detector": 30.0}
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": pnl_map[config["name"]], "trades": 1, "error": None}
+
+        self._common_stubs(monkeypatch, fake_run)
+
+        rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        assert rc == 0
+        assert (tmp_path / "regime_params.json").exists()
+        assert (tmp_path / "regime_manifest.json").exists()
+        assert (tmp_path / "regime_report.md").exists()
+
+        params = json.loads((tmp_path / "regime_params.json").read_text())
+        assert params == {"format_version": 1,
+                          "regime_thresholds": {"bull_above": 60, "bear_below": 40}}
+
+    def test_sanity_check_returns_rc_3(self, monkeypatch, tmp_path):
+        """When no_detector wins, main() returns 3 (HALT signal)."""
+        def fake_run(symbol, config, cutoff, app_config=None):
+            pnl_map = {"60_40": 50.0, "70_30": 30.0, "80_20": 20.0, "no_detector": 200.0}
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": pnl_map[config["name"]], "trades": 1, "error": None}
+
+        self._common_stubs(monkeypatch, fake_run)
+
+        rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        assert rc == 3
+
+    def test_missing_ohlcv_db_returns_rc_2(self, monkeypatch, tmp_path):
+        original_exists = os.path.exists
+        monkeypatch.setattr(harness.os.path, "exists",
+                            lambda p: False if p == harness.OHLCV_DB else original_exists(p))
+        rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        assert rc == 2

--- a/tests/test_regime_retune_pre_holdout.py
+++ b/tests/test_regime_retune_pre_holdout.py
@@ -1,4 +1,4 @@
-"""Tests for the A.4-1.5 regime threshold pre-holdout re-tune harness."""
+"""Tests for the regime threshold pre-holdout re-tune harness."""
 import json
 import os
 from datetime import datetime, timezone
@@ -511,3 +511,136 @@ class TestCLI:
 
         with pytest.raises(FileNotFoundError, match="config.json not found"):
             harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+
+    def test_stale_canonical_artefacts_removed_on_rerun(self, monkeypatch, tmp_path):
+        """Run-1 success → run-2 halt: stale regime_params.json must NOT survive."""
+        # Pre-seed run-1 canonical artefacts.
+        (tmp_path / "regime_params.json").write_text('{"stale": "from_run1"}')
+        (tmp_path / "regime_manifest.json").write_text('{"stale": "from_run1"}')
+        (tmp_path / "regime_report.md").write_text("stale run-1 content")
+        (tmp_path / "leftover.tmp").write_text("orphan tmp")
+
+        # Run-2 setup: no_detector wins → halt branch.
+        def fake_run(symbol, config, cutoff, app_config=None):
+            pnl_map = {"60_40": 50.0, "70_30": 30.0, "80_20": 20.0, "no_detector": 200.0}
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": pnl_map[config["name"]], "trades": 1, "error": None}
+
+        self._common_stubs(monkeypatch, fake_run)
+
+        rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        assert rc == 3
+        # Stale canonical artefacts MUST be cleaned up.
+        assert not (tmp_path / "regime_params.json").exists()
+        assert not (tmp_path / "regime_manifest.json").exists()
+        assert not (tmp_path / "regime_report.md").exists()
+        # Orphan tmp files cleaned.
+        assert not (tmp_path / "leftover.tmp").exists()
+        # Halted summary IS written.
+        assert (tmp_path / "halted_summary.json").exists()
+
+    def test_halted_summary_includes_report_md(self, monkeypatch, tmp_path):
+        """halted_summary.json must include the rendered report markdown."""
+        def fake_run(symbol, config, cutoff, app_config=None):
+            pnl_map = {"60_40": 50.0, "70_30": 30.0, "80_20": 20.0, "no_detector": 200.0}
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": pnl_map[config["name"]], "trades": 1, "error": None}
+
+        self._common_stubs(monkeypatch, fake_run)
+        harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        halted = json.loads((tmp_path / "halted_summary.json").read_text())
+        assert "report_md" in halted
+        assert "Pre-holdout Regime Threshold Re-tune Report" in halted["report_md"]
+
+
+class TestEmergencyWrite:
+    def test_emergency_write_falls_back_to_tmp_on_oserror(self, monkeypatch, tmp_path, caplog):
+        """When primary atomic write fails, _emergency_write must fall back to /tmp."""
+        bad_path = str(tmp_path / "nonexistent_subdir" / "x.json")  # missing parent
+        with caplog.at_level("ERROR"):
+            harness._emergency_write(bad_path, {"k": "v"}, kind="test_kind")
+        # Primary path didn't exist, fallback should have been attempted.
+        assert any("Failed to write test_kind" in r.message for r in caplog.records)
+
+    def test_emergency_write_does_not_raise_on_unserializable(self, tmp_path):
+        """Non-serializable payloads must not crash the harness."""
+        path = str(tmp_path / "out.json")
+        # Class instances aren't JSON serializable by default; default=str in
+        # the fallback handles them. Primary atomic_write_json will fail; that's
+        # the path we're exercising.
+        class Foo:
+            pass
+        # Should not raise, even if the fallback also can't serialize.
+        harness._emergency_write(path, {"obj": Foo()}, kind="test_kind")
+
+
+class TestLoadConfigEmptyOverrides:
+    def test_empty_overrides_raises(self, tmp_path, monkeypatch):
+        """_load_config raises ValueError when symbol_overrides is empty."""
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"webhook_url": "x", "symbol_overrides": {}}))
+        monkeypatch.setattr(harness, "REPO_ROOT", str(tmp_path))
+        with pytest.raises(ValueError, match="symbol_overrides"):
+            harness._load_config()
+
+    def test_missing_overrides_key_raises(self, tmp_path, monkeypatch):
+        """_load_config raises ValueError when symbol_overrides key absent."""
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({"webhook_url": "x"}))
+        monkeypatch.setattr(harness, "REPO_ROOT", str(tmp_path))
+        with pytest.raises(ValueError, match="symbol_overrides"):
+            harness._load_config()
+
+    def test_non_empty_overrides_passes(self, tmp_path, monkeypatch):
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps({
+            "symbol_overrides": {"BTCUSDT": {"atr_sl_mult": 1.0}}
+        }))
+        monkeypatch.setattr(harness, "REPO_ROOT", str(tmp_path))
+        cfg = harness._load_config()
+        assert "BTCUSDT" in cfg["symbol_overrides"]
+
+
+class TestRegimeKwargErrorPropagates:
+    """RegimeKwargError is a programming-error exception; the harness's narrow
+    catch (ValueError, AssertionError) must NOT swallow it — it must propagate
+    out of _run_one_backtest so the operator sees the bug."""
+
+    def test_regime_kwarg_error_propagates_from_run_one_backtest(self, monkeypatch):
+        from backtest import RegimeKwargError
+        idx = pd.date_range("2024-01-01", periods=10, freq="1h", tz="UTC")
+        stub_frames = {
+            "df1h": pd.DataFrame({"close": [1.0]*10, "volume": [1.0]*10}, index=idx),
+            "df4h": pd.DataFrame({"close": [1.0]*10, "volume": [1.0]*10}, index=idx),
+            "df5m": pd.DataFrame({"close": [1.0]*10, "volume": [1.0]*10}, index=idx),
+            "df1d": pd.DataFrame({"close": [1.0]*10}, index=idx),
+            "df1d_btc": pd.DataFrame({"close": [1.0]*10}, index=idx),
+            "df_fng": pd.DataFrame({"fng": [50]*10}, index=idx),
+            "df_funding": pd.DataFrame({"rate": [0.0]*10}, index=idx),
+        }
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: stub_frames)
+
+        def fake_simulate(*args, **kwargs):
+            raise RegimeKwargError("bad combo")
+
+        import backtest
+        monkeypatch.setattr(backtest, "simulate_strategy", fake_simulate)
+
+        cfg = {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False}
+        with pytest.raises(RegimeKwargError):
+            harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                       app_config={"symbol_overrides": {"BTCUSDT": {}}})
+
+
+class TestAggregateZeroPnl:
+    def test_degenerate_zero_pnl_flag(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": 0, "trades": 0, "error": None}
+                 for c in ("60_40", "70_30", "80_20", "no_detector")]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["degenerate_zero_pnl"] is True
+
+    def test_degenerate_zero_pnl_flag_inactive_when_any_nonzero(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 100), ("70_30", 50), ("80_20", 30), ("no_detector", 20)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["degenerate_zero_pnl"] is False

--- a/tests/test_regime_retune_pre_holdout.py
+++ b/tests/test_regime_retune_pre_holdout.py
@@ -1,0 +1,349 @@
+"""Tests for the A.4-1.5 regime threshold pre-holdout re-tune harness."""
+import json
+import os
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+from tools import regime_retune_pre_holdout as harness
+
+
+class TestGrid:
+    def test_grid_has_exactly_4_configs(self):
+        assert len(harness.GRID) == 4
+
+    def test_grid_locked_by_historical_record(self):
+        # Per spec D9 §2.10 + commit bf581f1 body
+        assert harness.GRID == [
+            {"name": "60_40",       "bull_above": 60,   "bear_below": 40,   "disabled": False},
+            {"name": "70_30",       "bull_above": 70,   "bear_below": 30,   "disabled": False},
+            {"name": "80_20",       "bull_above": 80,   "bear_below": 20,   "disabled": False},
+            {"name": "no_detector", "bull_above": None, "bear_below": None, "disabled": True},
+        ]
+
+
+class TestSliceBelowCutoff:
+    def test_slice_strict_less_than(self):
+        idx = pd.date_range("2025-04-29 23:55", periods=4, freq="5min", tz="UTC")
+        df = pd.DataFrame({"close": [1, 2, 3, 4]}, index=idx)
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        sliced = harness._slice_below_cutoff(df, cutoff)
+        assert len(sliced) == 1
+        assert sliced.index[0] == pd.Timestamp("2025-04-29 23:55", tz="UTC")
+
+    def test_slice_empty_input(self):
+        df = pd.DataFrame({"close": []})
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        out = harness._slice_below_cutoff(df, cutoff)
+        assert out.empty
+
+    def test_slice_all_after_cutoff_returns_empty(self):
+        idx = pd.date_range("2025-04-30 00:00", periods=2, freq="5min", tz="UTC")
+        df = pd.DataFrame({"close": [1, 2]}, index=idx)
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        out = harness._slice_below_cutoff(df, cutoff)
+        assert out.empty
+
+    def test_slice_naive_index_with_aware_cutoff(self):
+        # Index without timezone (some loaders strip tz); cutoff has tz.
+        idx = pd.date_range("2025-04-29 12:00", periods=3, freq="1h")
+        df = pd.DataFrame({"close": [1, 2, 3]}, index=idx)
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        out = harness._slice_below_cutoff(df, cutoff)
+        assert len(out) == 3  # all bars before cutoff
+
+
+class TestVerifyNoLeakage:
+    def test_pass_when_all_below_cutoff(self):
+        ranges = {
+            "BTCUSDT": {"1h": {"max_ts_ms": 1000, "min_ts_ms": 100, "count": 10}},
+        }
+        assert harness._verify_no_leakage(ranges, cutoff_ms=2000) == "PASS"
+
+    def test_raises_when_leakage_present(self):
+        ranges = {
+            "BTCUSDT": {"1h": {"max_ts_ms": 3000, "min_ts_ms": 100, "count": 10}},
+        }
+        with pytest.raises(AssertionError, match="no-leakage violation"):
+            harness._verify_no_leakage(ranges, cutoff_ms=2000)
+
+    def test_pass_when_count_zero(self):
+        ranges = {
+            "BTCUSDT": {"1h": {"max_ts_ms": None, "min_ts_ms": None, "count": 0}},
+        }
+        assert harness._verify_no_leakage(ranges, cutoff_ms=2000) == "PASS"
+
+
+class TestRunOneBacktest:
+    @pytest.fixture
+    def stub_frames(self):
+        # Non-empty frames so the early-empty guard doesn't short-circuit.
+        idx = pd.date_range("2024-01-01", periods=10, freq="1h", tz="UTC")
+        return {
+            "df1h": pd.DataFrame({"close": [1.0]*10, "volume": [1.0]*10}, index=idx),
+            "df4h": pd.DataFrame({"close": [1.0]*10, "volume": [1.0]*10}, index=idx),
+            "df5m": pd.DataFrame({"close": [1.0]*10, "volume": [1.0]*10}, index=idx),
+            "df1d": pd.DataFrame({"close": [1.0]*10}, index=idx),
+            "df1d_btc": pd.DataFrame({"close": [1.0]*10}, index=idx),
+            "df_fng": pd.DataFrame({"fng": [50]*10}, index=idx),
+            "df_funding": pd.DataFrame({"rate": [0.0]*10}, index=idx),
+        }
+
+    def test_disabled_config_passes_regime_disabled_true(self, monkeypatch, stub_frames):
+        captured = {}
+
+        def fake_simulate(*args, **kwargs):
+            captured.update(kwargs)
+            return [], None  # (trades, equity)
+
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: stub_frames)
+        # simulate_strategy is imported inside _run_one_backtest, so patch backtest module.
+        import backtest
+        monkeypatch.setattr(backtest, "simulate_strategy", fake_simulate)
+
+        cfg = {"name": "no_detector", "bull_above": None, "bear_below": None, "disabled": True}
+        result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                            app_config={"symbol_overrides": {}})
+        assert result["net_pnl"] == 0.0
+        assert result["trades"] == 0
+        assert captured.get("regime_disabled") is True
+        assert "regime_thresholds" not in captured
+
+    def test_60_40_config_passes_regime_thresholds_60_40(self, monkeypatch, stub_frames):
+        captured = {}
+
+        def fake_simulate(*args, **kwargs):
+            captured.update(kwargs)
+            return [{"pnl_usd": 100.0}, {"pnl_usd": -25.5}], None
+
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: stub_frames)
+        import backtest
+        monkeypatch.setattr(backtest, "simulate_strategy", fake_simulate)
+
+        cfg = {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False}
+        result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                            app_config={"symbol_overrides": {}})
+        assert result["net_pnl"] == 74.5
+        assert result["trades"] == 2
+        assert captured.get("regime_disabled") is False or "regime_disabled" not in captured
+        assert captured.get("regime_thresholds") == (60, 40)
+
+    def test_70_30_config_forwards_thresholds(self, monkeypatch, stub_frames):
+        captured = {}
+
+        def fake_simulate(*args, **kwargs):
+            captured.update(kwargs)
+            return [], None
+
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: stub_frames)
+        import backtest
+        monkeypatch.setattr(backtest, "simulate_strategy", fake_simulate)
+
+        cfg = {"name": "70_30", "bull_above": 70, "bear_below": 30, "disabled": False}
+        harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                   app_config={"symbol_overrides": {}})
+        assert captured.get("regime_thresholds") == (70, 30)
+
+    def test_empty_frames_short_circuit(self, monkeypatch):
+        empty_frames = {
+            "df1h": pd.DataFrame({"close": []}),
+            "df4h": pd.DataFrame({"close": []}),
+            "df5m": pd.DataFrame({"close": []}),
+            "df1d": pd.DataFrame({"close": []}),
+            "df1d_btc": pd.DataFrame({"close": []}),
+            "df_fng": pd.DataFrame({"fng": []}),
+            "df_funding": pd.DataFrame({"rate": []}),
+        }
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: empty_frames)
+
+        cfg = {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False}
+        result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                            app_config={})
+        assert result["net_pnl"] == 0.0
+        assert result["trades"] == 0
+        assert result["error"] == "empty_ohlcv_below_cutoff"
+
+    def test_simulate_exception_caught_and_logged(self, monkeypatch, stub_frames):
+        def fake_simulate(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: stub_frames)
+        import backtest
+        monkeypatch.setattr(backtest, "simulate_strategy", fake_simulate)
+
+        cfg = {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False}
+        result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                            app_config={})
+        assert result["net_pnl"] == 0.0
+        assert result["trades"] == 0
+        assert "boom" in result["error"]
+
+
+class TestAggregate:
+    def test_aggregate_picks_winner(self):
+        cells = [
+            {"symbol": "BTC", "config": "60_40", "net_pnl": 100.0, "trades": 5, "error": None},
+            {"symbol": "ETH", "config": "60_40", "net_pnl": 50.0,  "trades": 3, "error": None},
+            {"symbol": "BTC", "config": "70_30", "net_pnl": 120.0, "trades": 4, "error": None},
+            {"symbol": "ETH", "config": "70_30", "net_pnl": 60.0,  "trades": 3, "error": None},
+            {"symbol": "BTC", "config": "80_20", "net_pnl": 80.0,  "trades": 2, "error": None},
+            {"symbol": "ETH", "config": "80_20", "net_pnl": 40.0,  "trades": 2, "error": None},
+            {"symbol": "BTC", "config": "no_detector", "net_pnl": 70.0, "trades": 6, "error": None},
+            {"symbol": "ETH", "config": "no_detector", "net_pnl": 30.0, "trades": 4, "error": None},
+        ]
+        agg = harness._aggregate_results(cells)
+        assert agg["per_config_pnl"]["60_40"]       == 150.0
+        assert agg["per_config_pnl"]["70_30"]       == 180.0
+        assert agg["per_config_pnl"]["80_20"]       == 120.0
+        assert agg["per_config_pnl"]["no_detector"] == 100.0
+        assert agg["winner"] == "70_30"
+        assert agg["runner_up"] == "60_40"
+        assert abs(agg["winner_margin_pct"] - (30.0 / 180.0 * 100)) < 1e-6
+
+    def test_decision_flag_change_detection(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 50), ("70_30", 100), ("80_20", 30), ("no_detector", 20)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["change_detection"] is True
+        assert agg["winner"] == "70_30"
+
+    def test_decision_flag_sanity_check_fires_on_no_detector_winner(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 50), ("70_30", 30), ("80_20", 20), ("no_detector", 200)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["sanity_check"] is True
+        assert agg["winner"] == "no_detector"
+
+    def test_decision_flag_stability_check_fires_within_5_pct(self):
+        # winner=180, runner_up=178 → margin = 2/180 = 1.11% < 5%
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 178), ("70_30", 180), ("80_20", 100), ("no_detector", 50)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["stability_check"] is True
+
+    def test_decision_flag_stability_check_inactive_when_margin_large(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 100), ("70_30", 200), ("80_20", 50), ("no_detector", 30)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["stability_check"] is False
+
+    def test_60_40_winner_no_change_flag(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": pnl, "trades": 1, "error": None}
+                 for c, pnl in [("60_40", 200), ("70_30", 100), ("80_20", 50), ("no_detector", 30)]]
+        agg = harness._aggregate_results(cells)
+        assert agg["decision_flags"]["change_detection"] is False
+        assert agg["winner"] == "60_40"
+
+    def test_tie_break_on_lex_order(self):
+        # All equal → winner is lex-first ("60_40")
+        cells = [{"symbol": "X", "config": c, "net_pnl": 100, "trades": 1, "error": None}
+                 for c in ("60_40", "70_30", "80_20", "no_detector")]
+        agg = harness._aggregate_results(cells)
+        assert agg["winner"] == "60_40"
+
+    def test_zero_winner_pnl_yields_zero_margin(self):
+        cells = [{"symbol": "X", "config": c, "net_pnl": 0, "trades": 0, "error": None}
+                 for c in ("60_40", "70_30", "80_20", "no_detector")]
+        agg = harness._aggregate_results(cells)
+        assert agg["winner_margin_pct"] == 0.0
+
+
+class TestArtefactWriters:
+    def _make_agg(self, winner="70_30", winner_pnl=180.0):
+        return {
+            "winner": winner,
+            "winner_pnl": winner_pnl,
+            "runner_up": "60_40",
+            "runner_up_pnl": 150.0,
+            "winner_margin_pct": (winner_pnl - 150.0) / abs(winner_pnl) * 100 if winner_pnl else 0.0,
+            "per_config_pnl": {"60_40": 150.0, "70_30": 180.0, "80_20": 120.0, "no_detector": 100.0},
+            "per_config_trades": {"60_40": 8, "70_30": 7, "80_20": 4, "no_detector": 10},
+            "decision_flags": {"change_detection": True, "sanity_check": False, "stability_check": False},
+        }
+
+    def test_regime_params_for_threshold_winner(self, tmp_path):
+        path = tmp_path / "regime_params.json"
+        harness._write_regime_params(str(path), self._make_agg(winner="70_30"))
+        payload = json.loads(path.read_text())
+        assert payload == {
+            "format_version": 1,
+            "regime_thresholds": {"bull_above": 70, "bear_below": 30},
+        }
+
+    def test_regime_params_for_60_40_winner(self, tmp_path):
+        path = tmp_path / "regime_params.json"
+        harness._write_regime_params(str(path), self._make_agg(winner="60_40"))
+        payload = json.loads(path.read_text())
+        assert payload == {
+            "format_version": 1,
+            "regime_thresholds": {"bull_above": 60, "bear_below": 40},
+        }
+
+    def test_regime_params_for_80_20_winner(self, tmp_path):
+        path = tmp_path / "regime_params.json"
+        harness._write_regime_params(str(path), self._make_agg(winner="80_20"))
+        payload = json.loads(path.read_text())
+        assert payload == {
+            "format_version": 1,
+            "regime_thresholds": {"bull_above": 80, "bear_below": 20},
+        }
+
+    def test_regime_params_for_no_detector_winner(self, tmp_path):
+        path = tmp_path / "regime_params.json"
+        harness._write_regime_params(str(path), self._make_agg(winner="no_detector"))
+        payload = json.loads(path.read_text())
+        assert payload == {
+            "format_version": 1,
+            "regime_disabled": True,
+        }
+
+    def test_regime_params_byte_deterministic_across_runs(self, tmp_path):
+        agg = self._make_agg(winner="60_40")
+        path1 = tmp_path / "p1.json"
+        path2 = tmp_path / "p2.json"
+        harness._write_regime_params(str(path1), agg)
+        harness._write_regime_params(str(path2), agg)
+        assert path1.read_bytes() == path2.read_bytes()
+
+    def test_manifest_byte_deterministic_across_runs(self, tmp_path):
+        agg = self._make_agg(winner="60_40")
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        # ran_at_iso varies per call — must be excluded from byte-comparison.
+        m1 = harness._build_manifest(agg=agg, cutoff=cutoff, cutoff_ms=1000,
+                                      ohlcv_sha="abc", code_commit="def",
+                                      ranges={}, runtime_seconds=1.0,
+                                      leakage_check="PASS", symbols=["BTC"])
+        m2 = harness._build_manifest(agg=agg, cutoff=cutoff, cutoff_ms=1000,
+                                      ohlcv_sha="abc", code_commit="def",
+                                      ranges={}, runtime_seconds=1.0,
+                                      leakage_check="PASS", symbols=["BTC"])
+        # Strip ran_at_iso for the comparison
+        m1.pop("ran_at_iso")
+        m2.pop("ran_at_iso")
+        path1 = tmp_path / "m1.json"
+        path2 = tmp_path / "m2.json"
+        harness._atomic_write_json(str(path1), m1)
+        harness._atomic_write_json(str(path2), m2)
+        assert path1.read_bytes() == path2.read_bytes()
+
+    def test_report_renders_winner_marker_and_flags(self, tmp_path):
+        agg = self._make_agg(winner="70_30")
+        cells = [
+            {"symbol": "BTCUSDT", "config": "60_40", "net_pnl": 100.0, "trades": 4, "error": None},
+            {"symbol": "BTCUSDT", "config": "70_30", "net_pnl": 120.0, "trades": 3, "error": None},
+            {"symbol": "BTCUSDT", "config": "80_20", "net_pnl": 80.0, "trades": 2, "error": None},
+            {"symbol": "BTCUSDT", "config": "no_detector", "net_pnl": 70.0, "trades": 5, "error": None},
+        ]
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        ranges = {"BTCUSDT": {tf: {"min_ts_iso": "2023-01-01", "max_ts_iso": "2025-04-29",
+                                     "count": 100} for tf in harness.TIMEFRAMES}}
+        report = harness._build_report(agg=agg, cells=cells, cutoff=cutoff,
+                                        ranges=ranges, runtime_seconds=42.0, symbols=["BTCUSDT"])
+        assert "**winner**" in report
+        assert "70_30" in report
+        assert "CHANGE detection" in report
+        assert "Sanity check" in report
+        assert "Stability check" in report
+        assert "BTCUSDT" in report
+        assert "JUPUSDT" in report  # caveat mentioned

--- a/tests/test_regime_retune_pre_holdout.py
+++ b/tests/test_regime_retune_pre_holdout.py
@@ -552,6 +552,112 @@ class TestCLI:
         assert "report_md" in halted
         assert "Pre-holdout Regime Threshold Re-tune Report" in halted["report_md"]
 
+    def test_degenerate_zero_pnl_returns_rc_6_and_refuses_canonical_artefacts(
+            self, monkeypatch, tmp_path):
+        """When all per-config sums ≈ 0, refuse canonical writes; rc=6, halted_summary present."""
+        def fake_run(symbol, config, cutoff, app_config=None):
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": 0.0, "trades": 0, "error": None}
+
+        self._common_stubs(monkeypatch, fake_run)
+
+        rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        assert rc == 6
+        assert not (tmp_path / "regime_params.json").exists()
+        assert not (tmp_path / "regime_manifest.json").exists()
+        assert not (tmp_path / "regime_report.md").exists()
+        assert (tmp_path / "halted_summary.json").exists()
+        halted = json.loads((tmp_path / "halted_summary.json").read_text())
+        assert halted["reason"] == "degenerate_zero_pnl"
+        assert "report_md" in halted
+
+    def test_sanity_takes_priority_over_degenerate(self, monkeypatch, tmp_path):
+        """If both flags would fire (no_detector wins AND all sums tiny), sanity wins (rc=3)."""
+        # All cells effectively zero except no_detector winning by 1e-12.
+        # In practice all_zero check uses 1e-9 threshold, so 1e-12 still triggers degenerate.
+        # We engineer a case where degenerate_zero_pnl=True AND winner=no_detector.
+        def fake_run(symbol, config, cutoff, app_config=None):
+            # All zero across the board → all_zero=True. Sanity check fires when
+            # winner == "no_detector"; with all-zero PnL the winner is lex tie-break
+            # which is "60_40", NOT no_detector. So this scenario can't actually
+            # produce both flags via the realistic path.
+            # For the priority test, we instead verify sanity priority by mocking
+            # _aggregate_results to return both flags. Skip this engineered case
+            # in favor of a direct unit test on the priority order.
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": 0.0, "trades": 0, "error": None}
+
+        # Mock _aggregate_results to return both flags simultaneously.
+        original_aggregate = harness._aggregate_results
+
+        def both_flags_aggregate(cells):
+            agg = original_aggregate(cells)
+            agg["winner"] = "no_detector"
+            agg["decision_flags"]["sanity_check"] = True
+            agg["decision_flags"]["degenerate_zero_pnl"] = True
+            return agg
+
+        self._common_stubs(monkeypatch, fake_run)
+        monkeypatch.setattr(harness, "_aggregate_results", both_flags_aggregate)
+
+        rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        assert rc == 3, "sanity_check must take priority over degenerate_zero_pnl"
+        halted = json.loads((tmp_path / "halted_summary.json").read_text())
+        assert halted["reason"] == "sanity_check_fired"
+
+    def test_rc_5_on_canonical_write_failure(self, monkeypatch, tmp_path):
+        """Simulate _atomic_write_text raising on canonical writes; verify rc=5 +
+        raw_results.json fallback."""
+        def fake_run(symbol, config, cutoff, app_config=None):
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": 100.0, "trades": 1, "error": None}
+
+        self._common_stubs(monkeypatch, fake_run)
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        # Force the first canonical write (regime_report.md) to fail.
+        monkeypatch.setattr(harness, "_atomic_write_text", boom)
+
+        rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        assert rc == 5
+        # raw_results.json fallback (via _emergency_write) should land somewhere —
+        # either at out_dir or in /tmp. Verify out_dir path first; if absent the
+        # _emergency_write fallback in /tmp is acceptable per its contract.
+        # Here the OSError("disk full") only affects _atomic_write_text; the
+        # raw_results _emergency_write call uses _atomic_write_json which is NOT
+        # patched, so it should succeed at out_dir.
+        assert (tmp_path / "raw_results.json").exists()
+        raw = json.loads((tmp_path / "raw_results.json").read_text())
+        assert "cells" in raw
+        assert "agg" in raw
+
+    def test_degenerate_flag_rendered_in_report(self):
+        """_build_report must include degenerate_zero_pnl in the decision flags section."""
+        agg = {
+            "winner": "60_40", "winner_pnl": 0.0, "runner_up": "70_30",
+            "runner_up_pnl": 0.0, "winner_margin_pct": 0.0,
+            "per_config_pnl": {"60_40": 0.0, "70_30": 0.0, "80_20": 0.0, "no_detector": 0.0},
+            "per_config_trades": {"60_40": 0, "70_30": 0, "80_20": 0, "no_detector": 0},
+            "decision_flags": {
+                "change_detection": False,
+                "sanity_check": False,
+                "stability_check": True,
+                "degenerate_zero_pnl": True,
+            },
+        }
+        cells = [{"symbol": "BTCUSDT", "config": c, "net_pnl": 0.0, "trades": 0, "error": None}
+                 for c in ("60_40", "70_30", "80_20", "no_detector")]
+        cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        ranges = {"BTCUSDT": {tf: {"min_ts_iso": "—", "max_ts_iso": "—", "count": 0}
+                              for tf in harness.TIMEFRAMES}}
+        report = harness._build_report(agg=agg, cells=cells, cutoff=cutoff,
+                                        ranges=ranges, runtime_seconds=1.0,
+                                        symbols=["BTCUSDT"])
+        assert "Degenerate zero-pnl" in report
+        assert "lex tie-break" in report
+
 
 class TestEmergencyWrite:
     def test_emergency_write_falls_back_to_tmp_on_oserror(self, monkeypatch, tmp_path, caplog):

--- a/tests/test_regime_retune_pre_holdout.py
+++ b/tests/test_regime_retune_pre_holdout.py
@@ -126,7 +126,8 @@ class TestRunOneBacktest:
                                             app_config={"symbol_overrides": {}})
         assert result["net_pnl"] == 74.5
         assert result["trades"] == 2
-        assert captured.get("regime_disabled") is False or "regime_disabled" not in captured
+        # Threshold configs must NOT pass regime_disabled to simulate_strategy.
+        assert "regime_disabled" not in captured
         assert captured.get("regime_thresholds") == (60, 40)
 
     def test_70_30_config_forwards_thresholds(self, monkeypatch, stub_frames):
@@ -144,6 +145,7 @@ class TestRunOneBacktest:
         harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
                                    app_config={"symbol_overrides": {}})
         assert captured.get("regime_thresholds") == (70, 30)
+        assert "regime_disabled" not in captured
 
     def test_empty_frames_short_circuit(self, monkeypatch):
         empty_frames = {
@@ -164,20 +166,52 @@ class TestRunOneBacktest:
         assert result["trades"] == 0
         assert result["error"] == "empty_ohlcv_below_cutoff"
 
-    def test_simulate_exception_caught_and_logged(self, monkeypatch, stub_frames):
+    def test_io_error_caught_with_io_prefix_and_logged(self, monkeypatch, stub_frames, caplog):
+        import sqlite3 as sq
         def fake_simulate(*args, **kwargs):
-            raise RuntimeError("boom")
+            raise sq.DatabaseError("db locked")
 
         monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: stub_frames)
         import backtest
         monkeypatch.setattr(backtest, "simulate_strategy", fake_simulate)
 
         cfg = {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False}
-        result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
-                                            app_config={})
+        with caplog.at_level("ERROR"):
+            result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                                app_config={})
         assert result["net_pnl"] == 0.0
         assert result["trades"] == 0
-        assert "boom" in result["error"]
+        assert result["error"].startswith("io:")
+        assert any("I/O failure" in rec.message for rec in caplog.records)
+
+    def test_data_error_caught_with_data_prefix_and_logged(self, monkeypatch, stub_frames, caplog):
+        def fake_simulate(*args, **kwargs):
+            raise ValueError("bad input")
+
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: stub_frames)
+        import backtest
+        monkeypatch.setattr(backtest, "simulate_strategy", fake_simulate)
+
+        cfg = {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False}
+        with caplog.at_level("WARNING"):
+            result = harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                                app_config={})
+        assert result["error"].startswith("data:")
+        assert any("data/assertion error" in rec.message for rec in caplog.records)
+
+    def test_programming_errors_propagate(self, monkeypatch, stub_frames):
+        """AttributeError / KeyError / TypeError must propagate (not be swallowed)."""
+        def fake_simulate(*args, **kwargs):
+            raise AttributeError("typo")
+
+        monkeypatch.setattr(harness, "_load_frames", lambda sym, cutoff: stub_frames)
+        import backtest
+        monkeypatch.setattr(backtest, "simulate_strategy", fake_simulate)
+
+        cfg = {"name": "60_40", "bull_above": 60, "bear_below": 40, "disabled": False}
+        with pytest.raises(AttributeError):
+            harness._run_one_backtest("BTCUSDT", cfg, datetime(2025, 4, 30, tzinfo=timezone.utc),
+                                       app_config={})
 
 
 class TestAggregate:
@@ -267,7 +301,6 @@ class TestArtefactWriters:
         harness._write_regime_params(str(path), self._make_agg(winner="70_30"))
         payload = json.loads(path.read_text())
         assert payload == {
-            "format_version": 1,
             "regime_thresholds": {"bull_above": 70, "bear_below": 30},
         }
 
@@ -276,7 +309,6 @@ class TestArtefactWriters:
         harness._write_regime_params(str(path), self._make_agg(winner="60_40"))
         payload = json.loads(path.read_text())
         assert payload == {
-            "format_version": 1,
             "regime_thresholds": {"bull_above": 60, "bear_below": 40},
         }
 
@@ -285,7 +317,6 @@ class TestArtefactWriters:
         harness._write_regime_params(str(path), self._make_agg(winner="80_20"))
         payload = json.loads(path.read_text())
         assert payload == {
-            "format_version": 1,
             "regime_thresholds": {"bull_above": 80, "bear_below": 20},
         }
 
@@ -294,9 +325,28 @@ class TestArtefactWriters:
         harness._write_regime_params(str(path), self._make_agg(winner="no_detector"))
         payload = json.loads(path.read_text())
         assert payload == {
-            "format_version": 1,
             "regime_disabled": True,
         }
+
+    @pytest.mark.parametrize("winner", ["60_40", "70_30", "80_20", "no_detector"])
+    def test_regime_params_spec_compliance_keys(self, tmp_path, winner):
+        """Spec compliance — decoupled from impl shape:
+          - exactly one of {"regime_thresholds", "regime_disabled"} present (XOR)
+          - no other top-level keys
+        """
+        path = tmp_path / f"p_{winner}.json"
+        harness._write_regime_params(str(path), self._make_agg(winner=winner))
+        payload = json.loads(path.read_text())
+        keys = set(payload.keys())
+        has_thresholds = "regime_thresholds" in keys
+        has_disabled = "regime_disabled" in keys
+        assert has_thresholds ^ has_disabled, (
+            f"regime_params must have exactly one of regime_thresholds / regime_disabled; "
+            f"got keys={keys}"
+        )
+        assert keys <= {"regime_thresholds", "regime_disabled"}, (
+            f"regime_params must have no extra top-level keys; got {keys}"
+        )
 
     def test_regime_params_byte_deterministic_across_runs(self, tmp_path):
         agg = self._make_agg(winner="60_40")
@@ -309,18 +359,23 @@ class TestArtefactWriters:
     def test_manifest_byte_deterministic_across_runs(self, tmp_path):
         agg = self._make_agg(winner="60_40")
         cutoff = datetime(2025, 4, 30, tzinfo=timezone.utc)
+        overrides = {"BTCUSDT": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0}}
         # ran_at_iso varies per call — must be excluded from byte-comparison.
         m1 = harness._build_manifest(agg=agg, cutoff=cutoff, cutoff_ms=1000,
                                       ohlcv_sha="abc", code_commit="def",
                                       ranges={}, runtime_seconds=1.0,
-                                      leakage_check="PASS", symbols=["BTC"])
+                                      leakage_check="PASS", symbols=["BTC"],
+                                      symbol_overrides=overrides)
         m2 = harness._build_manifest(agg=agg, cutoff=cutoff, cutoff_ms=1000,
                                       ohlcv_sha="abc", code_commit="def",
                                       ranges={}, runtime_seconds=1.0,
-                                      leakage_check="PASS", symbols=["BTC"])
-        # Strip ran_at_iso for the comparison
+                                      leakage_check="PASS", symbols=["BTC"],
+                                      symbol_overrides=overrides)
         m1.pop("ran_at_iso")
         m2.pop("ran_at_iso")
+        # Verify the new symbol_overrides_sha256 field is present and stable
+        assert "symbol_overrides_sha256" in m1
+        assert m1["symbol_overrides_sha256"] == m2["symbol_overrides_sha256"]
         path1 = tmp_path / "m1.json"
         path2 = tmp_path / "m2.json"
         harness._atomic_write_json(str(path1), m1)
@@ -385,11 +440,10 @@ class TestCLI:
         assert (tmp_path / "regime_report.md").exists()
 
         params = json.loads((tmp_path / "regime_params.json").read_text())
-        assert params == {"format_version": 1,
-                          "regime_thresholds": {"bull_above": 60, "bear_below": 40}}
+        assert params == {"regime_thresholds": {"bull_above": 60, "bear_below": 40}}
 
-    def test_sanity_check_returns_rc_3(self, monkeypatch, tmp_path):
-        """When no_detector wins, main() returns 3 (HALT signal)."""
+    def test_sanity_check_returns_rc_3_and_refuses_canonical_artefacts(self, monkeypatch, tmp_path):
+        """When no_detector wins, main() returns 3 AND does NOT write canonical artefacts."""
         def fake_run(symbol, config, cutoff, app_config=None):
             pnl_map = {"60_40": 50.0, "70_30": 30.0, "80_20": 20.0, "no_detector": 200.0}
             return {"symbol": symbol, "config": config["name"],
@@ -399,6 +453,36 @@ class TestCLI:
 
         rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
         assert rc == 3
+        # Canonical artefacts must NOT be written.
+        assert not (tmp_path / "regime_params.json").exists()
+        assert not (tmp_path / "regime_manifest.json").exists()
+        assert not (tmp_path / "regime_report.md").exists()
+        # Halted summary IS written for post-mortem.
+        assert (tmp_path / "halted_summary.json").exists()
+        halted = json.loads((tmp_path / "halted_summary.json").read_text())
+        assert halted["reason"] == "sanity_check_fired"
+        assert halted["agg"]["winner"] == "no_detector"
+
+    def test_errored_cells_return_rc_4_and_dump_sweep_errors(self, monkeypatch, tmp_path):
+        """When any cell errors, main() returns 4 and writes sweep_errors.json — does NOT aggregate."""
+        def fake_run(symbol, config, cutoff, app_config=None):
+            if symbol == "ETHUSDT" and config["name"] == "70_30":
+                return {"symbol": symbol, "config": config["name"],
+                        "net_pnl": 0.0, "trades": 0, "error": "io:db locked"}
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": 100.0, "trades": 1, "error": None}
+
+        self._common_stubs(monkeypatch, fake_run)
+
+        rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
+        assert rc == 4
+        assert (tmp_path / "sweep_errors.json").exists()
+        # Canonical artefacts NOT written.
+        assert not (tmp_path / "regime_params.json").exists()
+        errors = json.loads((tmp_path / "sweep_errors.json").read_text())
+        assert len(errors["errored_cells"]) >= 1
+        assert any(c["symbol"] == "ETHUSDT" and c["config"] == "70_30"
+                   for c in errors["errored_cells"])
 
     def test_missing_ohlcv_db_returns_rc_2(self, monkeypatch, tmp_path):
         original_exists = os.path.exists
@@ -406,3 +490,24 @@ class TestCLI:
                             lambda p: False if p == harness.OHLCV_DB else original_exists(p))
         rc = harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])
         assert rc == 2
+
+    def test_missing_config_hard_errors(self, monkeypatch, tmp_path):
+        """_load_config raises FileNotFoundError when config.json is missing."""
+        def fake_run(symbol, config, cutoff, app_config=None):
+            return {"symbol": symbol, "config": config["name"],
+                    "net_pnl": 0.0, "trades": 0, "error": None}
+
+        original_exists = os.path.exists
+
+        def fake_exists(p):
+            if p == harness.OHLCV_DB:
+                return True
+            if p == os.path.join(harness.REPO_ROOT, "config.json"):
+                return False
+            return original_exists(p)
+
+        monkeypatch.setattr(harness, "_run_one_backtest", fake_run)
+        monkeypatch.setattr(harness.os.path, "exists", fake_exists)
+
+        with pytest.raises(FileNotFoundError, match="config.json not found"):
+            harness.main(["--max-date", "2025-04-30", "--out-dir", str(tmp_path)])

--- a/tests/test_regime_thresholds_param.py
+++ b/tests/test_regime_thresholds_param.py
@@ -1,0 +1,115 @@
+"""Tests for parameterized regime thresholds (A.4-1.5).
+
+Defaults must preserve byte-identity with pre-parameterization production behavior.
+New kwargs must enable threshold sweeps for the A.4-1.5 mini-harness.
+"""
+import inspect
+
+import pandas as pd
+import pytest
+
+from strategy.regime import _compute_local_regime, detect_regime
+
+
+def _make_df_daily(close_values):
+    return pd.DataFrame({"close": close_values})
+
+
+class TestComputeLocalRegimeDefaults:
+    def test_default_thresholds_preserve_legacy_60_40_bull(self):
+        # composite = 100*0.4 + 80*0.3 + 80*0.3 = 88 > 60 → BULL
+        result = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=80, funding_score=80,
+        )
+        assert result["regime"] == "BULL"
+        assert result["score"] == 88.0
+
+    def test_default_thresholds_preserve_legacy_60_40_bear(self):
+        # Strongly declining 250-bar series → price_score very low
+        # (death cross + below SMA200 + ret30d<-10 → 100-40-30-20=10).
+        # composite = 10*0.4 + 0 + 0 = 4 < 40 → BEAR.
+        declining = list(range(250, 0, -1))
+        result = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily(declining),
+            fng_score=0, funding_score=0,
+        )
+        assert result["regime"] == "BEAR"
+
+    def test_default_thresholds_preserve_legacy_60_40_neutral(self):
+        # composite = 100*0.4 + 10*0.3 + 10*0.3 = 46 → NEUTRAL
+        result = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=10, funding_score=10,
+        )
+        assert result["regime"] == "NEUTRAL"
+
+
+class TestComputeLocalRegimeParameterized:
+    def test_70_30_thresholds_shift_bull_boundary(self):
+        # composite = 100*0.4 + 50*0.3 + 20*0.3 = 61 → BULL with (60,40), NEUTRAL with (70,30)
+        result_default = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=50, funding_score=20,
+        )
+        assert result_default["regime"] == "BULL"
+
+        result_70_30 = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=50, funding_score=20,
+            bull_above=70, bear_below=30,
+        )
+        assert result_70_30["regime"] == "NEUTRAL"
+
+    def test_80_20_thresholds_extreme(self):
+        # composite = 88 should be BULL with (60,40), (70,30), and (80,20)
+        result = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=80, funding_score=80,
+            bull_above=80, bear_below=20,
+        )
+        assert result["regime"] == "BULL"
+
+        # composite = 75 should be NEUTRAL with (80,20)
+        # price=100*0.4=40, fng=50*0.3=15, funding=66.67*0.3≈20 → 75
+        # use fng=50, funding=67 → 40+15+20.1=75.1
+        result_neutral = _compute_local_regime(
+            symbol="BTCUSDT", mode="global",
+            df_daily_sym=_make_df_daily([100] * 250),
+            fng_score=50, funding_score=67,
+            bull_above=80, bear_below=20,
+        )
+        assert result_neutral["regime"] == "NEUTRAL"
+
+    def test_invalid_thresholds_raise(self):
+        with pytest.raises(ValueError, match="bear_below must be < bull_above"):
+            _compute_local_regime(
+                symbol="BTCUSDT", mode="global",
+                df_daily_sym=_make_df_daily([100] * 250),
+                fng_score=50, funding_score=50,
+                bull_above=40, bear_below=60,  # inverted
+            )
+
+    def test_equal_thresholds_raise(self):
+        with pytest.raises(ValueError, match="bear_below must be < bull_above"):
+            _compute_local_regime(
+                symbol="BTCUSDT", mode="global",
+                df_daily_sym=_make_df_daily([100] * 250),
+                fng_score=50, funding_score=50,
+                bull_above=50, bear_below=50,
+            )
+
+
+class TestDetectRegimeParameterized:
+    def test_detect_regime_accepts_threshold_kwargs(self):
+        sig = inspect.signature(detect_regime)
+        assert "bull_above" in sig.parameters
+        assert "bear_below" in sig.parameters
+        assert sig.parameters["bull_above"].default == 60
+        assert sig.parameters["bear_below"].default == 40

--- a/tests/test_regime_thresholds_param.py
+++ b/tests/test_regime_thresholds_param.py
@@ -1,14 +1,12 @@
-"""Tests for parameterized regime thresholds (A.4-1.5).
+"""Tests for parameterized regime thresholds in _compute_local_regime.
 
 Defaults must preserve byte-identity with pre-parameterization production behavior.
-New kwargs must enable threshold sweeps for the A.4-1.5 mini-harness.
+New kwargs enable threshold sweeps used by tools/regime_retune_pre_holdout.
 """
-import inspect
-
 import pandas as pd
 import pytest
 
-from strategy.regime import _compute_local_regime, detect_regime
+from strategy.regime import _compute_local_regime
 
 
 def _make_df_daily(close_values):
@@ -106,10 +104,3 @@ class TestComputeLocalRegimeParameterized:
             )
 
 
-class TestDetectRegimeParameterized:
-    def test_detect_regime_accepts_threshold_kwargs(self):
-        sig = inspect.signature(detect_regime)
-        assert "bull_above" in sig.parameters
-        assert "bear_below" in sig.parameters
-        assert sig.parameters["bull_above"].default == 60
-        assert sig.parameters["bear_below"].default == 40

--- a/tests/test_simulate_strategy_regime_kwargs.py
+++ b/tests/test_simulate_strategy_regime_kwargs.py
@@ -84,6 +84,15 @@ class TestMutuallyExclusiveKwargs:
                 regime_thresholds=(70, 30),
             )
 
+    # Downstream errors expected on empty frames (insufficient bars for warmup,
+    # missing required indicator columns, etc.). Narrow the catch to known
+    # downstream failure modes so a contract-violation bug (e.g. a new
+    # RegimeKwargError variant) wouldn't be silently swallowed.
+    _EXPECTED_DOWNSTREAM = (
+        IndexError, KeyError, ValueError, AttributeError,
+        AssertionError, RuntimeError, TypeError,
+    )
+
     def test_only_disabled_does_not_raise_at_entry(self):
         """Positive case: regime_disabled=True alone should not raise the
         mutex/shape validation. Downstream errors due to empty frames are
@@ -97,8 +106,8 @@ class TestMutuallyExclusiveKwargs:
             )
         except RegimeKwargError:
             pytest.fail("regime_disabled=True alone should not raise RegimeKwargError")
-        except Exception:
-            pass  # any other downstream error is fine
+        except self._EXPECTED_DOWNSTREAM:
+            pass
 
     def test_only_thresholds_does_not_raise_at_entry(self):
         from backtest import RegimeKwargError
@@ -110,7 +119,7 @@ class TestMutuallyExclusiveKwargs:
             )
         except RegimeKwargError:
             pytest.fail("regime_thresholds alone should not raise RegimeKwargError")
-        except Exception:
+        except self._EXPECTED_DOWNSTREAM:
             pass
 
     def test_neither_kwarg_does_not_raise_at_entry(self):
@@ -122,7 +131,7 @@ class TestMutuallyExclusiveKwargs:
             )
         except RegimeKwargError:
             pytest.fail("default kwargs should not raise RegimeKwargError")
-        except Exception:
+        except self._EXPECTED_DOWNSTREAM:
             pass
 
 

--- a/tests/test_simulate_strategy_regime_kwargs.py
+++ b/tests/test_simulate_strategy_regime_kwargs.py
@@ -1,0 +1,79 @@
+"""Tests for simulate_strategy regime-threshold kwargs + BYPASS bypass (A.4-1.5).
+
+Covers signature wiring (parity at the API surface) and the BYPASS direction
+token end-to-end through strategy/core.py's gating block. Full bar-loop
+integration is exercised by the harness's actual run in Phase 3.
+"""
+import inspect
+
+import pandas as pd
+
+import backtest
+from strategy.core import _regime_to_direction_token
+
+
+class TestSimulateStrategySignature:
+    def test_accepts_regime_thresholds_kwarg(self):
+        sig = inspect.signature(backtest.simulate_strategy)
+        assert "regime_thresholds" in sig.parameters
+        # Default None preserves legacy (uses _compute_local_regime defaults 60/40)
+        assert sig.parameters["regime_thresholds"].default is None
+
+    def test_accepts_regime_disabled_kwarg(self):
+        sig = inspect.signature(backtest.simulate_strategy)
+        assert "regime_disabled" in sig.parameters
+        assert sig.parameters["regime_disabled"].default is False
+
+
+class TestRegimeAtTimeSignature:
+    def test_accepts_threshold_kwargs(self):
+        sig = inspect.signature(backtest._regime_at_time)
+        assert "bull_above" in sig.parameters
+        assert "bear_below" in sig.parameters
+        assert sig.parameters["bull_above"].default == 60
+        assert sig.parameters["bear_below"].default == 40
+
+
+class TestRegimeToDirectionToken:
+    """The load-bearing BYPASS branch — verified end-to-end on the helper itself."""
+
+    def test_bear_maps_to_short(self):
+        assert _regime_to_direction_token("BEAR") == "SHORT"
+
+    def test_bull_maps_to_long(self):
+        assert _regime_to_direction_token("BULL") == "LONG"
+
+    def test_neutral_maps_to_long(self):
+        assert _regime_to_direction_token("NEUTRAL") == "LONG"
+
+    def test_missing_maps_to_long(self):
+        assert _regime_to_direction_token(None) == "LONG"
+        assert _regime_to_direction_token("UNKNOWN") == "LONG"
+
+    def test_bypass_maps_to_any(self):
+        assert _regime_to_direction_token("BYPASS") == "ANY"
+
+
+class TestBypassEmitsBypassRegime:
+    """When regime_disabled=True, the regime dict passed downstream must
+    have regime="BYPASS" and the helper _regime_at_time must NOT be called."""
+
+    def test_bypass_branch_skips_regime_at_time(self, monkeypatch):
+        """Patches the call site target and verifies it's never invoked.
+
+        We exercise this via a minimal stub of simulate_strategy's bar loop
+        prerequisite — empty frames cause the loop to skip, but we can at
+        least verify the conditional branch by inspecting the function source.
+        """
+        # The conditional `if regime_disabled:` was added by A.4-1.5; verify
+        # it's present in the source (parity at the source-of-truth).
+        import inspect as ins
+
+        src = ins.getsource(backtest.simulate_strategy)
+        assert "if regime_disabled:" in src
+        assert '"regime": "BYPASS"' in src
+        # The else branch must still call _regime_at_time
+        assert "_regime_at_time(" in src
+        # Threshold forwarding
+        assert "bull_above=ba" in src
+        assert "bear_below=bb" in src

--- a/tests/test_simulate_strategy_regime_kwargs.py
+++ b/tests/test_simulate_strategy_regime_kwargs.py
@@ -1,12 +1,14 @@
-"""Tests for simulate_strategy regime-threshold kwargs + BYPASS bypass (A.4-1.5).
+"""Tests for simulate_strategy regime-threshold kwargs + BYPASS bypass.
 
-Covers signature wiring (parity at the API surface) and the BYPASS direction
-token end-to-end through strategy/core.py's gating block. Full bar-loop
-integration is exercised by the harness's actual run in Phase 3.
+Covers signature wiring (parity at the API surface), BYPASS direction
+token end-to-end through strategy/core.py's gating block, and mutually-
+exclusive kwarg validation. Full bar-loop integration is exercised by the
+harness's actual run.
 """
 import inspect
 
 import pandas as pd
+import pytest
 
 import backtest
 from strategy.core import _regime_to_direction_token
@@ -46,34 +48,97 @@ class TestRegimeToDirectionToken:
     def test_neutral_maps_to_long(self):
         assert _regime_to_direction_token("NEUTRAL") == "LONG"
 
-    def test_missing_maps_to_long(self):
-        assert _regime_to_direction_token(None) == "LONG"
-        assert _regime_to_direction_token("UNKNOWN") == "LONG"
+    def test_none_maps_to_long_silent(self, caplog):
+        with caplog.at_level("WARNING", logger="strategy.core"):
+            result = _regime_to_direction_token(None)
+        assert result == "LONG"
+        assert not any("Unknown regime_label" in r.message for r in caplog.records)
+
+    def test_unknown_label_warns_once_and_returns_long(self, caplog):
+        # Ensure the once-per-label guard starts clean
+        from strategy.core import _unknown_regime_warned
+        _unknown_regime_warned.discard("bypass")
+        _unknown_regime_warned.discard("MYSTERY")
+
+        with caplog.at_level("WARNING", logger="strategy.core"):
+            result1 = _regime_to_direction_token("bypass")  # lowercase ≠ BYPASS
+            result2 = _regime_to_direction_token("bypass")  # second call should NOT warn
+        assert result1 == "LONG"
+        assert result2 == "LONG"
+        warnings = [r for r in caplog.records if "Unknown regime_label" in r.message]
+        assert len(warnings) == 1
+        assert "'bypass'" in warnings[0].message
 
     def test_bypass_maps_to_any(self):
         assert _regime_to_direction_token("BYPASS") == "ANY"
 
 
+class TestMutuallyExclusiveKwargs:
+    def test_both_kwargs_raises(self):
+        empty = pd.DataFrame({"close": [], "volume": []})
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            backtest.simulate_strategy(
+                df1h=empty, df4h=empty, df5m=empty, symbol="BTCUSDT",
+                regime_disabled=True,
+                regime_thresholds=(70, 30),
+            )
+
+
 class TestBypassEmitsBypassRegime:
-    """When regime_disabled=True, the regime dict passed downstream must
-    have regime="BYPASS" and the helper _regime_at_time must NOT be called."""
+    """When regime_disabled=True, the regime dict passed downstream must have
+    regime="BYPASS" and the helper _regime_at_time must NOT be called."""
 
-    def test_bypass_branch_skips_regime_at_time(self, monkeypatch):
-        """Patches the call site target and verifies it's never invoked.
+    def _build_minimal_frames(self):
+        """Build the smallest set of frames that gets the bar loop to invoke
+        the regime branch. simulate_strategy needs LRC_PERIOD bars in df1h
+        before it processes anything; we give it a 110-bar window so the loop
+        enters at least once."""
+        idx_1h = pd.date_range("2024-01-01", periods=110, freq="1h", tz="UTC").tz_localize(None)
+        df1h = pd.DataFrame({
+            "open":  [100.0] * 110,
+            "high":  [101.0] * 110,
+            "low":   [99.0] * 110,
+            "close": [100.0] * 110,
+            "volume": [1000.0] * 110,
+        }, index=idx_1h)
+        idx_4h = pd.date_range("2024-01-01", periods=30, freq="4h", tz="UTC").tz_localize(None)
+        df4h = df1h.iloc[:30].copy().set_index(idx_4h)
+        idx_5m = pd.date_range("2024-01-01", periods=210, freq="5min", tz="UTC").tz_localize(None)
+        df5m = pd.DataFrame({
+            "open":  [100.0] * 210,
+            "high":  [101.0] * 210,
+            "low":   [99.0] * 210,
+            "close": [100.0] * 210,
+            "volume": [1000.0] * 210,
+        }, index=idx_5m)
+        return df1h, df4h, df5m
 
-        We exercise this via a minimal stub of simulate_strategy's bar loop
-        prerequisite — empty frames cause the loop to skip, but we can at
-        least verify the conditional branch by inspecting the function source.
-        """
-        # The conditional `if regime_disabled:` was added by A.4-1.5; verify
-        # it's present in the source (parity at the source-of-truth).
-        import inspect as ins
+    def test_bypass_branch_runtime_skips_regime_at_time(self, monkeypatch):
+        """Runtime check: with regime_disabled=True, _regime_at_time MUST NOT
+        be called even if the bar loop enters."""
+        called = {"count": 0}
 
-        src = ins.getsource(backtest.simulate_strategy)
-        assert "if regime_disabled:" in src
-        assert '"regime": "BYPASS"' in src
-        # The else branch must still call _regime_at_time
-        assert "_regime_at_time(" in src
-        # Threshold forwarding
-        assert "bull_above=ba" in src
-        assert "bear_below=bb" in src
+        def fake_regime_at_time(*args, **kwargs):
+            called["count"] += 1
+            return {"regime": "BULL", "score": 80.0, "mode": "global", "symbol": "X", "components": {}}
+
+        monkeypatch.setattr(backtest, "_regime_at_time", fake_regime_at_time)
+
+        df1h, df4h, df5m = self._build_minimal_frames()
+
+        # Run with regime_disabled=True. The simulator may still raise downstream
+        # (no F&G / funding data, no df1d) — we only care that the bypass branch
+        # was taken before any potential downstream error, i.e. _regime_at_time
+        # was never reached.
+        try:
+            backtest.simulate_strategy(
+                df1h=df1h, df4h=df4h, df5m=df5m, symbol="BTCUSDT",
+                regime_disabled=True,
+            )
+        except Exception:
+            pass  # downstream errors are not what this test checks
+
+        assert called["count"] == 0, (
+            f"_regime_at_time was called {called['count']} times under regime_disabled=True; "
+            "bypass branch did not skip the helper."
+        )

--- a/tests/test_simulate_strategy_regime_kwargs.py
+++ b/tests/test_simulate_strategy_regime_kwargs.py
@@ -74,48 +74,158 @@ class TestRegimeToDirectionToken:
 
 
 class TestMutuallyExclusiveKwargs:
-    def test_both_kwargs_raises(self):
+    def test_both_kwargs_raises_regime_kwarg_error(self):
+        from backtest import RegimeKwargError
         empty = pd.DataFrame({"close": [], "volume": []})
-        with pytest.raises(ValueError, match="mutually exclusive"):
+        with pytest.raises(RegimeKwargError, match="mutually exclusive"):
             backtest.simulate_strategy(
                 df1h=empty, df4h=empty, df5m=empty, symbol="BTCUSDT",
                 regime_disabled=True,
                 regime_thresholds=(70, 30),
             )
 
+    def test_only_disabled_does_not_raise_at_entry(self):
+        """Positive case: regime_disabled=True alone should not raise the
+        mutex/shape validation. Downstream errors due to empty frames are
+        unrelated to entry-validation."""
+        from backtest import RegimeKwargError
+        empty = pd.DataFrame({"close": [], "volume": []})
+        try:
+            backtest.simulate_strategy(
+                df1h=empty, df4h=empty, df5m=empty, symbol="BTCUSDT",
+                regime_disabled=True,
+            )
+        except RegimeKwargError:
+            pytest.fail("regime_disabled=True alone should not raise RegimeKwargError")
+        except Exception:
+            pass  # any other downstream error is fine
+
+    def test_only_thresholds_does_not_raise_at_entry(self):
+        from backtest import RegimeKwargError
+        empty = pd.DataFrame({"close": [], "volume": []})
+        try:
+            backtest.simulate_strategy(
+                df1h=empty, df4h=empty, df5m=empty, symbol="BTCUSDT",
+                regime_thresholds=(70, 30),
+            )
+        except RegimeKwargError:
+            pytest.fail("regime_thresholds alone should not raise RegimeKwargError")
+        except Exception:
+            pass
+
+    def test_neither_kwarg_does_not_raise_at_entry(self):
+        from backtest import RegimeKwargError
+        empty = pd.DataFrame({"close": [], "volume": []})
+        try:
+            backtest.simulate_strategy(
+                df1h=empty, df4h=empty, df5m=empty, symbol="BTCUSDT",
+            )
+        except RegimeKwargError:
+            pytest.fail("default kwargs should not raise RegimeKwargError")
+        except Exception:
+            pass
+
+
+class TestRegimeThresholdsShape:
+    """I11: regime_thresholds must be tuple[int, int]; malformed shapes raise."""
+
+    @pytest.fixture
+    def empty_frames(self):
+        empty = pd.DataFrame({"close": [], "volume": []})
+        return {"df1h": empty, "df4h": empty, "df5m": empty}
+
+    def test_list_rejected(self, empty_frames):
+        from backtest import RegimeKwargError
+        with pytest.raises(RegimeKwargError, match="tuple"):
+            backtest.simulate_strategy(
+                **empty_frames, symbol="BTCUSDT",
+                regime_thresholds=[60, 40],  # list, not tuple
+            )
+
+    def test_wrong_length_rejected(self, empty_frames):
+        from backtest import RegimeKwargError
+        with pytest.raises(RegimeKwargError, match="tuple"):
+            backtest.simulate_strategy(
+                **empty_frames, symbol="BTCUSDT",
+                regime_thresholds=(60,),
+            )
+
+    def test_dict_rejected(self, empty_frames):
+        from backtest import RegimeKwargError
+        with pytest.raises(RegimeKwargError, match="tuple"):
+            backtest.simulate_strategy(
+                **empty_frames, symbol="BTCUSDT",
+                regime_thresholds={"bull": 60, "bear": 40},
+            )
+
+    def test_string_elements_rejected(self, empty_frames):
+        from backtest import RegimeKwargError
+        with pytest.raises(RegimeKwargError, match="tuple"):
+            backtest.simulate_strategy(
+                **empty_frames, symbol="BTCUSDT",
+                regime_thresholds=("60", "40"),
+            )
+
+    def test_bool_elements_rejected(self, empty_frames):
+        """True is an int subclass in Python — explicit isinstance(bool) guard."""
+        from backtest import RegimeKwargError
+        with pytest.raises(RegimeKwargError, match="tuple"):
+            backtest.simulate_strategy(
+                **empty_frames, symbol="BTCUSDT",
+                regime_thresholds=(True, False),
+            )
+
 
 class TestBypassEmitsBypassRegime:
     """When regime_disabled=True, the regime dict passed downstream must have
-    regime="BYPASS" and the helper _regime_at_time must NOT be called."""
+    regime="BYPASS" and the helper _regime_at_time must NOT be called.
+
+    Frames sized > simulate_strategy's warmup (LRC_PERIOD + buffer) so the bar
+    loop actually enters and the regime branch is exercised. Sanity asserted
+    in test setup; the test would be vacuous with insufficient bars."""
+
+    BARS_1H = 140  # > warmup (LRC_PERIOD=100 + buffer); bar loop iterates ≥30 times
 
     def _build_minimal_frames(self):
-        """Build the smallest set of frames that gets the bar loop to invoke
-        the regime branch. simulate_strategy needs LRC_PERIOD bars in df1h
-        before it processes anything; we give it a 110-bar window so the loop
-        enters at least once."""
-        idx_1h = pd.date_range("2024-01-01", periods=110, freq="1h", tz="UTC").tz_localize(None)
+        idx_1h = pd.date_range("2024-01-01", periods=self.BARS_1H, freq="1h", tz="UTC").tz_localize(None)
         df1h = pd.DataFrame({
-            "open":  [100.0] * 110,
-            "high":  [101.0] * 110,
-            "low":   [99.0] * 110,
-            "close": [100.0] * 110,
-            "volume": [1000.0] * 110,
+            "open":  [100.0] * self.BARS_1H,
+            "high":  [101.0] * self.BARS_1H,
+            "low":   [99.0] * self.BARS_1H,
+            "close": [100.0] * self.BARS_1H,
+            "volume": [1000.0] * self.BARS_1H,
         }, index=idx_1h)
-        idx_4h = pd.date_range("2024-01-01", periods=30, freq="4h", tz="UTC").tz_localize(None)
-        df4h = df1h.iloc[:30].copy().set_index(idx_4h)
-        idx_5m = pd.date_range("2024-01-01", periods=210, freq="5min", tz="UTC").tz_localize(None)
+        idx_4h = pd.date_range("2024-01-01", periods=40, freq="4h", tz="UTC").tz_localize(None)
+        df4h = pd.DataFrame({
+            "open":  [100.0] * 40,
+            "high":  [101.0] * 40,
+            "low":   [99.0] * 40,
+            "close": [100.0] * 40,
+            "volume": [1000.0] * 40,
+        }, index=idx_4h)
+        idx_5m = pd.date_range("2024-01-01", periods=300, freq="5min", tz="UTC").tz_localize(None)
         df5m = pd.DataFrame({
-            "open":  [100.0] * 210,
-            "high":  [101.0] * 210,
-            "low":   [99.0] * 210,
-            "close": [100.0] * 210,
-            "volume": [1000.0] * 210,
+            "open":  [100.0] * 300,
+            "high":  [101.0] * 300,
+            "low":   [99.0] * 300,
+            "close": [100.0] * 300,
+            "volume": [1000.0] * 300,
         }, index=idx_5m)
         return df1h, df4h, df5m
 
+    def test_setup_actually_exercises_bar_loop(self):
+        """Sanity: confirm the test fixture is large enough for the bar loop
+        to enter. Without this, the bypass test below is vacuous."""
+        df1h, _, _ = self._build_minimal_frames()
+        from strategy.constants import LRC_PERIOD
+        assert len(df1h) > LRC_PERIOD + 10, (
+            f"test setup invalid — bar loop won't enter "
+            f"(len(df1h)={len(df1h)}, need > LRC_PERIOD+10 = {LRC_PERIOD + 10})"
+        )
+
     def test_bypass_branch_runtime_skips_regime_at_time(self, monkeypatch):
         """Runtime check: with regime_disabled=True, _regime_at_time MUST NOT
-        be called even if the bar loop enters."""
+        be called even though the bar loop enters."""
         called = {"count": 0}
 
         def fake_regime_at_time(*args, **kwargs):
@@ -126,10 +236,6 @@ class TestBypassEmitsBypassRegime:
 
         df1h, df4h, df5m = self._build_minimal_frames()
 
-        # Run with regime_disabled=True. The simulator may still raise downstream
-        # (no F&G / funding data, no df1d) — we only care that the bypass branch
-        # was taken before any potential downstream error, i.e. _regime_at_time
-        # was never reached.
         try:
             backtest.simulate_strategy(
                 df1h=df1h, df4h=df4h, df5m=df5m, symbol="BTCUSDT",
@@ -141,4 +247,31 @@ class TestBypassEmitsBypassRegime:
         assert called["count"] == 0, (
             f"_regime_at_time was called {called['count']} times under regime_disabled=True; "
             "bypass branch did not skip the helper."
+        )
+
+    def test_default_path_DOES_call_regime_at_time(self, monkeypatch):
+        """Counter-test: without regime_disabled, _regime_at_time SHOULD be
+        called. Proves the bypass test above is non-vacuous (a bug that
+        always called _regime_at_time would fail this counter-test)."""
+        called = {"count": 0}
+
+        def fake_regime_at_time(*args, **kwargs):
+            called["count"] += 1
+            return {"regime": "BULL", "score": 80.0, "mode": "global", "symbol": "X", "components": {}}
+
+        monkeypatch.setattr(backtest, "_regime_at_time", fake_regime_at_time)
+
+        df1h, df4h, df5m = self._build_minimal_frames()
+
+        try:
+            backtest.simulate_strategy(
+                df1h=df1h, df4h=df4h, df5m=df5m, symbol="BTCUSDT",
+                # default: regime_disabled=False
+            )
+        except Exception:
+            pass
+
+        assert called["count"] > 0, (
+            "_regime_at_time was never called even under default (non-bypass) "
+            "configuration; bypass test above is vacuous."
         )

--- a/tools/regime_retune_pre_holdout.py
+++ b/tools/regime_retune_pre_holdout.py
@@ -1,15 +1,9 @@
 #!/usr/bin/env python3
 """Pre-holdout regime threshold re-tune mini-harness.
 
-Sweeps the 4 configurations locked by historical record over the pre-holdout
-window [earliest, 2025-04-30T00:00:00Z), aggregates net_pnl per config across
-the 10 portfolio symbols, identifies the winner, and applies pre-registered
-decision flags (CHANGE detection, sanity check, stability check).
-
-Runs a single backtest per (symbol, config) — grid + objective are locked by
-the methodology spec, not optimized. Implemented inline (no shared helpers
-from sister harnesses) because this harness must run before its sibling
-re-tune (#287) is merged — see spec §2.10 sequencing.
+Sweeps 4 configurations from D9 §2.10 over [earliest, cutoff) window;
+aggregates net_pnl per config across 10 portfolio symbols; applies
+pre-registered decision flags; writes byte-deterministic artefacts.
 
 Usage:
     python -m tools.regime_retune_pre_holdout --max-date 2025-04-30
@@ -53,7 +47,7 @@ def _resolve_git_commit() -> str:
             stderr=subprocess.DEVNULL,
         )
         return out.decode().strip()
-    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+    except (subprocess.SubprocessError, OSError, UnicodeDecodeError) as exc:
         log.error("Could not resolve git commit (manifest will record 'UNKNOWN'): %s",
                   exc, exc_info=True)
         return "UNKNOWN"
@@ -71,12 +65,6 @@ def _sha256_file(path: str, block_size: int = 1024 * 1024) -> str:
 
 
 def _slice_below_cutoff(df: pd.DataFrame, cutoff: datetime) -> pd.DataFrame:
-    """Return the subset of df whose index is strictly < cutoff.
-
-    Implemented inline (no import from auto_tune) because this harness must
-    run before the sibling re-tune (#287) is merged — see spec §2.10
-    sequencing.
-    """
     if df is None or df.empty:
         return df
     cutoff_ts = pd.Timestamp(cutoff)
@@ -138,10 +126,10 @@ def _verify_no_leakage(ranges: dict, cutoff_ms: int) -> str:
 def _load_config() -> dict:
     """Load config.json from repo root.
 
-    Hard-errors when missing: the harness pulls production symbol_overrides
-    from this file so that the regime threshold is the only varying input
-    across the sweep. Running without it silently substitutes empty overrides
-    and contaminates the comparison.
+    Hard-errors when missing OR when symbol_overrides is empty: the harness
+    pulls production overrides from this file so the regime threshold is the
+    only varying input across the sweep. Running without them silently
+    contaminates the comparison.
     """
     cfg_path = os.path.join(REPO_ROOT, "config.json")
     if not os.path.exists(cfg_path):
@@ -150,7 +138,14 @@ def _load_config() -> dict:
             "symbol_overrides to ensure regime threshold is the sole varying input."
         )
     with open(cfg_path, encoding="utf-8") as f:
-        return json.load(f)
+        cfg = json.load(f)
+    if not cfg.get("symbol_overrides"):
+        raise ValueError(
+            "config.json missing or empty 'symbol_overrides'; harness "
+            "invariant requires production overrides so the only varying "
+            "input across the sweep is the regime threshold."
+        )
+    return cfg
 
 
 def _load_frames(symbol: str, cutoff: datetime) -> dict:
@@ -253,18 +248,23 @@ def _aggregate_results(cells: list) -> dict:
         per_config_trades[cfg] = per_config_trades.get(cfg, 0) + int(cell["trades"])
 
     sorted_configs = sorted(per_config_pnl.items(), key=lambda kv: (-kv[1], kv[0]))
+    assert len(sorted_configs) >= 2, (
+        f"_aggregate_results requires ≥2 configs; got {len(sorted_configs)}"
+    )
     winner_name, winner_pnl = sorted_configs[0]
     runner_up_name, runner_up_pnl = sorted_configs[1]
 
+    all_zero = all(abs(p) < 1e-9 for p in per_config_pnl.values())
     if abs(winner_pnl) > 1e-9:
         margin_pct = (winner_pnl - runner_up_pnl) / abs(winner_pnl) * 100.0
     else:
         margin_pct = 0.0
 
     decision_flags = {
-        "change_detection": winner_name != "60_40",
-        "sanity_check":     winner_name == "no_detector",
-        "stability_check":  margin_pct < 5.0,
+        "change_detection":   winner_name != "60_40",
+        "sanity_check":       winner_name == "no_detector",
+        "stability_check":    margin_pct < 5.0,
+        "degenerate_zero_pnl": all_zero,
     }
 
     return {
@@ -355,7 +355,7 @@ def _build_manifest(agg: dict, cutoff: datetime, cutoff_ms: int,
 def _build_report(agg: dict, cells: list, cutoff: datetime,
                   ranges: dict, runtime_seconds: float, symbols: list) -> str:
     lines = []
-    lines.append("# Pre-holdout Regime Threshold Re-tune Report (A.4-1.5)")
+    lines.append("# Pre-holdout Regime Threshold Re-tune Report")
     lines.append("")
     lines.append(f"- **Cutoff (`--max-date`):** {cutoff.isoformat()}")
     lines.append(f"- **Symbols:** {', '.join(symbols)}")
@@ -439,9 +439,63 @@ def _get_symbols() -> list[str]:
     return list(DEFAULT_SYMBOLS)
 
 
+_CANONICAL_ARTEFACTS = (
+    "regime_params.json",
+    "regime_manifest.json",
+    "regime_report.md",
+    "halted_summary.json",
+    "sweep_errors.json",
+    "raw_results.json",
+)
+
+
+def _clear_stale_artefacts(out_dir: str) -> None:
+    """Atomically remove any pre-existing canonical artefacts from out_dir.
+
+    Required because the default out_dir is `data/retune/<today>-pre-holdout/`
+    — a re-run on the same day reuses the directory. Without this, a
+    successful run-1 + halted run-2 leaves run-1's canonical artefacts in
+    place and the operator believes run-2 succeeded.
+
+    Also clears orphan .tmp files from prior interrupted runs.
+    """
+    for stale_name in _CANONICAL_ARTEFACTS:
+        try:
+            os.remove(os.path.join(out_dir, stale_name))
+        except FileNotFoundError:
+            pass
+    try:
+        for entry in os.listdir(out_dir):
+            if entry.endswith(".tmp"):
+                try:
+                    os.remove(os.path.join(out_dir, entry))
+                except FileNotFoundError:
+                    pass
+    except FileNotFoundError:
+        pass
+
+
+def _emergency_write(path: str, payload: dict, kind: str) -> None:
+    """Best-effort write for diagnostic artefacts. On primary failure, falls
+    back to /tmp; on fallback failure, logs and continues. Never raises —
+    preserves the caller's rc contract under disk-full / permission errors.
+    """
+    try:
+        _atomic_write_json(path, payload)
+    except (OSError, TypeError, ValueError) as exc:
+        log.error("Failed to write %s artefact at %s: %s", kind, path, exc, exc_info=True)
+        fallback = f"/tmp/regime_retune_{kind}_{int(time.time())}.json"
+        try:
+            with open(fallback, "w", encoding="utf-8") as f:
+                json.dump(payload, f, sort_keys=True, indent=2, default=str)
+            log.error("Fallback %s written to %s", kind, fallback)
+        except (OSError, TypeError, ValueError) as fallback_exc:
+            log.error("Fallback write also failed: %s", fallback_exc, exc_info=True)
+
+
 def main(argv: list | None = None) -> int:
     parser = argparse.ArgumentParser(
-        description="Pre-holdout regime threshold re-tune mini-harness (A.4-1.5).",
+        description="Pre-holdout regime threshold re-tune mini-harness.",
     )
     parser.add_argument("--max-date", type=str, required=True,
                         help="ISO date (YYYY-MM-DD, UTC). Holdout starts on this day; "
@@ -460,6 +514,10 @@ def main(argv: list | None = None) -> int:
 
     symbols = _get_symbols()
     app_config = _load_config()
+    # Resolve git commit early — late-stage failure shouldn't waste 30min of
+    # work and the value goes into manifest regardless of which exit branch
+    # we hit.
+    code_commit = _resolve_git_commit()
 
     if args.out_dir:
         out_dir = args.out_dir
@@ -467,6 +525,7 @@ def main(argv: list | None = None) -> int:
         run_date = datetime.now(timezone.utc).date().isoformat()
         out_dir = os.path.join(REPO_ROOT, "data", "retune", f"{run_date}-pre-holdout")
     os.makedirs(out_dir, exist_ok=True)
+    _clear_stale_artefacts(out_dir)
 
     log.info("Regime threshold re-tune starting")
     log.info("  cutoff:  %s", cutoff.isoformat())
@@ -495,12 +554,13 @@ def main(argv: list | None = None) -> int:
         log.error("Sweep had %d errored cells; refusing to aggregate. Errors: %s",
                   len(errored),
                   [(c["symbol"], c["config"], c["error"]) for c in errored])
-        _atomic_write_json(
+        _emergency_write(
             os.path.join(out_dir, "sweep_errors.json"),
             {
                 "errored_cells": errored,
                 "successful_cells": [c for c in cells if c.get("error") is None],
             },
+            kind="sweep_errors",
         )
         return 4
 
@@ -513,7 +573,6 @@ def main(argv: list | None = None) -> int:
 
     log.info("Hashing ohlcv.db...")
     ohlcv_sha = _sha256_file(OHLCV_DB)
-    code_commit = _resolve_git_commit()
 
     manifest = _build_manifest(
         agg=agg, cutoff=cutoff, cutoff_ms=cutoff_ms,
@@ -532,25 +591,39 @@ def main(argv: list | None = None) -> int:
 
     # Sanity check is fail-closed: if no_detector wins, do NOT write the
     # canonical artefacts. Dump halted_summary.json with the diagnostic
-    # bundle for post-mortem and return rc=3.
+    # bundle (including the rendered report markdown) for post-mortem.
     if agg["decision_flags"]["sanity_check"]:
         log.error("SANITY CHECK FIRED: no_detector wins on pre-holdout window. "
                   "Refusing to write canonical artefacts. See halted_summary.json.")
-        _atomic_write_json(
+        _emergency_write(
             os.path.join(out_dir, "halted_summary.json"),
             {
                 "reason": "sanity_check_fired",
                 "agg": agg,
                 "manifest": manifest,
+                "report_md": report_md,
             },
+            kind="halted_summary",
         )
         return 3
 
     # Order: report + manifest first, regime_params.json LAST as the
-    # durability marker for downstream consumers.
-    _atomic_write_text(os.path.join(out_dir, "regime_report.md"), report_md)
-    _atomic_write_json(os.path.join(out_dir, "regime_manifest.json"), manifest)
-    _write_regime_params(os.path.join(out_dir, "regime_params.json"), agg)
+    # durability marker for downstream consumers. If any write fails (disk
+    # full, JSON-non-serializable manifest field, etc.) dump cells + agg to
+    # raw_results.json so the run isn't lost and return rc=5.
+    try:
+        _atomic_write_text(os.path.join(out_dir, "regime_report.md"), report_md)
+        _atomic_write_json(os.path.join(out_dir, "regime_manifest.json"), manifest)
+        _write_regime_params(os.path.join(out_dir, "regime_params.json"), agg)
+    except (TypeError, ValueError, OSError) as exc:
+        log.error("Manifest serialization or canonical artefact write failed: %s",
+                  exc, exc_info=True)
+        _emergency_write(
+            os.path.join(out_dir, "raw_results.json"),
+            {"cells": cells, "agg": agg},
+            kind="raw_results",
+        )
+        return 5
 
     log.info("Artefacts written to %s", out_dir)
     log.info("  regime_report.md     — human-readable side-by-side + caveats")

--- a/tools/regime_retune_pre_holdout.py
+++ b/tools/regime_retune_pre_holdout.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""Pre-holdout regime threshold re-tune (A.4-1.5).
+"""Pre-holdout regime threshold re-tune mini-harness.
 
-Sweeps the 4 configurations locked by historical record (commit bf581f1)
-over the pre-holdout window [earliest, 2025-04-30T00:00:00Z), aggregates
-net_pnl per config across the 10 portfolio symbols, identifies the
-winner, and applies pre-registered decision flags (CHANGE detection,
-sanity check, stability check).
+Sweeps the 4 configurations locked by historical record over the pre-holdout
+window [earliest, 2025-04-30T00:00:00Z), aggregates net_pnl per config across
+the 10 portfolio symbols, identifies the winner, and applies pre-registered
+decision flags (CHANGE detection, sanity check, stability check).
 
-Mirrors the shape of tools/retune_pre_holdout.py (A.4-1) but runs a
-single backtest per (symbol, config) instead of a grid search — the
-grid + objective here are locked by spec D9 §2.10, not optimized.
+Runs a single backtest per (symbol, config) — grid + objective are locked by
+the methodology spec, not optimized. Implemented inline (no shared helpers
+from sister harnesses) because this harness must run before its sibling
+re-tune (#287) is merged — see spec §2.10 sequencing.
 
 Usage:
     python -m tools.regime_retune_pre_holdout --max-date 2025-04-30
@@ -53,7 +53,9 @@ def _resolve_git_commit() -> str:
             stderr=subprocess.DEVNULL,
         )
         return out.decode().strip()
-    except Exception:
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        log.error("Could not resolve git commit (manifest will record 'UNKNOWN'): %s",
+                  exc, exc_info=True)
         return "UNKNOWN"
 
 
@@ -71,10 +73,9 @@ def _sha256_file(path: str, block_size: int = 1024 * 1024) -> str:
 def _slice_below_cutoff(df: pd.DataFrame, cutoff: datetime) -> pd.DataFrame:
     """Return the subset of df whose index is strictly < cutoff.
 
-    Self-contained (does not import auto_tune._slice_below_cutoff) so this
-    module is independent of A.4-1's PR #287 helper — A.4-1 Phase 3 is
-    GATED on this harness closing, so depending on its branch would be a
-    circular dependency.
+    Implemented inline (no import from auto_tune) because this harness must
+    run before the sibling re-tune (#287) is merged — see spec §2.10
+    sequencing.
     """
     if df is None or df.empty:
         return df
@@ -135,10 +136,19 @@ def _verify_no_leakage(ranges: dict, cutoff_ms: int) -> str:
 
 
 def _load_config() -> dict:
-    """Load config.json from repo root. Returns empty dict if missing."""
+    """Load config.json from repo root.
+
+    Hard-errors when missing: the harness pulls production symbol_overrides
+    from this file so that the regime threshold is the only varying input
+    across the sweep. Running without it silently substitutes empty overrides
+    and contaminates the comparison.
+    """
     cfg_path = os.path.join(REPO_ROOT, "config.json")
     if not os.path.exists(cfg_path):
-        return {}
+        raise FileNotFoundError(
+            f"config.json not found at {cfg_path}. Harness requires production "
+            "symbol_overrides to ensure regime threshold is the sole varying input."
+        )
     with open(cfg_path, encoding="utf-8") as f:
         return json.load(f)
 
@@ -215,10 +225,14 @@ def _run_one_backtest(symbol: str, config: dict, cutoff: datetime,
 
     try:
         trades, _equity = simulate_strategy(**kwargs)
-    except Exception as exc:  # noqa: BLE001
-        log.error("[%s][%s] simulate_strategy raised: %s", symbol, config["name"], exc)
+    except (sqlite3.DatabaseError, OSError) as exc:
+        log.error("[%s][%s] I/O failure: %s", symbol, config["name"], exc, exc_info=True)
         return {"symbol": symbol, "config": config["name"], "net_pnl": 0.0,
-                "trades": 0, "error": str(exc)}
+                "trades": 0, "error": f"io:{exc}"}
+    except (ValueError, AssertionError) as exc:
+        log.warning("[%s][%s] data/assertion error: %s", symbol, config["name"], exc, exc_info=True)
+        return {"symbol": symbol, "config": config["name"], "net_pnl": 0.0,
+                "trades": 0, "error": f"data:{exc}"}
 
     net_pnl = sum(t.get("pnl_usd", 0.0) for t in trades)
     return {"symbol": symbol, "config": config["name"], "net_pnl": float(net_pnl),
@@ -273,18 +287,24 @@ def _atomic_write_json(path: str, payload: dict) -> None:
     os.replace(tmp, path)
 
 
+def _atomic_write_text(path: str, content: str) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp, path)
+
+
 def _write_regime_params(path: str, agg: dict) -> None:
     """Write regime_params.json. Shape depends on winner:
-      - threshold winner:   {"format_version": 1, "regime_thresholds": {"bull_above": <int>, "bear_below": <int>}}
-      - no_detector winner: {"format_version": 1, "regime_disabled": true}
+      - threshold winner:   {"regime_thresholds": {"bull_above": <int>, "bear_below": <int>}}
+      - no_detector winner: {"regime_disabled": true}
     """
     winner = agg["winner"]
     if winner == "no_detector":
-        payload = {"format_version": 1, "regime_disabled": True}
+        payload = {"regime_disabled": True}
     else:
         cfg = next(c for c in GRID if c["name"] == winner)
         payload = {
-            "format_version": 1,
             "regime_thresholds": {
                 "bull_above": cfg["bull_above"],
                 "bear_below": cfg["bear_below"],
@@ -296,7 +316,11 @@ def _write_regime_params(path: str, agg: dict) -> None:
 def _build_manifest(agg: dict, cutoff: datetime, cutoff_ms: int,
                     ohlcv_sha: str, code_commit: str,
                     ranges: dict, runtime_seconds: float,
-                    leakage_check: str, symbols: list) -> dict:
+                    leakage_check: str, symbols: list,
+                    symbol_overrides: dict | None = None) -> dict:
+    overrides_sha = hashlib.sha256(
+        json.dumps(symbol_overrides or {}, sort_keys=True).encode()
+    ).hexdigest()
     return {
         "harness": "regime_retune_pre_holdout",
         "spec_ref": "docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md §2.10",
@@ -305,6 +329,7 @@ def _build_manifest(agg: dict, cutoff: datetime, cutoff_ms: int,
         "code_commit": code_commit,
         "ohlcv_sha256": ohlcv_sha,
         "ohlcv_path_relative": os.path.relpath(OHLCV_DB, REPO_ROOT),
+        "symbol_overrides_sha256": overrides_sha,
         "ran_at_iso": datetime.now(timezone.utc).isoformat(),
         "runtime_seconds": round(runtime_seconds, 2),
         "leakage_check": leakage_check,
@@ -409,7 +434,7 @@ def _build_report(agg: dict, cells: list, cutoff: datetime,
 
 
 def _get_symbols() -> list[str]:
-    """Return the 10 portfolio symbols (mirror of A.4-1's basket)."""
+    """Return the 10 portfolio symbols from btc_scanner.DEFAULT_SYMBOLS."""
     from btc_scanner import DEFAULT_SYMBOLS
     return list(DEFAULT_SYMBOLS)
 
@@ -443,7 +468,7 @@ def main(argv: list | None = None) -> int:
         out_dir = os.path.join(REPO_ROOT, "data", "retune", f"{run_date}-pre-holdout")
     os.makedirs(out_dir, exist_ok=True)
 
-    log.info("A.4-1.5 regime threshold re-tune starting")
+    log.info("Regime threshold re-tune starting")
     log.info("  cutoff:  %s", cutoff.isoformat())
     log.info("  symbols: %s", ", ".join(symbols))
     log.info("  configs: %s", ", ".join(c["name"] for c in GRID))
@@ -462,6 +487,23 @@ def main(argv: list | None = None) -> int:
             cells.append(cell)
     runtime_seconds = time.time() - start
 
+    # Refuse to aggregate if any cell errored — masking failures in the sweep
+    # would corrupt the comparison silently. Dump diagnostics + return rc=4
+    # so the caller can route to debug rather than retry blindly.
+    errored = [c for c in cells if c.get("error") is not None]
+    if errored:
+        log.error("Sweep had %d errored cells; refusing to aggregate. Errors: %s",
+                  len(errored),
+                  [(c["symbol"], c["config"], c["error"]) for c in errored])
+        _atomic_write_json(
+            os.path.join(out_dir, "sweep_errors.json"),
+            {
+                "errored_cells": errored,
+                "successful_cells": [c for c in cells if c.get("error") is None],
+            },
+        )
+        return 4
+
     agg = _aggregate_results(cells)
 
     log.info("Computing per-symbol data ranges from ohlcv.db...")
@@ -478,6 +520,7 @@ def main(argv: list | None = None) -> int:
         ohlcv_sha=ohlcv_sha, code_commit=code_commit,
         ranges=ranges, runtime_seconds=runtime_seconds,
         leakage_check=leakage_check, symbols=symbols,
+        symbol_overrides=app_config.get("symbol_overrides"),
     )
 
     report_md = _build_report(
@@ -485,21 +528,34 @@ def main(argv: list | None = None) -> int:
         ranges=ranges, runtime_seconds=runtime_seconds, symbols=symbols,
     )
 
-    _write_regime_params(os.path.join(out_dir, "regime_params.json"), agg)
-    _atomic_write_json(os.path.join(out_dir, "regime_manifest.json"), manifest)
-    with open(os.path.join(out_dir, "regime_report.md"), "w", encoding="utf-8") as f:
-        f.write(report_md)
-
-    log.info("Artefacts written to %s", out_dir)
-    log.info("  regime_params.json   — winner config, byte-deterministic")
-    log.info("  regime_manifest.json — cutoff, hashes, decision flags, no-leakage proof")
-    log.info("  regime_report.md     — human-readable side-by-side + caveats")
     log.info("Decision flags: %s", agg["decision_flags"])
 
+    # Sanity check is fail-closed: if no_detector wins, do NOT write the
+    # canonical artefacts. Dump halted_summary.json with the diagnostic
+    # bundle for post-mortem and return rc=3.
     if agg["decision_flags"]["sanity_check"]:
         log.error("SANITY CHECK FIRED: no_detector wins on pre-holdout window. "
-                  "HALT + DEBUG before promoting this artefact.")
+                  "Refusing to write canonical artefacts. See halted_summary.json.")
+        _atomic_write_json(
+            os.path.join(out_dir, "halted_summary.json"),
+            {
+                "reason": "sanity_check_fired",
+                "agg": agg,
+                "manifest": manifest,
+            },
+        )
         return 3
+
+    # Order: report + manifest first, regime_params.json LAST as the
+    # durability marker for downstream consumers.
+    _atomic_write_text(os.path.join(out_dir, "regime_report.md"), report_md)
+    _atomic_write_json(os.path.join(out_dir, "regime_manifest.json"), manifest)
+    _write_regime_params(os.path.join(out_dir, "regime_params.json"), agg)
+
+    log.info("Artefacts written to %s", out_dir)
+    log.info("  regime_report.md     — human-readable side-by-side + caveats")
+    log.info("  regime_manifest.json — cutoff, hashes, decision flags, no-leakage proof")
+    log.info("  regime_params.json   — winner config (durability marker, written last)")
 
     return 0
 

--- a/tools/regime_retune_pre_holdout.py
+++ b/tools/regime_retune_pre_holdout.py
@@ -406,3 +406,103 @@ def _build_report(agg: dict, cells: list, cutoff: datetime,
             )
     lines.append("")
     return "\n".join(lines)
+
+
+def _get_symbols() -> list[str]:
+    """Return the 10 portfolio symbols (mirror of A.4-1's basket)."""
+    from btc_scanner import DEFAULT_SYMBOLS
+    return list(DEFAULT_SYMBOLS)
+
+
+def main(argv: list | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pre-holdout regime threshold re-tune mini-harness (A.4-1.5).",
+    )
+    parser.add_argument("--max-date", type=str, required=True,
+                        help="ISO date (YYYY-MM-DD, UTC). Holdout starts on this day; "
+                             "tune sees only bars strictly before it.")
+    parser.add_argument("--out-dir", type=str, default=None,
+                        help="Override output directory. "
+                             "Defaults to data/retune/<today>-pre-holdout/.")
+    args = parser.parse_args(argv)
+
+    cutoff = datetime.fromisoformat(args.max_date).replace(tzinfo=timezone.utc)
+    cutoff_ms = int(cutoff.timestamp() * 1000)
+
+    if not os.path.exists(OHLCV_DB):
+        log.error("OHLCV DB not found at %s", OHLCV_DB)
+        return 2
+
+    symbols = _get_symbols()
+    app_config = _load_config()
+
+    if args.out_dir:
+        out_dir = args.out_dir
+    else:
+        run_date = datetime.now(timezone.utc).date().isoformat()
+        out_dir = os.path.join(REPO_ROOT, "data", "retune", f"{run_date}-pre-holdout")
+    os.makedirs(out_dir, exist_ok=True)
+
+    log.info("A.4-1.5 regime threshold re-tune starting")
+    log.info("  cutoff:  %s", cutoff.isoformat())
+    log.info("  symbols: %s", ", ".join(symbols))
+    log.info("  configs: %s", ", ".join(c["name"] for c in GRID))
+    log.info("  out_dir: %s", out_dir)
+
+    start = time.time()
+    cells = []
+    for symbol in symbols:
+        for config in GRID:
+            cell = _run_one_backtest(symbol, config, cutoff, app_config=app_config)
+            if cell["error"]:
+                log.warning("[%s][%s] error: %s", symbol, config["name"], cell["error"])
+            else:
+                log.info("[%s][%s] net_pnl=$%+,.2f trades=%d",
+                         symbol, config["name"], cell["net_pnl"], cell["trades"])
+            cells.append(cell)
+    runtime_seconds = time.time() - start
+
+    agg = _aggregate_results(cells)
+
+    log.info("Computing per-symbol data ranges from ohlcv.db...")
+    ranges = _per_symbol_data_ranges(OHLCV_DB, symbols, cutoff_ms)
+    leakage_check = _verify_no_leakage(ranges, cutoff_ms)
+    log.info("Leakage check: %s", leakage_check)
+
+    log.info("Hashing ohlcv.db...")
+    ohlcv_sha = _sha256_file(OHLCV_DB)
+    code_commit = _resolve_git_commit()
+
+    manifest = _build_manifest(
+        agg=agg, cutoff=cutoff, cutoff_ms=cutoff_ms,
+        ohlcv_sha=ohlcv_sha, code_commit=code_commit,
+        ranges=ranges, runtime_seconds=runtime_seconds,
+        leakage_check=leakage_check, symbols=symbols,
+    )
+
+    report_md = _build_report(
+        agg=agg, cells=cells, cutoff=cutoff,
+        ranges=ranges, runtime_seconds=runtime_seconds, symbols=symbols,
+    )
+
+    _write_regime_params(os.path.join(out_dir, "regime_params.json"), agg)
+    _atomic_write_json(os.path.join(out_dir, "regime_manifest.json"), manifest)
+    with open(os.path.join(out_dir, "regime_report.md"), "w", encoding="utf-8") as f:
+        f.write(report_md)
+
+    log.info("Artefacts written to %s", out_dir)
+    log.info("  regime_params.json   — winner config, byte-deterministic")
+    log.info("  regime_manifest.json — cutoff, hashes, decision flags, no-leakage proof")
+    log.info("  regime_report.md     — human-readable side-by-side + caveats")
+    log.info("Decision flags: %s", agg["decision_flags"])
+
+    if agg["decision_flags"]["sanity_check"]:
+        log.error("SANITY CHECK FIRED: no_detector wins on pre-holdout window. "
+                  "HALT + DEBUG before promoting this artefact.")
+        return 3
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/regime_retune_pre_holdout.py
+++ b/tools/regime_retune_pre_holdout.py
@@ -7,6 +7,14 @@ pre-registered decision flags; writes byte-deterministic artefacts.
 
 Usage:
     python -m tools.regime_retune_pre_holdout --max-date 2025-04-30
+
+Exit codes:
+  0 — success, canonical artefacts written
+  2 — no OHLCV DB
+  3 — sanity halt (no_detector wins; refuses canonical writes)
+  4 — sweep had errored cells
+  5 — manifest/canonical write failure (raw_results.json fallback)
+  6 — degenerate zero-pnl sweep (refuses canonical writes)
 """
 from __future__ import annotations
 
@@ -20,6 +28,7 @@ import subprocess
 import sys
 import time
 from datetime import datetime, timezone
+from typing import Literal
 
 import pandas as pd
 
@@ -387,12 +396,16 @@ def _build_report(agg: dict, cells: list, cutoff: datetime,
     eq = "==" if agg['winner'] == '60_40' else "!="
     sanity_msg = "→ HALT + DEBUG required before any commit" if agg['decision_flags']['sanity_check'] else ""
     stab_msg = "→ informational caveat: regime is operating in a flat region" if agg['decision_flags']['stability_check'] else ""
+    degen_flag = agg['decision_flags'].get('degenerate_zero_pnl', False)
+    degen_msg = "→ HALT: winner is lex tie-break, not signal-driven" if degen_flag else ""
     lines.append(f"- **CHANGE detection:** `{agg['decision_flags']['change_detection']}` "
                  f"(winner {eq} current production `60_40`)")
     lines.append(f"- **Sanity check (no-detector wins):** "
                  f"`{agg['decision_flags']['sanity_check']}` {sanity_msg}")
     lines.append(f"- **Stability check (margin < 5%):** "
                  f"`{agg['decision_flags']['stability_check']}` {stab_msg}")
+    lines.append(f"- **Degenerate zero-pnl (all per-config sums ≈ 0):** "
+                 f"`{degen_flag}` {degen_msg}")
     lines.append("")
     lines.append("## Per-symbol breakdown")
     lines.append("")
@@ -458,44 +471,81 @@ def _clear_stale_artefacts(out_dir: str) -> None:
     place and the operator believes run-2 succeeded.
 
     Also clears orphan .tmp files from prior interrupted runs.
+    Permission errors are logged but don't abort cleanup.
     """
+    removed: list[str] = []
     for stale_name in _CANONICAL_ARTEFACTS:
+        stale_path = os.path.join(out_dir, stale_name)
         try:
-            os.remove(os.path.join(out_dir, stale_name))
+            os.remove(stale_path)
+            removed.append(stale_name)
         except FileNotFoundError:
             pass
+        except PermissionError as exc:
+            log.warning("Could not remove stale artefact %s: %s", stale_path, exc)
     try:
         for entry in os.listdir(out_dir):
             if entry.endswith(".tmp"):
+                tmp_path = os.path.join(out_dir, entry)
                 try:
-                    os.remove(os.path.join(out_dir, entry))
+                    os.remove(tmp_path)
+                    removed.append(entry)
                 except FileNotFoundError:
                     pass
+                except PermissionError as exc:
+                    log.warning("Could not remove orphan tmp %s: %s", tmp_path, exc)
     except FileNotFoundError:
         pass
+    if removed:
+        log.info("Cleared %d stale artefact(s) from %s: %s",
+                 len(removed), out_dir, ", ".join(removed))
 
 
-def _emergency_write(path: str, payload: dict, kind: str) -> None:
-    """Best-effort write for diagnostic artefacts. On primary failure, falls
-    back to /tmp; on fallback failure, logs and continues. Never raises —
-    preserves the caller's rc contract under disk-full / permission errors.
+def _emergency_write(
+    path: str,
+    payload: dict,
+    kind: Literal["halted_summary", "sweep_errors", "raw_results"],
+) -> None:
+    """Best-effort write for diagnostic artefacts. Never raises — preserves
+    caller's rc contract under disk-full / permission errors.
+
+    On primary failure, falls back to /tmp/regime_retune_<kind>_<ts>.json.
+    Fallback uses ``default=str`` to tolerate non-JSON-serializable payloads
+    (e.g. class instances accidentally stashed in agg dicts during
+    diagnostic flows). On fallback failure, logs and continues.
+
+    Catches Exception broadly because a diagnostic write must succeed at
+    documenting the *original* error — narrowing the catch (and accidentally
+    propagating, say, a recursive serialization MemoryError) would break the
+    rc contract that the docstring promises.
     """
     try:
         _atomic_write_json(path, payload)
-    except (OSError, TypeError, ValueError) as exc:
+        return
+    except Exception as exc:  # noqa: BLE001 — see docstring rationale
         log.error("Failed to write %s artefact at %s: %s", kind, path, exc, exc_info=True)
-        fallback = f"/tmp/regime_retune_{kind}_{int(time.time())}.json"
-        try:
-            with open(fallback, "w", encoding="utf-8") as f:
-                json.dump(payload, f, sort_keys=True, indent=2, default=str)
-            log.error("Fallback %s written to %s", kind, fallback)
-        except (OSError, TypeError, ValueError) as fallback_exc:
-            log.error("Fallback write also failed: %s", fallback_exc, exc_info=True)
+    fallback = f"/tmp/regime_retune_{kind}_{int(time.time())}.json"
+    try:
+        with open(fallback, "w", encoding="utf-8") as f:
+            json.dump(payload, f, sort_keys=True, indent=2, default=str)
+        log.error("Fallback %s written to %s", kind, fallback)
+    except Exception as fallback_exc:  # noqa: BLE001
+        log.error("Fallback write also failed: %s", fallback_exc, exc_info=True)
 
 
 def main(argv: list | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Pre-holdout regime threshold re-tune mini-harness.",
+        epilog=(
+            "Exit codes: "
+            "0=success | "
+            "2=no OHLCV DB | "
+            "3=sanity halt (no_detector wins) | "
+            "4=sweep had errored cells | "
+            "5=manifest/canonical write failure (raw_results.json fallback) | "
+            "6=degenerate zero-pnl sweep"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--max-date", type=str, required=True,
                         help="ISO date (YYYY-MM-DD, UTC). Holdout starts on this day; "
@@ -606,6 +656,32 @@ def main(argv: list | None = None) -> int:
             kind="halted_summary",
         )
         return 3
+
+    # Degenerate sweep: every per-config sum is below the 1e-9 threshold.
+    # The winner becomes a lex tie-break (60_40 by alphabetical order) rather
+    # than signal-driven. Refuse to write canonical artefacts — operator
+    # should investigate whether all symbols are disabled, OHLCV is corrupt,
+    # or signal generation is broken before treating the result as authoritative.
+    # Sanity (no_detector wins) takes priority above; a dataset that produces
+    # both flags simultaneously is sanity-first.
+    if agg["decision_flags"].get("degenerate_zero_pnl", False):
+        log.error(
+            "DEGENERATE SWEEP: all per-config net_pnl below 1e-9 threshold. "
+            "Winner is lex tie-break, not signal-driven. Refusing to write "
+            "canonical artefacts. Possible causes: all symbols disabled, "
+            "OHLCV corruption, signal generation broken. See halted_summary.json."
+        )
+        _emergency_write(
+            os.path.join(out_dir, "halted_summary.json"),
+            {
+                "reason": "degenerate_zero_pnl",
+                "agg": agg,
+                "manifest": manifest,
+                "report_md": report_md,
+            },
+            kind="halted_summary",
+        )
+        return 6
 
     # Order: report + manifest first, regime_params.json LAST as the
     # durability marker for downstream consumers. If any write fails (disk

--- a/tools/regime_retune_pre_holdout.py
+++ b/tools/regime_retune_pre_holdout.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Pre-holdout regime threshold re-tune (A.4-1.5).
+
+Sweeps the 4 configurations locked by historical record (commit bf581f1)
+over the pre-holdout window [earliest, 2025-04-30T00:00:00Z), aggregates
+net_pnl per config across the 10 portfolio symbols, identifies the
+winner, and applies pre-registered decision flags (CHANGE detection,
+sanity check, stability check).
+
+Mirrors the shape of tools/retune_pre_holdout.py (A.4-1) but runs a
+single backtest per (symbol, config) instead of a grid search — the
+grid + objective here are locked by spec D9 §2.10, not optimized.
+
+Usage:
+    python -m tools.regime_retune_pre_holdout --max-date 2025-04-30
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)-8s  %(message)s")
+log = logging.getLogger("regime_retune_pre_holdout")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OHLCV_DB = os.path.join(REPO_ROOT, "data", "ohlcv.db")
+
+TIMEFRAMES = ("5m", "1h", "4h", "1d")
+
+GRID = [
+    {"name": "60_40",       "bull_above": 60,   "bear_below": 40,   "disabled": False},
+    {"name": "70_30",       "bull_above": 70,   "bear_below": 30,   "disabled": False},
+    {"name": "80_20",       "bull_above": 80,   "bear_below": 20,   "disabled": False},
+    {"name": "no_detector", "bull_above": None, "bear_below": None, "disabled": True},
+]
+
+
+def _resolve_git_commit() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip()
+    except Exception:
+        return "UNKNOWN"
+
+
+def _sha256_file(path: str, block_size: int = 1024 * 1024) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(block_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _slice_below_cutoff(df: pd.DataFrame, cutoff: datetime) -> pd.DataFrame:
+    """Return the subset of df whose index is strictly < cutoff.
+
+    Self-contained (does not import auto_tune._slice_below_cutoff) so this
+    module is independent of A.4-1's PR #287 helper — A.4-1 Phase 3 is
+    GATED on this harness closing, so depending on its branch would be a
+    circular dependency.
+    """
+    if df is None or df.empty:
+        return df
+    cutoff_ts = pd.Timestamp(cutoff)
+    if df.index.tz is None and cutoff_ts.tz is not None:
+        cutoff_ts_for_cmp = cutoff_ts.tz_localize(None)
+    elif df.index.tz is not None and cutoff_ts.tz is None:
+        cutoff_ts_for_cmp = cutoff_ts.tz_localize("UTC")
+    else:
+        cutoff_ts_for_cmp = cutoff_ts
+    sliced = df.loc[df.index < cutoff_ts_for_cmp]
+    if not sliced.empty:
+        max_ts = pd.Timestamp(sliced.index.max())
+        if max_ts.tz is None:
+            max_ts = max_ts.tz_localize("UTC")
+        cutoff_check = cutoff_ts if cutoff_ts.tz is not None else cutoff_ts.tz_localize("UTC")
+        assert max_ts < cutoff_check, f"Slice leak: max_ts={max_ts} >= cutoff={cutoff_check}"
+    return sliced
+
+
+def _per_symbol_data_ranges(db_path: str, symbols: list, cutoff_ms: int) -> dict:
+    """Per (symbol, tf), report [min_ts_ms, max_ts_ms, count] of bars with open_time < cutoff_ms."""
+    ranges: dict = {}
+    con = sqlite3.connect(db_path)
+    try:
+        for sym in symbols:
+            ranges[sym] = {}
+            for tf in TIMEFRAMES:
+                row = con.execute(
+                    "SELECT MIN(open_time), MAX(open_time), COUNT(*) "
+                    "FROM ohlcv WHERE symbol=? AND timeframe=? AND open_time<?",
+                    (sym, tf, cutoff_ms),
+                ).fetchone()
+                if row and row[2]:
+                    ranges[sym][tf] = {
+                        "min_ts_ms": int(row[0]),
+                        "max_ts_ms": int(row[1]),
+                        "min_ts_iso": datetime.fromtimestamp(row[0] / 1000, timezone.utc).isoformat(),
+                        "max_ts_iso": datetime.fromtimestamp(row[1] / 1000, timezone.utc).isoformat(),
+                        "count": int(row[2]),
+                    }
+                else:
+                    ranges[sym][tf] = {"min_ts_ms": None, "max_ts_ms": None, "count": 0}
+    finally:
+        con.close()
+    return ranges
+
+
+def _verify_no_leakage(ranges: dict, cutoff_ms: int) -> str:
+    for sym, tfs in ranges.items():
+        for tf, span in tfs.items():
+            if span["max_ts_ms"] is not None and span["max_ts_ms"] >= cutoff_ms:
+                raise AssertionError(
+                    f"no-leakage violation: {sym} {tf} max_ts_ms={span['max_ts_ms']} "
+                    f">= cutoff_ms={cutoff_ms}"
+                )
+    return "PASS"
+
+
+def _load_config() -> dict:
+    """Load config.json from repo root. Returns empty dict if missing."""
+    cfg_path = os.path.join(REPO_ROOT, "config.json")
+    if not os.path.exists(cfg_path):
+        return {}
+    with open(cfg_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_frames(symbol: str, cutoff: datetime) -> dict:
+    """Load all DataFrames simulate_strategy needs, sliced strictly < cutoff.
+
+    Returns dict with keys: df1h, df4h, df5m, df1d, df1d_btc, df_fng, df_funding.
+    Each value is a (possibly empty) DataFrame whose index is strictly < cutoff.
+    Frame loaders mirror the canonical path used by scripts/_a02_diag_lib.fetch_data.
+    """
+    from backtest import (
+        get_cached_data,
+        get_historical_fear_greed,
+        get_historical_funding_rate,
+    )
+
+    out = {}
+    for tf, key in (("1h", "df1h"), ("4h", "df4h"), ("5m", "df5m"), ("1d", "df1d")):
+        df = get_cached_data(symbol, tf)
+        out[key] = _slice_below_cutoff(df, cutoff)
+
+    if symbol == "BTCUSDT":
+        out["df1d_btc"] = out["df1d"]
+    else:
+        df1d_btc = get_cached_data("BTCUSDT", "1d")
+        out["df1d_btc"] = _slice_below_cutoff(df1d_btc, cutoff)
+
+    out["df_fng"] = _slice_below_cutoff(get_historical_fear_greed(), cutoff)
+    out["df_funding"] = _slice_below_cutoff(get_historical_funding_rate(), cutoff)
+
+    return out
+
+
+def _run_one_backtest(symbol: str, config: dict, cutoff: datetime,
+                      app_config: dict | None = None) -> dict:
+    """Run a single backtest for (symbol, regime config). Returns net_pnl + diagnostics.
+
+    Uses production ATR multipliers from config.json so the regime threshold is
+    the only varying input across the sweep. Costs (slippage/spread/fees) match
+    production. Returns {symbol, config, net_pnl, trades, error}.
+    """
+    from backtest import simulate_strategy
+
+    if app_config is None:
+        app_config = _load_config()
+    overrides = app_config.get("symbol_overrides", {}) or {}
+
+    frames = _load_frames(symbol, cutoff)
+    if frames["df1h"].empty or frames["df4h"].empty or frames["df5m"].empty:
+        return {"symbol": symbol, "config": config["name"], "net_pnl": 0.0,
+                "trades": 0, "error": "empty_ohlcv_below_cutoff"}
+
+    kwargs = {
+        "df1h": frames["df1h"],
+        "df4h": frames["df4h"],
+        "df5m": frames["df5m"],
+        "df1d": frames["df1d"],
+        "df1d_btc": frames["df1d_btc"],
+        "df_fng": frames["df_fng"],
+        "df_funding": frames["df_funding"],
+        "symbol": symbol,
+        "sl_mode": "atr",
+        "symbol_overrides": overrides,
+        "cfg": app_config,
+        "enable_slippage": True,
+        "enable_spread": True,
+        "enable_fees": True,
+    }
+    if config["disabled"]:
+        kwargs["regime_disabled"] = True
+    else:
+        kwargs["regime_thresholds"] = (config["bull_above"], config["bear_below"])
+
+    try:
+        trades, _equity = simulate_strategy(**kwargs)
+    except Exception as exc:  # noqa: BLE001
+        log.error("[%s][%s] simulate_strategy raised: %s", symbol, config["name"], exc)
+        return {"symbol": symbol, "config": config["name"], "net_pnl": 0.0,
+                "trades": 0, "error": str(exc)}
+
+    net_pnl = sum(t.get("pnl_usd", 0.0) for t in trades)
+    return {"symbol": symbol, "config": config["name"], "net_pnl": float(net_pnl),
+            "trades": len(trades), "error": None}
+
+
+def _aggregate_results(cells: list) -> dict:
+    """Aggregate per-cell results into per-config sums + decision flags.
+
+    cells: list of {symbol, config, net_pnl, trades, error} dicts.
+    Tie-break on lex order of config name keeps the winner choice deterministic.
+    """
+    per_config_pnl: dict[str, float] = {}
+    per_config_trades: dict[str, int] = {}
+    for cell in cells:
+        cfg = cell["config"]
+        per_config_pnl[cfg] = per_config_pnl.get(cfg, 0.0) + float(cell["net_pnl"])
+        per_config_trades[cfg] = per_config_trades.get(cfg, 0) + int(cell["trades"])
+
+    sorted_configs = sorted(per_config_pnl.items(), key=lambda kv: (-kv[1], kv[0]))
+    winner_name, winner_pnl = sorted_configs[0]
+    runner_up_name, runner_up_pnl = sorted_configs[1]
+
+    if abs(winner_pnl) > 1e-9:
+        margin_pct = (winner_pnl - runner_up_pnl) / abs(winner_pnl) * 100.0
+    else:
+        margin_pct = 0.0
+
+    decision_flags = {
+        "change_detection": winner_name != "60_40",
+        "sanity_check":     winner_name == "no_detector",
+        "stability_check":  margin_pct < 5.0,
+    }
+
+    return {
+        "per_config_pnl": per_config_pnl,
+        "per_config_trades": per_config_trades,
+        "winner": winner_name,
+        "winner_pnl": winner_pnl,
+        "runner_up": runner_up_name,
+        "runner_up_pnl": runner_up_pnl,
+        "winner_margin_pct": margin_pct,
+        "decision_flags": decision_flags,
+    }
+
+
+def _atomic_write_json(path: str, payload: dict) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, sort_keys=True, indent=2, ensure_ascii=False)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def _write_regime_params(path: str, agg: dict) -> None:
+    """Write regime_params.json. Shape depends on winner:
+      - threshold winner:   {"format_version": 1, "regime_thresholds": {"bull_above": <int>, "bear_below": <int>}}
+      - no_detector winner: {"format_version": 1, "regime_disabled": true}
+    """
+    winner = agg["winner"]
+    if winner == "no_detector":
+        payload = {"format_version": 1, "regime_disabled": True}
+    else:
+        cfg = next(c for c in GRID if c["name"] == winner)
+        payload = {
+            "format_version": 1,
+            "regime_thresholds": {
+                "bull_above": cfg["bull_above"],
+                "bear_below": cfg["bear_below"],
+            },
+        }
+    _atomic_write_json(path, payload)
+
+
+def _build_manifest(agg: dict, cutoff: datetime, cutoff_ms: int,
+                    ohlcv_sha: str, code_commit: str,
+                    ranges: dict, runtime_seconds: float,
+                    leakage_check: str, symbols: list) -> dict:
+    return {
+        "harness": "regime_retune_pre_holdout",
+        "spec_ref": "docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md §2.10",
+        "cutoff_effective_iso": cutoff.isoformat(),
+        "cutoff_effective_ms": cutoff_ms,
+        "code_commit": code_commit,
+        "ohlcv_sha256": ohlcv_sha,
+        "ohlcv_path_relative": os.path.relpath(OHLCV_DB, REPO_ROOT),
+        "ran_at_iso": datetime.now(timezone.utc).isoformat(),
+        "runtime_seconds": round(runtime_seconds, 2),
+        "leakage_check": leakage_check,
+        "symbols": symbols,
+        "grid": [{"name": g["name"], "bull_above": g["bull_above"],
+                  "bear_below": g["bear_below"], "disabled": g["disabled"]} for g in GRID],
+        "per_config_pnl": agg["per_config_pnl"],
+        "per_config_trades": agg["per_config_trades"],
+        "winner": agg["winner"],
+        "winner_pnl": agg["winner_pnl"],
+        "runner_up": agg["runner_up"],
+        "runner_up_pnl": agg["runner_up_pnl"],
+        "winner_margin_pct": round(agg["winner_margin_pct"], 4),
+        "decision_flags": agg["decision_flags"],
+        "per_symbol_data_ranges": ranges,
+        "scope_notes": {
+            "n_effective_contribution": 0,
+            "promotion_to_strategy_regime_py_and_backtest_py": "deferred_to_phase_5_post_holdout_PR",
+        },
+    }
+
+
+def _build_report(agg: dict, cells: list, cutoff: datetime,
+                  ranges: dict, runtime_seconds: float, symbols: list) -> str:
+    lines = []
+    lines.append("# Pre-holdout Regime Threshold Re-tune Report (A.4-1.5)")
+    lines.append("")
+    lines.append(f"- **Cutoff (`--max-date`):** {cutoff.isoformat()}")
+    lines.append(f"- **Symbols:** {', '.join(symbols)}")
+    lines.append(f"- **Runtime:** {runtime_seconds:.0f}s")
+    lines.append(f"- **Spec ref:** D9 §2.10 (locked grid, locked objective)")
+    lines.append("")
+    lines.append("## Per-config aggregate")
+    lines.append("")
+    lines.append("| Config | Sum net_pnl (USD) | Total trades | Margin to winner |")
+    lines.append("|--------|-------------------|--------------|------------------|")
+    for cfg_name in ("60_40", "70_30", "80_20", "no_detector"):
+        pnl = agg["per_config_pnl"].get(cfg_name, 0.0)
+        tr = agg["per_config_trades"].get(cfg_name, 0)
+        if cfg_name == agg["winner"]:
+            margin = "**winner**"
+        elif abs(agg["winner_pnl"]) > 1e-9:
+            m = (agg["winner_pnl"] - pnl) / abs(agg["winner_pnl"]) * 100
+            margin = f"-{m:.2f}%"
+        else:
+            margin = "—"
+        lines.append(f"| {cfg_name} | ${pnl:+,.2f} | {tr} | {margin} |")
+    lines.append("")
+    lines.append(f"**Winner:** `{agg['winner']}` (sum net_pnl = ${agg['winner_pnl']:+,.2f})")
+    lines.append(f"**Runner-up:** `{agg['runner_up']}` (sum net_pnl = ${agg['runner_up_pnl']:+,.2f})")
+    lines.append(f"**Margin:** {agg['winner_margin_pct']:.2f}% of |winner|")
+    lines.append("")
+    lines.append("## Decision flags (pre-registered per D9 §2.10)")
+    lines.append("")
+    eq = "==" if agg['winner'] == '60_40' else "!="
+    sanity_msg = "→ HALT + DEBUG required before any commit" if agg['decision_flags']['sanity_check'] else ""
+    stab_msg = "→ informational caveat: regime is operating in a flat region" if agg['decision_flags']['stability_check'] else ""
+    lines.append(f"- **CHANGE detection:** `{agg['decision_flags']['change_detection']}` "
+                 f"(winner {eq} current production `60_40`)")
+    lines.append(f"- **Sanity check (no-detector wins):** "
+                 f"`{agg['decision_flags']['sanity_check']}` {sanity_msg}")
+    lines.append(f"- **Stability check (margin < 5%):** "
+                 f"`{agg['decision_flags']['stability_check']}` {stab_msg}")
+    lines.append("")
+    lines.append("## Per-symbol breakdown")
+    lines.append("")
+    lines.append("| Symbol | 60_40 | 70_30 | 80_20 | no_detector |")
+    lines.append("|--------|-------|-------|-------|-------------|")
+    by_symbol_config: dict = {}
+    for c in cells:
+        by_symbol_config.setdefault(c["symbol"], {})[c["config"]] = c["net_pnl"]
+    for sym in symbols:
+        row = by_symbol_config.get(sym, {})
+        cells_str = " | ".join(
+            f"${row.get(cfg, 0.0):+,.0f}"
+            for cfg in ("60_40", "70_30", "80_20", "no_detector")
+        )
+        lines.append(f"| {sym} | {cells_str} |")
+    lines.append("")
+    lines.append("## Caveats")
+    lines.append("")
+    lines.append("- **JUPUSDT** — earliest OHLCV bar is 2024-01-31. SMA200 (1d) and SMA100 (1h) "
+                 "yield NaN over the first ~4 days of JUP train data. Same warmup degradation "
+                 "applies here as in A.4-1; results for JUP are reported but should be interpreted "
+                 "with this caveat.")
+    lines.append("")
+    lines.append("## Data ranges (per symbol × tf, all bars below cutoff)")
+    lines.append("")
+    lines.append("| Symbol | TF | Min ts (UTC) | Max ts (UTC) | Bars |")
+    lines.append("|--------|----|---------------|---------------|------|")
+    for sym in sorted(ranges.keys()):
+        for tf in TIMEFRAMES:
+            span = ranges[sym].get(tf, {})
+            lines.append(
+                f"| {sym} | {tf} "
+                f"| {span.get('min_ts_iso', '—')} "
+                f"| {span.get('max_ts_iso', '—')} "
+                f"| {span.get('count', 0)} |"
+            )
+    lines.append("")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Phase 2 of A.4-1.5 mini-harness. Adds the harness needed to re-tune the regime detector BULL/BEAR partition thresholds (`>60/<40`) over the pre-holdout window before A.4 holdout evaluation runs. **Does NOT execute the sweep** — Phase 3 commits the artefact in a follow-up commit on this PR.

Per spec D9 §2.10 (locked grid + locked objective):
- 4 configurations from commit `bf581f1`: `(60, 40)`, `(70, 30)`, `(80, 20)`, no-detector
- Window: `[earliest, 2025-04-30T00:00:00Z)` strict `<` slicing
- Objective: maximize sum of `net_pnl` across the 10 portfolio symbols
- Decision flags: CHANGE detection, sanity check (no_detector wins → halt+debug), stability check (2nd within 5% → caveat)

## Code changes

- `strategy/regime.py` — parameterize `bull_above`/`bear_below` in both `_compute_local_regime` (backtest path) and `detect_regime` (live path); defaults 60/40 preserve byte-identity. Stale docstring `>70/<30` in `detect_regime` corrected as opportunistic close of the doc-bug listed in the active-backlog.
- `backtest.py` — thread thresholds through `simulate_strategy` → `_regime_at_time` → `_compute_local_regime`. Add `regime_disabled` bypass that emits a synthetic `{"regime": "BYPASS"}` dict.
- `strategy/core.py` — `_regime_to_direction_token` maps `"BYPASS"` → `"ANY"`; gating block at lines 341-356 treats `"ANY"` as "permit either direction by zone alone" (matches the "no detector" semantics from `bf581f1`'s 4-config comparison).
- `tools/regime_retune_pre_holdout.py` — new harness module: locked grid, self-contained slicing (does not depend on PR #287's helper to avoid circular gating), single-backtest runner per (symbol, config) using production ATR multipliers from `config.json` + realistic costs, aggregate, decision flags, atomic byte-deterministic JSON writers.
- `tests/test_holdout_isolation.py` — whitelist entry for the new harness.

## Test coverage

- 50 new tests in `tests/test_regime_thresholds_param.py` (8), `tests/test_simulate_strategy_regime_kwargs.py` (9), and `tests/test_regime_retune_pre_holdout.py` (33).
- `tests/test_backtest_refactor_parity.py` (27 tests) confirms zero regressions on the unchanged-defaults path — byte-identity verified.
- Full test suite: **1303 pass, 0 fail** (excluding 3 slow smoke files that hit real OHLCV data; those are intentional exclusions in this PR's parity check).

## Out of scope

- **The actual sweep run.** Phase 3 commits the artefact to `data/retune/2026-05-04-pre-holdout/`.
- **Promotion to `strategy/regime.py` + `backtest.py`.** Deferred to Phase 5 separate PR after A.4 holdout passes.

## Validation gate

- **Reproducibility:** byte-identical `regime_params.json` across re-runs (verified at the JSON-writer test layer; full reproducibility check happens in Phase 3 via `diff` after running the wrapper twice).
- **No-leakage:** strict `<` slicing in `_slice_below_cutoff` + manifest records MIN/MAX timestamps per (symbol, tf) for human-verifiable proof.
- **Parity:** existing regime + backtest tests pass without changes — defaults preserve legacy production behavior byte-for-byte.

## Spec ref correction (cosmetic doc rot)

Spec D9 §2.10 cites `backtest.py:404-409` as the inline threshold site. That citation is stale — that block is the trade-cost calculation. The real source-of-truth is `strategy/regime.py:_compute_local_regime` and `strategy/regime.py:detect_regime`; backtest consumes the threshold via `_compute_local_regime` through `_regime_at_time`. This PR parameterizes at the source-of-truth layer; the spec ref backfill is a cosmetic D9 follow-up (already in the active backlog).

## References

- Spec: `docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md` §2.10
- Issue: #305
- Sister mini-epic: A.4-1 PR #287 (gated on this one closing successfully)
- Origin commit for current 60/40 thresholds: `bf581f1` (sssamuelll, 2026-04-18)