### PR TITLE
docs(plans): archive A.4-1 + A.4-1.5 Phase 3 execution plans

### DIFF
--- a/docs/superpowers/plans/2026-05-04-a4-1-5-phase3-regime-retune-execution.md
+++ b/docs/superpowers/plans/2026-05-04-a4-1-5-phase3-regime-retune-execution.md
@@ -1,0 +1,672 @@
+# A.4-1.5 Phase 3 — Pre-holdout Regime Threshold Re-tune Execution Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run the merged regime threshold re-tune harness (`tools/regime_retune_pre_holdout.py`, PR #306 / commit `f38d94d`) over the pre-holdout window `[earliest, 2025-04-30T00:00:00Z)`, produce byte-deterministic artefacts under `data/retune/2026-05-04-pre-holdout/`, evaluate the four pre-registered decision flags from spec D9 §2.10, and ship the artefact as a single commit on a fresh branch + draft PR. Phase 4 (multi-agent review) and Phase 5 (promotion) are out of scope.
+
+**Architecture:** Two consecutive harness invocations. Run 1 writes canonical artefacts to the default out-dir (`data/retune/2026-05-04-pre-holdout/`); Run 2 writes to `/tmp` for reproducibility comparison. The harness already implements: locked grid (60_40, 70_30, 80_20, no_detector), strict `<` slicing in `_slice_below_cutoff`, decision flag aggregation (`change_detection`, `sanity_check`, `stability_check`, `degenerate_zero_pnl`), atomic JSON+text writers, stale-artefact cleanup, and emergency fallbacks for rc=3/4/5/6 halt branches. This plan does not modify the harness — only invokes it, verifies the outputs against the manifest contract, runs an independent SQL leakage cross-check, and commits the artefacts.
+
+**Tech Stack:** Python 3.x, `tools.regime_retune_pre_holdout` (merged), `sqlite3`, `pandas`, `pytest`, `gh` CLI, `git`. No new dependencies. No reads from `data/holdout/`.
+
+---
+
+## Pre-execution constraints (kickoff — non-negotiable)
+
+- **NO read of `data/holdout/`** by anything in this PR. Harness reads `data/ohlcv.db` only.
+- **NO chmod / monkey-patch / Guard B suppression** at any point.
+- **NO promotion** of `regime_params.json` → `strategy/regime.py` + `backtest.py` in this PR (Phase 5 separate).
+- **NO `--no-verify`, `--no-gpg-sign`, `push --force`** (use `--force-with-lease` if ever needed; not needed on this fresh branch).
+- **NO `gh pr merge --auto`**.
+- **NO `Closes #N` / `Fixes #N` / `Resolves #N`** in commit body or PR body — `## References` only.
+- **NO touching `data/retune/2026-05-01-pre-holdout/`** — that is A.4-1's stale artefact, owned by a different plan (`docs/superpowers/plans/2026-05-04-a4-1-phase3-retune-execution.md`).
+- **Locked-by-historical-record (do not adjust):** grid = 4 configs from `bf581f1`; cutoff = `2025-04-30T00:00:00 UTC`; objective = sum of `net_pnl` across the 10 portfolio symbols; basket = `BTCUSDT, ETHUSDT, ADAUSDT, AVAXUSDT, DOGEUSDT, UNIUSDT, XLMUSDT, PENDLEUSDT, JUPUSDT, RUNEUSDT`. Any post-hoc adjustment disqualifies as primary validation.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `data/retune/2026-05-04-pre-holdout/regime_params.json` | Create (via harness) | Winner config — either `{"regime_thresholds": {...}}` or `{"regime_disabled": true}`; byte-deterministic durability marker |
+| `data/retune/2026-05-04-pre-holdout/regime_manifest.json` | Create (via harness) | Cutoff, ohlcv.db sha256, code commit, symbol_overrides sha256, per-(symbol, tf) MIN/MAX timestamps, leakage_check, decision_flags, per_config_pnl, runtime, ran_at_iso |
+| `data/retune/2026-05-04-pre-holdout/regime_report.md` | Create (via harness) | Human-readable per-config aggregate + per-symbol breakdown + caveats + data-ranges table |
+| `git commit` on `feat/methodology-a4-1-5-phase3-artefact` | Create | Single Phase 3 commit; PR opens as draft |
+
+**No changes to** harness module, tests, `strategy/regime.py`, `backtest.py`, `config.json`, `config.defaults.json`, or anything else. The branch is artefact-only.
+
+---
+
+## Phase 3 — Sweep execution
+
+### Task 1: Branch off main and verify pre-flight invariants
+
+**Files:**
+- No code changes; verification only.
+
+- [ ] **Step 1: Confirm clean main and HEAD == f38d94d**
+
+```bash
+git status
+git log --oneline -1
+```
+
+Expected: working tree shows only untracked items (`.claude/`, `data/retune/2026-05-01-pre-holdout/` from a different plan, and this plan file under `docs/superpowers/plans/`). HEAD prints `f38d94d feat(methodology): A.4-1.5 pre-holdout regime threshold re-tune harness (#306)`.
+
+If working tree has tracked modifications: STOP and report.
+
+- [ ] **Step 2: Create the artefact branch**
+
+```bash
+git checkout -b feat/methodology-a4-1-5-phase3-artefact
+```
+
+Expected: switches cleanly. Branch is fresh, no commits added yet.
+
+- [ ] **Step 3: Capture ohlcv.db sha256 (pre-flight reference)**
+
+```bash
+shasum -a 256 data/ohlcv.db | tee /tmp/ohlcv_sha_preflight.txt
+```
+
+Expected: prints `<64-hex-chars>  data/ohlcv.db`. Save this value — it must match the `ohlcv_sha256` field the harness writes into `regime_manifest.json` in Task 3 / Task 4.
+
+If `data/ohlcv.db` does not exist: STOP. Harness will exit rc=2.
+
+- [ ] **Step 4: Verify Guard B AST scanner is green**
+
+```bash
+pytest tests/test_holdout_isolation.py -v
+```
+
+Expected: all tests pass, including `test_no_holdout_references_in_non_whitelisted_modules`. The harness module is already whitelisted (committed in #306).
+
+If any test fails: STOP and report — do NOT proceed to the sweep.
+
+- [ ] **Step 5: Verify harness tests still pass**
+
+```bash
+pytest tests/test_regime_retune_pre_holdout.py -v
+```
+
+Expected: all tests pass (PR #306 body cites 33 tests in this file; pytest may report parametrized variants). Look for any post-merge drift.
+
+If any test fails: STOP and report.
+
+- [ ] **Step 6: Commit**
+
+No commit — verification only.
+
+---
+
+### Task 2: Execute Run 1 (canonical artefact)
+
+**Files:**
+- Create (via harness): `data/retune/2026-05-04-pre-holdout/{regime_params.json, regime_manifest.json, regime_report.md}`
+
+**This step requires Sam's "dale" before execution.** Surface the plan and wait.
+
+Default out-dir is computed by the harness from `datetime.now(timezone.utc).date().isoformat()`; today's UTC date is `2026-05-04`, so the dir will be `data/retune/2026-05-04-pre-holdout/`. The harness creates it if missing and clears any stale canonical artefacts before writing (`_clear_stale_artefacts`).
+
+- [ ] **Step 1: Run the harness**
+
+```bash
+python -m tools.regime_retune_pre_holdout --max-date 2025-04-30 2>&1 | tee /tmp/regime_retune_run1.log
+```
+
+Expected: log lines per `(symbol, config)` cell with `net_pnl=$+,.2f trades=N`. Final log lines: `Leakage check: PASS`, `Decision flags: {...}`, `Artefacts written to data/retune/2026-05-04-pre-holdout/`. Exit code 0.
+
+Halt branches (do NOT proceed to commit; report to reviewer with the log + halted_summary.json):
+- rc=2 — no OHLCV DB (caught at Task 1 Step 3)
+- rc=3 — sanity halt: `no_detector` won → bug in harness or dataset slicing; investigate
+- rc=4 — sweep had errored cells → triage `data/retune/.../sweep_errors.json`
+- rc=5 — manifest/canonical write failure → check `data/retune/.../raw_results.json`
+- rc=6 — degenerate zero-pnl: every per-config sum below 1e-9 → catastrophic upstream
+
+- [ ] **Step 2: Capture rc and proceed conditionally**
+
+```bash
+echo "rc=$?"
+```
+
+Expected: `rc=0`. If non-zero, STOP. Do NOT delete the halted_summary.json — it's the diagnostic for reviewer triage.
+
+- [ ] **Step 3: Inspect the artefact directory**
+
+```bash
+ls -la data/retune/2026-05-04-pre-holdout/
+```
+
+Expected: exactly three files — `regime_params.json`, `regime_manifest.json`, `regime_report.md`. No `.tmp` orphans, no `halted_summary.json`, no `sweep_errors.json`, no `raw_results.json`.
+
+If any halt-branch artefact is present: STOP — rc=0 should not coexist with a halt artefact.
+
+- [ ] **Step 4: Commit**
+
+No commit — Run 2 reproducibility check still pending.
+
+---
+
+### Task 3: Execute Run 2 (reproducibility check to /tmp)
+
+**Files:**
+- Create (in temp): `/tmp/regime_retune_run2/{regime_params.json, regime_manifest.json, regime_report.md}` (NOT under `data/retune/`)
+
+The reproducibility gate is: `regime_params.json` byte-identical across two runs with same cutoff + same code commit + same OHLCV DB. `regime_manifest.json` will differ in `ran_at_iso` and `runtime_seconds` by design; everything else must match.
+
+- [ ] **Step 1: Run the harness into a temp dir**
+
+```bash
+python -m tools.regime_retune_pre_holdout --max-date 2025-04-30 --out-dir /tmp/regime_retune_run2 2>&1 | tee /tmp/regime_retune_run2.log
+```
+
+Expected: same final log lines as Run 1 (`Leakage check: PASS`, same decision flags), exit code 0.
+
+If rc != 0 here but Run 1 succeeded: STOP. Indicates non-determinism in the harness path itself or environmental drift between runs.
+
+- [ ] **Step 2: Diff `regime_params.json` byte-for-byte**
+
+```bash
+diff data/retune/2026-05-04-pre-holdout/regime_params.json /tmp/regime_retune_run2/regime_params.json
+```
+
+Expected: empty output (exit code 0).
+
+If diff is non-empty: STOP. Reproducibility broken — winner choice or threshold values are non-deterministic. Report immediately with both files attached.
+
+- [ ] **Step 3: Diff `regime_manifest.json` excluding expected drift fields**
+
+```bash
+diff <(python3 -c "import json; m=json.load(open('data/retune/2026-05-04-pre-holdout/regime_manifest.json')); m.pop('ran_at_iso',None); m.pop('runtime_seconds',None); print(json.dumps(m, sort_keys=True, indent=2))") \
+     <(python3 -c "import json; m=json.load(open('/tmp/regime_retune_run2/regime_manifest.json')); m.pop('ran_at_iso',None); m.pop('runtime_seconds',None); print(json.dumps(m, sort_keys=True, indent=2))")
+```
+
+Expected: empty output. Strips the two known-drift fields and verifies everything else (cutoff, ohlcv_sha256, code_commit, symbol_overrides_sha256, per_config_pnl, per_config_trades, winner, runner_up, winner_margin_pct, decision_flags, per_symbol_data_ranges, scope_notes, grid, leakage_check, symbols, harness, spec_ref) is byte-identical.
+
+If any other field differs: STOP. Manifest non-determinism — investigate before committing. Common causes: cells run in non-deterministic order (re-check that `_aggregate_results` sums float-stably), or harness picked up a different `code_commit` between invocations (would be the case if a commit landed between runs — unlikely but verifiable).
+
+- [ ] **Step 4: Cleanup the temp dir**
+
+```bash
+rm -rf /tmp/regime_retune_run2
+```
+
+- [ ] **Step 5: Commit**
+
+No commit — verification only.
+
+---
+
+### Task 4: Manifest gate — independent SQL no-leakage cross-check
+
+**Files:**
+- Read-only: `data/retune/2026-05-04-pre-holdout/regime_manifest.json`, `data/ohlcv.db`
+
+The harness's internal `_verify_no_leakage` already asserts every per-(symbol, tf) MAX timestamp is `< cutoff_ms`. This task does an **independent** SQL query against `data/ohlcv.db` to cross-check, modeled after A.4-1's Phase 3 Task 8.
+
+- [ ] **Step 1: Run the cross-check script**
+
+```bash
+python3 <<'EOF'
+import json, sqlite3, sys
+from datetime import datetime, timezone
+
+CUTOFF_ISO = "2025-04-30T00:00:00+00:00"
+cutoff_ms = int(datetime.fromisoformat(CUTOFF_ISO).timestamp() * 1000)
+
+with open("data/retune/2026-05-04-pre-holdout/regime_manifest.json") as f:
+    manifest = json.load(f)
+
+con = sqlite3.connect("data/ohlcv.db")
+problems = []
+for sym, tfs in manifest["per_symbol_data_ranges"].items():
+    for tf, span in tfs.items():
+        # Manifest-declared MAX must be strictly < cutoff
+        if span["max_ts_ms"] is not None and span["max_ts_ms"] >= cutoff_ms:
+            problems.append(f"{sym} {tf}: manifest max_ts_ms {span['max_ts_ms']} >= cutoff {cutoff_ms}")
+        # Independent triangulation: ask the DB directly
+        row = con.execute(
+            "SELECT MAX(open_time) FROM ohlcv "
+            "WHERE symbol=? AND timeframe=? AND open_time<?",
+            (sym, tf, cutoff_ms),
+        ).fetchone()
+        db_max = row[0]
+        if db_max != span["max_ts_ms"]:
+            problems.append(
+                f"{sym} {tf}: manifest max_ts_ms {span['max_ts_ms']} != "
+                f"independent DB max {db_max}"
+            )
+        # Sanity (advisory): if the production DB has zero post-cutoff bars,
+        # the leakage test is weaker but not wrong.
+        n_post_row = con.execute(
+            "SELECT COUNT(*) FROM ohlcv "
+            "WHERE symbol=? AND timeframe=? AND open_time>=?",
+            (sym, tf, cutoff_ms),
+        ).fetchone()
+        if n_post_row[0] == 0:
+            print(f"INFO  {sym} {tf}: production DB has no bars >= cutoff (weaker leakage test)",
+                  file=sys.stderr)
+
+if problems:
+    print("LEAKAGE GATE FAILED:", file=sys.stderr)
+    for p in problems:
+        print(f"  - {p}", file=sys.stderr)
+    sys.exit(1)
+print("LEAKAGE GATE PASS — manifest MAX timestamps strictly < cutoff "
+      "AND match independent DB query for all (symbol, tf).")
+EOF
+```
+
+Expected: prints `LEAKAGE GATE PASS`. INFO lines are advisory.
+
+If `LEAKAGE GATE FAILED` for any reason: STOP and report. Do NOT commit. Critical.
+
+- [ ] **Step 2: Verify ohlcv.db sha256 matches Task 1 Step 3 capture**
+
+```bash
+python3 -c "import json; m=json.load(open('data/retune/2026-05-04-pre-holdout/regime_manifest.json')); print('manifest:', m['ohlcv_sha256'])"
+cat /tmp/ohlcv_sha_preflight.txt
+```
+
+Expected: the manifest's `ohlcv_sha256` matches the pre-flight `shasum -a 256` capture. The DB has not been mutated mid-run.
+
+If mismatch: STOP. Means the DB changed between pre-flight and the harness's hash step (corruption or concurrent write). Report and re-run.
+
+- [ ] **Step 3: Verify cutoff fields in manifest**
+
+```bash
+python3 -c "
+import json
+m = json.load(open('data/retune/2026-05-04-pre-holdout/regime_manifest.json'))
+assert m['cutoff_effective_iso'] == '2025-04-30T00:00:00+00:00', m['cutoff_effective_iso']
+assert m['cutoff_effective_ms'] == 1745971200000, m['cutoff_effective_ms']
+print('cutoff invariants OK:', m['cutoff_effective_iso'], m['cutoff_effective_ms'])
+"
+```
+
+Expected: prints `cutoff invariants OK: 2025-04-30T00:00:00+00:00 1745971200000`.
+
+The integer `1745971200000` is `int(datetime(2025,4,30,tzinfo=UTC).timestamp() * 1000)` — matches the holdout dataset MANIFEST.json `cutoff.start_inclusive_utc`.
+
+- [ ] **Step 4: Commit**
+
+No commit — verification only.
+
+---
+
+### Task 5: Evaluate decision flags and prepare commit body
+
+**Files:**
+- Read-only: `data/retune/2026-05-04-pre-holdout/regime_manifest.json`, `data/retune/2026-05-04-pre-holdout/regime_report.md`
+
+By the time we reach this task, halt-branch flags (sanity_check, degenerate_zero_pnl) cannot be true — the harness would have returned rc=3/6 and the canonical artefacts would not exist. So at this point the only flags whose interpretation matters are `change_detection` and `stability_check`.
+
+- [ ] **Step 1: Read the four decision flags**
+
+```bash
+python3 -c "
+import json
+m = json.load(open('data/retune/2026-05-04-pre-holdout/regime_manifest.json'))
+df = m['decision_flags']
+print('change_detection:', df['change_detection'])
+print('sanity_check:', df['sanity_check'])
+print('stability_check:', df['stability_check'])
+print('degenerate_zero_pnl:', df['degenerate_zero_pnl'])
+print('winner:', m['winner'])
+print('runner_up:', m['runner_up'])
+print('winner_margin_pct:', m['winner_margin_pct'])
+print('per_config_pnl:', json.dumps(m['per_config_pnl'], sort_keys=True, indent=2))
+"
+```
+
+Expected: `sanity_check: False` and `degenerate_zero_pnl: False` (else we'd not be here). The other two values inform commit body framing.
+
+- [ ] **Step 2: Apply flag interpretation**
+
+Interpretation matrix per spec D9 §2.10:
+
+- `change_detection == True` → winner ≠ `60_40`. Document explicitly in commit body: `CHANGE substantivo registrado per spec D9 §2.10. Phase 5 promotion requires explicit review`.
+- `change_detection == False` → winner == `60_40`. No CHANGE; commit body says `Re-tune confirms current production thresholds (60_40)`.
+- `stability_check == True` → 2nd-best within 5% of winner. Add caveat to commit body: `Stability caveat: 2nd-best (<runner_up>) within 5% of winner. Regime detection operating in flat region; choice is somewhat arbitrary on objective alone — qualitative tradeoffs should weigh in at promotion`.
+- `stability_check == False` → margin is decisive. No caveat needed; mention `Margin: <X>% of |winner|`.
+
+- [ ] **Step 3: Verify regime_params.json shape matches winner**
+
+```bash
+python3 -c "
+import json
+m = json.load(open('data/retune/2026-05-04-pre-holdout/regime_manifest.json'))
+p = json.load(open('data/retune/2026-05-04-pre-holdout/regime_params.json'))
+winner = m['winner']
+if winner == 'no_detector':
+    assert p == {'regime_disabled': True}, p
+    print('regime_params.json shape OK: regime_disabled')
+else:
+    assert 'regime_thresholds' in p, p
+    rt = p['regime_thresholds']
+    assert set(rt.keys()) == {'bull_above', 'bear_below'}, rt
+    assert isinstance(rt['bull_above'], int)
+    assert isinstance(rt['bear_below'], int)
+    print(f'regime_params.json shape OK: regime_thresholds bull_above={rt[\"bull_above\"]} bear_below={rt[\"bear_below\"]}')
+"
+```
+
+Expected: prints either `regime_disabled` (impossible at this point — would have halted at rc=3) or `regime_thresholds bull_above=<int> bear_below=<int>`.
+
+- [ ] **Step 4: Commit**
+
+No commit — preparation only.
+
+---
+
+### Task 6: Stage, commit, and push the artefact
+
+**Files:**
+- Add: `data/retune/2026-05-04-pre-holdout/regime_params.json`
+- Add: `data/retune/2026-05-04-pre-holdout/regime_manifest.json`
+- Add: `data/retune/2026-05-04-pre-holdout/regime_report.md`
+
+**This step requires a fresh "dale" from Sam** (the Task 2 "dale" authorized the run, not the commit; closure-by-closer rule). Before this task, also surface the decision-flag summary so Sam can authorize with full context.
+
+- [ ] **Step 1: Stage the three artefact files explicitly**
+
+```bash
+git add data/retune/2026-05-04-pre-holdout/regime_params.json
+git add data/retune/2026-05-04-pre-holdout/regime_manifest.json
+git add data/retune/2026-05-04-pre-holdout/regime_report.md
+git status
+```
+
+Expected: `git status` shows exactly three new files staged under `data/retune/2026-05-04-pre-holdout/`. Nothing else staged. Untracked items (`.claude/`, `data/retune/2026-05-01-pre-holdout/`, this plan file) remain untracked — do NOT stage them.
+
+If anything unexpected is staged: `git restore --staged <path>` to unstage, then re-verify.
+
+- [ ] **Step 2: Build the commit message body**
+
+Pull these values from `regime_manifest.json` (Task 5 Step 1 output):
+
+- `<ohlcv_sha>` — manifest's `ohlcv_sha256`
+- `<code_commit>` — manifest's `code_commit` (will be the branch HEAD = the parent of this commit)
+- `<overrides_sha>` — manifest's `symbol_overrides_sha256`
+- `<runtime>` — manifest's `runtime_seconds`
+- `<winner>` — manifest's `winner`
+- `<winner_pnl>` — manifest's `winner_pnl`
+- `<runner_up>` — manifest's `runner_up`
+- `<runner_up_pnl>` — manifest's `runner_up_pnl`
+- `<margin_pct>` — manifest's `winner_margin_pct`
+- `<pnl_60_40>`, `<pnl_70_30>`, `<pnl_80_20>`, `<pnl_no_detector>` — manifest's `per_config_pnl`
+- `<change_flag>`, `<sanity_flag>`, `<stability_flag>`, `<degenerate_flag>` — manifest's `decision_flags`
+
+Conditional sections:
+
+- If `<change_flag> == True`:
+  ```
+  CHANGE substantivo registrado per spec D9 §2.10. Winner is <winner>, not the
+  current production 60_40. Phase 5 promotion requires explicit review and
+  separate post-A.4-holdout-pass PR; this commit does NOT promote.
+  ```
+- If `<change_flag> == False`:
+  ```
+  Re-tune confirms current production thresholds (60_40). No CHANGE; Phase 5
+  promotion is a no-op for this artefact.
+  ```
+- If `<stability_flag> == True`:
+  ```
+  Stability caveat: 2nd-best (<runner_up>) within 5% of winner (<margin_pct>%).
+  Regime detection operating in flat region; choice is somewhat arbitrary on
+  objective alone — qualitative tradeoffs should weigh in at promotion.
+  ```
+- If `<stability_flag> == False`: omit the stability caveat block.
+
+- [ ] **Step 3: Commit (HEREDOC, with placeholders filled in)**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(methodology): A.4-1.5 Phase 3 — regime threshold re-tune artefact
+
+Sweep complete over [earliest, 2025-04-30T00:00:00Z), 4 configs × 10 symbols.
+
+Cutoff (--max-date): 2025-04-30T00:00:00+00:00 UTC
+OHLCV DB sha256: <ohlcv_sha>
+Code commit (in manifest): <code_commit>
+symbol_overrides sha256: <overrides_sha>
+Runtime: ~<runtime>s
+Leakage check: PASS (independent SQL cross-check confirmed)
+
+Winner: <winner> (sum net_pnl $<winner_pnl>)
+Runner-up: <runner_up> (sum net_pnl $<runner_up_pnl>)
+Margin: <margin_pct>% of |winner|
+
+Per-config breakdown:
+- 60_40:       $<pnl_60_40>
+- 70_30:       $<pnl_70_30>
+- 80_20:       $<pnl_80_20>
+- no_detector: $<pnl_no_detector>
+
+Decision flags:
+- change_detection:    <change_flag>
+- sanity_check:        <sanity_flag>
+- stability_check:     <stability_flag>
+- degenerate_zero_pnl: <degenerate_flag>
+
+[CHANGE block — include only if change_detection == True]
+[Stability block — include only if stability_check == True]
+
+Reproducibility verified: Run-2 to /tmp produced byte-identical
+regime_params.json (diff empty). Manifest fields outside ran_at_iso
+and runtime_seconds also identical.
+
+References (this commit closes nothing):
+- #305 (A.4-1.5 ticket — Phase 4 review pending)
+- #306 (harness PR, merged)
+- #287 (A.4-1 ATR retune, gated by A.4-1.5 closure)
+- #250 (A.4 holdout evaluation epic)
+- bf581f1 (origin commit for current 60/40 thresholds)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Note: the HEREDOC body must have literal numerical / boolean values substituted before committing — pasting the placeholders verbatim is a plan failure. The implementer (or subagent) must read the manifest in Task 5 and inline the actual values.
+
+- [ ] **Step 4: Verify the commit**
+
+```bash
+git log --oneline -1
+git show --stat HEAD
+```
+
+Expected: one commit on top of `f38d94d` with title `feat(methodology): A.4-1.5 Phase 3 — regime threshold re-tune artefact`. `git show --stat` shows three files added under `data/retune/2026-05-04-pre-holdout/`, no other changes.
+
+If the commit added unexpected files: `git reset --soft HEAD~1`, fix the staging, retry. Do NOT amend after push.
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin feat/methodology-a4-1-5-phase3-artefact
+```
+
+Expected: push succeeds; `-u` sets upstream tracking. No `--force`, no `--no-verify`.
+
+- [ ] **Step 6: Commit**
+
+Already done above. No additional commit at this step.
+
+---
+
+### Task 7: Open the draft PR
+
+**Files:**
+- No file changes — `gh` invocation only.
+
+PR opens as draft. Phase 4 multi-agent review is reviewer-driven and out of scope for this plan. Body uses `## References` (never `Closes #N`).
+
+- [ ] **Step 1: Verify recent merge convention**
+
+```bash
+gh pr list --state merged --limit 5 --json mergeCommit,title,headRefName,number
+```
+
+Expected: prints last 5 merged PRs. Note the merge style (squash vs merge commit) — relevant only at Phase 5 close, not here.
+
+- [ ] **Step 2: Open the draft PR**
+
+Build the body inline. The `<...>` placeholders use the same manifest values pulled in Task 6 Step 2.
+
+```bash
+gh pr create --draft --title "feat(methodology): A.4-1.5 Phase 3 artefact" --body "$(cat <<'EOF'
+## Summary
+
+Phase 3 of A.4-1.5 mini-epic. Single commit adding the pre-holdout regime threshold re-tune artefact under `data/retune/2026-05-04-pre-holdout/`. The harness (`tools/regime_retune_pre_holdout.py`, merged as #306 / `f38d94d`) was invoked with `--max-date 2025-04-30`, ran the locked 4-config grid over the 10 portfolio symbols, and emitted the three artefact files. **No code changes** in this PR — artefact only.
+
+## Run summary
+
+- Cutoff (`--max-date`): `2025-04-30T00:00:00+00:00` UTC (strict `<` slicing)
+- OHLCV DB sha256: `<ohlcv_sha>`
+- Code commit recorded in manifest: `<code_commit>`
+- Runtime: ~`<runtime>`s
+- Leakage check: PASS (independent SQL cross-check confirmed)
+- Winner: `<winner>` (sum net_pnl `$<winner_pnl>`)
+- Runner-up: `<runner_up>` (sum net_pnl `$<runner_up_pnl>`)
+- Margin: `<margin_pct>`% of |winner|
+
+## Decision flags
+
+| Flag | Value | Interpretation |
+|------|-------|----------------|
+| `change_detection`   | `<change_flag>`   | <`Winner ≠ 60_40 — CHANGE substantivo` if True else `Winner == 60_40 — no CHANGE`> |
+| `sanity_check`       | `<sanity_flag>`   | False (else rc=3 halt path; canonical artefacts would not exist) |
+| `stability_check`    | `<stability_flag>`| <`2nd-best within 5% — flat-region caveat` if True else `Margin decisive`> |
+| `degenerate_zero_pnl`| `<degenerate_flag>`| False (else rc=6 halt path; canonical artefacts would not exist) |
+
+## Per-config aggregate
+
+| Config       | Sum net_pnl |
+|--------------|-------------|
+| 60_40        | `$<pnl_60_40>` |
+| 70_30        | `$<pnl_70_30>` |
+| 80_20        | `$<pnl_80_20>` |
+| no_detector  | `$<pnl_no_detector>` |
+
+## Verification gate (all green)
+
+- Byte-identical `regime_params.json` across two consecutive runs (diff empty)
+- Manifest MAX(timestamp) strictly < `2025-04-30T00:00:00 UTC` for every (symbol, tf)
+- Independent SQL cross-check confirmed no-leakage AND match between manifest declared MAX and the production DB query
+- OHLCV DB sha256 stable from pre-flight to manifest hash step
+- Cutoff fields in manifest match holdout MANIFEST.json (`cutoff_effective_iso == 2025-04-30T00:00:00+00:00`, `cutoff_effective_ms == 1745971200000`)
+- `regime_params.json` shape matches winner (either `{"regime_thresholds": {...}}` or `{"regime_disabled": true}`)
+- Guard B AST scanner passes — no new holdout references
+- `tests/test_regime_retune_pre_holdout.py` still green at `f38d94d` HEAD
+
+## Out of scope
+
+- **Phase 4 multi-agent review** — reviewer-driven, follows this PR draft.
+- **Promotion of `regime_params.json`** → `strategy/regime.py` + `backtest.py`. Phase 5 separate PR after A.4 holdout passes.
+- **Closing #305.** This PR `## References` it; Sam closes after Phase 4 sign-off.
+- **A.4-1 (#287) unblocking.** Closure-by-closer rule: A.4-1 unblocks only after #305 is explicitly closed by Sam, not by this PR's merge.
+
+## Phase 4 review checklist (for reviewer agent)
+
+Phase 4 evaluates the artefact (data), not the harness code. Suggested briefing focus:
+- Magnitude check: are `per_config_pnl` values plausible vs known historical baselines?
+- Leakage proof verification: re-run the independent SQL cross-check from Task 4
+- Decision flag interpretation accuracy: does the commit body framing match the flag values?
+- Commit message and PR body accuracy: do all numbers in narrative match `regime_manifest.json`?
+
+## References (this PR closes nothing)
+
+- #305 (A.4-1.5 ticket)
+- #306 (harness PR, merged as f38d94d)
+- #287 (A.4-1 ATR retune — gated by A.4-1.5 closure)
+- #250 (A.4 holdout evaluation epic)
+- spec: docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md §2.10
+- bf581f1 (origin commit for current 60/40 thresholds)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Note: same placeholder rule as Task 6 Step 3 — substitute literal values from `regime_manifest.json` before invoking. Pasting verbatim is a plan failure.
+
+- [ ] **Step 3: Verify the PR opened as draft**
+
+```bash
+gh pr view --json number,isDraft,title,headRefName
+```
+
+Expected: `isDraft: true`, `headRefName: feat/methodology-a4-1-5-phase3-artefact`, title matches Step 2. Capture the PR number for later reference.
+
+- [ ] **Step 4: Surface PR URL to Sam + reviewer**
+
+Print the PR URL. Phase 4 multi-agent review (reviewer's responsibility) starts from this draft.
+
+- [ ] **Step 5: Commit**
+
+No commit — `gh pr create` does not modify the repo.
+
+---
+
+## Phase 4 — Multi-agent review (out of scope; reviewer-driven)
+
+Documented here for awareness only — the Dev agent does not execute Phase 4. The reviewer agent dispatches in parallel:
+
+- `code-reviewer` — evaluate artefact data quality, magnitude plausibility, commit message and PR body accuracy
+- `silent-failure-hunter` — re-run the independent SQL cross-check; verify no halt-branch artefacts in canonical dir
+- `comment-analyzer` — review `regime_report.md` content for accuracy / forward-references / rot
+- `type-design-analyzer` — verify `regime_params.json` and `regime_manifest.json` shapes match harness contract
+
+Phase 4 of an artefact PR is typically faster than a code PR (1-2 rounds vs 3 for code, per A.4-1.5 Phase 2 lessons). The Dev agent may be re-summoned to address criticals but does not initiate the review.
+
+---
+
+## Verification gate (Phase 3 done = ALL of these)
+
+- [ ] Sweep run 1 completes with rc=0 AND canonical artefacts present (`regime_params.json`, `regime_manifest.json`, `regime_report.md`)
+- [ ] No halt-branch artefacts (`halted_summary.json`, `sweep_errors.json`, `raw_results.json`) in the canonical dir
+- [ ] `regime_params.json` byte-identical between Run 1 and Run 2 (diff empty)
+- [ ] `regime_manifest.json` byte-identical between Run 1 and Run 2 excluding `ran_at_iso` and `runtime_seconds` (diff empty)
+- [ ] Manifest MAX(timestamp) strictly `<` `2025-04-30T00:00:00 UTC` for every (symbol, tf) AND matches independent DB query
+- [ ] Manifest `ohlcv_sha256` matches the pre-flight `shasum -a 256 data/ohlcv.db` capture
+- [ ] Manifest `cutoff_effective_iso == "2025-04-30T00:00:00+00:00"` and `cutoff_effective_ms == 1745971200000`
+- [ ] `regime_params.json` shape matches winner (either `regime_thresholds` keys are valid ints, or `regime_disabled: true`)
+- [ ] Decision flags evaluated; sanity_check and degenerate_zero_pnl confirmed False (else canonical artefacts would not exist)
+- [ ] Single commit on `feat/methodology-a4-1-5-phase3-artefact` adding exactly the three artefact files; no other staged content
+- [ ] Branch pushed; draft PR open with `## References` (no `Closes #N`)
+- [ ] Guard B AST scanner still passes
+- [ ] `tests/test_regime_retune_pre_holdout.py` still green
+- [ ] No reads of `data/holdout/` performed at any point during this plan's execution
+
+---
+
+## Halt-branch protocol (rc != 0)
+
+If at any point the harness returns rc != 0:
+
+1. STOP. Do NOT delete halt-branch artefacts; they are the diagnostic.
+2. Capture the full stderr of the run plus the contents of `halted_summary.json` / `sweep_errors.json` / `raw_results.json` as appropriate.
+3. Report to reviewer (Sam) with:
+   - The rc value and its pre-registered meaning per spec D9 §2.10
+   - The flag values from `agg["decision_flags"]` (also embedded in halted_summary.json)
+   - A first-pass hypothesis on root cause:
+     - rc=2: ohlcv.db missing (pre-flight should have caught)
+     - rc=3 (sanity_check / no_detector wins): bug in harness slicing OR regime detector OR severe regime composition issue in pre-holdout window
+     - rc=4 (errored cells): likely transient I/O or upstream API hiccup; check sweep_errors.json
+     - rc=5 (write failure): disk-full / permissions / non-serializable manifest field
+     - rc=6 (degenerate_zero_pnl): all per-config sums below 1e-9 — catastrophic upstream (all symbols disabled? OHLCV corruption? signal generation broken?)
+4. Do NOT commit or push. Do NOT retry blindly.
+5. Wait for reviewer triage decision.
+
+---
+
+## Hard constraints recap (kickoff)
+
+- NO read of `data/holdout/`
+- NO chmod / monkey-patch / Guard B suppression
+- NO promotion to `strategy/regime.py` or `backtest.py` in this PR
+- NO `--no-verify`, `--no-gpg-sign`, `push --force`
+- NO `gh pr merge --auto`
+- NO `Closes #N` / `Fixes #N` / `Resolves #N` anywhere — `## References` only
+- NO touching `data/retune/2026-05-01-pre-holdout/`
+- NO ajuste post-holdout to grid, cutoff, objective, or basket — locked by historical record

--- a/docs/superpowers/plans/2026-05-04-a4-1-phase3-retune-execution.md
+++ b/docs/superpowers/plans/2026-05-04-a4-1-phase3-retune-execution.md
@@ -1,0 +1,798 @@
+# A.4-1 Phase 3 + Phase 4 — Pre-holdout ATR Re-tune Execution Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Execute the pre-holdout re-tune of the 30 ATR multipliers (10 symbols × {atr_sl_mult, atr_tp_mult, atr_be_mult}) on PR #287 branch, produce a byte-deterministic artefact under `data/retune/2026-05-04-pre-holdout/`, commit on the existing draft PR, and shepherd the PR through the multi-agent R1 + R2 review loop until criticals = 0 and Sam authorizes merge.
+
+**Architecture:** Two-phase. Phase 3 runs `tools/retune_pre_holdout.py --max-date 2025-04-30` against the production `data/ohlcv.db` (NOT the holdout dataset — verified: harness is whitelisted for the `-pre-holdout` token in its output dir, but reads no holdout data). Wrapper invokes `auto_tune.optimize_symbol(..., cutoff=cutoff)` per symbol via a `ProcessPoolExecutor`, with `auto_tune._slice_below_cutoff` enforcing strict `<` slicing on every OHLCV / F&G / funding frame. Three artefacts emitted: `params.json` (sort_keys-stable, the only byte-gated artefact), `manifest.json` (run-time + hashes + per-(symbol, tf) MIN/MAX timestamp ranges as no-leakage proof), `report.md` (current vs re-tuned table, grid-edge convergence, runtime). Phase 4 runs the multi-agent review loop already proven across PR1/PR2/PR3 of epic #294.
+
+**Tech Stack:** Python 3.x, pandas, sqlite3, `auto_tune.py` (existing grid + walk-forward), `tools/retune_pre_holdout.py` (Phase 2 wrapper), `pytest`, `gh` CLI, `git` (rebase + commit). No new dependencies. No code on the holdout reading path.
+
+---
+
+## Pre-execution Decision Point — Sam authorization required
+
+**Branch is 12 commits behind main**, including #296 (per-symbol `time_limit_hours`), #297 (per-symbol `max_participation_rate`), #299 (per-symbol `cooldown_hours`). Post-rebase, `config.defaults.json` carries **6 keys per symbol**, but `tools/retune_pre_holdout.py:_build_params_block` only emits the 3 `atr_*` keys (verified at `tools/retune_pre_holdout.py:178-209`). This means the resulting `params.json` is **NOT a complete drop-in** for `symbol_overrides` — promoting it (Phase 5) would silently strip the 30 locked TL/cap/cooldown values committed ex-ante in D9 §4.1.
+
+**Two options:**
+
+- **Option A (recommended) — Pass-through fix in Phase 3.** Modify `_build_params_block` so KEEP/CHANGE paths preserve every key from the current override, only overwriting the 3 `atr_*` keys when CHANGE. Adds 2 unit tests. Net effect: `params.json` becomes genuinely drop-in safe; the 30 locked values pass through verbatim; **no new tuning DOFs**. Aligns with kickoff "Solo los 30 ATR multipliers son re-tuned. Nada más." (the values being passed through are not being re-tuned, they're being preserved).
+- **Option B — Defer schema fix to Phase 5 promotion PR.** Document `params.json` as an "atr-only sub-block" in the wrapper docstring + `report.md`. Phase 5 promotion procedure manually merges atr_* keys into the live `symbol_overrides` instead of `dict.update`. Smaller Phase 3 diff, but pushes a load-bearing risk to Phase 5.
+
+**Plan body assumes Option A.** Tasks 4-5 implement it; if Sam picks Option B, drop tasks 4-5 and replace with a docstring update + a `report.md` callout.
+
+**Secondary doc-coordination note:** `docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md` §2.9 says *"NO re-tunear (#272 deferred per Sam, A.4-1 retune harness #287 stays open draft)"*. The kickoff supersedes that — caveat #1 in CLAUDE.md ("Re-tune required") is the authoritative path. The §2.9 wording will need a follow-up edit acknowledging the re-tune ran, but **that edit is OUT OF SCOPE for this PR** (it's a chore-spec PR, not a Phase 3 commit). Flag for reviewer to track post-merge.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `tools/retune_pre_holdout.py` | Modify (Option A only) | `_build_params_block` preserves all keys, only overwriting `atr_*` on CHANGE |
+| `tests/test_auto_tune_max_date.py` | Modify (Option A only) | +2 tests covering pass-through of TL/cap/cooldown keys |
+| `data/retune/2026-05-04-pre-holdout/params.json` | Create | 30 ATR values (+ pass-through locked values under Option A); `sort_keys=True`, atomic write |
+| `data/retune/2026-05-04-pre-holdout/manifest.json` | Create | Cutoff, code commit SHA, ohlcv.db sha256, seed, per-(symbol, tf) MIN/MAX timestamp ranges, leakage check = PASS |
+| `data/retune/2026-05-04-pre-holdout/report.md` | Create | Side-by-side current vs re-tuned, grid-edge convergence, JUP warmup caveat, data ranges table |
+| `data/retune/2026-05-01-pre-holdout/` | Delete | Stale Run-1 artefact (PRE-#299, descartá per kickoff) |
+| `data/retune/2026-05-04-pre-holdout/params.json` (re-run) | Verify byte-identical | Reproducibility gate; diff must be empty |
+| `git commit` on `feat/methodology-a4-1-retune-pre-holdout` | Create | Single Phase 3 commit; PR #287 stays DRAFT until R1+R2 → Sam |
+
+**No changes to** `auto_tune.py`, `btc_scanner.py`, `backtest.py`, `config.json`, `config.defaults.json`, `tests/test_holdout_isolation.py` (Guard B already whitelists `tools/retune_pre_holdout.py`), or anything reading `data/holdout/`.
+
+---
+
+## Phase 3 — Tune execution
+
+### Task 1: Rebase branch onto origin/main
+
+**Files:**
+- Modify (rebase resolution likely required): `tools/retune_pre_holdout.py`, `tests/test_auto_tune_max_date.py`, `tests/test_holdout_isolation.py`, `auto_tune.py`, `config.defaults.json`, `tools/__init__.py`
+
+Branch is 12 commits behind main. 6 conflict-candidate files (touched by both branch and incoming main commits). The branch's `tools/retune_pre_holdout.py` and `tests/test_auto_tune_max_date.py` are net-new on the branch (no conflicts expected on the file content itself, but their presence on top of main's diff in the same files needs verification). `tools/__init__.py` is empty on both sides — trivial. `auto_tune.py` and `config.defaults.json` and `tests/test_holdout_isolation.py` are the substantive overlap.
+
+- [ ] **Step 1: Confirm clean working tree**
+
+```bash
+git status
+```
+
+Expected: only untracked `.claude/` and `data/retune/` (stale Run-1). No staged or unstaged modifications.
+
+- [ ] **Step 2: Snapshot current branch HEAD (rollback insurance)**
+
+```bash
+git rev-parse HEAD
+git tag retune-phase3-pre-rebase-snapshot
+```
+
+Expected: prints SHA `4c5a50d…`, creates a local tag.
+
+- [ ] **Step 3: Rebase onto origin/main**
+
+```bash
+git rebase origin/main
+```
+
+Expected outcomes:
+- **Best case:** Clean rebase, no conflicts. Proceed to Step 5.
+- **Likely case:** Conflicts in 1+ of the 6 conflict-candidate files. Stop rebase, do NOT auto-resolve, escalate to reviewer for inspection.
+
+- [ ] **Step 4: If conflicts arise, document and pause**
+
+If `git status` after Step 3 shows `Unmerged paths`:
+
+```bash
+git status
+git diff --name-only --diff-filter=U
+```
+
+For each unmerged file, run `git diff <file>` and capture the conflict markers. Do NOT resolve unilaterally — surface to reviewer with:
+- File + line numbers of conflict
+- Branch's intent vs main's intent
+- Proposed resolution
+
+Common expected resolutions:
+- `tests/test_holdout_isolation.py`: branch added the `tools/retune_pre_holdout.py` line to `HOLDOUT_LEGITIMATE_MODULES`. Main may have also touched the whitelist (#296/#297 added other entries? — verify via `git log origin/main -- tests/test_holdout_isolation.py`). Resolution: union of both whitelist additions; preserve docstring comments on each entry.
+- `auto_tune.py`: branch added `--max-date` flag, `_slice_below_cutoff`, `cutoff=` propagation, `initialize_seed` config knob. Main may have touched `optimize_symbol` for cost-aware metrics (#289). Resolution: keep all branch additions; integrate with main's signature changes if any.
+- `config.defaults.json`: branch added `auto_tune.seed` knob. Main added `time_limit_hours` / `max_participation_rate` / `cooldown_hours` per symbol. These additions are at different JSON paths — should merge cleanly without semantic conflict.
+
+If a non-trivial conflict arises, abort the rebase (`git rebase --abort`) and STOP. Report to reviewer.
+
+- [ ] **Step 5: Push rebased branch (force-with-lease)**
+
+```bash
+git push --force-with-lease origin feat/methodology-a4-1-retune-pre-holdout
+```
+
+`--force-with-lease` (NOT `--force`) refuses to overwrite remote if it has commits we don't have locally. Safe variant.
+
+**This step requires Sam authorization.** Do NOT execute Step 5 without an explicit "dale" from Sam — force push is a shared-state action even on a draft PR branch.
+
+- [ ] **Step 6: Commit (NO commit — rebase is not a commit)**
+
+Skipped. The rebase produces no new commit; only re-applies existing branch commits onto main.
+
+---
+
+### Task 2: Verify Phase 2 tests + holdout guards still pass post-rebase
+
+**Files:**
+- Test: `tests/test_auto_tune_max_date.py`, `tests/test_holdout_isolation.py`
+
+- [ ] **Step 1: Run Phase 2 unit + E2E tests**
+
+```bash
+pytest tests/test_auto_tune_max_date.py -v
+```
+
+Expected: all tests pass. The E2E test `TestEndToEndWithRealOhlcv::test_optimize_symbol_with_cutoff_does_not_leak` will run if `data/ohlcv.db` exists (skip otherwise). Look for any post-rebase signature drift — e.g., if `optimize_symbol` gained a new keyword arg in main, the test stub may need updating.
+
+If any test fails, STOP. Report to reviewer with full failure output. Do NOT proceed to tune execution.
+
+- [ ] **Step 2: Run Guard B AST scanner**
+
+```bash
+pytest tests/test_holdout_isolation.py -v
+```
+
+Expected: all tests pass, including `test_no_holdout_references_in_non_whitelisted_modules`. If any new file added by main commits (#296/#297/#299 etc.) introduces a holdout reference outside the whitelist, this fails. STOP and report.
+
+- [ ] **Step 3: Run full test suite (sanity)**
+
+```bash
+pytest tests/ -v --ignore=tests/test_backtest_smoke_cooldown.py --ignore=tests/test_backtest_smoke_sizing_cap.py --ignore=tests/test_backtest_smoke_time_limit.py
+```
+
+Expected: 1254+ tests pass (post-#299 baseline per kickoff). Smokes are excluded here because they each take 6-7 min — they run in Task 7 separately. **This is the only place where `--ignore` is permitted, and only for the three smoke files explicitly listed.**
+
+If any non-smoke test fails, STOP and triage. Likely causes: post-rebase signature drift in `auto_tune.py`, schema drift in `config.defaults.json` test fixtures, or a flaky test surfaced by the rebase.
+
+- [ ] **Step 4: Commit**
+
+No commit — these are verification-only steps, no file modifications.
+
+---
+
+### Task 3: Delete stale Run-1 artefact
+
+**Files:**
+- Delete: `data/retune/2026-05-01-pre-holdout/`
+
+The kickoff explicitly notes this directory is PRE-#299 (it predates the cooldown auto-enforce merge) and must be discarded.
+
+- [ ] **Step 1: Verify the directory contents before deleting (defensive)**
+
+```bash
+ls -la data/retune/2026-05-01-pre-holdout/
+```
+
+Expected: 3 files (`params.json`, `manifest.json`, `report.md`). If unexpected contents (e.g., a draft file Sam was inspecting), stop and ask before deleting.
+
+- [ ] **Step 2: Delete**
+
+```bash
+rm -rf data/retune/2026-05-01-pre-holdout/
+```
+
+- [ ] **Step 3: Verify deletion**
+
+```bash
+ls data/retune/ 2>&1 || true
+```
+
+Expected: empty (or "no such file or directory" if the parent is now empty).
+
+- [ ] **Step 4: Commit**
+
+No commit at this step — the parent `data/retune/` was already untracked, so the deletion has no git effect. The new artefact (Task 6) will be the first thing committed under `data/retune/`.
+
+---
+
+### Task 4 (Option A only): Fix `_build_params_block` to pass through locked keys
+
+**Files:**
+- Modify: `tools/retune_pre_holdout.py:165-210` (function `_build_params_block`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_auto_tune_max_date.py` inside `class TestBuildParamsBlock`:
+
+```python
+    def test_passes_through_time_limit_and_cap_and_cooldown_on_change(self):
+        from tools.retune_pre_holdout import _build_params_block
+
+        results = [self._result(
+            "BTC", "CHANGE",
+            {"atr_sl_mult": 1.5, "atr_tp_mult": 5.0, "atr_be_mult": 2.0},
+        )]
+        current = {"BTC": {
+            "atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5,
+            "time_limit_hours": 14,
+            "max_participation_rate": 0.010,
+            "cooldown_hours": 14,
+        }}
+        out = _build_params_block(results, current)
+        assert out == {"BTC": {
+            "atr_sl_mult": 1.5, "atr_tp_mult": 5.0, "atr_be_mult": 2.0,
+            "time_limit_hours": 14,
+            "max_participation_rate": 0.010,
+            "cooldown_hours": 14,
+        }}, "CHANGE path must overwrite atr_* and pass-through locked keys"
+
+    def test_passes_through_locked_keys_on_keep(self):
+        from tools.retune_pre_holdout import _build_params_block
+
+        results = [self._result("BTC", "KEEP")]
+        current = {"BTC": {
+            "atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5,
+            "time_limit_hours": 14,
+            "max_participation_rate": 0.010,
+            "cooldown_hours": 14,
+        }}
+        out = _build_params_block(results, current)
+        assert out == current["BTC"] | {}, "KEEP path must preserve every key verbatim"
+        # Defensive: identity of nested dict must NOT be the same object
+        # (avoid leaking a reference that downstream callers could mutate).
+        assert out["BTC"] is not current["BTC"]
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+```bash
+pytest tests/test_auto_tune_max_date.py::TestBuildParamsBlock::test_passes_through_time_limit_and_cap_and_cooldown_on_change tests/test_auto_tune_max_date.py::TestBuildParamsBlock::test_passes_through_locked_keys_on_keep -v
+```
+
+Expected: FAIL — the current implementation only emits 3 atr_* keys; assertion on TL/cap/cooldown presence fails.
+
+- [ ] **Step 3: Patch `_build_params_block`**
+
+Replace the body of `_build_params_block` in `tools/retune_pre_holdout.py:165-210` with:
+
+```python
+def _build_params_block(results: list, current_overrides: dict) -> dict:
+    """Build the new ``symbol_overrides`` block from re-tune results.
+
+    Output preserves every key of the current override verbatim; only the
+    three ``atr_*`` keys are overwritten when the optimizer recommended
+    CHANGE. Locked structural-fix values (``time_limit_hours``,
+    ``max_participation_rate``, ``cooldown_hours``) pre-registered in
+    D9 §4.1 pass through unchanged so that ``params.json`` remains a
+    complete drop-in for ``config["symbol_overrides"]``.
+
+    KEEP / NO_DATA / ERROR → preserve current overrides verbatim (deep copy).
+    CHANGE without ``proposed_params`` → treated as KEEP (defensive).
+    """
+    out: dict = {}
+    for r in results:
+        sym = r["symbol"]
+        cur = current_overrides.get(sym)
+
+        if cur is False:
+            out[sym] = False
+            continue
+        if not isinstance(cur, dict):
+            raise ValueError(
+                f"_build_params_block: symbol {sym!r} is in the active portfolio "
+                f"(recommendation={r.get('recommendation')!r}) but has no flat "
+                f"override entry in current config (got {cur!r}). Refusing to "
+                f"emit a partial params.json with None values — fix the input "
+                f"config or extend this helper to handle non-flat shapes."
+            )
+        missing = [k for k in ("atr_sl_mult", "atr_tp_mult", "atr_be_mult") if k not in cur]
+        if missing:
+            raise ValueError(
+                f"_build_params_block: symbol {sym!r} current override is "
+                f"missing required keys {missing}. params.json must be a "
+                f"complete drop-in; refusing to emit None placeholders."
+            )
+
+        merged = copy.deepcopy(cur)
+        if r.get("recommendation") == "CHANGE" and r.get("proposed_params"):
+            pp = r["proposed_params"]
+            merged["atr_sl_mult"] = pp["atr_sl_mult"]
+            merged["atr_tp_mult"] = pp["atr_tp_mult"]
+            merged["atr_be_mult"] = pp["atr_be_mult"]
+        out[sym] = merged
+    return out
+```
+
+The `copy.deepcopy(cur)` ensures the output dict has no shared mutable references with the input `current_overrides` (prevents downstream mutation surprises, hence the second test). `copy` is already imported at `tools/retune_pre_holdout.py:34`.
+
+- [ ] **Step 4: Run the failing tests to verify they now pass**
+
+```bash
+pytest tests/test_auto_tune_max_date.py::TestBuildParamsBlock -v
+```
+
+Expected: PASS for all 7 tests in `TestBuildParamsBlock` (5 pre-existing + 2 new).
+
+- [ ] **Step 5: Run the full test file to verify no regression in adjacent tests**
+
+```bash
+pytest tests/test_auto_tune_max_date.py -v
+```
+
+Expected: every test passes. If any pre-existing test now fails, the deepcopy or merge logic has a bug — investigate before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/retune_pre_holdout.py tests/test_auto_tune_max_date.py
+git commit -m "$(cat <<'EOF'
+fix(methodology): A.4-1 _build_params_block preserves locked TL/cap/cooldown keys
+
+post-#296/#297/#299, current symbol_overrides carry six keys per symbol
+(atr_sl_mult/tp/be + time_limit_hours + max_participation_rate +
+cooldown_hours). The previous KEEP/CHANGE paths emitted only the three
+atr_* keys, so promoting params.json to config.json would silently
+strip the 30 locked structural-fix values pre-registered in D9 §4.1.
+
+CHANGE path now overwrites atr_* and deepcopies the rest from the
+current override; KEEP path is a deepcopy. Output is a complete drop-in
+for symbol_overrides without re-tuning anything beyond the 30 atr_*
+values (locked values pass through unchanged, so no new DOFs).
+
++2 tests in TestBuildParamsBlock covering CHANGE pass-through and KEEP
+deepcopy identity.
+
+EOF
+)"
+```
+
+---
+
+### Task 5 (Option A only): Run full test suite + holdout guards on the patched harness
+
+**Files:**
+- Test: all of `tests/`
+
+- [ ] **Step 1: Re-run full suite excluding smokes**
+
+```bash
+pytest tests/ -v --ignore=tests/test_backtest_smoke_cooldown.py --ignore=tests/test_backtest_smoke_sizing_cap.py --ignore=tests/test_backtest_smoke_time_limit.py
+```
+
+Expected: 1256+ tests pass (1254 baseline + 2 new in Task 4).
+
+- [ ] **Step 2: Re-run Guard B**
+
+```bash
+pytest tests/test_holdout_isolation.py -v
+```
+
+Expected: pass. The Task 4 patch did not introduce any holdout reference; this is a defensive double-check.
+
+- [ ] **Step 3: Commit**
+
+No commit — verification only.
+
+---
+
+### Task 6: Execute the tune (Run 1)
+
+**Files:**
+- Create (via the wrapper): `data/retune/2026-05-04-pre-holdout/{params.json,manifest.json,report.md}`
+
+**This step requires Sam's "dale" before execution.** Reviewer surfaces the plan + the Option A vs B decision; on Sam's authorization for the tune, proceed.
+
+Cutoff is `2025-04-30T00:00:00 UTC` (strict `<` slicing — drops the cutoff bar itself; verified at `auto_tune.py:168`).
+
+- [ ] **Step 1: Confirm working tree clean and on branch HEAD**
+
+```bash
+git status
+git rev-parse HEAD
+git rev-parse origin/feat/methodology-a4-1-retune-pre-holdout
+```
+
+Expected: clean tree (no unstaged changes; the `data/retune/` dir is empty after Task 3); local HEAD == remote HEAD post-rebase + Task 4 commit + push.
+
+- [ ] **Step 2: Confirm `data/ohlcv.db` exists and is the production cache**
+
+```bash
+ls -la data/ohlcv.db
+sha256sum data/ohlcv.db
+```
+
+Expected: file exists, ~few hundred MB. Capture the sha256 — it must match what the manifest records in Step 4. If `sha256sum` is not available on macOS, use `shasum -a 256 data/ohlcv.db`.
+
+- [ ] **Step 3: Run the wrapper (Run 1)**
+
+```bash
+python -m tools.retune_pre_holdout --max-date 2025-04-30 2>&1 | tee /tmp/retune_run1.log
+```
+
+Expected: ~tens of minutes runtime depending on `os.cpu_count()` and dataset size (the wrapper parallelizes across symbols). Log lines per symbol show recommendation (CHANGE / KEEP / NO_DATA / ERROR). Final lines: `Leakage check: PASS`, then `Artefacts written to data/retune/2026-05-04-pre-holdout/`.
+
+If the wrapper exits non-zero, STOP. Capture the full stderr; do NOT iterate or rerun blindly. Report to reviewer.
+
+If `Leakage check: FAIL` (any symbol/tf has `max_ts_ms >= cutoff_ms`), STOP — this is a BLOCKER that means the slicing logic or the OHLCV DB has post-cutoff bars that escaped the strict `<` filter. Report immediately.
+
+- [ ] **Step 4: Inspect the artefact directory**
+
+```bash
+ls -la data/retune/2026-05-04-pre-holdout/
+```
+
+Expected: `params.json`, `manifest.json`, `report.md` (3 files).
+
+- [ ] **Step 5: Commit**
+
+No commit yet — Run 1 alone is not the final artefact. Run 2 (Task 7) is the byte-identical reproducibility proof; commit happens in Task 9 after both runs and the manifest gate pass.
+
+---
+
+### Task 7: Execute the tune again (Run 2 — reproducibility check)
+
+**Files:**
+- Create (in temp): `/tmp/retune-run2/{params.json,manifest.json,report.md}` (NOT under `data/retune/`)
+
+The reproducibility gate is: `params.json` byte-identical across two runs with same cutoff + same code commit + same OHLCV DB. `manifest.json` is NOT byte-identical by design (`ran_at_iso`, `runtime_seconds` differ).
+
+- [ ] **Step 1: Run the wrapper into a temp directory**
+
+```bash
+python -m tools.retune_pre_holdout --max-date 2025-04-30 --out-dir /tmp/retune-run2 2>&1 | tee /tmp/retune_run2.log
+```
+
+Expected: completes successfully, same `Leakage check: PASS`, same per-symbol recommendations.
+
+- [ ] **Step 2: Diff `params.json` byte-for-byte**
+
+```bash
+diff data/retune/2026-05-04-pre-holdout/params.json /tmp/retune-run2/params.json
+```
+
+Expected: empty output (exit code 0). If diff is non-empty, STOP. The wrapper has a non-determinism source (likely an unseeded RNG entering the grid search — but Phase 2 already guards against that). Report immediately.
+
+- [ ] **Step 3: Diff `manifest.json` for expected-only differences**
+
+```bash
+diff <(python3 -c "import json; m=json.load(open('data/retune/2026-05-04-pre-holdout/manifest.json')); m.pop('ran_at_iso',None); m.pop('runtime_seconds',None); print(json.dumps(m, sort_keys=True, indent=2))") \
+     <(python3 -c "import json; m=json.load(open('/tmp/retune-run2/manifest.json')); m.pop('ran_at_iso',None); m.pop('runtime_seconds',None); print(json.dumps(m, sort_keys=True, indent=2))")
+```
+
+Expected: empty output. Strips `ran_at_iso` and `runtime_seconds` (which differ by design) and verifies everything else (cutoff, code commit, ohlcv sha256, seed, workers, leakage_check, symbols, per_symbol_data_ranges, scope_notes) is identical.
+
+If any other field differs (e.g., `code_commit` — would mean someone amended/committed between runs), STOP. The reproducibility proof requires identical code state.
+
+- [ ] **Step 4: Cleanup the temp dir**
+
+```bash
+rm -rf /tmp/retune-run2
+```
+
+- [ ] **Step 5: Commit**
+
+No commit — verification only.
+
+---
+
+### Task 8: Manifest gate — verify no-leakage proof externally
+
+**Files:**
+- Read-only: `data/retune/2026-05-04-pre-holdout/manifest.json`, `data/ohlcv.db`
+
+The wrapper's internal `_verify_no_leakage` already checks every per-(symbol, tf) MAX timestamp is `< cutoff_ms`. This task does an **independent** SQL query against `data/ohlcv.db` to triangulate.
+
+- [ ] **Step 1: Run the cross-check SQL**
+
+```bash
+python3 <<'EOF'
+import json, sqlite3, sys
+from datetime import datetime, timezone
+
+CUTOFF_ISO = "2025-04-30T00:00:00+00:00"
+cutoff_ms = int(datetime.fromisoformat(CUTOFF_ISO).timestamp() * 1000)
+
+with open("data/retune/2026-05-04-pre-holdout/manifest.json") as f:
+    manifest = json.load(f)
+
+con = sqlite3.connect("data/ohlcv.db")
+problems = []
+for sym, tfs in manifest["per_symbol_data_ranges"].items():
+    for tf, span in tfs.items():
+        # Independent query — bars at-or-after cutoff in production DB
+        row = con.execute(
+            "SELECT COUNT(*), MIN(open_time), MAX(open_time) "
+            "FROM ohlcv WHERE symbol=? AND timeframe=? AND open_time>=?",
+            (sym, tf, cutoff_ms),
+        ).fetchone()
+        n_post, min_post, max_post = row
+        # Manifest-declared MAX must be strictly < cutoff
+        if span["max_ts_ms"] is not None and span["max_ts_ms"] >= cutoff_ms:
+            problems.append(f"{sym} {tf}: manifest max_ts_ms {span['max_ts_ms']} >= cutoff {cutoff_ms}")
+        # Sanity: if production DB has post-cutoff bars, the wrapper saw them and excluded them — that's correct.
+        # If production DB has zero post-cutoff bars (e.g., dataset hasn't been refreshed past holdout start),
+        # the test is weaker but not wrong. Print a warning in that case.
+        if n_post == 0:
+            print(f"INFO  {sym} {tf}: production DB has no bars >= cutoff (weaker leakage test)", file=sys.stderr)
+
+if problems:
+    print("LEAKAGE GATE FAILED:", file=sys.stderr)
+    for p in problems:
+        print(f"  - {p}", file=sys.stderr)
+    sys.exit(1)
+print("LEAKAGE GATE PASS — manifest MAX timestamps strictly below cutoff for all (symbol, tf).")
+EOF
+```
+
+Expected: prints `LEAKAGE GATE PASS`. INFO lines are advisory (not failures). If `LEAKAGE GATE FAILED`, STOP and report.
+
+- [ ] **Step 2: Verify count of atr params in `params.json`**
+
+```bash
+python3 <<'EOF'
+import json
+with open("data/retune/2026-05-04-pre-holdout/params.json") as f:
+    p = json.load(f)
+ov = p["symbol_overrides"]
+atr_count = 0
+locked_count = 0
+for sym, v in ov.items():
+    if v is False:
+        continue
+    for k in ("atr_sl_mult", "atr_tp_mult", "atr_be_mult"):
+        assert k in v, f"missing {k} in {sym}"
+        atr_count += 1
+    # Option A only: pass-through locked keys
+    for k in ("time_limit_hours", "max_participation_rate", "cooldown_hours"):
+        if k in v:
+            locked_count += 1
+print(f"atr params: {atr_count}  (expected 30)")
+print(f"locked passthroughs: {locked_count}  (expected 30 under Option A, 0 under Option B)")
+assert atr_count == 30, f"expected 30 atr params, got {atr_count}"
+EOF
+```
+
+Expected: `atr params: 30`, `locked passthroughs: 30` (Option A) or `0` (Option B).
+
+- [ ] **Step 3: Commit**
+
+No commit — verification only.
+
+---
+
+### Task 9: Run long-form smokes
+
+**Files:**
+- Test: `tests/test_backtest_smoke_cooldown.py`, `tests/test_backtest_smoke_sizing_cap.py`, `tests/test_backtest_smoke_time_limit.py`
+
+Each smoke runs ~6-7 min. Run all three sequentially. Per kickoff: NO `--ignore` blanket — these MUST pass before commit.
+
+- [ ] **Step 1: Run smokes**
+
+```bash
+pytest tests/test_backtest_smoke_cooldown.py tests/test_backtest_smoke_sizing_cap.py tests/test_backtest_smoke_time_limit.py -v
+```
+
+Expected: all pass. Total runtime ~20 min. If any fails, STOP and triage. None of these tests touch `tools/retune_pre_holdout.py` or the artefact, so failure here would point to a rebase regression, not a Phase 3 bug.
+
+- [ ] **Step 2: Commit**
+
+No commit — verification only.
+
+---
+
+### Task 10: Commit Phase 3 artefact and push
+
+**Files:**
+- Add: `data/retune/2026-05-04-pre-holdout/params.json`, `data/retune/2026-05-04-pre-holdout/manifest.json`, `data/retune/2026-05-04-pre-holdout/report.md`
+
+**This step requires Sam authorization** before push (force-with-lease was already done in Task 1; this is a normal push, but a draft-PR commit is still observable).
+
+- [ ] **Step 1: Stage the artefact files explicitly (no `git add -A`)**
+
+```bash
+git add data/retune/2026-05-04-pre-holdout/params.json
+git add data/retune/2026-05-04-pre-holdout/manifest.json
+git add data/retune/2026-05-04-pre-holdout/report.md
+git status
+```
+
+Expected: 3 new files staged, nothing else. Confirm `data/retune/2026-05-01-pre-holdout/` is gone (Task 3) and not staged.
+
+- [ ] **Step 2: Compose the commit message body**
+
+Pull the manifest summary and report performance summary into the commit body. Example skeleton (fill in actual numbers from the artefact):
+
+```
+feat(methodology): A.4-1 Phase 3 — re-tune ATR multipliers pre-holdout
+
+Cutoff (--max-date): 2025-04-30T00:00:00+00:00 UTC
+OHLCV DB sha256: <from manifest>
+Code commit (in manifest): <SHA from manifest>
+Seed: 42
+Runtime: ~<seconds>s, workers=<n>
+Leakage check: PASS (independent SQL cross-check confirmed)
+
+params.json byte-hash (sha256): <compute>
+- 30 atr_* values (10 symbols × {sl, tp, be})
+- 30 locked pass-through values (10 symbols × {time_limit_hours, max_participation_rate, cooldown_hours})  [Option A]
+
+Per-(symbol, tf) data ranges:
+- 1d: <min> → <max>  (<rows> bars)
+- 1h: <min> → <max>  (<rows> bars)
+- 4h: <min> → <max>  (<rows> bars)
+- 5m: <min> → <max>  (<rows> bars)
+All MAX timestamps strictly < 2025-04-30T00:00:00 UTC.
+
+Performance (NOT gated):
+- CHANGE recommendations: <list of symbols>
+- KEEP recommendations: <list>
+- NO_DATA / ERROR: <list, if any>
+- Notable val P&L deltas: <top movers>
+- Grid-edge convergence: <symbols at boundary, if any>
+
+Reproducibility verified: Run-2 to /tmp/retune-run2 produced byte-identical
+params.json (diff empty). Manifest fields outside ran_at_iso/runtime_seconds
+also identical.
+
+References: #250 (A.4 epic), #287 (this PR — stays draft until R1+R2 pass)
+```
+
+- [ ] **Step 3: Commit with HEREDOC**
+
+```bash
+git commit -m "$(cat <<'EOF'
+<paste filled-in body from Step 2>
+EOF
+)"
+```
+
+- [ ] **Step 4: Push**
+
+```bash
+git push origin feat/methodology-a4-1-retune-pre-holdout
+```
+
+Expected: push succeeds. `gh pr view 287 --json commits` should now show 4 commits on the branch (3 prior + this one).
+
+- [ ] **Step 5: Update PR #287 body with Phase 3 summary**
+
+```bash
+gh pr edit 287 --body "$(cat <<'EOF'
+<existing body content from Phase 2 PR description>
+
+---
+
+## Phase 3 update (2026-05-04)
+
+Phase 3 commits the actual re-tune artefact under `data/retune/2026-05-04-pre-holdout/`.
+Reproducibility, leakage, and test gates all green.
+
+**Verification gate (all green):**
+- Byte-identical `params.json` across two consecutive runs (diff empty)
+- Manifest MAX(timestamp) strictly < `2025-04-30T00:00:00 UTC` for every (symbol, tf)
+- Independent SQL cross-check confirmed no-leakage
+- Full test suite passing (1256+ tests post-#299; 2 new in TestBuildParamsBlock under Option A)
+- Long-form smokes passing (cooldown / sizing-cap / time-limit, ~20 min total)
+- params.json covers 30 atr_* values exactly (10 symbols × {sl, tp, be})
+- params.json passes through 30 locked structural-fix values (TL/cap/cooldown) [Option A]
+- Performance reported in report.md (NOT gated)
+
+**Out of scope (deferred):**
+- Promotion to `config.json` — separate PR after A.4 holdout pass
+- Per-direction tuning — A.4-1 option (b), separate ticket if/when needed
+- D9 §2.9 doc update acknowledging the re-tune ran — separate chore-spec PR
+
+## References
+- #250 (A.4 epic)
+- #246, #247 (holdout dataset lock)
+EOF
+)"
+```
+
+**Note:** PR body uses `## References` (NOT `Closes #N`) per kickoff. Closing the issue is Sam's call after Phase 4 + holdout evaluation.
+
+- [ ] **Step 6: Verify PR shows expected file changes**
+
+```bash
+gh pr view 287 --json files,additions,deletions
+```
+
+Expected: `data/retune/2026-05-04-pre-holdout/{params,manifest,report}` files appear; total additions delta ≈ harness diff (Phase 2) + 3-key-passthrough patch (Task 4 if Option A) + the artefact JSON.
+
+---
+
+## Phase 4 — Multi-agent review iteration
+
+The kickoff documents the R1 → fix → R2 → fix → loop pattern proven across PR1/PR2/PR3 of epic #294. **Reviewer drives this phase**, not the Dev agent. The Dev agent's role is: address criticals as the reviewer triages them, with verification (grep + cheap checks), no rubber-stamp self-claims.
+
+### Task 11: Reviewer launches R1 (parallel multi-agent review)
+
+**Operator:** Reviewer agent (separate from this Dev agent).
+
+Reviewer dispatches in parallel via a single message containing 4 Agent tool calls:
+- `code-reviewer` (general code-review)
+- `silent-failure-hunter` (try/except / fallback / suppression patterns)
+- `comment-analyzer` (any added docstrings / inline comments — `report.md` content too)
+- `type-design-analyzer` (params.json shape, manifest fields, the patched `_build_params_block` if Option A)
+
+Each briefing must be self-contained (subagents have zero conversation history). Briefings should reference:
+- Kickoff invariants (N=3 PRIMARY, basket=4, locked TL/cap/cooldown values)
+- File paths + line numbers under review
+- The Option A vs B decision (so reviewers don't flag the schema fix as unrelated scope)
+- The "no `Closes #N` in PR body" convention
+
+### Task 12: Dev agent addresses R1 criticals
+
+**Operator:** Dev agent (this plan's executor).
+
+For each critical surfaced in R1:
+
+- [ ] Read the full critical (don't just skim). Identify the file:line and the claim.
+- [ ] Verify the claim independently — grep, run a focused test, read adjacent context. Refuse to apply a "fix" for a claim that doesn't reproduce.
+- [ ] If the critical is valid: write a failing test, fix, run all related tests, commit.
+- [ ] If the critical is invalid (mistake by reviewer agent): document why in a reply to the reviewer. Do NOT silently ignore.
+- [ ] After all criticals processed, re-run full suite + smokes (only if any code changed).
+- [ ] Push.
+
+Each fix is its own commit on the PR branch. No squashing.
+
+### Task 13: Reviewer launches R2
+
+**Operator:** Reviewer agent.
+
+R2 ALWAYS finds 1-3 NEW criticals introduced by R1 fixes (pattern observed across PR1/PR2/PR3 of epic #294). Skipping R2 is the most expensive shortcut available. Same 4-agent parallel dispatch as R1.
+
+### Task 14: Dev agent addresses R2 criticals
+
+Same protocol as Task 12.
+
+### Task 15: Reviewer presents to Sam for merge
+
+When criticals = 0:
+
+- [ ] Reviewer summarizes the verification gate (kickoff Phase 3 list).
+- [ ] Reviewer surfaces the Option A vs B path that landed and why.
+- [ ] Reviewer asks Sam: "¿Dale al merge?"
+- [ ] On Sam's "dale", reviewer (or Dev agent on instruction) marks PR ready-for-review (`gh pr ready 287`), confirms CI green, then merges.
+
+**Merge protocol:**
+- NO `gh pr merge --auto` (kickoff: branch protection doesn't enforce required checks).
+- If CI green at the time of "dale", merge directly: `gh pr merge 287 --squash` or `--merge` per repo convention (verify last 5 PR merges to detect the convention: `gh pr list --state merged --limit 5 --json mergeCommit,title`).
+- Do NOT use `--no-verify` or `--no-gpg-sign`.
+- Do NOT close any other issue from this PR — `## References` only.
+
+### Task 16: Post-merge — open follow-up tickets
+
+After merge:
+
+- [ ] **D9 §2.9 doc edit ticket** — open issue acknowledging the re-tune ran, cross-link the artefact path. Title: `chore(specs): D9 §2.9 — acknowledge A.4-1 retune ran`. Body should be ~5 lines.
+- [ ] **A.4-2 walk-forward harness ticket** (if not already open under #250). The retune harness is the input to A.4-2; A.4-2 is the input to A.4-3 holdout evaluation.
+- [ ] **#302 basket governance** stays blocked by #250 closure — no action.
+- [ ] **#287** can be closed by Sam once #250 (A.4 epic) is satisfied; `## References` does not auto-close.
+
+---
+
+## Verification gate (Phase 3 done = ALL of these)
+
+Single-line checklist for the reviewer's pre-merge summary:
+
+- [ ] Byte-identical `params.json` across Run 1 (`data/retune/2026-05-04-pre-holdout/`) and Run 2 (`/tmp/retune-run2/`). Diff empty.
+- [ ] Manifest MAX(timestamp) strictly `<` `2025-04-30T00:00:00 UTC` for every (symbol, tf). Independent SQL cross-check confirms.
+- [ ] Full test suite passing (1254+ tests post-#299, +2 new under Option A).
+- [ ] Long-form smokes passing (cooldown / sizing-cap / time-limit; ~20 min total).
+- [ ] `params.json["symbol_overrides"]` covers 30 atr_* values exactly (10 symbols × 3 keys).
+- [ ] `params.json["symbol_overrides"]` passes through 30 locked structural-fix values (Option A) OR `report.md` documents atr-only sub-block semantics (Option B).
+- [ ] Performance reported in `report.md` (NOT gated).
+- [ ] Guard B AST scanner (`tests/test_holdout_isolation.py`) passes — wrapper module still whitelisted, no new holdout references.
+- [ ] No `data/holdout/` paths read by the wrapper (verified by Guard B + the manifest pointing to `data/ohlcv.db` for OHLCV ranges).
+
+---
+
+## Hard constraints (kickoff — non-negotiable)
+
+- **NO read of `data/holdout/`** by any code path on this PR. Wrapper consumes `data/ohlcv.db`; manifest cross-checks `data/ohlcv.db`.
+- **NO chmod of holdout** files or directory.
+- **NO monkey-patch of Guard A** (`data/holdout_access.py`).
+- **NO suppression of Guard B** AST scanner.
+- **NO addition of the wrapper to a wider whitelist** beyond what Phase 2 already did.
+- **NO promotion of `params.json` → `config.json`** in this PR (Phase 5 separate PR).
+- **NO `--no-verify`, `--no-gpg-sign`, `push --force` (use `--force-with-lease`)**.
+- **NO `gh pr merge --auto`** — manual merge after CI confirmed green.
+- **NO closing of issues / PRs** in PR body (`## References` only, never `Closes #N`).
+- **NO ajuste post-holdout to N or to locked TL/cap/cooldown values** — would disqualify validation primaria.
+- **Re-tune scope is exactly the 30 atr_* values.** Pass-through preservation of locked keys (Option A) is not re-tuning; it's a faithful artefact shape.


### PR DESCRIPTION
## Summary

Archives two execution plans authored during the Claude usage-limit window (early May 2026) that were never committed at execution time:

- `docs/superpowers/plans/2026-05-04-a4-1-phase3-retune-execution.md` — A.4-1 (ATR) Phase 3 sweep execution plan
- `docs/superpowers/plans/2026-05-04-a4-1-5-phase3-regime-retune-execution.md` — A.4-1.5 (regime) Phase 3 sweep execution plan

## Why archive them now

The methodology trail makes more sense in retrospect with these plans in the repo: they document the exact preflight invariants, decision flags, and halt criteria used during the sweeps that culminated in #305 (sweep halt) → #309 (K=10 cap) → #312 (operator override, since closed) → #313 (#280 per-symbol bankruptcy handler).

Future readers (and re-running the sweeps post-#313) benefit from having the original plans visible.

## Will these be re-executed?

No — not verbatim. The re-runs will use the existing harnesses (`tools/regime_retune_pre_holdout.py` already on main from #306, and the A.4-1 harness from open PR #287 once merged) on top of clean post-#313 main. The plans here serve as methodology reference, not an executable instruction set.

## References

- #305 — A.4-1.5 sweep halt that motivated #309
- #309 — K=10 per-trade overshoot cap
- #312 — A.4-1.5 artefact PR (closed as superseded)
- #313 — #280 per-symbol bankruptcy handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)