### PR TITLE
docs(retune): archive 2026-05-11 regime sweep halt as #280 efficacy evidence

### DIFF
--- a/data/retune/2026-05-11-pre-holdout-regime-evidence/README.md
+++ b/data/retune/2026-05-11-pre-holdout-regime-evidence/README.md
@@ -1,0 +1,62 @@
+# A.4-1.5 Regime Sweep — 2026-05-11 (Halted Summary)
+
+**Status:** Sanity-halted (exit code 3). No canonical artefacts written. Sweep summary preserved here as methodology evidence.
+
+## Why this run was halted
+
+`no_detector` won the raw `sum(net_pnl)` aggregate by 2.18% over the runner-up (`70_30`). Per spec D9 §2.10, the sanity check fires when `no_detector` wins — the harness refuses to write canonical artefacts and dumps the full run state to `halted_summary.json`.
+
+## Why this is **not** the same failure as 2026-05-06
+
+The 5-06 sweep also sanity-halted with `no_detector` winning, but that was a Bankruptcy Bias artefact (per-symbol bankruptcy continued generating zero-`risk_amount` trades, inflating the no_detector trade count and distorting the aggregate). #313 (#280) shipped a per-symbol bankruptcy halt that fixes that mechanism.
+
+Evidence #313 fixed the mechanism:
+
+| Sweep | Cutoff | 60_40 trades | no_detector trades | Total trades |
+|---|---|---|---|---|
+| 2026-05-06 | 2025-04-30 | 4539 | 8277 | 21,193 |
+| 2026-05-11 | 2025-04-30 | 418 | 567 | **1,840** |
+
+Trade count dropped 92%. The ~19,000 trades that disappeared are exactly the post-bankruptcy fictional zero-PnL trades that #280 now halts at the per-symbol bankruptcy floor.
+
+## Root cause of the 5-11 sanity halt
+
+CLAUDE.md "Caveats heredados — A.4 (#250) MUST honor" caveat #1: the current `atr_sl_mult/tp/be` values in `config.json["symbol_overrides"]` were tuned over the full history **including the holdout range**. A.4-1 must re-tune over `[earliest, holdout_start - 1 bar]` before regime evaluation is interpretable.
+
+Per-symbol breakdown from `halted_summary.json` confirms this: every symbol bottoms out at ~$-9K (= $10K initial − $1K bankruptcy floor) under **all four regime configurations**. PENDLE saturates at $-15,171 and JUP at $-11,953 due to K=10-capped overshoots immediately before the bankruptcy halt fires.
+
+| Symbol | 60_40 | 70_30 | 80_20 | no_detector |
+|---|---|---|---|---|
+| BTC | -9,016 | -9,000 | -9,009 | -9,004 |
+| ETH | -9,006 | -9,008 | -9,016 | -9,009 |
+| ADA | -9,004 | -9,004 | -9,004 | -9,011 |
+| AVAX | -9,002 | -9,002 | -9,002 | -9,061 |
+| DOGE | -9,020 | -9,020 | -9,020 | -9,087 |
+| UNI | -9,070 | -9,070 | -9,070 | -9,033 |
+| XLM | -9,006 | -9,006 | -9,006 | -9,019 |
+| PENDLE | -15,171 | -15,171 | -15,171 | -15,171 |
+| JUP | -11,953 | -11,953 | -11,953 | -9,712 |
+| RUNE | -9,301 | -9,301 | -9,301 | -9,301 |
+
+With every symbol bankrupting under every config, the per-config `sum(net_pnl)` is approximately `10 × $-9K = $-90K` ± per-symbol noise. The 2.18% margin between winner and runner-up is noise within the bankruptcy floor, not regime signal.
+
+## Methodological interpretation
+
+The regime threshold **is not evaluable** on the pre-holdout window with the current production ATR multipliers. The sanity halt is the correct outcome: any winner here would reflect bankruptcy-floor ranking, not regime edge.
+
+The correct ordering per spec D9 §2.10 is:
+
+1. A.4-1 ATR re-tune (re-derive per-symbol ATR multipliers on the pre-holdout window without leakage) — **kicked off after this evidence was captured**.
+2. A.4-1.5 regime re-tune **with the new ATR multipliers active** — TBD after step 1 lands.
+3. A.4-2 walk-forward → A.4-3 holdout.
+
+## Files
+
+- `halted_summary.json` — full halt state including aggregate, per-config, per-symbol breakdown, and report markdown. Schema matches `tools/regime_retune_pre_holdout.py` halt-branch contract (rc=3).
+
+## References
+
+- Spec D9 §2.10 — decision flag pre-registration
+- CLAUDE.md caveat #1 (ATR leakage) and caveat #4 (per-symbol vs portfolio aggregation gap)
+- PR #313 (#280) — per-symbol bankruptcy handler that surfaced this cleanly
+- PR #312 (closed superseded) — the 2026-05-06 sweep that motivated #280

--- a/data/retune/2026-05-11-pre-holdout-regime-evidence/halted_summary.json
+++ b/data/retune/2026-05-11-pre-holdout-regime-evidence/halted_summary.json
@@ -1,0 +1,409 @@
+{
+  "agg": {
+    "decision_flags": {
+      "change_detection": true,
+      "degenerate_zero_pnl": false,
+      "sanity_check": true,
+      "stability_check": true
+    },
+    "per_config_pnl": {
+      "60_40": -99550.25,
+      "70_30": -99535.99,
+      "80_20": -99553.13,
+      "no_detector": -97407.95
+    },
+    "per_config_trades": {
+      "60_40": 418,
+      "70_30": 447,
+      "80_20": 408,
+      "no_detector": 567
+    },
+    "runner_up": "70_30",
+    "runner_up_pnl": -99535.99,
+    "winner": "no_detector",
+    "winner_margin_pct": 2.184667678562179,
+    "winner_pnl": -97407.95
+  },
+  "manifest": {
+    "code_commit": "47a1956fa50b09824db6953ea9df6b347ce1d3e6",
+    "cutoff_effective_iso": "2025-04-30T00:00:00+00:00",
+    "cutoff_effective_ms": 1745971200000,
+    "decision_flags": {
+      "change_detection": true,
+      "degenerate_zero_pnl": false,
+      "sanity_check": true,
+      "stability_check": true
+    },
+    "grid": [
+      {
+        "bear_below": 40,
+        "bull_above": 60,
+        "disabled": false,
+        "name": "60_40"
+      },
+      {
+        "bear_below": 30,
+        "bull_above": 70,
+        "disabled": false,
+        "name": "70_30"
+      },
+      {
+        "bear_below": 20,
+        "bull_above": 80,
+        "disabled": false,
+        "name": "80_20"
+      },
+      {
+        "bear_below": null,
+        "bull_above": null,
+        "disabled": true,
+        "name": "no_detector"
+      }
+    ],
+    "harness": "regime_retune_pre_holdout",
+    "leakage_check": "PASS",
+    "ohlcv_path_relative": "data/ohlcv.db",
+    "ohlcv_sha256": "5c3fd66caa77aaf0c43b41a8961f10b4deeaf082198cec0759fe4722ca5cc856",
+    "per_config_pnl": {
+      "60_40": -99550.25,
+      "70_30": -99535.99,
+      "80_20": -99553.13,
+      "no_detector": -97407.95
+    },
+    "per_config_trades": {
+      "60_40": 418,
+      "70_30": 447,
+      "80_20": 408,
+      "no_detector": 567
+    },
+    "per_symbol_data_ranges": {
+      "ADAUSDT": {
+        "1d": {
+          "count": 1580,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "1h": {
+          "count": 37906,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "4h": {
+          "count": 9480,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "5m": {
+          "count": 454827,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        }
+      },
+      "AVAXUSDT": {
+        "1d": {
+          "count": 1580,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "1h": {
+          "count": 37906,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "4h": {
+          "count": 9480,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "5m": {
+          "count": 454827,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        }
+      },
+      "BTCUSDT": {
+        "1d": {
+          "count": 1580,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "1h": {
+          "count": 37906,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "4h": {
+          "count": 9480,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "5m": {
+          "count": 454827,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        }
+      },
+      "DOGEUSDT": {
+        "1d": {
+          "count": 1580,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "1h": {
+          "count": 37906,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "4h": {
+          "count": 9480,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "5m": {
+          "count": 454827,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        }
+      },
+      "ETHUSDT": {
+        "1d": {
+          "count": 1580,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "1h": {
+          "count": 37906,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "4h": {
+          "count": 9480,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "5m": {
+          "count": 454827,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        }
+      },
+      "JUPUSDT": {
+        "1d": {
+          "count": 455,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2024-01-31T00:00:00+00:00",
+          "min_ts_ms": 1706659200000
+        },
+        "1h": {
+          "count": 10904,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2024-01-31T16:00:00+00:00",
+          "min_ts_ms": 1706716800000
+        },
+        "4h": {
+          "count": 2726,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2024-01-31T16:00:00+00:00",
+          "min_ts_ms": 1706716800000
+        },
+        "5m": {
+          "count": 130848,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2024-01-31T16:00:00+00:00",
+          "min_ts_ms": 1706716800000
+        }
+      },
+      "PENDLEUSDT": {
+        "1d": {
+          "count": 667,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2023-07-03T00:00:00+00:00",
+          "min_ts_ms": 1688342400000
+        },
+        "1h": {
+          "count": 15998,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2023-07-03T10:00:00+00:00",
+          "min_ts_ms": 1688378400000
+        },
+        "4h": {
+          "count": 4000,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2023-07-03T08:00:00+00:00",
+          "min_ts_ms": 1688371200000
+        },
+        "5m": {
+          "count": 191976,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2023-07-03T10:00:00+00:00",
+          "min_ts_ms": 1688378400000
+        }
+      },
+      "RUNEUSDT": {
+        "1d": {
+          "count": 1580,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "1h": {
+          "count": 37906,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "4h": {
+          "count": 9480,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "5m": {
+          "count": 454827,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        }
+      },
+      "UNIUSDT": {
+        "1d": {
+          "count": 1580,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "1h": {
+          "count": 37906,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "4h": {
+          "count": 9480,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "5m": {
+          "count": 454827,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        }
+      },
+      "XLMUSDT": {
+        "1d": {
+          "count": 1580,
+          "max_ts_iso": "2025-04-29T00:00:00+00:00",
+          "max_ts_ms": 1745884800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "1h": {
+          "count": 37906,
+          "max_ts_iso": "2025-04-29T23:00:00+00:00",
+          "max_ts_ms": 1745967600000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "4h": {
+          "count": 9480,
+          "max_ts_iso": "2025-04-29T20:00:00+00:00",
+          "max_ts_ms": 1745956800000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        },
+        "5m": {
+          "count": 454827,
+          "max_ts_iso": "2025-04-29T23:55:00+00:00",
+          "max_ts_ms": 1745970900000,
+          "min_ts_iso": "2021-01-01T00:00:00+00:00",
+          "min_ts_ms": 1609459200000
+        }
+      }
+    },
+    "ran_at_iso": "2026-05-11T09:53:01.555152+00:00",
+    "runner_up": "70_30",
+    "runner_up_pnl": -99535.99,
+    "runtime_seconds": 625.84,
+    "scope_notes": {
+      "n_effective_contribution": 0,
+      "promotion_to_strategy_regime_py_and_backtest_py": "deferred_to_phase_5_post_holdout_PR"
+    },
+    "spec_ref": "docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md §2.10",
+    "symbol_overrides_sha256": "da2bd8943aa197f09a621d1d7cfd7da88848e99d734753f74b1b70380279e80a",
+    "symbols": [
+      "BTCUSDT",
+      "ETHUSDT",
+      "ADAUSDT",
+      "AVAXUSDT",
+      "DOGEUSDT",
+      "UNIUSDT",
+      "XLMUSDT",
+      "PENDLEUSDT",
+      "JUPUSDT",
+      "RUNEUSDT"
+    ],
+    "winner": "no_detector",
+    "winner_margin_pct": 2.1847,
+    "winner_pnl": -97407.95
+  },
+  "reason": "sanity_check_fired",
+  "report_md": "# Pre-holdout Regime Threshold Re-tune Report\n\n- **Cutoff (`--max-date`):** 2025-04-30T00:00:00+00:00\n- **Symbols:** BTCUSDT, ETHUSDT, ADAUSDT, AVAXUSDT, DOGEUSDT, UNIUSDT, XLMUSDT, PENDLEUSDT, JUPUSDT, RUNEUSDT\n- **Runtime:** 626s\n- **Spec ref:** D9 §2.10 (locked grid, locked objective)\n\n## Per-config aggregate\n\n| Config | Sum net_pnl (USD) | Total trades | Margin to winner |\n|--------|-------------------|--------------|------------------|\n| 60_40 | $-99,550.25 | 418 | -2.20% |\n| 70_30 | $-99,535.99 | 447 | -2.18% |\n| 80_20 | $-99,553.13 | 408 | -2.20% |\n| no_detector | $-97,407.95 | 567 | **winner** |\n\n**Winner:** `no_detector` (sum net_pnl = $-97,407.95)\n**Runner-up:** `70_30` (sum net_pnl = $-99,535.99)\n**Margin:** 2.18% of |winner|\n\n## Decision flags (pre-registered per D9 §2.10)\n\n- **CHANGE detection:** `True` (winner != current production `60_40`)\n- **Sanity check (no-detector wins):** `True` → HALT + DEBUG required before any commit\n- **Stability check (margin < 5%):** `True` → informational caveat: regime is operating in a flat region\n- **Degenerate zero-pnl (all per-config sums ≈ 0):** `False` \n\n## Per-symbol breakdown\n\n| Symbol | 60_40 | 70_30 | 80_20 | no_detector |\n|--------|-------|-------|-------|-------------|\n| BTCUSDT | $-9,016 | $-9,000 | $-9,009 | $-9,004 |\n| ETHUSDT | $-9,006 | $-9,008 | $-9,016 | $-9,009 |\n| ADAUSDT | $-9,004 | $-9,004 | $-9,004 | $-9,011 |\n| AVAXUSDT | $-9,002 | $-9,002 | $-9,002 | $-9,061 |\n| DOGEUSDT | $-9,020 | $-9,020 | $-9,020 | $-9,087 |\n| UNIUSDT | $-9,070 | $-9,070 | $-9,070 | $-9,033 |\n| XLMUSDT | $-9,006 | $-9,006 | $-9,006 | $-9,019 |\n| PENDLEUSDT | $-15,171 | $-15,171 | $-15,171 | $-15,171 |\n| JUPUSDT | $-11,953 | $-11,953 | $-11,953 | $-9,712 |\n| RUNEUSDT | $-9,301 | $-9,301 | $-9,301 | $-9,301 |\n\n## Caveats\n\n- **JUPUSDT** — earliest OHLCV bar is 2024-01-31. SMA200 (1d) and SMA100 (1h) yield NaN over the first ~4 days of JUP train data. Same warmup degradation applies here as in A.4-1; results for JUP are reported but should be interpreted with this caveat.\n\n## Data ranges (per symbol × tf, all bars below cutoff)\n\n| Symbol | TF | Min ts (UTC) | Max ts (UTC) | Bars |\n|--------|----|---------------|---------------|------|\n| ADAUSDT | 5m | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 454827 |\n| ADAUSDT | 1h | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 37906 |\n| ADAUSDT | 4h | 2021-01-01T00:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 9480 |\n| ADAUSDT | 1d | 2021-01-01T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 1580 |\n| AVAXUSDT | 5m | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 454827 |\n| AVAXUSDT | 1h | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 37906 |\n| AVAXUSDT | 4h | 2021-01-01T00:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 9480 |\n| AVAXUSDT | 1d | 2021-01-01T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 1580 |\n| BTCUSDT | 5m | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 454827 |\n| BTCUSDT | 1h | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 37906 |\n| BTCUSDT | 4h | 2021-01-01T00:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 9480 |\n| BTCUSDT | 1d | 2021-01-01T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 1580 |\n| DOGEUSDT | 5m | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 454827 |\n| DOGEUSDT | 1h | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 37906 |\n| DOGEUSDT | 4h | 2021-01-01T00:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 9480 |\n| DOGEUSDT | 1d | 2021-01-01T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 1580 |\n| ETHUSDT | 5m | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 454827 |\n| ETHUSDT | 1h | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 37906 |\n| ETHUSDT | 4h | 2021-01-01T00:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 9480 |\n| ETHUSDT | 1d | 2021-01-01T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 1580 |\n| JUPUSDT | 5m | 2024-01-31T16:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 130848 |\n| JUPUSDT | 1h | 2024-01-31T16:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 10904 |\n| JUPUSDT | 4h | 2024-01-31T16:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 2726 |\n| JUPUSDT | 1d | 2024-01-31T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 455 |\n| PENDLEUSDT | 5m | 2023-07-03T10:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 191976 |\n| PENDLEUSDT | 1h | 2023-07-03T10:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 15998 |\n| PENDLEUSDT | 4h | 2023-07-03T08:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 4000 |\n| PENDLEUSDT | 1d | 2023-07-03T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 667 |\n| RUNEUSDT | 5m | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 454827 |\n| RUNEUSDT | 1h | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 37906 |\n| RUNEUSDT | 4h | 2021-01-01T00:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 9480 |\n| RUNEUSDT | 1d | 2021-01-01T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 1580 |\n| UNIUSDT | 5m | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 454827 |\n| UNIUSDT | 1h | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 37906 |\n| UNIUSDT | 4h | 2021-01-01T00:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 9480 |\n| UNIUSDT | 1d | 2021-01-01T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 1580 |\n| XLMUSDT | 5m | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:55:00+00:00 | 454827 |\n| XLMUSDT | 1h | 2021-01-01T00:00:00+00:00 | 2025-04-29T23:00:00+00:00 | 37906 |\n| XLMUSDT | 4h | 2021-01-01T00:00:00+00:00 | 2025-04-29T20:00:00+00:00 | 9480 |\n| XLMUSDT | 1d | 2021-01-01T00:00:00+00:00 | 2025-04-29T00:00:00+00:00 | 1580 |\n"
+}


### PR DESCRIPTION
## Summary

Archives the halted_summary from the 2026-05-11 A.4-1.5 regime sweep (rc=3, sanity halt) plus a README documenting the methodology interpretation.

## Why this evidence matters

The 5-11 sweep sanity-halted in the same outcome class as the 5-06 sweep (#312, closed superseded) — but for a different reason. The README walks through:

1. **#313 (#280) worked** — total trade count dropped 92% (21,193 → 1,840), exactly removing the post-bankruptcy fictional zero-PnL trades that drove Bankruptcy Bias.
2. **The next problem** — every symbol bottoms out at ~$-9K (= $10K − $1K bankruptcy floor) under all four regime configurations on the pre-holdout window. The 2.18% margin between winner and runner-up is noise within the bankruptcy floor, not regime signal.
3. **Root cause** — CLAUDE.md caveat #1 (ATR leakage). Current `atr_sl_mult/tp/be` were tuned including the holdout range. Without clean ATR params, regime is not evaluable.
4. **Corrected ordering** — A.4-1 ATR re-tune **first**, then A.4-1.5 regime re-tune with the new ATR active. A.4-1 is already running in background; this PR captures the evidence that motivated reordering.

## What this PR is not

- Not a sweep artefact (would have `regime_*` prefix and live at `data/retune/2026-05-11-pre-holdout/`). The halted_summary at that path is local-only; this branch archives a copy at `data/retune/2026-05-11-pre-holdout-regime-evidence/` with the README explaining why.
- Not a promotion / not changing any config / not touching any code.

## References

- #312 (closed superseded) — 2026-05-06 sweep
- #313 — per-symbol bankruptcy handler that fixed the mechanism this halt now correctly surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)