### PR TITLE
feat(methodology): R1 harness tooling-debt — tests + classifier guards

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -560,9 +560,10 @@ def _should_signal_exit(direction, lrc_pct, threshold: float) -> bool:
     if math.isnan(v):
         return False
     thr = float(threshold)
-    if direction == "LONG":
+    d = (direction or "").upper()
+    if d == "LONG":
         return v >= thr
-    if direction == "SHORT":
+    if d == "SHORT":
         return v <= (100.0 - thr)
     return False
 

--- a/data/retune/2026-05-12-r1-dynamic-exit/derivation_audit.md
+++ b/data/retune/2026-05-12-r1-dynamic-exit/derivation_audit.md
@@ -97,7 +97,7 @@ Implementation:
 | XLMUSDT | (2.5, 1.5, 40.0) | 13 | -7,197.80 | -553.68 | 0.00 | 61.5 ⚠️ | 30.8 |
 | RUNEUSDT | (2.5, 2.0, 55.0) | 32 | -7,519.11 | -234.97 | 0.00 | 87.5 ⚠️ | 3.1 |
 
-Hours. ⚠️ = `TL% > 35%` halt-condition contributor. **7 of 8** symbols breach the `TIME_LIMIT% > 35%` threshold on their argmax cell ⇒ pre-reg §10 halt-after-A fires (required: >6).
+⚠️ = `TL% > 35%` halt-condition contributor. **7 of 8** symbols breach the `TIME_LIMIT% > 35%` threshold on their argmax cell ⇒ pre-reg §10 halt-after-A fires (required: >6).
 
 **All 8 net_pnl values are negative.** Avg_pnl_per_trade likewise. Profit factors ≤ 0.09. Primary criterion (§4) is FAIL by every dimension.
 
@@ -166,7 +166,7 @@ The halt is firing on the operational definition pre-registered (`TIME_LIMIT% > 
 
 Per §10 explicit halt rule: running B+C after A's halt would not change interpretation. The mechanism's lift on profitability is fundamentally not present in A; without a mechanistic reason to expect B/C to differ, compute on B+C is not justified.
 
-**Compute saved:** 1,500 backtests × ~1.5s/cell × 8 workers parallel = ~5 min wall (modest, but the principle is what matters — pre-registration of the halt condition prevents post-hoc rationalization in either direction).
+**Compute saved:** modest in wall time; the principle is what matters — pre-registration of the halt condition prevents post-hoc rationalization in either direction.
 
 **Cross-sub-window stability (§4.4) is therefore unavailable.** Only window A's argmax cells exist. The "stable across all 3 windows" / "diverges" diagnostic is empty.
 

--- a/tests/test_backtest_refactor_parity.py
+++ b/tests/test_backtest_refactor_parity.py
@@ -84,6 +84,78 @@ def test_simulate_strategy_parity_without_kill_switch(tmp_path, monkeypatch):
 @pytest.mark.skipif(
     not os.path.exists(OHLCV_DB), reason="requires cached market data (data/ohlcv.db)",
 )
+def test_simulate_strategy_dynamic_exit_flag_off_real_data_parity(tmp_path, monkeypatch):
+    """`cfg.dynamic_exit_enabled=False` produces byte-identical trades vs no-field baseline.
+
+    Extends `test_signal_exit.test_flag_off_byte_identical_to_no_field_baseline`
+    (synthetic flat-bars) to real-data fixture (BTCUSDT 2024-01-01 → 2024-03-01).
+    Catches drift between the no-field and the explicit-False code paths under
+    realistic OHLCV that exercises full SL/TP/TIME_LIMIT logic.
+    """
+    from backtest import simulate_strategy, get_cached_data
+    import btc_api
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    symbol = "BTCUSDT"
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    data_start = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    df1h = get_cached_data(symbol, "1h", start_date=data_start)
+    df4h = get_cached_data(symbol, "4h", start_date=data_start)
+    df5m = get_cached_data(symbol, "5m", start_date=data_start)
+    df1d = get_cached_data(symbol, "1d", start_date=data_start)
+
+    if df1h.empty or df4h.empty or df5m.empty:
+        pytest.skip("BTCUSDT market data not cached in data/ohlcv.db")
+
+    cfg_no_field = {}
+    cfg_flag_off = {"dynamic_exit_enabled": False, "lrc_exit_threshold": 50.0}
+
+    trades_baseline, equity_baseline = simulate_strategy(
+        df1h.copy(), df4h.copy(), df5m.copy(), symbol,
+        sim_start=start, sim_end=end, df1d=df1d.copy(),
+        cfg=cfg_no_field,
+        enable_slippage=False, enable_spread=False, enable_fees=False,
+    )
+    trades_flag_off, equity_flag_off = simulate_strategy(
+        df1h.copy(), df4h.copy(), df5m.copy(), symbol,
+        sim_start=start, sim_end=end, df1d=df1d.copy(),
+        cfg=cfg_flag_off,
+        enable_slippage=False, enable_spread=False, enable_fees=False,
+    )
+
+    assert len(trades_baseline) == len(trades_flag_off), (
+        f"trade count drift: baseline={len(trades_baseline)} flag_off={len(trades_flag_off)}"
+    )
+
+    def _signature(t: dict) -> tuple:
+        return (
+            t.get("direction"),
+            t.get("exit_reason"),
+            round(float(t.get("entry_price", 0.0)), 8),
+            round(float(t.get("exit_price", 0.0)), 8),
+            round(float(t.get("pnl_usd", 0.0)), 8),
+            t.get("entry_time"),
+            t.get("exit_time"),
+        )
+
+    for tb, tf in zip(trades_baseline, trades_flag_off):
+        assert _signature(tb) == _signature(tf), (
+            f"trade drift: baseline={tb}\n  flag_off={tf}"
+        )
+
+    assert equity_baseline[-1]["equity"] == pytest.approx(equity_flag_off[-1]["equity"], rel=1e-9)
+    assert not any(t.get("exit_reason") == "SIGNAL_EXIT" for t in trades_baseline)
+    assert not any(t.get("exit_reason") == "SIGNAL_EXIT" for t in trades_flag_off)
+
+
+@pytest.mark.skipif(
+    not os.path.exists(OHLCV_DB), reason="requires cached market data (data/ohlcv.db)",
+)
 def test_simulate_strategy_with_simulator_wires_correctly(tmp_path, monkeypatch):
     """With apply_kill_switch=True + shared_simulator, closed trades feed the
     simulator and the tier can evolve mid-backtest.

--- a/tests/test_holdout_isolation.py
+++ b/tests/test_holdout_isolation.py
@@ -64,6 +64,10 @@ HOLDOUT_LEGITIMATE_MODULES: set[str] = {
     # above — reads data/ohlcv.db only; artefact dir carries the literal
     # '-pre-holdout' suffix.
     "tools/regime_retune_pre_holdout.py",
+    # R2 gates re-derivation tool (Phase 2 R2). Prints "Pre-holdout end: <ts>"
+    # as a console label — `HOLDOUT_START` is the cutoff timestamp constant,
+    # the literal string is operator-facing output, not a data access path.
+    "tools/r2_gates_rederivation.py",
     # A.2 walk-forward harness modules and A.4 evaluation modules will be
     # added here when those tickets land.
 }

--- a/tests/test_r1_sweep_defensive.py
+++ b/tests/test_r1_sweep_defensive.py
@@ -1,0 +1,92 @@
+"""Defensive-output tests for `tools.r1_signal_exit_sweep`.
+
+Coverage:
+  - `_save_json` rejects NaN / Inf payloads (fail-loud rather than emit
+    silently-invalid JSON that downstream verdict code might mis-parse).
+  - `_run_jobs_parallel` summarizes worker errors at end of sweep (operator
+    visibility into mid-sweep failures that would otherwise be buried).
+"""
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from tools.r1_signal_exit_sweep import _save_json
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _save_json — fail-loud on inf / NaN
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_save_json_rejects_nan(tmp_path):
+    """NaN must raise rather than serialize to invalid JSON."""
+    payload = {"net_pnl": math.nan}
+    with pytest.raises(ValueError):
+        _save_json(tmp_path / "out.json", payload)
+
+
+def test_save_json_rejects_inf(tmp_path):
+    """Infinity must raise rather than serialize to invalid JSON."""
+    payload = {"net_pnl": math.inf}
+    with pytest.raises(ValueError):
+        _save_json(tmp_path / "out.json", payload)
+
+
+def test_save_json_rejects_negative_inf_inside_nested_list(tmp_path):
+    """allow_nan=False applies to nested structures too."""
+    payload = {"results": [{"value": float("-inf")}]}
+    with pytest.raises(ValueError):
+        _save_json(tmp_path / "out.json", payload)
+
+
+def test_save_json_writes_normal_payload(tmp_path):
+    """Happy path: finite numbers serialize and round-trip cleanly."""
+    payload = {"net_pnl": -1234.56, "n_trades": 42, "label": "ok"}
+    target = tmp_path / "out.json"
+    _save_json(target, payload)
+    assert json.loads(target.read_text()) == payload
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _summarize_worker_errors — aggregates the `error` field across sweep results
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_summarize_worker_errors_returns_none_on_clean_results():
+    """No `error` field on any result → no summary message."""
+    from tools.r1_signal_exit_sweep import _summarize_worker_errors
+
+    results = [{"symbol": "BTCUSDT", "n_trades": 5}, {"symbol": "ETHUSDT", "n_trades": 3}]
+    assert _summarize_worker_errors(results) is None
+
+
+def test_summarize_worker_errors_counts_total_and_distinct():
+    """Workers emitting `error` → message counts total errors + distinct messages."""
+    from tools.r1_signal_exit_sweep import _summarize_worker_errors
+
+    results = [
+        {"symbol": "BTCUSDT", "error": "ValueError: bad data"},
+        {"symbol": "ETHUSDT", "error": "ValueError: bad data"},
+        {"symbol": "ADAUSDT", "error": "RuntimeError: cutoff drift"},
+        {"symbol": "AVAXUSDT", "n_trades": 5},
+    ]
+    msg = _summarize_worker_errors(results)
+    assert msg is not None
+    assert "3 workers errored" in msg
+    assert "2 distinct" in msg
+
+
+def test_summarize_worker_errors_includes_distinct_message_text():
+    """Operator visibility: distinct error strings appear in the summary."""
+    from tools.r1_signal_exit_sweep import _summarize_worker_errors
+
+    results = [
+        {"symbol": "BTCUSDT", "error": "ValueError: bad data"},
+        {"symbol": "ADAUSDT", "error": "RuntimeError: cutoff drift"},
+    ]
+    msg = _summarize_worker_errors(results)
+    assert "ValueError: bad data" in msg
+    assert "RuntimeError: cutoff drift" in msg

--- a/tests/test_r1_sweep_halt.py
+++ b/tests/test_r1_sweep_halt.py
@@ -1,0 +1,159 @@
+"""Tests for `tools.r1_signal_exit_sweep._check_halt_after_a`.
+
+Pre-reg §10: halt if `TIME_LIMIT% > 35%` on argmax cell for `> 6` symbols.
+
+Coverage:
+  - Real R1 fixture reproduces halt=True with 7 symbols breaching (regression net
+    against the 2026-05-12 halt event).
+  - Counterfactual synthetic inputs that should NOT halt (empty, all-low-TL,
+    boundary at exactly 6 breaches).
+  - Synthetic input that SHOULD halt (7 breaches).
+  - No-data symbols (n_trades < N_TRADES_MIN) contribute None to per_symbol_tl_pct
+    and do not count as breaches.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.r1_signal_exit_sweep import (
+    HALT_SYMBOLS_THRESHOLD,
+    HALT_TL_PCT_THRESHOLD,
+    N_TRADES_MIN,
+    _check_halt_after_a,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_DIR = REPO_ROOT / "data" / "retune" / "2026-05-12-r1-dynamic-exit"
+
+
+def _cell(
+    *,
+    symbol: str = "BTCUSDT",
+    sl: float = 1.0,
+    be: float = 1.5,
+    lrc_thr: float = 50.0,
+    n_trades: int = 20,
+    net_pnl: float = 0.0,
+    time_limit: int = 0,
+    signal_exit: int = 0,
+    sl_exits: int = 0,
+    tp_exits: int = 0,
+) -> dict:
+    """Build a synthetic cell dict matching the sweep harness output shape."""
+    return {
+        "symbol": symbol,
+        "sl": sl,
+        "be": be,
+        "lrc_thr": lrc_thr,
+        "n_trades": n_trades,
+        "net_pnl": net_pnl,
+        "profit_factor": 1.0,
+        "exit_reasons": {
+            "TIME_LIMIT": time_limit,
+            "SIGNAL_EXIT": signal_exit,
+            "SL": sl_exits,
+            "TP": tp_exits,
+        },
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Real R1 fixture: halt=True with 7 symbols breaching
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    not (FIXTURE_DIR / "sweep_results_A.json").exists(),
+    reason="R1 sweep fixture not present in this branch",
+)
+def test_check_halt_after_a_reproduces_recorded_halt_event():
+    """Real R1 window-A sweep fixture → halt=True with 7-symbol breach (2026-05-12 event)."""
+    with open(FIXTURE_DIR / "sweep_results_A.json") as f:
+        a_results = json.load(f)
+    with open(FIXTURE_DIR / "halt_after_a_diagnostic.json") as f:
+        expected = json.load(f)
+
+    diag = _check_halt_after_a(a_results)
+
+    assert diag["halt"] is True
+    assert diag["halt"] == expected["halt"]
+    assert diag["n_symbols_over_threshold"] == 7
+    assert diag["n_symbols_over_threshold"] == expected["n_symbols_over_threshold"]
+    assert diag["symbols_over_threshold"] == expected["symbols_over_threshold"]
+    assert diag["halt_tl_pct_threshold"] == HALT_TL_PCT_THRESHOLD
+    assert diag["halt_symbols_threshold"] == HALT_SYMBOLS_THRESHOLD
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Synthetic counterfactuals
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_check_halt_after_a_empty_results_does_not_halt():
+    diag = _check_halt_after_a([])
+    assert diag["halt"] is False
+    assert diag["n_symbols_over_threshold"] == 0
+    assert diag["symbols_over_threshold"] == []
+
+
+def test_check_halt_after_a_all_symbols_below_threshold_does_not_halt():
+    """Every symbol's argmax has TL%=25 (< 35) → no breach, halt=False."""
+    results = [
+        _cell(symbol=s, n_trades=20, net_pnl=-100.0, time_limit=5)
+        for s in (
+            "BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT",
+            "DOGEUSDT", "UNIUSDT", "XLMUSDT", "RUNEUSDT",
+        )
+    ]
+    diag = _check_halt_after_a(results)
+    assert diag["halt"] is False
+    assert diag["n_symbols_over_threshold"] == 0
+
+
+def test_check_halt_after_a_exactly_six_breaches_does_not_halt():
+    """Halt requires STRICTLY MORE than 6 breaches — exactly 6 stays under the bar."""
+    six_breach = [
+        _cell(symbol=s, n_trades=20, net_pnl=-100.0, time_limit=15)  # TL%=75
+        for s in ("BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT", "UNIUSDT")
+    ]
+    rest = [
+        _cell(symbol=s, n_trades=20, net_pnl=-100.0, time_limit=2)  # TL%=10
+        for s in ("XLMUSDT", "RUNEUSDT")
+    ]
+    diag = _check_halt_after_a(six_breach + rest)
+    assert diag["n_symbols_over_threshold"] == HALT_SYMBOLS_THRESHOLD
+    assert diag["halt"] is False
+
+
+def test_check_halt_after_a_seven_breaches_halts():
+    seven_breach = [
+        _cell(symbol=s, n_trades=20, net_pnl=-100.0, time_limit=15)  # TL%=75
+        for s in (
+            "BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT",
+            "DOGEUSDT", "UNIUSDT", "XLMUSDT",
+        )
+    ]
+    diag = _check_halt_after_a(seven_breach)
+    assert diag["n_symbols_over_threshold"] == 7
+    assert diag["halt"] is True
+
+
+def test_check_halt_after_a_no_data_symbols_contribute_none_tl_pct():
+    """Symbols with no eligible cell (all n_trades < N_TRADES_MIN) → None, not breach."""
+    results = [
+        # Real breach
+        _cell(symbol="BTCUSDT", n_trades=20, net_pnl=-100.0, time_limit=15),
+        # No-data: every cell below the trade-count floor
+        _cell(symbol="JUPUSDT", n_trades=N_TRADES_MIN - 1, net_pnl=0.0, time_limit=0),
+        _cell(symbol="PENDLEUSDT", n_trades=N_TRADES_MIN - 1, net_pnl=0.0, time_limit=0),
+    ]
+    diag = _check_halt_after_a(results)
+    assert diag["per_symbol_tl_pct"]["JUPUSDT"] is None
+    assert diag["per_symbol_tl_pct"]["PENDLEUSDT"] is None
+    assert diag["per_symbol_tl_pct"]["BTCUSDT"] == 75.0
+    assert diag["n_symbols_over_threshold"] == 1
+    assert diag["halt"] is False

--- a/tests/test_r1_verdict.py
+++ b/tests/test_r1_verdict.py
@@ -1,0 +1,472 @@
+"""Unit tests for tools/r1_verdict.py — R1 verdict calculator helpers.
+
+Pre-reg: docs/superpowers/plans/2026-05-12-r1-dynamic-exit-pre-reg.md §4
+
+Coverage:
+  - `_argmax_cell`: eligibility filter + deterministic tie-break (gap #2).
+  - `_avg_pnl_per_trade` / `_time_limit_pct` / `_signal_exit_pct`: None/zero guards.
+  - `_analyze_window`: per-symbol argmax + primary/secondary aggregation.
+  - `_cross_window_stability`: stable / diverges / single-window flag.
+  - `_classify_verdict`: pre-reg §4.2 outcomes + halt+n_windows<3 guard (gap #4).
+  - `_load_json`: missing-file → None, present-file → parsed dict.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.r1_verdict import (
+    ALL_SYMBOLS,
+    N_TRADES_MIN,
+    _analyze_window,
+    _argmax_cell,
+    _avg_pnl_per_trade,
+    _classify_verdict,
+    _cross_window_stability,
+    _load_json,
+    _signal_exit_pct,
+    _time_limit_pct,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Synthetic cell helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _cell(
+    *,
+    symbol: str = "BTCUSDT",
+    sl: float = 1.0,
+    be: float = 1.5,
+    lrc_thr: float = 50.0,
+    n_trades: int = 20,
+    net_pnl: float = 0.0,
+    profit_factor: float = 1.0,
+    time_limit: int = 0,
+    signal_exit: int = 0,
+    sl_exits: int = 0,
+    tp_exits: int = 0,
+) -> dict:
+    """Build a synthetic cell dict matching tools.r1_signal_exit_sweep output shape."""
+    return {
+        "symbol": symbol,
+        "sl": sl,
+        "be": be,
+        "lrc_thr": lrc_thr,
+        "n_trades": n_trades,
+        "net_pnl": net_pnl,
+        "profit_factor": profit_factor,
+        "exit_reasons": {
+            "TIME_LIMIT": time_limit,
+            "SIGNAL_EXIT": signal_exit,
+            "SL": sl_exits,
+            "TP": tp_exits,
+        },
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _argmax_cell — eligibility + deterministic tie-break (gap #2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_argmax_cell_returns_none_on_empty_list():
+    assert _argmax_cell([]) is None
+
+
+def test_argmax_cell_returns_none_when_no_cell_meets_min_trades():
+    cells = [_cell(n_trades=N_TRADES_MIN - 1, net_pnl=100.0)]
+    assert _argmax_cell(cells) is None
+
+
+def test_argmax_cell_picks_max_net_pnl_when_no_ties():
+    cells = [
+        _cell(sl=1.0, net_pnl=100.0),
+        _cell(sl=2.0, net_pnl=200.0),
+        _cell(sl=3.0, net_pnl=50.0),
+    ]
+    winner = _argmax_cell(cells)
+    assert winner["net_pnl"] == 200.0
+    assert winner["sl"] == 2.0
+
+
+def test_argmax_cell_excludes_cells_below_min_trades():
+    cells = [
+        _cell(n_trades=N_TRADES_MIN, net_pnl=50.0),
+        _cell(n_trades=N_TRADES_MIN - 1, net_pnl=1000.0),  # excluded
+    ]
+    winner = _argmax_cell(cells)
+    assert winner["net_pnl"] == 50.0
+
+
+def test_argmax_cell_tiebreak_prefers_lower_sl():
+    """Gap #2: when net_pnl ties, tie-break by lower sl (more conservative)."""
+    cells = [
+        _cell(sl=2.5, be=2.0, lrc_thr=50.0, net_pnl=100.0),
+        _cell(sl=1.0, be=2.0, lrc_thr=50.0, net_pnl=100.0),
+        _cell(sl=1.5, be=2.0, lrc_thr=50.0, net_pnl=100.0),
+    ]
+    winner = _argmax_cell(cells)
+    assert winner["sl"] == 1.0
+
+
+def test_argmax_cell_tiebreak_prefers_lower_be_when_sl_ties():
+    """Gap #2: net_pnl + sl tied → break by lower be."""
+    cells = [
+        _cell(sl=1.0, be=2.5, lrc_thr=50.0, net_pnl=100.0),
+        _cell(sl=1.0, be=1.5, lrc_thr=50.0, net_pnl=100.0),
+        _cell(sl=1.0, be=2.0, lrc_thr=50.0, net_pnl=100.0),
+    ]
+    winner = _argmax_cell(cells)
+    assert winner["be"] == 1.5
+
+
+def test_argmax_cell_tiebreak_prefers_lower_lrc_thr_when_sl_and_be_tie():
+    """Gap #2: net_pnl + sl + be tied → break by lower lrc_thr."""
+    cells = [
+        _cell(sl=1.0, be=1.5, lrc_thr=55.0, net_pnl=100.0),
+        _cell(sl=1.0, be=1.5, lrc_thr=35.0, net_pnl=100.0),
+        _cell(sl=1.0, be=1.5, lrc_thr=45.0, net_pnl=100.0),
+    ]
+    winner = _argmax_cell(cells)
+    assert winner["lrc_thr"] == 35.0
+
+
+def test_argmax_cell_tiebreak_deterministic_across_input_orders():
+    """Gap #2: tie-break is independent of insertion order — all 6 permutations agree."""
+    a = _cell(sl=1.0, be=1.5, lrc_thr=35.0, net_pnl=100.0)
+    b = _cell(sl=1.5, be=1.5, lrc_thr=35.0, net_pnl=100.0)
+    c = _cell(sl=2.0, be=1.5, lrc_thr=35.0, net_pnl=100.0)
+    for cells in (
+        [a, b, c], [a, c, b], [b, a, c], [b, c, a], [c, a, b], [c, b, a],
+    ):
+        assert _argmax_cell(cells)["sl"] == 1.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _avg_pnl_per_trade / _time_limit_pct / _signal_exit_pct — None/zero guards
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_avg_pnl_per_trade_none_for_missing_cell():
+    assert _avg_pnl_per_trade(None) is None
+
+
+def test_avg_pnl_per_trade_none_for_zero_trades():
+    assert _avg_pnl_per_trade({"n_trades": 0, "net_pnl": 0.0}) is None
+
+
+def test_avg_pnl_per_trade_divides_net_pnl_by_n_trades():
+    assert _avg_pnl_per_trade({"n_trades": 10, "net_pnl": 100.0}) == 10.0
+
+
+def test_time_limit_pct_none_for_missing_cell():
+    assert _time_limit_pct(None) is None
+
+
+def test_time_limit_pct_none_for_zero_trades():
+    assert _time_limit_pct({"n_trades": 0, "exit_reasons": {"TIME_LIMIT": 5}}) is None
+
+
+def test_time_limit_pct_computes_percentage_on_argmax_cell():
+    cell = _cell(n_trades=20, time_limit=10)
+    assert _time_limit_pct(cell) == 50.0
+
+
+def test_signal_exit_pct_none_for_missing_cell():
+    assert _signal_exit_pct(None) is None
+
+
+def test_signal_exit_pct_none_for_zero_trades():
+    assert _signal_exit_pct({"n_trades": 0, "exit_reasons": {"SIGNAL_EXIT": 5}}) is None
+
+
+def test_signal_exit_pct_computes_percentage_on_argmax_cell():
+    cell = _cell(n_trades=20, signal_exit=5)
+    assert _signal_exit_pct(cell) == 25.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _analyze_window — primary / secondary criteria
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_analyze_window_empty_results_all_none():
+    """No sweep results → every ALL_SYMBOLS entry maps to None."""
+    out = _analyze_window("A", [])
+    for sym in ALL_SYMBOLS:
+        assert out["per_symbol_argmax_cell"][sym] is None
+    assert out["primary_criterion"]["pass"] is False
+    assert out["secondary_criterion"]["pass"] is False
+
+
+def test_analyze_window_symbol_with_only_zero_trade_cells_is_none():
+    """If every cell for a symbol has n_trades=0, argmax cell is None."""
+    results = [_cell(symbol="BTCUSDT", n_trades=0, net_pnl=0.0)]
+    out = _analyze_window("A", results)
+    assert out["per_symbol_argmax_cell"]["BTCUSDT"] is None
+
+
+def test_analyze_window_primary_pass_when_all_three_clauses_met():
+    """Primary §4: ≥1 sym avg_ppt>0 AND ≥3 sym net_pnl>0 AND avg PF on positive subset > 1.2."""
+    results = [
+        _cell(symbol="BTCUSDT", n_trades=20, net_pnl=200.0, profit_factor=2.0),
+        _cell(symbol="ETHUSDT", n_trades=20, net_pnl=200.0, profit_factor=2.0),
+        _cell(symbol="ADAUSDT", n_trades=20, net_pnl=200.0, profit_factor=2.0),
+    ]
+    out = _analyze_window("A", results)
+    assert out["primary_criterion"]["pass"] is True
+    assert out["primary_criterion"]["n_syms_net_pnl_positive"] == 3
+    assert out["primary_criterion"]["avg_pf_on_positive_subset"] == pytest.approx(2.0)
+
+
+def test_analyze_window_primary_fail_avg_pf_below_threshold():
+    """Three positive symbols but avg PF on positive subset ≤ 1.2 → primary fails."""
+    results = [
+        _cell(symbol="BTCUSDT", n_trades=20, net_pnl=200.0, profit_factor=1.0),
+        _cell(symbol="ETHUSDT", n_trades=20, net_pnl=200.0, profit_factor=1.1),
+        _cell(symbol="ADAUSDT", n_trades=20, net_pnl=200.0, profit_factor=1.15),
+    ]
+    out = _analyze_window("A", results)
+    assert out["primary_criterion"]["pass"] is False
+
+
+def test_analyze_window_primary_fail_below_min_net_pnl_positive_count():
+    """Only 2 syms with net_pnl>0 → primary fails (needs ≥3)."""
+    results = [
+        _cell(symbol="BTCUSDT", n_trades=20, net_pnl=200.0, profit_factor=2.0),
+        _cell(symbol="ETHUSDT", n_trades=20, net_pnl=200.0, profit_factor=2.0),
+        _cell(symbol="ADAUSDT", n_trades=20, net_pnl=-100.0, profit_factor=0.5),
+    ]
+    out = _analyze_window("A", results)
+    assert out["primary_criterion"]["pass"] is False
+
+
+def test_analyze_window_secondary_pass_when_six_bankrupt_syms_have_low_tl():
+    """6 of 8 currently-bankrupt symbols with TL%<20% on argmax cell → secondary pass."""
+    bankrupt_low_tl = ("ADAUSDT", "AVAXUSDT", "DOGEUSDT", "UNIUSDT", "XLMUSDT", "PENDLEUSDT")
+    results = [
+        _cell(symbol=s, n_trades=20, net_pnl=-100.0, time_limit=2)  # TL% = 10%
+        for s in bankrupt_low_tl
+    ]
+    out = _analyze_window("A", results)
+    assert out["secondary_criterion"]["pass"] is True
+    assert set(out["secondary_criterion"]["bankrupt_pass_tl_under_20pct"]) >= set(bankrupt_low_tl)
+
+
+def test_analyze_window_secondary_fail_when_bankrupt_syms_have_high_tl():
+    """All 8 bankrupt syms have TL%>=20% → secondary fails."""
+    bankrupt_all = (
+        "ADAUSDT", "AVAXUSDT", "DOGEUSDT", "UNIUSDT", "XLMUSDT",
+        "PENDLEUSDT", "JUPUSDT", "RUNEUSDT",
+    )
+    results = [
+        _cell(symbol=s, n_trades=20, net_pnl=-100.0, time_limit=10)  # TL% = 50%
+        for s in bankrupt_all
+    ]
+    out = _analyze_window("A", results)
+    assert out["secondary_criterion"]["pass"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _cross_window_stability
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_cross_window_stability_same_cell_across_three_windows():
+    """Identical (sl, be, lrc_thr) in all three windows → stable=True."""
+    cell = {"sl": 1.0, "be": 1.5, "lrc_thr": 35.0}
+    per_window = {"A": {"BTCUSDT": cell}, "B": {"BTCUSDT": cell}, "C": {"BTCUSDT": cell}}
+    out = _cross_window_stability(per_window)
+    assert out["BTCUSDT"]["same_cell_across_windows"] is True
+    assert out["BTCUSDT"]["n_windows_with_data"] == 3
+
+
+def test_cross_window_stability_diverges_when_cells_differ():
+    per_window = {
+        "A": {"BTCUSDT": {"sl": 1.0, "be": 1.5, "lrc_thr": 35.0}},
+        "B": {"BTCUSDT": {"sl": 2.0, "be": 1.5, "lrc_thr": 35.0}},
+        "C": {"BTCUSDT": None},
+    }
+    out = _cross_window_stability(per_window)
+    assert out["BTCUSDT"]["same_cell_across_windows"] is False
+    assert out["BTCUSDT"]["n_windows_with_data"] == 2
+
+
+def test_cross_window_stability_single_window_flag_is_none():
+    """Only one window has data → can't determine stability."""
+    per_window = {
+        "A": {"BTCUSDT": {"sl": 1.0, "be": 1.5, "lrc_thr": 35.0}},
+        "B": {"BTCUSDT": None},
+        "C": {"BTCUSDT": None},
+    }
+    out = _cross_window_stability(per_window)
+    assert out["BTCUSDT"]["same_cell_across_windows"] is None
+    assert out["BTCUSDT"]["n_windows_with_data"] == 1
+
+
+def test_cross_window_stability_no_data_flag_is_none_count_zero():
+    per_window = {"A": {"BTCUSDT": None}, "B": {"BTCUSDT": None}, "C": {"BTCUSDT": None}}
+    out = _cross_window_stability(per_window)
+    assert out["BTCUSDT"]["same_cell_across_windows"] is None
+    assert out["BTCUSDT"]["n_windows_with_data"] == 0
+
+
+def test_cross_window_stability_covers_all_symbols_when_per_window_dicts_partial():
+    """Symbols absent from a per_window dict still appear in output (with None)."""
+    out = _cross_window_stability({"A": {}, "B": {}, "C": {}})
+    for sym in ALL_SYMBOLS:
+        assert sym in out
+        assert out[sym]["n_windows_with_data"] == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _classify_verdict — pre-reg §4.2 outcomes + gap #4 halt guard
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _per_window_analysis(p_per_w: dict, s_per_w: dict) -> dict:
+    """Build the minimal _classify_verdict input from primary/secondary pass flags."""
+    return {
+        w: {
+            "primary_criterion": {"pass": p_per_w[w]},
+            "secondary_criterion": {"pass": s_per_w[w]},
+        }
+        for w in p_per_w
+    }
+
+
+def test_classify_verdict_success_all_windows_pass_both():
+    pwa = _per_window_analysis(
+        {"A": True, "B": True, "C": True},
+        {"A": True, "B": True, "C": True},
+    )
+    assert _classify_verdict(pwa)["verdict"] == "R1_SUCCESS"
+
+
+def test_classify_verdict_fail_all_windows_fail_both():
+    pwa = _per_window_analysis(
+        {"A": False, "B": False, "C": False},
+        {"A": False, "B": False, "C": False},
+    )
+    assert _classify_verdict(pwa)["verdict"] == "R1_FAIL"
+
+
+def test_classify_verdict_success_conditional_one_primary_fail_secondary_all_pass():
+    """Exactly one window fails primary while secondary passes everywhere → SUCCESS_CONDITIONAL."""
+    pwa = _per_window_analysis(
+        {"A": True, "B": True, "C": False},
+        {"A": True, "B": True, "C": True},
+    )
+    assert _classify_verdict(pwa)["verdict"] == "R1_SUCCESS_CONDITIONAL"
+
+
+def test_classify_verdict_inconclusive_two_primary_fail_secondary_high():
+    """Two windows fail primary but secondary still meets the (n_windows-1) bar → INCONCLUSIVE."""
+    pwa = _per_window_analysis(
+        {"A": True, "B": False, "C": False},
+        {"A": True, "B": True, "C": True},
+    )
+    assert _classify_verdict(pwa)["verdict"] == "R1_INCONCLUSIVE"
+
+
+def test_classify_verdict_default_halt_false_preserves_existing_behavior():
+    """Gap #4: default halt=False — caller without the flag gets pre-fix behavior."""
+    pwa = _per_window_analysis(
+        {"A": False, "B": False, "C": False},
+        {"A": False, "B": False, "C": False},
+    )
+    assert _classify_verdict(pwa)["verdict"] == "R1_FAIL"
+
+
+def test_classify_verdict_halt_with_one_window_returns_insufficient_data():
+    """Gap #4: halt fired + single window — even if A passes, we cannot declare SUCCESS."""
+    pwa = _per_window_analysis({"A": True}, {"A": True})
+    out = _classify_verdict(pwa, halt=True)
+    assert out["verdict"] == "R1_INSUFFICIENT_DATA"
+
+
+def test_classify_verdict_halt_with_two_windows_returns_insufficient_data():
+    """Gap #4: halt fired + only A+B run — still <3 windows ⇒ INSUFFICIENT_DATA."""
+    pwa = _per_window_analysis(
+        {"A": True, "B": True},
+        {"A": True, "B": True},
+    )
+    out = _classify_verdict(pwa, halt=True)
+    assert out["verdict"] == "R1_INSUFFICIENT_DATA"
+
+
+def test_classify_verdict_halt_with_three_windows_runs_normal_logic():
+    """Gap #4: halt fired but operator overrode and ran all 3 → normal classification."""
+    pwa = _per_window_analysis(
+        {"A": True, "B": True, "C": True},
+        {"A": True, "B": True, "C": True},
+    )
+    assert _classify_verdict(pwa, halt=True)["verdict"] == "R1_SUCCESS"
+
+
+def test_classify_verdict_no_halt_one_window_normal_logic():
+    """Gap #4: halt=False + 1 window → existing logic, no INSUFFICIENT_DATA guard."""
+    pwa = _per_window_analysis({"A": False}, {"A": False})
+    assert _classify_verdict(pwa, halt=False)["verdict"] == "R1_FAIL"
+
+
+def test_classify_verdict_halt_with_one_window_primary_fails_stays_fail():
+    """Gap #4 scope: halt + 1 window + clear FAIL is NOT spurious — verdict stays FAIL.
+
+    The halt guard targets favorable verdicts on partial evidence; negative
+    evidence (primary/secondary failing in the windows that ran) is honest
+    and not invalidated by the early halt. Locks the recorded R1 outcome
+    (halt=True, n_windows=1, primary+secondary both failed → R1_FAIL).
+    """
+    pwa = _per_window_analysis({"A": False}, {"A": False})
+    assert _classify_verdict(pwa, halt=True)["verdict"] == "R1_FAIL"
+
+
+def test_classify_verdict_halt_with_two_windows_inconclusive_stays_inconclusive():
+    """Gap #4 scope: halt + naive INCONCLUSIVE stays INCONCLUSIVE.
+
+    Halt overrides only favorable verdicts (SUCCESS / SUCCESS_CONDITIONAL).
+    INCONCLUSIVE is an honest "we can't tell from these windows" — halt
+    doesn't invalidate that, and replacing it with INSUFFICIENT_DATA would
+    erase informative content.
+    """
+    pwa = _per_window_analysis(
+        {"A": True, "B": False},
+        {"A": True, "B": False},
+    )
+    assert _classify_verdict(pwa, halt=True)["verdict"] == "R1_INCONCLUSIVE"
+
+
+def test_classify_verdict_halt_with_two_windows_success_conditional_overridden():
+    """Gap #4 scope: halt + naive SUCCESS_CONDITIONAL on 2 windows → INSUFFICIENT_DATA.
+
+    SUCCESS_CONDITIONAL is still favorable evidence on partial windows, so
+    halt should block it the same way it blocks SUCCESS.
+    """
+    pwa = _per_window_analysis(
+        {"A": True, "B": False},
+        {"A": True, "B": True},
+    )
+    assert _classify_verdict(pwa, halt=True)["verdict"] == "R1_INSUFFICIENT_DATA"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _load_json — missing vs present
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_load_json_returns_none_for_missing_file(tmp_path, monkeypatch):
+    from tools import r1_verdict
+    monkeypatch.setattr(r1_verdict, "OUTPUT_DIR", tmp_path)
+    assert r1_verdict._load_json("does_not_exist.json") is None
+
+
+def test_load_json_parses_existing_file(tmp_path, monkeypatch):
+    from tools import r1_verdict
+    monkeypatch.setattr(r1_verdict, "OUTPUT_DIR", tmp_path)
+    payload = {"foo": "bar", "n": 42}
+    (tmp_path / "test.json").write_text(json.dumps(payload))
+    assert r1_verdict._load_json("test.json") == payload

--- a/tests/test_signal_exit.py
+++ b/tests/test_signal_exit.py
@@ -160,6 +160,20 @@ def test_should_signal_exit_nan_lrc_returns_false():
     assert _should_signal_exit("SHORT", float("nan"), 50.0) is False
 
 
+def test_should_signal_exit_lowercase_direction_case_insensitive():
+    """Defensive: accept lowercase/mixed-case direction strings (operator config drift)."""
+    from backtest import _should_signal_exit
+    assert _should_signal_exit("long", 80.0, 50.0) is True
+    assert _should_signal_exit("Short", 20.0, 50.0) is True
+    assert _should_signal_exit("LoNg", 80.0, 50.0) is True
+
+
+def test_should_signal_exit_none_direction_returns_false():
+    """Defensive: None direction (e.g., position lacking a side) never triggers exit."""
+    from backtest import _should_signal_exit
+    assert _should_signal_exit(None, 80.0, 50.0) is False
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # §2.2 — SIGNAL_EXIT fires via the simulator (integration)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tools/r1_signal_exit_sweep.py
+++ b/tools/r1_signal_exit_sweep.py
@@ -363,9 +363,34 @@ def _git_commit() -> str:
 
 
 def _save_json(path: Path, payload):
+    """Write `payload` as JSON. NaN / Inf raise rather than serialize.
+
+    The default `json.dump` emits `NaN` / `Infinity` tokens that are not valid
+    JSON — `json.loads` accepts them but the standard does not, and downstream
+    parsers (verdict calculator, audit doc consumers) may silently mishandle
+    them. Failing here surfaces the upstream metric pollution at write time.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
-        json.dump(payload, f, indent=2, sort_keys=True, default=str)
+        json.dump(payload, f, indent=2, sort_keys=True, default=str, allow_nan=False)
+
+
+def _summarize_worker_errors(results: list[dict]) -> str | None:
+    """Aggregate the `error` field across sweep results.
+
+    Returns a one-line summary if any worker reported an error, else None.
+    Surfaces multi-worker failure modes that would otherwise be buried in the
+    750-cell result list — without this, an operator scanning stderr at the
+    end of the sweep has no signal that anything went wrong.
+    """
+    errors = [r.get("error") for r in results if r.get("error")]
+    if not errors:
+        return None
+    distinct = sorted(set(errors))
+    return (
+        f"[r1_sweep] {len(errors)} workers errored "
+        f"({len(distinct)} distinct): {distinct}"
+    )
 
 
 def _run_jobs_parallel(jobs: list[dict], workers: int, label: str) -> list[dict]:
@@ -378,6 +403,9 @@ def _run_jobs_parallel(jobs: list[dict], workers: int, label: str) -> list[dict]
         results = pool.map(_process_cell, jobs)
     elapsed = time.monotonic() - t0
     sys.stderr.write(f"[r1_sweep] {label}: completed in {elapsed:.1f}s\n")
+    err_summary = _summarize_worker_errors(results)
+    if err_summary:
+        sys.stderr.write(err_summary + "\n")
     return results
 
 

--- a/tools/r1_verdict.py
+++ b/tools/r1_verdict.py
@@ -52,11 +52,20 @@ def _load_json(name: str):
 
 
 def _argmax_cell(cells: list[dict]) -> dict | None:
-    """Pre-reg §4.1: argmax(net_pnl) among cells with n_trades >= N_TRADES_MIN."""
+    """Pre-reg §4.1: argmax(net_pnl) among cells with n_trades >= N_TRADES_MIN.
+
+    Tie-break: when two cells tie on net_pnl, favor lower `sl`, then lower `be`,
+    then lower `lrc_thr` — i.e., the more conservative parameter combination.
+    Determinism matters because the previous insertion-order tie-break made
+    cell selection fragile to job-execution order across parallel workers.
+    """
     eligible = [c for c in cells if c.get("n_trades", 0) >= N_TRADES_MIN]
     if not eligible:
         return None
-    return max(eligible, key=lambda c: c["net_pnl"])
+    return max(
+        eligible,
+        key=lambda c: (c["net_pnl"], -c["sl"], -c["be"], -c["lrc_thr"]),
+    )
 
 
 def _avg_pnl_per_trade(cell: dict | None) -> float | None:
@@ -190,8 +199,16 @@ def _cross_window_stability(per_window_argmax: dict[str, dict]) -> dict:
     return out
 
 
-def _classify_verdict(per_window_analysis: dict[str, dict]) -> dict:
-    """Pre-reg §4.2 verdict classification."""
+def _classify_verdict(per_window_analysis: dict[str, dict], *, halt: bool = False) -> dict:
+    """Pre-reg §4.2 verdict classification.
+
+    Gap #4 (halt guard): if `halt=True` and fewer than 3 sub-windows ran, a naive
+    `R1_SUCCESS` / `R1_SUCCESS_CONDITIONAL` is overridden to `R1_INSUFFICIENT_DATA`.
+    Rationale: a favorable verdict on partial evidence is "spurious" — we can't
+    declare success without seeing B+C. `R1_FAIL` / `R1_INCONCLUSIVE` are kept
+    as-is: clear negative evidence on the windows that did run is not spurious,
+    and halt does not invalidate it.
+    """
     p_per_w = {w: a["primary_criterion"]["pass"] for w, a in per_window_analysis.items()}
     s_per_w = {w: a["secondary_criterion"]["pass"] for w, a in per_window_analysis.items()}
 
@@ -209,6 +226,9 @@ def _classify_verdict(per_window_analysis: dict[str, dict]) -> dict:
     else:
         verdict = "R1_FAIL"
 
+    if halt and n_windows < 3 and verdict in ("R1_SUCCESS", "R1_SUCCESS_CONDITIONAL"):
+        verdict = "R1_INSUFFICIENT_DATA"
+
     return {
         "verdict": verdict,
         "primary_pass_per_window": p_per_w,
@@ -216,6 +236,7 @@ def _classify_verdict(per_window_analysis: dict[str, dict]) -> dict:
         "n_primary_pass": n_primary_pass,
         "n_secondary_pass": n_secondary_pass,
         "n_windows": n_windows,
+        "halt": halt,
     }
 
 
@@ -257,6 +278,8 @@ def main() -> int:
     sweep_b = _load_json("sweep_results_B.json")
     sweep_c = _load_json("sweep_results_C.json")
     baseline = _load_json("baseline_pre_signal_exit.json")
+    halt_diag = _load_json("halt_after_a_diagnostic.json")
+    halt = bool(halt_diag and halt_diag.get("halt"))
 
     if baseline is None:
         print("WARNING: baseline_pre_signal_exit.json missing", file=sys.stderr)
@@ -291,10 +314,12 @@ def main() -> int:
             flag = "  [diverges]"
         print(f"  {sym:<12}  A:{cells.get('A')}  B:{cells.get('B')}  C:{cells.get('C')}{flag}")
 
-    verdict = _classify_verdict(analyses)
+    verdict = _classify_verdict(analyses, halt=halt)
     print(f"\n=== Verdict (§4.2) ===")
     print(f"  Primary pass per window:   {verdict['primary_pass_per_window']}")
     print(f"  Secondary pass per window: {verdict['secondary_pass_per_window']}")
+    if halt:
+        print(f"  Pre-reg §10 halt fired:    True (loaded from halt_after_a_diagnostic.json)")
     print(f"  ==> VERDICT: {verdict['verdict']}")
 
     out = {


### PR DESCRIPTION
## Summary

Closes operator-review gaps identified in PR #329 (R1 signal-exit sweep, merged 2026-05-12). Same pattern as R1: flag-gated changes, no live-path impact, TDD strict on the new code paths.

R1 verdict.json still reproduces `R1_FAIL` under the option-2 scope of gap #4 (verified by re-running `_classify_verdict` on the recorded `sweep_results_A.json` + `halt_after_a_diagnostic.json`).

## 12 items closed

### 5 gaps

- **#1 — Coverage** on `tools/r1_verdict.py` (0 tests → 43 tests in `tests/test_r1_verdict.py`). Covers every helper (`_load_json`, `_argmax_cell`, `_avg_pnl_per_trade`, `_time_limit_pct`, `_signal_exit_pct`, `_analyze_window`, `_cross_window_stability`, `_classify_verdict`) plus edge cases (empty cells, INSUFFICIENT_DATA, ties in argmax, missing/zero trade counts).
- **#2 — Deterministic tie-break** in `tools/r1_verdict.py:_argmax_cell` (line 54-68). On net_pnl ties, favors lower `sl`, then lower `be`, then lower `lrc_thr` — documented in the docstring. Eliminates insertion-order dependence on parallel worker output.
- **#3 — Halt fixture regression net** in `tests/test_r1_sweep_halt.py` (6 tests). Loads the recorded `sweep_results_A.json` + `halt_after_a_diagnostic.json` and verifies `_check_halt_after_a` reproduces `halt=True` with the 7-symbol breach. Plus synthetic counterfactuals: empty results, all-low-TL, exactly-6-breaches (does not halt), exactly-7-breaches (halts), no-data symbols (None TL%).
- **#4 — `_classify_verdict` halt guard** in `tools/r1_verdict.py:202-238`. Keyword-only `*, halt: bool = False`. **Scope (per operator decision on the gap-4 framing question)**: only overrides `R1_SUCCESS` / `R1_SUCCESS_CONDITIONAL` → `R1_INSUFFICIENT_DATA` when `halt=True` and `n_windows<3`. `R1_FAIL` / `R1_INCONCLUSIVE` are preserved — negative evidence on partial windows is honest, not spurious, and halt does not invalidate it. The recorded R1 (`halt=True, n_windows=1, primary+secondary both fail`) still classifies as `R1_FAIL`. `main()` now loads `halt_after_a_diagnostic.json` and passes `halt=` through; tests assert: spurious SUCCESS on 1/2 windows → INSUFFICIENT_DATA; clear FAIL on 1 window stays FAIL; INCONCLUSIVE on partial evidence stays INCONCLUSIVE; halt on 3-window run defers to normal logic; default `halt=False` preserves pre-fix behavior.
- **#5 — Real-data parity case** in `tests/test_backtest_refactor_parity.py:test_simulate_strategy_dynamic_exit_flag_off_real_data_parity`. Extends the synthetic flat-bar coverage in `test_signal_exit.test_flag_off_byte_identical_to_no_field_baseline` to BTCUSDT 2024-01-01 → 2024-03-01 with full SL/TP/TIME_LIMIT exercise. `cfg.dynamic_exit_enabled=False` produces byte-identical trade signatures vs no-cfg-field baseline.

### 2 defensive items

- **(f) `_save_json` fail-loud** on `tools/r1_signal_exit_sweep.py:365-374`. Adds `allow_nan=False` to `json.dump`. NaN / inf in any metric raises `ValueError` at write time rather than emitting non-standard JSON tokens. 4 tests in `tests/test_r1_sweep_defensive.py` (NaN, inf, nested -inf, happy path).
- **(g) Worker error summary** via new `_summarize_worker_errors(results) -> str | None` in `tools/r1_signal_exit_sweep.py:377-391` + wired into `_run_jobs_parallel` line 405-406. Aggregates the `error` field across results; emits `[r1_sweep] N workers errored (M distinct): [...]` on stderr if any errors present, silent if clean. 3 tests in `tests/test_r1_sweep_defensive.py` (clean, multi-distinct, distinct-message-text).

### 4 cosmetic items

- **`derivation_audit.md` line 100** — "Hours." orphan removed (was a leftover token from a deleted column).
- **`derivation_audit.md` §5** — wall-clock numeric (`1,500 backtests × ~1.5s/cell × 8 workers parallel = ~5 min wall`) replaced with principle-only framing ("modest in wall time; the principle is what matters").
- **`derivation_audit.md` §4.3** — kickoff referenced a placeholder stub but the current audit doc has no §4.3 section (verified via grep; only §3.1-§3.5, §4 standalone, §5+ exist). No edit needed.
- **`backtest.py:_should_signal_exit` defensive** — `d = (direction or "").upper()` accepts lowercase / mixed-case / None direction strings. 2 new tests in `tests/test_signal_exit.py` (lowercase variants, None).

### 1 AST scanner fix

- **`tests/test_holdout_isolation.py:HOLDOUT_LEGITIMATE_MODULES`** adds `"tools/r2_gates_rederivation.py"` with justification: line 244 prints `"Pre-holdout end: <ts>"` as a console label, `HOLDOUT_START` is the cutoff timestamp constant, no data access. The pre-existing `test_no_holdout_references_in_non_whitelisted_modules` failure is now cured (verified: 1 → 0 failures locally).

## Test count delta

`+59` new tests, all green:

| File | New tests | Notes |
|---|---:|---|
| `tests/test_r1_verdict.py` | 43 | new file — full coverage of r1_verdict helpers |
| `tests/test_r1_sweep_halt.py` | 6 | new file — halt fixture regression net |
| `tests/test_r1_sweep_defensive.py` | 7 | new file — allow_nan + worker errors |
| `tests/test_signal_exit.py` | +2 | lowercase + None direction |
| `tests/test_backtest_refactor_parity.py` | +1 | dynamic_exit_disabled real-data parity |

## Verification

Full suite locally: `1478 passed, 2 failed in 2163s (36 min wall)`.

- **The 2 failures are pre-existing**, verified on main `a592298`:
  - `tests/test_backtest_with_costs.py::test_simulate_strategy_with_costs_enabled_emits_cost_fields`
  - `tests/test_backtest_with_costs.py::test_simulate_strategy_with_costs_enabled_net_equals_gross_minus_cost`

  Cause: BANKRUPT trade records emitted by PR #313's per-symbol bankruptcy handler lack the cost fields (`gross_pnl_usd`, `entry_slippage_bps`, etc.) that PR #289's cost-test suite expects on all trade records. Two PRs that didn't cross-validate. Out of scope for this tooling-debt PR — flagging here so it can be addressed separately.

- **Pre-existing `test_holdout_isolation` failure is cured.** AST scanner now passes (13/13 green).

- **R1 verdict.json reproducibility** preserved under the option-2 framing of gap #4: re-running `_classify_verdict` on the recorded `sweep_results_A.json` + `halt_after_a_diagnostic.json` still yields `R1_FAIL`.

## Live-path safety

- SIGNAL_EXIT branch still flag-gated `cfg.dynamic_exit_enabled` default `False`.
- No behavior change when flag is off (confirmed by both synthetic flat-bar parity test and the new real-data BTC parity test).
- Legacy `atr_*` kwargs path (cfg=None) bypasses SIGNAL_EXIT entirely (existing test_signal_exit coverage).

## Test plan

- [x] `pytest tests/test_r1_verdict.py -q` → 43 passed
- [x] `pytest tests/test_r1_sweep_halt.py -q` → 6 passed
- [x] `pytest tests/test_r1_sweep_defensive.py -q` → 7 passed
- [x] `pytest tests/test_signal_exit.py -q` → 22 passed
- [x] `pytest tests/test_holdout_isolation.py -q` → 13 passed (was 12/13 on main)
- [x] `pytest tests/test_backtest_refactor_parity.py::test_simulate_strategy_dynamic_exit_flag_off_real_data_parity -q` → 1 passed
- [x] Full suite: 1478 passed + 2 pre-existing failures (verified on main HEAD)
- [x] Recorded R1 verdict.json still produces `R1_FAIL` under new classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)