### PR TITLE
docs(methodology): R1 pre-reg §4.6 amendment — halt-guard scope clarified

### DIFF
--- a/docs/superpowers/plans/2026-05-12-r1-dynamic-exit-pre-reg.md
+++ b/docs/superpowers/plans/2026-05-12-r1-dynamic-exit-pre-reg.md
@@ -265,6 +265,18 @@ Per kickoff: "si primary falla pero secondary muestra TIME_LIMIT shift correcto,
 
 Operator picks one. Pre-registered: NO running both in parallel. NO running R3 with multiple signal candidates.
 
+### §4.6 — Halt-guard scope (2026-05-13 amendment, post-PR #330)
+
+§10 halt + `n_windows < 3` → `R1_INSUFFICIENT_DATA` **only** when the naive verdict is `R1_SUCCESS` / `R1_SUCCESS_CONDITIONAL`. Negative verdicts (`R1_FAIL` / `R1_INCONCLUSIVE`) on partial windows are **preserved** — §10 was pre-registered to act on dispositive partial negative evidence, not to suspend its inferential weight.
+
+**Asymmetry rationale:** spurious favorable verdicts have one-sided incentive bias (operator + project momentum favor declaring success early); honest negative evidence does not carry the same bias. Demanding symmetric sample-size discipline here would penalize the discipline-preserving move (acting on dispositive evidence) and reward the discipline-eroding move (burning compute to formalize an already-decided outcome).
+
+**Scope of this amendment:** clarifies §4.2 verdict-table behavior under §10 halt. Does **not** modify the verdict criteria themselves nor the §10 halt threshold. Implementation lives at `tools/r1_verdict.py:_classify_verdict` (PR #330, merged 2026-05-12).
+
+**Implication for R1:** recorded R1 verdict (halt=True, n_windows=1, primary 0/0, secondary 0/0) classifies as `R1_FAIL` per the asymmetric guard. §A.4 P(viable) <10% trigger fires; H5 escalation strongly considered (per audit §A.4 + §A.5).
+
+**Methodology framing:** this is an **explicit pre-reg amendment**, not a soft post-hoc clarification. The asymmetric scope was chosen by the dev agent during PR #330 implementation as the more methodologically defensible interpretation; operator + reviewer concurred (post-multi-agent review). Documenting the choice here, in the pre-reg, prevents future readers from interpreting the asymmetry as silent rationalization.
+
 ---
 
 ## §5 · Edge cases pre-registrados
@@ -491,5 +503,6 @@ Per audit §A.7 + §A.8 + §6 retrospective, R1 inherits these caveats:
 | Fecha | Cambio | Autor |
 |---|---|---|
 | 2026-05-12 | Pre-reg sub-spec inicial — drafted from kickoff prompt + R2 derivation_audit + structural audit context | Claude Opus 4.7 (sesión kickoff) + sssamuelll |
+| 2026-05-13 | §4.6 amendment — halt-guard scope clarified (asymmetric, favorable-direction only); references §4.2 + §10. Post-PR #330 multi-agent review surfaced the methodology question; operator + reviewer concurred on interpretation A. | sssamuelll + Claude Opus 4.7 |
 
 Reservar líneas para iteración post-operator-review en §9.


### PR DESCRIPTION
## Summary

Pre-reg amendment closing the methodology question surfaced in the multi-agent review of #330. Adds §4.6 to `docs/superpowers/plans/2026-05-12-r1-dynamic-exit-pre-reg.md` documenting the asymmetric scope of the §10 halt-guard implemented in `tools/r1_verdict.py:_classify_verdict`.

## What this amendment fixes

PR #330 implemented gap #4 (`_classify_verdict` halt-guard) with a specific scope choice: only override `R1_SUCCESS` / `R1_SUCCESS_CONDITIONAL` → `R1_INSUFFICIENT_DATA` when `halt=True` and `n_windows<3`. Negative verdicts (`R1_FAIL` / `R1_INCONCLUSIVE`) preserved on partial windows.

This wasn't explicitly pre-registered — the original gap description was loose. Multi-agent review surfaced two interpretations:

- **A (dev agent's choice):** asymmetric — favorable verdicts on partial windows ARE post-hoc rationalization (operator incentive bias); negative verdicts reflect honest dispositive evidence.
- **B (strict pre-reg):** §4.2 verdict table requires 2-of-3 evidence for ALL categories; only `R1_INSUFFICIENT_DATA` reportable from 1-window evidence regardless of direction.

Operator + reviewer concurred on **A** with the explicit-amendment requirement (per `feedback_pre_registration_correction` discipline: fix contradicting specs BEFORE action, frame as explicit correction not soft clarification).

## What's in the amendment

New §4.6 in pre-reg:
- Locks the asymmetric scope (favorable-direction only)
- Documents asymmetry rationale (one-sided incentive bias)
- References §4.2 + §10 + PR #330 implementation
- States implication for recorded R1: stays `R1_FAIL`, §A.4 trigger fires, H5 escalation strongly considered
- Frames this as **explicit pre-reg amendment**, not soft clarification

§14 history table updated with 2026-05-13 entry.

## Why this matters

Without the amendment, the asymmetric implementation in `tools/r1_verdict.py` is silent rationalization — methodologically the exact pattern pre-registration is meant to defeat. The amendment makes the choice explicit, traces it to operator + reviewer concurrence, and pins it for future readers.

The choice itself respects:
- §10's pre-registered intent (act on dispositive partial negative evidence)
- The empirical pull (0/8 symbols × 600 cells × mechanism engaged in 52% of cells is dispositive)
- One-directional bias asymmetry (success vs failure on partial windows have different rationalization risk)

## What this does NOT do

- Does not modify `_classify_verdict` code (PR #330 implementation stands)
- Does not modify §4.2 verdict table or §10 halt threshold
- Does not modify `verdict.json` for recorded R1 (still `R1_FAIL`)
- Does not affect downstream §A.4 trigger or H5 escalation framing

## Dependency

Stacked on main post-#330 merge. Single-commit, single-file diff.

## Status

READY. Operator-approved per chat. No code changes; documentation amendment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)