### PR TITLE
feat(methodology): R1 harness tooling-debt follow-up — closes #332 items 1-5 (#330 minor follow-ups)

### DIFF
--- a/tests/test_r1_sweep_defensive.py
+++ b/tests/test_r1_sweep_defensive.py
@@ -133,6 +133,63 @@ def test_emit_worker_error_summary_silent_on_clean_results(capsys):
     assert captured.out == ""
 
 
+def test_run_jobs_parallel_writes_error_summary_to_stderr_end_to_end(
+    capsys, monkeypatch
+):
+    """Polish-2: end-to-end test that _run_jobs_parallel actually invokes the wiring.
+
+    Item 5 tests verified `_emit_worker_error_summary` writes to stderr in
+    isolation, and verified silence on clean results. But the call site
+    inside `_run_jobs_parallel` had no test — a future refactor that
+    accidentally removes that call would still pass all helper-level tests.
+
+    This test monkeypatches `Pool` to a fake that returns synthetic results
+    (one errored, one clean), invokes `_run_jobs_parallel`, and asserts the
+    error summary lands in stderr via the wiring at `_run_jobs_parallel`.
+
+    Hypothetical regression caught: removing or commenting out the line
+    `_emit_worker_error_summary(results)` inside `_run_jobs_parallel`.
+    """
+    from tools import r1_signal_exit_sweep
+
+    synthetic_results = [
+        {"symbol": "BTCUSDT", "error": "ValueError: synthetic worker failure",
+         "n_trades": 0, "sl": 1.0, "be": 1.5, "lrc_thr": 50.0, "exit_reasons": {}},
+        {"symbol": "ETHUSDT", "n_trades": 5,
+         "sl": 1.0, "be": 1.5, "lrc_thr": 50.0, "exit_reasons": {}, "net_pnl": 10.0},
+    ]
+
+    class _FakePool:
+        """Minimal Pool replacement: context manager + map returning synthetic results."""
+
+        def __init__(self, n_workers):
+            self.n_workers = n_workers
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def map(self, fn, jobs):
+            return synthetic_results
+
+    monkeypatch.setattr(r1_signal_exit_sweep, "Pool", _FakePool)
+
+    jobs = [{"symbol": "BTCUSDT"}, {"symbol": "ETHUSDT"}]
+    results = r1_signal_exit_sweep._run_jobs_parallel(jobs, workers=2, label="polish2_test")
+
+    captured = capsys.readouterr()
+    # Wiring assertion: error summary must reach stderr via _emit_worker_error_summary.
+    assert "1 workers errored" in captured.err, (
+        "Expected error summary in stderr — wiring "
+        "_run_jobs_parallel → _emit_worker_error_summary may be broken"
+    )
+    assert "ValueError: synthetic worker failure" in captured.err
+    # Pool.map result still returned correctly.
+    assert results == synthetic_results
+
+
 def test_summarize_worker_errors_uses_is_not_none_filter_not_truthy():
     """Closes #332 item 4: empty-string `error` field must count, not silently filter.
 
@@ -238,3 +295,45 @@ def test_argmax_cell_per_symbol_higher_net_pnl_wins_over_tie_break():
     assert out["BTCUSDT"]["net_pnl"] == 200.0, (
         "net_pnl must dominate tie-break fields"
     )
+
+
+def test_argmax_cell_per_symbol_tiebreak_deterministic_across_input_orders():
+    """Polish-1: all 24 permutations of 4 tied cells yield same deterministic winner.
+
+    Mirrors `test_r1_verdict.py:test_argmax_cell_tiebreak_deterministic_across_input_orders`
+    pattern for the sweep tool's `_argmax_cell_per_symbol`. Exhausts
+    `itertools.permutations` to catch sign bugs that affect only specific
+    input orderings — sequential tests would pass even if the tie-break key
+    were inverted for one level.
+
+    Hypothetical regression caught: if `_argmax_cell_per_symbol` reverted to
+    raw `max(eligible, key=lambda c: c["net_pnl"])`, some permutations would
+    return different cells (insertion-order fallback differs by permutation).
+    """
+    from itertools import permutations
+
+    from tools.r1_signal_exit_sweep import _argmax_cell_per_symbol
+
+    # 4 cells engineered to tie at every successive tie-break level.
+    # All have net_pnl=100.0 — forces tie-break to walk through (-sl, -be, -lrc_thr).
+    # Cell D is the expected winner (most conservative on every level).
+    cells = [
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 1.0, "be": 2.0,
+         "lrc_thr": 50.0, "n_trades": 15, "exit_reasons": {}},  # A: worst on every level
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 1.0, "be": 2.0,
+         "lrc_thr": 35.0, "n_trades": 15, "exit_reasons": {}},  # B: beats A on lrc_thr
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 1.0, "be": 1.5,
+         "lrc_thr": 35.0, "n_trades": 15, "exit_reasons": {}},  # C: beats B on be
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 0.5, "be": 1.5,
+         "lrc_thr": 35.0, "n_trades": 15, "exit_reasons": {}},  # D: beats C on sl (winner)
+    ]
+
+    expected = {"sl": 0.5, "be": 1.5, "lrc_thr": 35.0}
+    for perm in permutations(cells):
+        out = _argmax_cell_per_symbol(list(perm))
+        winner = out["BTCUSDT"]
+        for k, v in expected.items():
+            assert winner[k] == v, (
+                f"Permutation order {[c['sl'] for c in perm]}: "
+                f"expected {k}={v}, got {k}={winner[k]}"
+            )

--- a/tests/test_r1_sweep_defensive.py
+++ b/tests/test_r1_sweep_defensive.py
@@ -92,6 +92,31 @@ def test_summarize_worker_errors_includes_distinct_message_text():
     assert "RuntimeError: cutoff drift" in msg
 
 
+def test_summarize_worker_errors_uses_is_not_none_filter_not_truthy():
+    """Closes #332 item 4: empty-string `error` field must count, not silently filter.
+
+    Producer `_process_cell` currently only writes `out["error"] = err` when err
+    is non-empty (safe in practice), but the truthy filter
+    `r.get("error") for r in results if r.get("error")` was contract-fragile —
+    if producer ever set `out["error"] = ""` deliberately (e.g., empty error
+    flag), the truthy filter would silently swallow it.
+
+    Fix: `is not None` check distinguishes "explicit empty error" from "no key".
+    """
+    from tools.r1_signal_exit_sweep import _summarize_worker_errors
+
+    results = [
+        {"symbol": "BTCUSDT", "error": ""},   # Explicit empty string (key set)
+        {"symbol": "ETHUSDT"},                 # No error key at all
+    ]
+    msg = _summarize_worker_errors(results)
+    assert msg is not None, (
+        "Empty-string error must be counted (is not None semantics), "
+        "not silently filtered by truthy check"
+    )
+    assert "1 workers errored" in msg
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # _argmax_cell_per_symbol — deterministic tie-break (issue #332 item 1)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_r1_sweep_defensive.py
+++ b/tests/test_r1_sweep_defensive.py
@@ -90,3 +90,85 @@ def test_summarize_worker_errors_includes_distinct_message_text():
     msg = _summarize_worker_errors(results)
     assert "ValueError: bad data" in msg
     assert "RuntimeError: cutoff drift" in msg
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _argmax_cell_per_symbol — deterministic tie-break (issue #332 item 1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_argmax_cell_per_symbol_deterministic_tie_break_lower_sl_wins():
+    """On net_pnl tie, deterministic tie-break by (-sl, -be, -lrc_thr) tuple key.
+
+    Mirrors `tools/r1_verdict.py:_argmax_cell` behavior. Prevents drift between
+    sweep tool's argmax (used for halt diagnostic JSON) and verdict tool's
+    argmax (used for §4 classification) when cells tie on net_pnl. Without
+    this fix, raw `max(cells, key=lambda c: c["net_pnl"])` falls back to
+    insertion-order, which is contract-fragile across parallel worker orderings.
+    """
+    from tools.r1_signal_exit_sweep import _argmax_cell_per_symbol
+
+    # Two BTC cells with identical net_pnl but different sl values.
+    # Tie-break key (net_pnl, -sl, -be, -lrc_thr) on max picks lower sl
+    # because max sees larger -sl (-0.5 > -1.0).
+    results = [
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 1.0, "be": 2.0,
+         "lrc_thr": 50.0, "n_trades": 15, "exit_reasons": {}},
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 0.5, "be": 2.0,
+         "lrc_thr": 50.0, "n_trades": 15, "exit_reasons": {}},
+    ]
+    out = _argmax_cell_per_symbol(results)
+    assert out["BTCUSDT"]["sl"] == 0.5, (
+        f"Expected sl=0.5 (deterministic tie-break: lower sl preferred), "
+        f"got sl={out['BTCUSDT']['sl']}"
+    )
+
+
+def test_argmax_cell_per_symbol_tie_break_lower_be_wins_when_sl_tied():
+    """When net_pnl and sl tie, tie-break by lower be."""
+    from tools.r1_signal_exit_sweep import _argmax_cell_per_symbol
+
+    results = [
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 1.0, "be": 2.5,
+         "lrc_thr": 50.0, "n_trades": 15, "exit_reasons": {}},
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 1.0, "be": 1.5,
+         "lrc_thr": 50.0, "n_trades": 15, "exit_reasons": {}},
+    ]
+    out = _argmax_cell_per_symbol(results)
+    assert out["BTCUSDT"]["be"] == 1.5, (
+        f"Expected be=1.5 (tie-break: lower be preferred when sl tied), "
+        f"got be={out['BTCUSDT']['be']}"
+    )
+
+
+def test_argmax_cell_per_symbol_tie_break_lower_lrc_thr_wins_when_sl_be_tied():
+    """When net_pnl, sl, be all tie, tie-break by lower lrc_thr."""
+    from tools.r1_signal_exit_sweep import _argmax_cell_per_symbol
+
+    results = [
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 1.0, "be": 2.0,
+         "lrc_thr": 55.0, "n_trades": 15, "exit_reasons": {}},
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 1.0, "be": 2.0,
+         "lrc_thr": 35.0, "n_trades": 15, "exit_reasons": {}},
+    ]
+    out = _argmax_cell_per_symbol(results)
+    assert out["BTCUSDT"]["lrc_thr"] == 35.0, (
+        f"Expected lrc_thr=35.0 (tie-break: lower lrc_thr preferred when sl+be tied), "
+        f"got lrc_thr={out['BTCUSDT']['lrc_thr']}"
+    )
+
+
+def test_argmax_cell_per_symbol_higher_net_pnl_wins_over_tie_break():
+    """net_pnl dominates: higher net_pnl wins even if sl/be/lrc_thr would prefer the other cell."""
+    from tools.r1_signal_exit_sweep import _argmax_cell_per_symbol
+
+    results = [
+        {"symbol": "BTCUSDT", "net_pnl": 200.0, "sl": 2.5, "be": 2.5,
+         "lrc_thr": 55.0, "n_trades": 15, "exit_reasons": {}},  # higher net_pnl, worse tie-break
+        {"symbol": "BTCUSDT", "net_pnl": 100.0, "sl": 0.5, "be": 1.5,
+         "lrc_thr": 35.0, "n_trades": 15, "exit_reasons": {}},  # lower net_pnl, better tie-break
+    ]
+    out = _argmax_cell_per_symbol(results)
+    assert out["BTCUSDT"]["net_pnl"] == 200.0, (
+        "net_pnl must dominate tie-break fields"
+    )

--- a/tests/test_r1_sweep_defensive.py
+++ b/tests/test_r1_sweep_defensive.py
@@ -92,6 +92,47 @@ def test_summarize_worker_errors_includes_distinct_message_text():
     assert "RuntimeError: cutoff drift" in msg
 
 
+def test_emit_worker_error_summary_writes_to_stderr_when_errors_present(capsys):
+    """Closes #332 item 5: stderr-integration test for _summarize_worker_errors wiring.
+
+    Verifies the line at `_run_jobs_parallel` that writes the error summary
+    to `sys.stderr`. Without this test, the helper return string is covered
+    but the wiring (helper → stderr) is not — the exact gap noted in #332:
+    'we wrote the helper, did we wire it correctly'.
+
+    Helper `_emit_worker_error_summary` is the extracted wiring point.
+    """
+    from tools.r1_signal_exit_sweep import _emit_worker_error_summary
+
+    results = [
+        {"symbol": "BTCUSDT", "error": "ValueError: bad data"},
+        {"symbol": "ETHUSDT", "error": "RuntimeError: cutoff drift"},
+    ]
+    _emit_worker_error_summary(results)
+    captured = capsys.readouterr()
+    assert "2 workers errored" in captured.err
+    assert "ValueError: bad data" in captured.err
+    assert "RuntimeError: cutoff drift" in captured.err
+    assert captured.out == "", (
+        "Worker error summary must go to stderr, not stdout (operator scans "
+        "stderr at sweep completion; mixed streams obscure the signal)"
+    )
+
+
+def test_emit_worker_error_summary_silent_on_clean_results(capsys):
+    """No errors in results → no stderr emission (avoids noise)."""
+    from tools.r1_signal_exit_sweep import _emit_worker_error_summary
+
+    results = [
+        {"symbol": "BTCUSDT", "n_trades": 5},
+        {"symbol": "ETHUSDT", "n_trades": 3},
+    ]
+    _emit_worker_error_summary(results)
+    captured = capsys.readouterr()
+    assert captured.err == "", "No errors → no stderr emission"
+    assert captured.out == ""
+
+
 def test_summarize_worker_errors_uses_is_not_none_filter_not_truthy():
     """Closes #332 item 4: empty-string `error` field must count, not silently filter.
 

--- a/tests/test_r1_verdict.py
+++ b/tests/test_r1_verdict.py
@@ -470,3 +470,67 @@ def test_load_json_parses_existing_file(tmp_path, monkeypatch):
     payload = {"foo": "bar", "n": 42}
     (tmp_path / "test.json").write_text(json.dumps(payload))
     assert r1_verdict._load_json("test.json") == payload
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _extract_halt_from_diagnostic — isinstance validation (issue #332 item 2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_halt_from_diagnostic_none_returns_false():
+    """No halt diagnostic file → halt=False (sweep completed normally)."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    assert _extract_halt_from_diagnostic(None) is False
+
+
+def test_extract_halt_from_diagnostic_empty_dict_returns_false():
+    """Empty dict (no 'halt' key) → halt=False, key-missing default."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    assert _extract_halt_from_diagnostic({}) is False
+
+
+def test_extract_halt_from_diagnostic_true_value_returns_true():
+    """{'halt': True} → True (normal halt-after-A fired case)."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    assert _extract_halt_from_diagnostic({"halt": True}) is True
+
+
+def test_extract_halt_from_diagnostic_false_value_returns_false():
+    """{'halt': False} → False (halt diagnostic present but did not fire)."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    assert _extract_halt_from_diagnostic({"halt": False}) is False
+
+
+def test_extract_halt_from_diagnostic_string_value_raises():
+    """{'halt': 'false'} → ValueError (was silently coerced to True under bool())."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    with pytest.raises(ValueError, match=r"halt_diag\['halt'\] must be bool"):
+        _extract_halt_from_diagnostic({"halt": "false"})
+
+
+def test_extract_halt_from_diagnostic_int_zero_raises():
+    """{'halt': 0} → ValueError (was silently coerced to False under bool())."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    with pytest.raises(ValueError, match=r"halt_diag\['halt'\] must be bool"):
+        _extract_halt_from_diagnostic({"halt": 0})
+
+
+def test_extract_halt_from_diagnostic_int_one_raises():
+    """{'halt': 1} → ValueError (no implicit int→bool coercion accepted)."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    with pytest.raises(ValueError, match=r"halt_diag\['halt'\] must be bool"):
+        _extract_halt_from_diagnostic({"halt": 1})
+
+
+def test_extract_halt_from_diagnostic_non_dict_raises():
+    """Non-dict halt_diag → ValueError (defends against JSON parser returning unexpected type)."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    with pytest.raises(ValueError, match=r"halt_diag must be dict or None"):
+        _extract_halt_from_diagnostic("not a dict")
+
+
+def test_extract_halt_from_diagnostic_list_raises():
+    """List halt_diag → ValueError (same: defensive against malformed JSON)."""
+    from tools.r1_verdict import _extract_halt_from_diagnostic
+    with pytest.raises(ValueError, match=r"halt_diag must be dict or None"):
+        _extract_halt_from_diagnostic([{"halt": True}])

--- a/tests/test_r1_verdict.py
+++ b/tests/test_r1_verdict.py
@@ -134,6 +134,46 @@ def test_argmax_cell_tiebreak_prefers_lower_lrc_thr_when_sl_and_be_tie():
     assert winner["lrc_thr"] == 35.0
 
 
+def test_argmax_cell_5th_tiebreak_symbol_lex_order_on_full_4tuple_tie():
+    """Closes #332 item 3: 5th tie-break on symbol lex order for fully-tied 4-tuple cells.
+
+    In normal per-symbol use (cells all share same symbol), 5th key is a no-op.
+    Defensive contract: if `_argmax_cell` is ever called with multi-symbol cells
+    (current caller passes per-symbol, but signature doesn't enforce), the 5th
+    tie-break makes ordering deterministic via lex order on symbol.
+
+    Without this 5th key, `max` falls back to Python's insertion-order tie-break,
+    which is contract-fragile against any caller change (e.g., a future
+    multi-symbol caller that batches cells from concurrent workers in
+    non-deterministic order).
+    """
+    cells = [
+        _cell(symbol="BTCUSDT", net_pnl=100.0, sl=1.0, be=2.0, lrc_thr=50.0, n_trades=15),
+        _cell(symbol="ETHUSDT", net_pnl=100.0, sl=1.0, be=2.0, lrc_thr=50.0, n_trades=15),
+    ]
+    # max picks the lex-greater symbol on full 4-tuple tie.
+    # max(("BTCUSDT",), ("ETHUSDT",)) = ("ETHUSDT",) because "ETHUSDT" > "BTCUSDT".
+    out = _argmax_cell(cells)
+    assert out["symbol"] == "ETHUSDT", (
+        "5th tie-break (symbol lex order) must select lex-greater symbol on full 4-tuple tie"
+    )
+
+
+def test_argmax_cell_5th_tiebreak_noop_for_per_symbol_caller():
+    """When all cells share the same symbol (normal caller), 5th key is a no-op.
+
+    Existing 4-tuple tie-break (lower sl wins) still applies; symbol equality
+    means the 5th key collapses and doesn't change selection.
+    """
+    cells = [
+        _cell(symbol="BTCUSDT", net_pnl=100.0, sl=1.0, be=2.0, lrc_thr=50.0, n_trades=15),
+        _cell(symbol="BTCUSDT", net_pnl=100.0, sl=0.5, be=2.0, lrc_thr=50.0, n_trades=15),
+    ]
+    out = _argmax_cell(cells)
+    # 4-tuple tie-break: lower sl (0.5) wins; 5th key (symbol) is identical so no override.
+    assert out["sl"] == 0.5
+
+
 def test_argmax_cell_tiebreak_deterministic_across_input_orders():
     """Gap #2: tie-break is independent of insertion order — all 6 permutations agree."""
     a = _cell(sl=1.0, be=1.5, lrc_thr=35.0, net_pnl=100.0)

--- a/tests/test_r1_verdict.py
+++ b/tests/test_r1_verdict.py
@@ -174,6 +174,30 @@ def test_argmax_cell_5th_tiebreak_noop_for_per_symbol_caller():
     assert out["sl"] == 0.5
 
 
+def test_argmax_cell_5th_tiebreak_reverse_input_order_same_winner():
+    """Polish-3: reverse-input deterministic — [ETH, BTC] → ETH (same as [BTC, ETH] → ETH).
+
+    The forward-direction test alone would pass even if the 5th tie-break key
+    accidentally inverted (e.g., a hypothetical change to `-c.get("symbol", "")`
+    couldn't apply since strings aren't negatable, but a buggy `key=...` lambda
+    that swapped the 5th element direction would slip through the
+    forward-only test). Reverse-direction test ensures determinism is
+    independent of input order — the symmetric counterpart to Polish-1's
+    permutation exhaust for the sweep tool.
+
+    Hypothetical regression caught: any 5th key change that makes the winner
+    depend on input order (sign inversion, removal, etc.).
+    """
+    cells_reversed = [
+        _cell(symbol="ETHUSDT", net_pnl=100.0, sl=1.0, be=2.0, lrc_thr=50.0, n_trades=15),
+        _cell(symbol="BTCUSDT", net_pnl=100.0, sl=1.0, be=2.0, lrc_thr=50.0, n_trades=15),
+    ]
+    out = _argmax_cell(cells_reversed)
+    assert out["symbol"] == "ETHUSDT", (
+        "Lex-greater symbol must win regardless of input order"
+    )
+
+
 def test_argmax_cell_tiebreak_deterministic_across_input_orders():
     """Gap #2: tie-break is independent of insertion order — all 6 permutations agree."""
     a = _cell(sl=1.0, be=1.5, lrc_thr=35.0, net_pnl=100.0)

--- a/tools/r1_signal_exit_sweep.py
+++ b/tools/r1_signal_exit_sweep.py
@@ -393,8 +393,14 @@ def _summarize_worker_errors(results: list[dict]) -> str | None:
     Surfaces multi-worker failure modes that would otherwise be buried in the
     750-cell result list — without this, an operator scanning stderr at the
     end of the sweep has no signal that anything went wrong.
+
+    Filter uses `is not None` rather than truthy semantics so that an explicit
+    empty-string `error` field (intentional flag from producer) is not silently
+    swallowed. Producer `_process_cell` currently only writes the field when
+    non-empty, so the practical behavior is unchanged; this hardens the
+    contract against future producer changes.
     """
-    errors = [r.get("error") for r in results if r.get("error")]
+    errors = [r.get("error") for r in results if r.get("error") is not None]
     if not errors:
         return None
     distinct = sorted(set(errors))

--- a/tools/r1_signal_exit_sweep.py
+++ b/tools/r1_signal_exit_sweep.py
@@ -290,9 +290,10 @@ def _argmax_cell_per_symbol(results: list[dict]) -> dict[str, dict | None]:
 
     Tie-break: when two cells tie on net_pnl, favor lower `sl`, then lower `be`,
     then lower `lrc_thr` — i.e., the more conservative parameter combination.
-    Mirrors `tools/r1_verdict.py:_argmax_cell` tie-break. Determinism matters
-    because the previous insertion-order tie-break made cell selection fragile
-    to job-execution order across parallel workers, and could cause drift
+    Mirrors `tools/r1_verdict.py:_argmax_cell` tie-break (modulo 5th key — see
+    inline comment near the `max` call). Determinism matters because the
+    previous insertion-order tie-break made cell selection fragile to
+    job-execution order across parallel workers, and could cause drift
     between the sweep tool's halt diagnostic JSON and the verdict tool's
     §4 classification on the same data.
 
@@ -310,6 +311,11 @@ def _argmax_cell_per_symbol(results: list[dict]) -> dict[str, dict | None]:
         if not eligible:
             out[sym] = None
         else:
+            # 5th tie-break field (symbol lex order, per r1_verdict._argmax_cell)
+            # omitted intentionally: per-symbol grouping above (by_symbol bucket)
+            # guarantees all eligible cells share the same symbol, so the 5th
+            # key would be a literal no-op. See r1_verdict._argmax_cell
+            # docstring for full 5-level contract.
             out[sym] = max(
                 eligible,
                 key=lambda c: (c["net_pnl"], -c["sl"], -c["be"], -c["lrc_thr"]),

--- a/tools/r1_signal_exit_sweep.py
+++ b/tools/r1_signal_exit_sweep.py
@@ -386,6 +386,21 @@ def _save_json(path: Path, payload):
         json.dump(payload, f, indent=2, sort_keys=True, default=str, allow_nan=False)
 
 
+def _emit_worker_error_summary(results: list[dict]) -> None:
+    """Write `_summarize_worker_errors` output to sys.stderr if non-None.
+
+    Extracted wiring point for #332 item 5 (stderr-integration test). The
+    operator scans stderr at sweep completion for any "[r1_sweep] N workers
+    errored" line; mixing into stdout would obscure the signal among the
+    sweep's normal progress output.
+
+    No-op when results are clean (no `error` fields present).
+    """
+    err_summary = _summarize_worker_errors(results)
+    if err_summary:
+        sys.stderr.write(err_summary + "\n")
+
+
 def _summarize_worker_errors(results: list[dict]) -> str | None:
     """Aggregate the `error` field across sweep results.
 
@@ -420,9 +435,7 @@ def _run_jobs_parallel(jobs: list[dict], workers: int, label: str) -> list[dict]
         results = pool.map(_process_cell, jobs)
     elapsed = time.monotonic() - t0
     sys.stderr.write(f"[r1_sweep] {label}: completed in {elapsed:.1f}s\n")
-    err_summary = _summarize_worker_errors(results)
-    if err_summary:
-        sys.stderr.write(err_summary + "\n")
+    _emit_worker_error_summary(results)
     return results
 
 

--- a/tools/r1_signal_exit_sweep.py
+++ b/tools/r1_signal_exit_sweep.py
@@ -288,6 +288,14 @@ def _coverage_for_window(window_id: str, app_config_path: str) -> dict[str, int]
 def _argmax_cell_per_symbol(results: list[dict]) -> dict[str, dict | None]:
     """Pre-reg §4.1: argmax(net_pnl) per symbol, subject to n_trades >= N_TRADES_MIN.
 
+    Tie-break: when two cells tie on net_pnl, favor lower `sl`, then lower `be`,
+    then lower `lrc_thr` — i.e., the more conservative parameter combination.
+    Mirrors `tools/r1_verdict.py:_argmax_cell` tie-break. Determinism matters
+    because the previous insertion-order tie-break made cell selection fragile
+    to job-execution order across parallel workers, and could cause drift
+    between the sweep tool's halt diagnostic JSON and the verdict tool's
+    §4 classification on the same data.
+
     Returns {symbol -> cell dict or None if no cell satisfies constraint}.
     """
     by_symbol: dict[str, list[dict]] = {}
@@ -302,7 +310,10 @@ def _argmax_cell_per_symbol(results: list[dict]) -> dict[str, dict | None]:
         if not eligible:
             out[sym] = None
         else:
-            out[sym] = max(eligible, key=lambda c: c["net_pnl"])
+            out[sym] = max(
+                eligible,
+                key=lambda c: (c["net_pnl"], -c["sl"], -c["be"], -c["lrc_thr"]),
+            )
     # Ensure all symbols have an entry
     for sym in CURATED_SYMBOLS:
         out.setdefault(sym, None)

--- a/tools/r1_verdict.py
+++ b/tools/r1_verdict.py
@@ -51,6 +51,39 @@ def _load_json(name: str):
         return json.load(f)
 
 
+def _extract_halt_from_diagnostic(halt_diag) -> bool:
+    """Extract halt boolean from diagnostic dict, raising on malformed input.
+
+    Closes #332 item 2. Replaces the previous
+    `bool(halt_diag and halt_diag.get("halt"))` coercion which silently
+    accepted truthy non-bool values (e.g., `{"halt": "false"}` → True via
+    truthy-string coercion, `{"halt": 0}` → False) — both methodologically
+    wrong because a malformed halt diagnostic should be loud, not silent.
+
+    Accepts:
+      - `None` → False (no halt diagnostic file written by sweep)
+      - `{}` (no "halt" key) → False (key-missing default)
+      - `{"halt": True}` → True
+      - `{"halt": False}` → False
+
+    Raises ValueError on:
+      - non-dict (e.g., list, str, int) — JSON parser returned unexpected type
+      - non-bool "halt" value (e.g., string, int) — producer contract violation
+    """
+    if halt_diag is None:
+        return False
+    if not isinstance(halt_diag, dict):
+        raise ValueError(
+            f"halt_diag must be dict or None, got {type(halt_diag).__name__}: {halt_diag!r}"
+        )
+    halt_value = halt_diag.get("halt", False)
+    if not isinstance(halt_value, bool):
+        raise ValueError(
+            f"halt_diag['halt'] must be bool, got {type(halt_value).__name__}: {halt_value!r}"
+        )
+    return halt_value
+
+
 def _argmax_cell(cells: list[dict]) -> dict | None:
     """Pre-reg §4.1: argmax(net_pnl) among cells with n_trades >= N_TRADES_MIN.
 
@@ -279,7 +312,7 @@ def main() -> int:
     sweep_c = _load_json("sweep_results_C.json")
     baseline = _load_json("baseline_pre_signal_exit.json")
     halt_diag = _load_json("halt_after_a_diagnostic.json")
-    halt = bool(halt_diag and halt_diag.get("halt"))
+    halt = _extract_halt_from_diagnostic(halt_diag)
 
     if baseline is None:
         print("WARNING: baseline_pre_signal_exit.json missing", file=sys.stderr)

--- a/tools/r1_verdict.py
+++ b/tools/r1_verdict.py
@@ -87,17 +87,42 @@ def _extract_halt_from_diagnostic(halt_diag) -> bool:
 def _argmax_cell(cells: list[dict]) -> dict | None:
     """Pre-reg §4.1: argmax(net_pnl) among cells with n_trades >= N_TRADES_MIN.
 
-    Tie-break: when two cells tie on net_pnl, favor lower `sl`, then lower `be`,
-    then lower `lrc_thr` — i.e., the more conservative parameter combination.
+    Tie-break order (5 levels, all deterministic):
+      1. higher net_pnl wins
+      2. lower `sl` wins (more conservative stop)
+      3. lower `be` wins (more conservative break-even)
+      4. lower `lrc_thr` wins (more aggressive exit threshold)
+      5. lex-greater `symbol` wins (#332 item 3 defensive 5th key)
+
+    Tie-break levels 1-4 are the methodologically-justified contract: among
+    cells with same P&L, prefer more-conservative parameters. Level 5 is
+    purely defensive: in normal per-symbol use (cells all share same symbol)
+    it's a no-op, but it makes the function safe against any future
+    multi-symbol caller — falling back to Python's insertion-order tie-break
+    would be contract-fragile against concurrent-worker batching.
+
     Determinism matters because the previous insertion-order tie-break made
     cell selection fragile to job-execution order across parallel workers.
+
+    Contract: the 4-tuple `(net_pnl, sl, be, lrc_thr)` is expected to uniquely
+    identify a cell in the canonical sweep grid for a single symbol. True
+    duplicates (same 4-tuple within same symbol) indicate upstream bug — the
+    5th key resolves the order silently rather than raising, but the grid
+    constructor in `tools/r1_signal_exit_sweep.py` should be audited if
+    diagnostic output shows duplicate cell counts.
     """
     eligible = [c for c in cells if c.get("n_trades", 0) >= N_TRADES_MIN]
     if not eligible:
         return None
     return max(
         eligible,
-        key=lambda c: (c["net_pnl"], -c["sl"], -c["be"], -c["lrc_thr"]),
+        key=lambda c: (
+            c["net_pnl"],
+            -c["sl"],
+            -c["be"],
+            -c["lrc_thr"],
+            c.get("symbol", ""),  # 5th defensive tie-break: lex order on symbol
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

Closes #332 items 1, 2, 3, 4, 5 — the deferred minor items from PR #330's multi-agent review. Item 6 (cosmetic AST whitelist vs f-string preference) already addressed in #330 via the AST whitelist approach.

5 TDD-developed commits, one per item. No live-path impact (all changes to offline sweep/verdict tools).

## Discovery + correction

This PR was originally green-lit as "open standalone PR for commit `4b2b763`" per PR #333 §9.4 (a). Verification during Phase 3a kickoff revealed that `4b2b763` is **content-identical to merged PR #330 (commit `7d89b2a`)** — both share parent `a592298`, and `git diff 4b2b763 7d89b2a --stat` is empty. The pre-reg's §9.4 commit reference was based on my own incorrect characterization (propagated from a multi-agent comment-analyzer pass that didn't run `git diff` against main).

After verification:
- #332 items 1, 2, 4 unambiguously open in current main (`8c8c9e0`).
- #332 items 3, 5 partial in current main.
- #332 item 6 addressed via AST whitelist alternative.

This PR closes the actual gap that §9.4 (a) intended to address. Pre-reg §9.4 historical reference left as-is (no amendment); this PR description supersedes the stale commit reference.

## Items closed (with item-by-item verification)

| Item | Description | Pre-this-PR | Post-this-PR | Commit |
|---|---|---|---|---|
| 1 | tuple-key tie-break in `tools/r1_signal_exit_sweep.py:_argmax_cell_per_symbol` | raw `max(eligible, key=lambda c: c["net_pnl"])` | matches `r1_verdict.py:_argmax_cell` tuple `(net_pnl, -sl, -be, -lrc_thr)` | `25dcfbf` |
| 2 | isinstance check on `tools/r1_verdict.py:halt_diag["halt"]` | `bool(halt_diag and halt_diag.get("halt"))` (silent coercion) | extracted `_extract_halt_from_diagnostic()` with explicit isinstance + ValueError on malformed | `eb531d8` |
| 3 | 5th defensive tie-break (or contract doc) in `_argmax_cell` | 4-tuple only; insertion-order fallback | 5th key (`c.get("symbol", "")`) + expanded contract docstring | `83677f7` |
| 4 | `is not None` filter in `_summarize_worker_errors` | truthy filter `if r.get("error")` (swallows `""`) | explicit `is not None` | `a734491` |
| 5 | stderr-integration test for `_summarize_worker_errors` wiring | helper return value tested; wiring NOT tested | extracted `_emit_worker_error_summary()` helper + 2 capsys-based stderr tests | `ca8cee6` |

## What this PR does NOT do

- Does **NOT** modify any production runtime code (`backtest.py`, `strategy/*.py`, `btc_api.py`, `btc_scanner.py` unchanged)
- Does **NOT** promote any config flag or change `config.defaults.json`
- Does **NOT** touch holdout (issue #322 hard block remains)
- Does **NOT** touch R3-specific code (`tools/r3_*` not created here — that's Phase 3b)
- Does **NOT** address #332 item 6 (already addressed in #330 via AST whitelist alternative; cosmetic f-string rephrase remains optional follow-up)

## Why this matters for Phase 3b (R3 implementation)

The R3 sweep harness (`tools/r3_trend_pullback_sweep.py` per pre-reg §6) and verdict tool (`tools/r3_verdict.py`) will mirror R1's pattern. With items 1-5 closed on the R1 baseline, the R3 implementation can copy-paste the hardened pattern by default rather than careful manual port — reducing the chance of inheriting the same gaps.

## Test plan

- [x] All R1 verdict tests pass: 52 tests in `tests/test_r1_verdict.py` (was 43; +9 for item 2 isinstance + 2 for item 3 5th tie-break, with some refactored under sections)
- [x] R1 sweep defensive tests pass: 14 tests in `tests/test_r1_sweep_defensive.py` (was 7; +4 for item 1 tie-break + 1 for item 4 is-not-none + 2 for item 5 stderr-integration)
- [x] R1 sweep halt tests pass: 6 tests (unchanged)
- [x] Holdout isolation tests pass (12 tests in `tests/test_holdout_isolation.py`)
- [x] Signal-exit unit tests pass (22 tests in `tests/test_signal_exit.py`)
- [x] Backtest refactor parity tests: 5 skipped (existing marker-based skips, unchanged)
- [x] Aggregate: 109 passed, 5 skipped, 0 failed
- [x] No live-path impact verified by absence of changes to `backtest.py`, `strategy/`, `btc_api.py`, `btc_scanner.py`

## TDD discipline

Each item followed RED → GREEN → REFACTOR per `superpowers:test-driven-development`:

1. Item 1: 4 tests added; 3 of 4 failed initially (4th asserted existing dominance behavior).
2. Item 4: 1 test added; failed initially (empty-string `""` was truthy-filtered to None summary).
3. Item 5: 2 tests added; failed initially (`ImportError: cannot import name '_emit_worker_error_summary'`).
4. Item 2: 9 tests added; all failed initially (`ImportError: cannot import name '_extract_halt_from_diagnostic'`).
5. Item 3: 2 tests added; 1 failed initially (5th tie-break path), 1 passed initially (no-op single-symbol case).

GREEN verified for each item before committing. Cross-item regression suite (109 tests) green after all 5 commits.

## References

- Issue #332 (this PR closes items 1-5; item 6 addressed in #330)
- PR #330 (R1 harness tooling-debt — original; merged 2026-05-12)
- PR #329 (R1 signal-exit sweep — original verdict PR whose review surfaced #332)
- PR #331 (R1 pre-reg §4.6 amendment — asymmetric halt-guard, related to item 2 wiring)
- PR #333 (R3 pre-registration — §9.4 (a) confirmation; merged 2026-05-13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)