### PR TITLE
feat(strategy): Donchian ensemble + vol-targeting pure modules (Phase 1A of epic #338)

### DIFF
--- a/strategy/donchian_ensemble.py
+++ b/strategy/donchian_ensemble.py
@@ -1,0 +1,266 @@
+"""Donchian channel ensemble for regime-allocation strategy (epic #338 Phase 1).
+
+Implements multi-timeframe Donchian breakout signals aggregated by equal-weight
+vote, per the parameters locked in §8 of the epic spec (Zarattini, Pagani &
+Barbon 2025 "Catching Crypto Trends" replication).
+
+## Parameters (LOCKED §8 of epic spec)
+
+- Lookbacks: 5, 10, 20, 30, 60, 90, 150, 250, 360 days (9 total)
+- Aggregation: equal-weight vote
+- Update frequency: daily (caller-orchestrated; module is timeframe-agnostic)
+
+## Mechanics
+
+Each Donchian channel at lookback N produces a sticky direction signal:
+
+- **LONG** when latest close > N-day prior upper bound (close broke above
+  the prior N-day high range, excluding today)
+- **SHORT** when latest close < N-day prior lower bound
+- Otherwise: **maintain previous direction** (classic Donchian sticky-breakout
+  rule; once you're long, you stay long until you break the lower bound)
+
+The ensemble votes equally across all lookbacks:
+- `vote = sum(directions)` ∈ [-N_lookbacks, +N_lookbacks]
+- `position_direction = sign(vote)` ∈ {-1, 0, +1}
+- `confidence = abs(vote) / n_lookbacks` ∈ [0, 1]
+
+## NOT in this module
+
+- Position sizing (see `strategy/vol_targeting.py`)
+- Integration into evaluate_signal / scanner (Phase 1B)
+- Live execution (deferred to Phase 6 after holdout validation)
+- Cost-aware execution (Phase 1C wires to `backtest_costs.py`)
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+
+# Locked per §8.4 of epic #338 spec — Zarattini exact 9.
+ZARATTINI_LOOKBACKS: tuple[int, ...] = (5, 10, 20, 30, 60, 90, 150, 250, 360)
+
+
+def compute_donchian_channel(
+    *,
+    highs: pd.Series,
+    lows: pd.Series,
+    lookback_days: int,
+) -> dict[str, float]:
+    """Compute the current Donchian channel from the latest bar.
+
+    The channel for lookback N spans the highest high and lowest low of the
+    last N bars INCLUDING the latest. The "prior" channel (excluding today)
+    is what direction signals use — see `compute_donchian_direction_history`.
+
+    Args:
+        highs: daily high prices, indexed by date.
+        lows: daily low prices, indexed by date.
+        lookback_days: N. Must be ≥ 2.
+
+    Returns:
+        dict with keys: upper, lower, mid. NaN if insufficient history.
+
+    Raises:
+        ValueError: lookback_days < 2.
+    """
+    if lookback_days < 2:
+        raise ValueError(f"lookback_days must be ≥ 2; got {lookback_days}")
+
+    if len(highs) < lookback_days or len(lows) < lookback_days:
+        return {"upper": float("nan"), "lower": float("nan"), "mid": float("nan")}
+
+    window_high = highs.iloc[-lookback_days:]
+    window_low = lows.iloc[-lookback_days:]
+    upper = float(window_high.max())
+    lower = float(window_low.min())
+    mid = 0.5 * (upper + lower)
+    return {"upper": upper, "lower": lower, "mid": mid}
+
+
+def compute_donchian_direction_history(
+    *,
+    closes: pd.Series,
+    highs: pd.Series,
+    lows: pd.Series,
+    lookback_days: int,
+) -> pd.Series:
+    """Compute sticky breakout direction at each bar over the full history.
+
+    For each bar t (after warmup), the direction is determined by:
+    - If close[t] > max(highs[t-lookback_days : t])  (PRIOR N-day high) → LONG (+1)
+    - Elif close[t] < min(lows[t-lookback_days : t])  (PRIOR N-day low)  → SHORT (-1)
+    - Else: maintain previous direction (sticky)
+
+    The first lookback_days bars are warmup (direction = 0, flat).
+
+    Args:
+        closes: daily close prices.
+        highs: daily high prices.
+        lows: daily low prices.
+        lookback_days: N (must be ≥ 2).
+
+    Returns:
+        pd.Series of int in {-1, 0, +1} with the same index as `closes`.
+
+    Raises:
+        ValueError: lookback_days < 2.
+        ValueError: input series have mismatched indexes.
+    """
+    if lookback_days < 2:
+        raise ValueError(f"lookback_days must be ≥ 2; got {lookback_days}")
+    if not (closes.index.equals(highs.index) and closes.index.equals(lows.index)):
+        raise ValueError(
+            "closes/highs/lows must share the same index — provide daily-aligned series"
+        )
+
+    n = len(closes)
+    direction = np.zeros(n, dtype=np.int8)
+    if n <= lookback_days:
+        # Insufficient history for any breakout signal → all flat
+        return pd.Series(direction, index=closes.index, dtype=np.int8)
+
+    # Rolling prior N-day extremes (shifted by 1 to exclude today's bar)
+    # Use min_periods=lookback_days so we get NaN before warmup completes
+    prior_high = highs.rolling(window=lookback_days, min_periods=lookback_days).max().shift(1)
+    prior_low = lows.rolling(window=lookback_days, min_periods=lookback_days).min().shift(1)
+
+    closes_arr = closes.to_numpy()
+    prior_high_arr = prior_high.to_numpy()
+    prior_low_arr = prior_low.to_numpy()
+
+    last_dir = 0
+    for i in range(n):
+        if np.isnan(prior_high_arr[i]) or np.isnan(prior_low_arr[i]):
+            direction[i] = 0  # warmup
+            continue
+        if closes_arr[i] > prior_high_arr[i]:
+            last_dir = 1
+        elif closes_arr[i] < prior_low_arr[i]:
+            last_dir = -1
+        # else: sticky, keep last_dir
+        direction[i] = last_dir
+
+    return pd.Series(direction, index=closes.index, dtype=np.int8)
+
+
+def aggregate_ensemble(
+    directions: dict[int, int],
+    *,
+    method: Literal["equal_weight_vote"] = "equal_weight_vote",
+) -> dict[str, float | int]:
+    """Aggregate per-lookback directions into a single ensemble decision.
+
+    Locked aggregation method per §8.1 of epic spec: equal-weight vote.
+
+    Args:
+        directions: mapping {lookback_days → direction ∈ {-1, 0, +1}}.
+            Empty dict raises ValueError.
+        method: must be 'equal_weight_vote'. Other methods raise
+            NotImplementedError (reserved for future migrations).
+
+    Returns:
+        dict with keys:
+            - direction: int in {-1, 0, +1} (sign of vote)
+            - vote: int in [-n_lookbacks, +n_lookbacks]
+            - confidence: float in [0, 1] = abs(vote) / n_lookbacks
+            - n_long: int, count of LONG signals
+            - n_short: int, count of SHORT signals
+            - n_flat: int, count of flat signals
+            - n_lookbacks: int
+
+    Raises:
+        ValueError: directions is empty.
+        ValueError: any direction not in {-1, 0, +1}.
+        NotImplementedError: method != 'equal_weight_vote'.
+    """
+    if method != "equal_weight_vote":
+        raise NotImplementedError(
+            f"Aggregation method {method!r} not implemented. Only "
+            f"'equal_weight_vote' is supported per §8.1 of epic #338 spec."
+        )
+    if not directions:
+        raise ValueError("directions dict is empty; need at least one lookback")
+    for lookback, d in directions.items():
+        if d not in (-1, 0, 1):
+            raise ValueError(
+                f"Direction for lookback {lookback} must be in {{-1, 0, 1}}; got {d!r}"
+            )
+
+    vote = sum(directions.values())
+    n_lookbacks = len(directions)
+
+    if vote > 0:
+        direction = 1
+    elif vote < 0:
+        direction = -1
+    else:
+        direction = 0
+
+    n_long = sum(1 for d in directions.values() if d > 0)
+    n_short = sum(1 for d in directions.values() if d < 0)
+    n_flat = n_lookbacks - n_long - n_short
+
+    return {
+        "direction": direction,
+        "vote": vote,
+        "confidence": abs(vote) / n_lookbacks,
+        "n_long": n_long,
+        "n_short": n_short,
+        "n_flat": n_flat,
+        "n_lookbacks": n_lookbacks,
+    }
+
+
+def compute_ensemble_history(
+    *,
+    closes: pd.Series,
+    highs: pd.Series,
+    lows: pd.Series,
+    lookbacks: tuple[int, ...] = ZARATTINI_LOOKBACKS,
+) -> pd.DataFrame:
+    """Run the full Donchian ensemble over a price history.
+
+    For each bar t, computes per-lookback direction and the aggregated
+    ensemble decision. Convenience wrapper that combines
+    `compute_donchian_direction_history` over all lookbacks +
+    `aggregate_ensemble` row-wise.
+
+    Args:
+        closes: daily close prices.
+        highs: daily high prices.
+        lows: daily low prices.
+        lookbacks: tuple of lookback periods. Defaults to ZARATTINI_LOOKBACKS.
+
+    Returns:
+        DataFrame indexed by date with columns:
+            - dir_{N} for each N in lookbacks (per-lookback direction)
+            - vote, direction, confidence, n_long, n_short, n_flat
+    """
+    if not lookbacks:
+        raise ValueError("lookbacks tuple is empty")
+
+    per_lookback = {}
+    for n in lookbacks:
+        per_lookback[n] = compute_donchian_direction_history(
+            closes=closes, highs=highs, lows=lows, lookback_days=n
+        )
+
+    # Build directions matrix
+    df = pd.DataFrame(
+        {f"dir_{n}": series for n, series in per_lookback.items()},
+        index=closes.index,
+    )
+
+    # Vote column (sum of per-lookback dirs)
+    df["vote"] = df[[f"dir_{n}" for n in lookbacks]].sum(axis=1)
+    n_lookbacks = len(lookbacks)
+    df["direction"] = df["vote"].apply(lambda v: 1 if v > 0 else (-1 if v < 0 else 0)).astype(np.int8)
+    df["confidence"] = df["vote"].abs() / n_lookbacks
+    df["n_long"] = df[[f"dir_{n}" for n in lookbacks]].apply(lambda r: (r > 0).sum(), axis=1)
+    df["n_short"] = df[[f"dir_{n}" for n in lookbacks]].apply(lambda r: (r < 0).sum(), axis=1)
+    df["n_flat"] = n_lookbacks - df["n_long"] - df["n_short"]
+
+    return df

--- a/strategy/vol_targeting.py
+++ b/strategy/vol_targeting.py
@@ -1,0 +1,252 @@
+"""Volatility-targeting position sizing for regime-allocation strategy
+(epic #338 Phase 1).
+
+Replaces R-multiple sizing (which produced bankruptcy via path-dependency
+under the LRC architecture — see audit #323 H4) with portfolio-vol-targeting.
+
+## Mechanics (§4.3 + §8 of epic spec)
+
+For a symbol with realized volatility `σ_30d` and target volatility share
+`target_vol_per_symbol`:
+
+    position_size_USD = capital_USD × target_vol_per_symbol / σ_30d
+
+Where:
+- `target_vol_per_symbol = portfolio_vol_target / n_active_symbols`
+- `portfolio_vol_target` = 30% annualized (locked §8.3)
+- `σ_30d` = annualized close-to-close realized vol over 30 daily returns
+- `n_active_symbols` = count of symbols with non-zero ensemble direction
+  (caller supplies this — module is symbol-agnostic)
+
+Then signed position direction (LONG/SHORT) is applied:
+
+    signed_position_USD = position_size_USD × direction
+
+Hard caps:
+- Per-symbol position ≤ `max_position_pct` of capital (default 20%)
+- Position size ≥ `min_position_usd` (default $50, Binance min);
+  below threshold returns 0 (skip the trade)
+- Portfolio leverage: `sum(|positions|) ≤ max_leverage × capital`
+  (default 2.0× per §8.6). Excess scales proportionally across all symbols.
+
+## Volatility estimation
+
+Default: **close-to-close daily** annualized via `sqrt(365)` (crypto is 24/7,
+no weekend adjustment). Window: 30 daily bars.
+
+Alternative: Yang-Zhang vol (`strategy/vol.py:annualized_vol_yang_zhang`)
+is available but NOT used here — close-to-close is the academic standard for
+trend-following sizing (Zarattini 2025 uses it implicitly). Switching to
+Yang-Zhang would be a pre-Phase 3 decision documented separately.
+
+## NOT in this module
+
+- Donchian ensemble signal (see `strategy/donchian_ensemble.py`)
+- Integration into evaluate_signal / scanner (Phase 1B)
+- Live execution (deferred to Phase 6 after holdout validation)
+- Funding cost accounting (Phase 1C wires to `backtest_costs.py`)
+"""
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+
+# Crypto trades 365 days/year — no weekend adjustment.
+TRADING_DAYS_PER_YEAR = 365
+
+# Defaults locked per §8.3 / §8.6 of epic #338 spec.
+DEFAULT_PORTFOLIO_VOL_TARGET = 0.30  # 30% annualized
+DEFAULT_MAX_LEVERAGE = 2.0
+DEFAULT_MAX_POSITION_PCT = 0.20  # 20% per symbol hard cap
+DEFAULT_MIN_POSITION_USD = 50.0  # Binance min order
+
+# Vol estimation window
+DEFAULT_VOL_WINDOW_DAYS = 30
+
+
+def compute_realized_vol_annualized(
+    daily_returns: pd.Series,
+    *,
+    window: int = DEFAULT_VOL_WINDOW_DAYS,
+) -> float:
+    """Compute annualized close-to-close realized volatility from daily returns.
+
+    Args:
+        daily_returns: pd.Series of simple or log daily returns (the difference
+            between simple/log returns is negligible at daily horizon for
+            crypto-typical magnitudes). Index ignored — only last `window`
+            values are used.
+        window: number of daily returns to use. Default 30.
+
+    Returns:
+        Annualized volatility (e.g., 0.50 = 50% annualized). NaN if fewer than
+        `window` returns are available or std is undefined.
+    """
+    if window < 2:
+        raise ValueError(f"window must be ≥ 2; got {window}")
+    if len(daily_returns) < window:
+        return float("nan")
+    sample = daily_returns.iloc[-window:].dropna()
+    if len(sample) < 2:
+        return float("nan")
+    std_daily = sample.std(ddof=1)
+    if not math.isfinite(std_daily) or std_daily <= 0.0:
+        return float("nan")
+    return float(std_daily * math.sqrt(TRADING_DAYS_PER_YEAR))
+
+
+def compute_position_size(
+    *,
+    capital_usd: float,
+    direction: int,
+    target_vol_per_symbol: float,
+    realized_vol_annualized: float,
+    max_position_pct: float = DEFAULT_MAX_POSITION_PCT,
+    min_position_usd: float = DEFAULT_MIN_POSITION_USD,
+) -> float:
+    """Compute the signed USD position size for a single symbol.
+
+    Args:
+        capital_usd: total portfolio capital in USD.
+        direction: -1 (SHORT), 0 (flat), or +1 (LONG). 0 returns 0.
+        target_vol_per_symbol: portfolio vol target divided by number of
+            active symbols (caller-supplied). E.g., 0.30 / 6 = 0.05 for a
+            6-symbol active book.
+        realized_vol_annualized: σ_30d annualized for the symbol. NaN or
+            non-positive → returns 0.
+        max_position_pct: hard cap on per-symbol notional as fraction of
+            capital. Default 20%.
+        min_position_usd: minimum notional below which we skip the trade.
+            Default $50 (Binance min). Returns 0 if computed size falls below.
+
+    Returns:
+        Signed position size in USD. Positive = LONG, negative = SHORT,
+        zero = flat or below caps. Sign matches `direction`.
+    """
+    if direction not in (-1, 0, 1):
+        raise ValueError(f"direction must be in {{-1, 0, 1}}; got {direction!r}")
+    if direction == 0:
+        return 0.0
+    if capital_usd <= 0.0 or not math.isfinite(capital_usd):
+        return 0.0
+    if target_vol_per_symbol <= 0.0 or not math.isfinite(target_vol_per_symbol):
+        return 0.0
+    if (
+        realized_vol_annualized is None
+        or not math.isfinite(realized_vol_annualized)
+        or realized_vol_annualized <= 0.0
+    ):
+        return 0.0
+
+    # Vol-targeted raw notional
+    raw_notional = capital_usd * target_vol_per_symbol / realized_vol_annualized
+
+    # Hard cap: per-symbol fraction of capital
+    if max_position_pct > 0:
+        cap_usd = capital_usd * max_position_pct
+        raw_notional = min(raw_notional, cap_usd)
+
+    # Min order threshold
+    if raw_notional < min_position_usd:
+        return 0.0
+
+    return raw_notional * direction
+
+
+def apply_leverage_cap(
+    positions: dict[str, float],
+    *,
+    capital_usd: float,
+    max_leverage: float = DEFAULT_MAX_LEVERAGE,
+) -> dict[str, float]:
+    """Apply portfolio leverage cap by proportional scaling.
+
+    If `sum(|positions|) > max_leverage × capital_usd`, scale every position
+    by the same factor so the constraint binds exactly. Otherwise unchanged.
+
+    Args:
+        positions: mapping {symbol → signed position USD}.
+        capital_usd: total capital in USD. Must be positive.
+        max_leverage: ceiling on sum(|positions|) / capital_usd. Default 2.0
+            per §8.6 of epic spec.
+
+    Returns:
+        Same shape mapping with positions possibly scaled down. Signs
+        preserved.
+
+    Raises:
+        ValueError: capital_usd ≤ 0 or non-finite.
+        ValueError: max_leverage ≤ 0.
+    """
+    if capital_usd <= 0.0 or not math.isfinite(capital_usd):
+        raise ValueError(f"capital_usd must be positive finite; got {capital_usd!r}")
+    if max_leverage <= 0.0 or not math.isfinite(max_leverage):
+        raise ValueError(f"max_leverage must be positive finite; got {max_leverage!r}")
+
+    if not positions:
+        return {}
+
+    total_notional = sum(abs(p) for p in positions.values())
+    cap_usd = max_leverage * capital_usd
+
+    if total_notional <= cap_usd or total_notional == 0.0:
+        return dict(positions)  # already within cap (or all zero)
+
+    scale = cap_usd / total_notional
+    return {sym: p * scale for sym, p in positions.items()}
+
+
+def compute_portfolio_positions(
+    *,
+    capital_usd: float,
+    directions: dict[str, int],
+    realized_vols: dict[str, float],
+    portfolio_vol_target: float = DEFAULT_PORTFOLIO_VOL_TARGET,
+    max_leverage: float = DEFAULT_MAX_LEVERAGE,
+    max_position_pct: float = DEFAULT_MAX_POSITION_PCT,
+    min_position_usd: float = DEFAULT_MIN_POSITION_USD,
+) -> dict[str, float]:
+    """End-to-end portfolio sizing: per-symbol vol-targeted + leverage cap.
+
+    Convenience orchestrator that:
+    1. Counts active symbols (direction != 0)
+    2. Computes target_vol_per_symbol = portfolio_vol_target / n_active
+    3. Calls compute_position_size per symbol
+    4. Applies leverage cap on the resulting book
+
+    Args:
+        capital_usd: total portfolio capital.
+        directions: mapping {symbol → -1|0|+1} from ensemble.
+        realized_vols: mapping {symbol → σ_30d annualized}.
+        portfolio_vol_target: total target vol (default 30%).
+        max_leverage: leverage cap (default 2x).
+        max_position_pct: per-symbol hard cap fraction (default 20%).
+        min_position_usd: minimum notional (default $50).
+
+    Returns:
+        dict {symbol → signed USD position}, leverage-capped. Symbols with
+        direction=0 are excluded from the result (not in dict).
+    """
+    active_symbols = [sym for sym, d in directions.items() if d != 0]
+    if not active_symbols:
+        return {}
+
+    target_per_symbol = portfolio_vol_target / len(active_symbols)
+
+    positions: dict[str, float] = {}
+    for sym in active_symbols:
+        size = compute_position_size(
+            capital_usd=capital_usd,
+            direction=directions[sym],
+            target_vol_per_symbol=target_per_symbol,
+            realized_vol_annualized=realized_vols.get(sym, float("nan")),
+            max_position_pct=max_position_pct,
+            min_position_usd=min_position_usd,
+        )
+        if size != 0.0:
+            positions[sym] = size
+
+    return apply_leverage_cap(
+        positions, capital_usd=capital_usd, max_leverage=max_leverage
+    )

--- a/tests/test_donchian_ensemble.py
+++ b/tests/test_donchian_ensemble.py
@@ -1,0 +1,370 @@
+"""Tests for strategy.donchian_ensemble (epic #338 Phase 1A, closes #342 in part).
+
+Covers Donchian channel computation, sticky breakout direction over history,
+equal-weight vote aggregation, and the convenience `compute_ensemble_history`
+wrapper. All TDD-developed.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from strategy.donchian_ensemble import (
+    ZARATTINI_LOOKBACKS,
+    aggregate_ensemble,
+    compute_donchian_channel,
+    compute_donchian_direction_history,
+    compute_ensemble_history,
+)
+
+
+@pytest.fixture
+def daily_index_60():
+    """60 consecutive daily timestamps."""
+    return pd.date_range("2024-01-01", periods=60, freq="D")
+
+
+@pytest.fixture
+def constant_price_60(daily_index_60):
+    """Constant price = 100.0 over 60 days. No breakouts possible."""
+    return pd.DataFrame(
+        {
+            "close": [100.0] * 60,
+            "high": [100.0] * 60,
+            "low": [100.0] * 60,
+        },
+        index=daily_index_60,
+    )
+
+
+@pytest.fixture
+def linear_uptrend_60(daily_index_60):
+    """Linear uptrend 100 → 159 over 60 days. Every bar makes new high."""
+    closes = np.arange(100.0, 160.0)
+    return pd.DataFrame(
+        {"close": closes, "high": closes + 0.5, "low": closes - 0.5},
+        index=daily_index_60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_donchian_channel — pure point-in-time channel
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDonchianChannel:
+    def test_basic_5_day_channel(self):
+        """5-bar window: upper = max highs, lower = min lows, mid = avg."""
+        highs = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+        lows = pd.Series([0.5, 1.5, 2.5, 3.5, 4.5])
+        ch = compute_donchian_channel(highs=highs, lows=lows, lookback_days=5)
+        assert ch["upper"] == 5.0
+        assert ch["lower"] == 0.5
+        assert ch["mid"] == pytest.approx(2.75)
+
+    def test_uses_only_last_n_bars(self):
+        """Earlier bars outside the window must NOT contribute."""
+        # Last 3 bars should give upper=8, lower=6
+        highs = pd.Series([100.0, 100.0, 5.0, 8.0, 7.0])
+        lows = pd.Series([90.0, 90.0, 4.0, 7.0, 6.0])
+        ch = compute_donchian_channel(highs=highs, lows=lows, lookback_days=3)
+        assert ch["upper"] == 8.0
+        assert ch["lower"] == 4.0
+
+    def test_insufficient_history_returns_nan(self):
+        """Fewer bars than lookback → all NaN."""
+        highs = pd.Series([1.0, 2.0])
+        lows = pd.Series([0.5, 1.5])
+        ch = compute_donchian_channel(highs=highs, lows=lows, lookback_days=5)
+        assert np.isnan(ch["upper"])
+        assert np.isnan(ch["lower"])
+        assert np.isnan(ch["mid"])
+
+    def test_exactly_n_bars_works(self):
+        """Exactly lookback bars: edge case should compute (not NaN)."""
+        highs = pd.Series([1.0, 2.0, 3.0])
+        lows = pd.Series([0.5, 1.5, 2.5])
+        ch = compute_donchian_channel(highs=highs, lows=lows, lookback_days=3)
+        assert ch["upper"] == 3.0
+        assert ch["lower"] == 0.5
+
+    def test_lookback_lt_2_raises(self):
+        """Sanity: a 1-bar Donchian is just the bar itself; reject as invalid."""
+        highs = pd.Series([1.0, 2.0])
+        lows = pd.Series([0.5, 1.5])
+        with pytest.raises(ValueError, match="lookback_days must be"):
+            compute_donchian_channel(highs=highs, lows=lows, lookback_days=1)
+
+
+# ---------------------------------------------------------------------------
+# compute_donchian_direction_history — sticky breakout direction
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDonchianDirectionHistory:
+    def test_warmup_returns_zeros(self, daily_index_60):
+        """First lookback_days bars are warmup: direction = 0."""
+        closes = pd.Series(np.arange(100.0, 160.0), index=daily_index_60)
+        highs = closes + 0.5
+        lows = closes - 0.5
+        dirs = compute_donchian_direction_history(
+            closes=closes, highs=highs, lows=lows, lookback_days=5
+        )
+        # Warmup is the first 5 bars (need lookback_days of history to compute
+        # prior N-day extremes, which then need to be shifted by 1 → first 5
+        # are NaN in the rolling-shifted-extremes → direction = 0)
+        assert all(dirs.iloc[:5] == 0)
+
+    def test_uptrend_eventually_signals_long_throughout(self, linear_uptrend_60):
+        """Linear uptrend: after warmup, direction should be LONG (+1) every bar
+        because each bar breaks the prior N-day high."""
+        df = linear_uptrend_60
+        dirs = compute_donchian_direction_history(
+            closes=df["close"], highs=df["high"], lows=df["low"], lookback_days=5
+        )
+        # After warmup (first 5 bars), the uptrend should produce all +1
+        post_warmup = dirs.iloc[5:]
+        assert (post_warmup == 1).all(), (
+            f"uptrend should yield all LONG post-warmup; got {post_warmup.value_counts()}"
+        )
+
+    def test_downtrend_signals_short(self, daily_index_60):
+        """Linear downtrend produces all SHORT post-warmup."""
+        closes = pd.Series(np.arange(160.0, 100.0, -1.0), index=daily_index_60)
+        highs = closes + 0.5
+        lows = closes - 0.5
+        dirs = compute_donchian_direction_history(
+            closes=closes, highs=highs, lows=lows, lookback_days=5
+        )
+        post_warmup = dirs.iloc[5:]
+        assert (post_warmup == -1).all()
+
+    def test_constant_price_no_signals(self, constant_price_60):
+        """Constant price never breaks any range → direction always 0."""
+        df = constant_price_60
+        dirs = compute_donchian_direction_history(
+            closes=df["close"], highs=df["high"], lows=df["low"], lookback_days=5
+        )
+        assert (dirs == 0).all()
+
+    def test_sticky_long_through_pullback(self, daily_index_60):
+        """Once LONG, direction holds through pullbacks until SHORT breakout fires."""
+        # Up for 20 bars to 120, then sideways at 115-119 (pullback that doesn't break lower)
+        closes_up = np.linspace(100, 120, 20)
+        closes_pullback = np.full(20, 117.0)  # pulls back but well above prior low
+        closes_total = np.concatenate([closes_up, closes_pullback, np.full(20, 117.0)])
+        highs = closes_total + 0.5
+        lows = closes_total - 0.5
+        df = pd.DataFrame(
+            {"close": closes_total, "high": highs, "low": lows}, index=daily_index_60
+        )
+        dirs = compute_donchian_direction_history(
+            closes=df["close"], highs=df["high"], lows=df["low"], lookback_days=5
+        )
+        # After uptrend establishes LONG (~bar 6), direction should remain +1
+        # through the pullback (since 117 doesn't break the prior 5-day low)
+        # Final direction should be +1
+        assert dirs.iloc[-1] == 1, f"Expected sticky LONG; got {dirs.iloc[-1]}"
+
+    def test_flip_long_to_short_on_breakout_down(self, daily_index_60):
+        """Long established, then sharp drop below prior N-day low → flip to SHORT."""
+        # 30 bars uptrend, then 30 bars sharp downtrend below prior lows
+        closes_up = np.linspace(100, 150, 30)
+        closes_down = np.linspace(149, 80, 30)
+        closes_total = np.concatenate([closes_up, closes_down])
+        highs = closes_total + 0.5
+        lows = closes_total - 0.5
+        df = pd.DataFrame(
+            {"close": closes_total, "high": highs, "low": lows}, index=daily_index_60
+        )
+        dirs = compute_donchian_direction_history(
+            closes=df["close"], highs=df["high"], lows=df["low"], lookback_days=5
+        )
+        # By the end of the downtrend, direction should be SHORT
+        assert dirs.iloc[-1] == -1
+
+    def test_lookback_lt_2_raises(self, daily_index_60):
+        """Bad lookback raises."""
+        closes = pd.Series(np.arange(60.0), index=daily_index_60)
+        highs = closes + 0.5
+        lows = closes - 0.5
+        with pytest.raises(ValueError, match="lookback_days must be"):
+            compute_donchian_direction_history(
+                closes=closes, highs=highs, lows=lows, lookback_days=1
+            )
+
+    def test_mismatched_index_raises(self, daily_index_60):
+        """Misaligned indexes are caught — protects against silent bugs."""
+        closes = pd.Series(np.arange(60.0), index=daily_index_60)
+        # Different index
+        bad_index = pd.date_range("2025-01-01", periods=60, freq="D")
+        highs = pd.Series(np.arange(60.0), index=bad_index)
+        lows = pd.Series(np.arange(60.0), index=daily_index_60)
+        with pytest.raises(ValueError, match="same index"):
+            compute_donchian_direction_history(
+                closes=closes, highs=highs, lows=lows, lookback_days=5
+            )
+
+    def test_insufficient_data_returns_zero_series(self, daily_index_60):
+        """Series with fewer than lookback_days bars → all zeros."""
+        idx = daily_index_60[:3]  # only 3 bars
+        closes = pd.Series([100.0, 101.0, 102.0], index=idx)
+        highs = closes + 0.5
+        lows = closes - 0.5
+        dirs = compute_donchian_direction_history(
+            closes=closes, highs=highs, lows=lows, lookback_days=5
+        )
+        assert (dirs == 0).all()
+        assert len(dirs) == 3
+
+
+# ---------------------------------------------------------------------------
+# aggregate_ensemble — equal-weight vote
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateEnsemble:
+    def test_all_long_returns_long_with_full_confidence(self):
+        """9 LONG signals → direction=+1, confidence=1.0."""
+        directions = {n: 1 for n in (5, 10, 20, 30, 60, 90, 150, 250, 360)}
+        result = aggregate_ensemble(directions)
+        assert result["direction"] == 1
+        assert result["vote"] == 9
+        assert result["confidence"] == pytest.approx(1.0)
+        assert result["n_long"] == 9
+        assert result["n_short"] == 0
+        assert result["n_flat"] == 0
+        assert result["n_lookbacks"] == 9
+
+    def test_all_short_returns_short_with_full_confidence(self):
+        directions = {n: -1 for n in (5, 10, 20, 30, 60, 90, 150, 250, 360)}
+        result = aggregate_ensemble(directions)
+        assert result["direction"] == -1
+        assert result["vote"] == -9
+        assert result["confidence"] == pytest.approx(1.0)
+        assert result["n_short"] == 9
+
+    def test_all_flat_returns_flat_zero_confidence(self):
+        directions = {n: 0 for n in (5, 10, 20, 30, 60, 90, 150, 250, 360)}
+        result = aggregate_ensemble(directions)
+        assert result["direction"] == 0
+        assert result["vote"] == 0
+        assert result["confidence"] == 0.0
+        assert result["n_flat"] == 9
+
+    def test_majority_long_wins_when_5_vs_4(self):
+        """5 LONG + 4 SHORT → vote=+1, direction=+1, confidence=1/9."""
+        directions = {5: 1, 10: 1, 20: 1, 30: 1, 60: 1, 90: -1, 150: -1, 250: -1, 360: -1}
+        result = aggregate_ensemble(directions)
+        assert result["direction"] == 1
+        assert result["vote"] == 1
+        assert result["confidence"] == pytest.approx(1 / 9, abs=1e-6)
+        assert result["n_long"] == 5
+        assert result["n_short"] == 4
+
+    def test_tied_vote_returns_flat(self):
+        """3 LONG + 3 SHORT + 3 FLAT → vote=0 → flat."""
+        directions = {5: 1, 10: 1, 20: 1, 30: -1, 60: -1, 90: -1, 150: 0, 250: 0, 360: 0}
+        result = aggregate_ensemble(directions)
+        assert result["direction"] == 0
+        assert result["vote"] == 0
+        assert result["confidence"] == 0.0
+        assert result["n_long"] == 3
+        assert result["n_short"] == 3
+        assert result["n_flat"] == 3
+
+    def test_partial_lookback_set_works(self):
+        """Aggregation works with fewer lookbacks (e.g. 4 from a subset config)."""
+        directions = {10: 1, 30: 1, 90: -1, 180: 1}
+        result = aggregate_ensemble(directions)
+        assert result["direction"] == 1
+        assert result["vote"] == 2
+        assert result["confidence"] == pytest.approx(0.5)
+        assert result["n_lookbacks"] == 4
+
+    def test_empty_directions_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            aggregate_ensemble({})
+
+    def test_invalid_direction_value_raises(self):
+        """Direction outside {-1, 0, +1} is rejected — anti-bug guard."""
+        with pytest.raises(ValueError, match="must be in"):
+            aggregate_ensemble({5: 2})  # noqa
+
+    def test_invalid_direction_float_raises(self):
+        with pytest.raises(ValueError):
+            aggregate_ensemble({5: 0.5})  # noqa: float not in {-1,0,1}
+
+    def test_unknown_aggregation_method_raises(self):
+        """Future method names should raise NotImplementedError."""
+        with pytest.raises(NotImplementedError, match="not implemented"):
+            aggregate_ensemble({5: 1}, method="signal_strength_weighted")  # noqa
+
+
+# ---------------------------------------------------------------------------
+# compute_ensemble_history — convenience wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestComputeEnsembleHistory:
+    def test_returns_dataframe_with_per_lookback_columns(self, linear_uptrend_60):
+        """Output has dir_N columns + ensemble aggregates."""
+        df = linear_uptrend_60
+        out = compute_ensemble_history(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+            lookbacks=(5, 10, 20),
+        )
+        assert "dir_5" in out.columns
+        assert "dir_10" in out.columns
+        assert "dir_20" in out.columns
+        assert "vote" in out.columns
+        assert "direction" in out.columns
+        assert "confidence" in out.columns
+        assert "n_long" in out.columns
+        assert len(out) == 60
+
+    def test_uptrend_terminal_direction_is_long(self, linear_uptrend_60):
+        """In a clean uptrend, by the end the ensemble votes LONG with full confidence."""
+        df = linear_uptrend_60
+        out = compute_ensemble_history(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+            lookbacks=(5, 10, 20),
+        )
+        assert out["direction"].iloc[-1] == 1
+        # In a perfect uptrend, all 3 lookbacks vote LONG → vote = 3, confidence = 1.0
+        assert out["vote"].iloc[-1] == 3
+        assert out["confidence"].iloc[-1] == pytest.approx(1.0)
+
+    def test_zarattini_default_lookbacks_used(self, linear_uptrend_60):
+        """If lookbacks tuple not specified, defaults to ZARATTINI_LOOKBACKS."""
+        df = linear_uptrend_60
+        out = compute_ensemble_history(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+        )
+        for n in ZARATTINI_LOOKBACKS:
+            assert f"dir_{n}" in out.columns
+        # 360-day lookback won't have signal in 60-bar data (still warming up)
+        assert out["dir_360"].iloc[-1] == 0
+
+    def test_empty_lookbacks_raises(self, linear_uptrend_60):
+        df = linear_uptrend_60
+        with pytest.raises(ValueError, match="empty"):
+            compute_ensemble_history(
+                closes=df["close"], highs=df["high"], lows=df["low"],
+                lookbacks=(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# ZARATTINI_LOOKBACKS constant
+# ---------------------------------------------------------------------------
+
+
+class TestZarattiniLookbacks:
+    def test_exact_9_lookbacks_locked(self):
+        """§8.4 of epic #338 spec locked 9 lookbacks. This test guards drift."""
+        assert ZARATTINI_LOOKBACKS == (5, 10, 20, 30, 60, 90, 150, 250, 360)
+        assert len(ZARATTINI_LOOKBACKS) == 9
+
+    def test_lookbacks_monotonically_increasing(self):
+        """Sanity: lookbacks should be ordered for legibility."""
+        assert list(ZARATTINI_LOOKBACKS) == sorted(ZARATTINI_LOOKBACKS)

--- a/tests/test_vol_targeting.py
+++ b/tests/test_vol_targeting.py
@@ -1,0 +1,405 @@
+"""Tests for strategy.vol_targeting (epic #338 Phase 1A, closes #342 in part).
+
+Covers realized-volatility annualization, vol-targeted position sizing with
+hard caps, leverage-cap proportional scaling, and the end-to-end portfolio
+orchestrator. All TDD-developed.
+"""
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from strategy.vol_targeting import (
+    DEFAULT_MAX_LEVERAGE,
+    DEFAULT_MAX_POSITION_PCT,
+    DEFAULT_MIN_POSITION_USD,
+    DEFAULT_PORTFOLIO_VOL_TARGET,
+    DEFAULT_VOL_WINDOW_DAYS,
+    TRADING_DAYS_PER_YEAR,
+    apply_leverage_cap,
+    compute_portfolio_positions,
+    compute_position_size,
+    compute_realized_vol_annualized,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_locked_defaults_match_epic_spec(self):
+        """§8.3 locked 30% vol target; §8.6 locked 2x leverage; §4.3 locked
+        20% per-symbol cap + $50 min order."""
+        assert DEFAULT_PORTFOLIO_VOL_TARGET == 0.30
+        assert DEFAULT_MAX_LEVERAGE == 2.0
+        assert DEFAULT_MAX_POSITION_PCT == 0.20
+        assert DEFAULT_MIN_POSITION_USD == 50.0
+        assert DEFAULT_VOL_WINDOW_DAYS == 30
+        assert TRADING_DAYS_PER_YEAR == 365
+
+
+# ---------------------------------------------------------------------------
+# compute_realized_vol_annualized
+# ---------------------------------------------------------------------------
+
+
+class TestComputeRealizedVolAnnualized:
+    def test_zero_vol_returns_nan(self):
+        """Constant returns (std = 0) cannot be sized against → NaN."""
+        returns = pd.Series([0.0] * 30)
+        vol = compute_realized_vol_annualized(returns)
+        assert math.isnan(vol)
+
+    def test_constant_1pct_daily_std(self):
+        """30 returns alternating ±1% give std ≈ 1% (sample, ddof=1), annualized.
+
+        Sample std (ddof=1) of [+0.01,-0.01,...] over n obs = 0.01 × sqrt(n/(n-1)).
+        For n=30: 0.01 × sqrt(30/29) ≈ 0.01017. Annualized: × sqrt(365) ≈ 0.1943.
+        """
+        returns = pd.Series([0.01, -0.01] * 15)
+        vol = compute_realized_vol_annualized(returns)
+        expected = 0.01 * math.sqrt(30 / 29) * math.sqrt(365)
+        assert vol == pytest.approx(expected, abs=1e-4)
+
+    def test_insufficient_data_returns_nan(self):
+        """Fewer returns than window → NaN."""
+        returns = pd.Series([0.01] * 10)
+        vol = compute_realized_vol_annualized(returns, window=30)
+        assert math.isnan(vol)
+
+    def test_uses_only_last_window_returns(self):
+        """Earlier returns (beyond window) must be ignored."""
+        # First 100 bars high-vol (5%), last 30 bars low-vol (alternating ±1%)
+        np.random.seed(42)
+        old = np.random.normal(0, 0.05, 100)
+        new = np.array([0.01, -0.01] * 15)
+        returns = pd.Series(np.concatenate([old, new]))
+        vol = compute_realized_vol_annualized(returns, window=30)
+        # Should reflect last 30 (alt ±0.01), not full 130
+        expected = 0.01 * math.sqrt(30 / 29) * math.sqrt(365)
+        assert vol == pytest.approx(expected, abs=1e-3)
+
+    def test_nan_returns_dropped(self):
+        """NaN returns in the window are dropped before computing std."""
+        returns = pd.Series([0.01, -0.01] * 14 + [float("nan"), float("nan")])
+        vol = compute_realized_vol_annualized(returns, window=30)
+        # 28 valid + 2 nan dropped → sample std on 28 obs of ±0.01 = 0.01 × sqrt(28/27)
+        assert math.isfinite(vol)
+        expected = 0.01 * math.sqrt(28 / 27) * math.sqrt(365)
+        assert vol == pytest.approx(expected, abs=1e-3)
+
+    def test_too_few_valid_after_dropna_returns_nan(self):
+        """If NaN-stripped window has fewer than 2 returns → NaN."""
+        returns = pd.Series([float("nan")] * 30)
+        vol = compute_realized_vol_annualized(returns, window=30)
+        assert math.isnan(vol)
+
+    def test_window_lt_2_raises(self):
+        """std requires ≥ 2 obs."""
+        with pytest.raises(ValueError, match="window must be"):
+            compute_realized_vol_annualized(pd.Series([0.01, 0.02]), window=1)
+
+    def test_high_vol_50pct_annualized(self):
+        """30 returns of std 2.6% → annualized ≈ 50%.
+
+        Sample std (ddof=1) over n=30 alt ±0.026 = 0.026 × sqrt(30/29).
+        Annualized × sqrt(365) ≈ 0.5052.
+        """
+        returns = pd.Series([0.026, -0.026] * 15)
+        vol = compute_realized_vol_annualized(returns)
+        expected = 0.026 * math.sqrt(30 / 29) * math.sqrt(365)
+        assert vol == pytest.approx(expected, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# compute_position_size
+# ---------------------------------------------------------------------------
+
+
+class TestComputePositionSize:
+    def test_direction_zero_returns_zero(self):
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=0,
+            target_vol_per_symbol=0.05, realized_vol_annualized=0.50,
+        )
+        assert size == 0.0
+
+    def test_long_basic_math(self):
+        """capital=$10k, target=5%, realized=50% → notional = 10000*0.05/0.50 = $1000."""
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=1,
+            target_vol_per_symbol=0.05, realized_vol_annualized=0.50,
+            max_position_pct=1.0,  # no cap
+            min_position_usd=0.0,  # no floor
+        )
+        assert size == pytest.approx(1_000.0)
+
+    def test_short_returns_negative(self):
+        """SHORT direction returns negative signed notional."""
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=-1,
+            target_vol_per_symbol=0.05, realized_vol_annualized=0.50,
+            max_position_pct=1.0, min_position_usd=0.0,
+        )
+        assert size == pytest.approx(-1_000.0)
+
+    def test_max_position_pct_caps_notional(self):
+        """If vol-targeted size would exceed 20% of capital, hard cap applies."""
+        # Tiny vol → huge implied size
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=1,
+            target_vol_per_symbol=0.05, realized_vol_annualized=0.10,  # raw = $5000 = 50%
+            max_position_pct=0.20,  # cap at $2000
+            min_position_usd=0.0,
+        )
+        assert size == pytest.approx(2_000.0)
+
+    def test_min_position_usd_skips_tiny_trade(self):
+        """If sizing produces a notional < $50, return 0 (skip the trade)."""
+        # Huge vol → tiny implied size
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=1,
+            target_vol_per_symbol=0.05, realized_vol_annualized=20.0,  # raw = $25
+            max_position_pct=1.0, min_position_usd=50.0,
+        )
+        assert size == 0.0
+
+    def test_nan_realized_vol_returns_zero(self):
+        """Can't size without a valid vol estimate."""
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=1,
+            target_vol_per_symbol=0.05, realized_vol_annualized=float("nan"),
+        )
+        assert size == 0.0
+
+    def test_zero_realized_vol_returns_zero(self):
+        """Division-by-zero guard."""
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=1,
+            target_vol_per_symbol=0.05, realized_vol_annualized=0.0,
+        )
+        assert size == 0.0
+
+    def test_negative_realized_vol_returns_zero(self):
+        """Defensive: nonsensical vol → no position."""
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=1,
+            target_vol_per_symbol=0.05, realized_vol_annualized=-0.10,
+        )
+        assert size == 0.0
+
+    def test_zero_capital_returns_zero(self):
+        size = compute_position_size(
+            capital_usd=0.0, direction=1,
+            target_vol_per_symbol=0.05, realized_vol_annualized=0.50,
+        )
+        assert size == 0.0
+
+    def test_invalid_direction_raises(self):
+        """Anti-typo: only -1, 0, +1 accepted."""
+        with pytest.raises(ValueError, match="direction must be in"):
+            compute_position_size(
+                capital_usd=10_000.0, direction=2,  # noqa
+                target_vol_per_symbol=0.05, realized_vol_annualized=0.50,
+            )
+
+    def test_zero_target_vol_returns_zero(self):
+        size = compute_position_size(
+            capital_usd=10_000.0, direction=1,
+            target_vol_per_symbol=0.0, realized_vol_annualized=0.50,
+        )
+        assert size == 0.0
+
+
+# ---------------------------------------------------------------------------
+# apply_leverage_cap
+# ---------------------------------------------------------------------------
+
+
+class TestApplyLeverageCap:
+    def test_within_cap_returns_unchanged(self):
+        """Sum |positions| ≤ cap → no scaling."""
+        positions = {"BTC": 5000.0, "ETH": -3000.0}
+        # Sum = $8000 < 2 × $10000 = $20000 cap
+        out = apply_leverage_cap(positions, capital_usd=10_000.0, max_leverage=2.0)
+        assert out == {"BTC": 5000.0, "ETH": -3000.0}
+
+    def test_at_cap_returns_unchanged(self):
+        """At the cap exactly (boundary) → no scaling."""
+        positions = {"BTC": 12_000.0, "ETH": -8_000.0}
+        # Sum = $20000 = cap
+        out = apply_leverage_cap(positions, capital_usd=10_000.0, max_leverage=2.0)
+        assert out == {"BTC": 12_000.0, "ETH": -8_000.0}
+
+    def test_over_cap_scaled_proportionally(self):
+        """Sum $25k > $20k cap → scale by 0.8 across all positions."""
+        positions = {"BTC": 15_000.0, "ETH": -10_000.0}
+        out = apply_leverage_cap(positions, capital_usd=10_000.0, max_leverage=2.0)
+        # Scale factor = 20000 / 25000 = 0.8
+        assert out["BTC"] == pytest.approx(12_000.0)
+        assert out["ETH"] == pytest.approx(-8_000.0)
+        total = sum(abs(p) for p in out.values())
+        assert total == pytest.approx(20_000.0)
+
+    def test_signs_preserved(self):
+        """LONG positions stay LONG, SHORT positions stay SHORT after scaling."""
+        positions = {"A": 30_000.0, "B": -20_000.0, "C": 10_000.0}
+        out = apply_leverage_cap(positions, capital_usd=10_000.0, max_leverage=2.0)
+        assert out["A"] > 0
+        assert out["B"] < 0
+        assert out["C"] > 0
+
+    def test_empty_returns_empty(self):
+        out = apply_leverage_cap({}, capital_usd=10_000.0, max_leverage=2.0)
+        assert out == {}
+
+    def test_all_zero_positions_returns_unchanged(self):
+        """No notional to scale → return as-is (no division by zero)."""
+        positions = {"BTC": 0.0, "ETH": 0.0}
+        out = apply_leverage_cap(positions, capital_usd=10_000.0, max_leverage=2.0)
+        assert out == positions
+
+    def test_single_position_capped(self):
+        """One symbol with notional > cap → scaled to exactly cap."""
+        positions = {"BTC": 100_000.0}
+        out = apply_leverage_cap(positions, capital_usd=10_000.0, max_leverage=2.0)
+        assert out["BTC"] == pytest.approx(20_000.0)
+
+    def test_negative_capital_raises(self):
+        with pytest.raises(ValueError, match="capital_usd"):
+            apply_leverage_cap({"A": 100.0}, capital_usd=-10.0)
+
+    def test_zero_capital_raises(self):
+        with pytest.raises(ValueError, match="capital_usd"):
+            apply_leverage_cap({"A": 100.0}, capital_usd=0.0)
+
+    def test_negative_leverage_raises(self):
+        with pytest.raises(ValueError, match="max_leverage"):
+            apply_leverage_cap({"A": 100.0}, capital_usd=10_000.0, max_leverage=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# compute_portfolio_positions — end-to-end orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestComputePortfolioPositions:
+    def test_all_zero_directions_returns_empty(self):
+        """No active symbols → no positions."""
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={"BTC": 0, "ETH": 0, "ADA": 0},
+            realized_vols={"BTC": 0.50, "ETH": 0.60, "ADA": 1.0},
+        )
+        assert out == {}
+
+    def test_single_active_symbol_gets_full_vol_budget(self):
+        """One active symbol → target_per_symbol = portfolio_vol_target / 1."""
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={"BTC": 1, "ETH": 0},
+            realized_vols={"BTC": 0.30, "ETH": 0.60},
+            max_position_pct=1.0,  # disable per-symbol cap
+        )
+        # target = 0.30 / 1 = 0.30; size = 10000 × 0.30 / 0.30 = $10000
+        # But default max_position_pct = 1.0 (since we passed it explicitly), no cap
+        # Leverage cap: sum |positions| = $10000 ≤ $20000 → no scale
+        assert "BTC" in out
+        assert out["BTC"] == pytest.approx(10_000.0, rel=0.01)
+        assert "ETH" not in out  # flat
+
+    def test_three_active_long_symbols(self):
+        """3 active LONG symbols, each with realized vol = portfolio_target → each
+        gets equal share of vol budget."""
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={"BTC": 1, "ETH": 1, "ADA": 1, "DOGE": 0},
+            realized_vols={"BTC": 0.30, "ETH": 0.30, "ADA": 0.30, "DOGE": 0.50},
+            portfolio_vol_target=0.30,
+            max_position_pct=1.0,
+        )
+        # target_per_symbol = 0.30 / 3 = 0.10
+        # size_each = 10000 × 0.10 / 0.30 ≈ $3333
+        for sym in ("BTC", "ETH", "ADA"):
+            assert out[sym] == pytest.approx(3_333.33, rel=0.01)
+        assert "DOGE" not in out
+
+    def test_short_returns_negative_position(self):
+        """SHORT direction yields negative signed position USD."""
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={"BTC": -1},
+            realized_vols={"BTC": 0.30},
+            max_position_pct=1.0,
+        )
+        assert out["BTC"] < 0
+        assert out["BTC"] == pytest.approx(-10_000.0, rel=0.01)
+
+    def test_leverage_cap_kicks_in_with_many_symbols(self):
+        """5 LONG + 5 SHORT, each ≈ 100% of capital pre-cap, gets scaled to 2x total."""
+        # Set realized vols equal to target so raw_per_symbol = capital
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={
+                "S1": 1, "S2": 1, "S3": 1, "S4": 1, "S5": 1,
+                "S6": -1, "S7": -1, "S8": -1, "S9": -1, "S10": -1,
+            },
+            realized_vols={f"S{i}": 0.03 for i in range(1, 11)},  # target/10 each
+            portfolio_vol_target=0.30,
+            max_position_pct=1.0,  # so per-symbol cap doesn't bite
+            max_leverage=2.0,
+        )
+        total = sum(abs(p) for p in out.values())
+        assert total == pytest.approx(20_000.0, rel=0.001)  # exactly leverage cap
+
+    def test_per_symbol_cap_bites_before_leverage_cap(self):
+        """If each symbol's individual cap triggers, leverage cap is downstream."""
+        # 10 symbols, each with very low vol → each would be ~100% of capital
+        # Per-symbol cap = 20% → each = $2000, total = $20000 = leverage cap (just at)
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={f"S{i}": 1 for i in range(1, 11)},
+            realized_vols={f"S{i}": 0.03 for i in range(1, 11)},
+            portfolio_vol_target=0.30,
+            max_position_pct=0.20,
+            max_leverage=2.0,
+        )
+        # Each symbol capped at $2000; total = $20000 = leverage cap exactly
+        for sym in out:
+            assert out[sym] == pytest.approx(2_000.0, rel=0.01)
+
+    def test_missing_realized_vol_skips_symbol(self):
+        """If a symbol has no vol entry, it gets size 0 and is excluded."""
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={"BTC": 1, "ETH": 1},
+            realized_vols={"BTC": 0.30},  # ETH missing
+            max_position_pct=1.0,
+        )
+        assert "BTC" in out
+        assert "ETH" not in out
+
+    def test_below_min_threshold_excluded(self):
+        """Symbol whose vol-targeted size falls below $50 is excluded."""
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={"BTC": 1},
+            realized_vols={"BTC": 100.0},  # crazy high vol → tiny size
+            portfolio_vol_target=0.30,
+            min_position_usd=50.0,
+        )
+        # size = 10000 × 0.30 / 100 = $30 < $50 → excluded
+        assert out == {}
+
+    def test_defaults_used_when_not_specified(self):
+        """Calling without explicit params uses locked defaults."""
+        out = compute_portfolio_positions(
+            capital_usd=10_000.0,
+            directions={"BTC": 1},
+            realized_vols={"BTC": 0.30},
+        )
+        # With defaults: target=0.30/1=0.30; raw=$10000; max_pct=0.20 → cap=$2000
+        assert out["BTC"] == pytest.approx(2_000.0, rel=0.01)


### PR DESCRIPTION
## Summary

Phase 1A of epic #338 / issue #342. Adds two pure-function modules with TDD test suites. No integration with `strategy/core.py` or `backtest.py` yet — Phase 1B and 1C cover that.

## Modules

**`strategy/donchian_ensemble.py`** — multi-timeframe Donchian breakout signals
- `ZARATTINI_LOOKBACKS = (5, 10, 20, 30, 60, 90, 150, 250, 360)` — §8.4 locked
- `compute_donchian_channel`, `compute_donchian_direction_history`, `aggregate_ensemble`, `compute_ensemble_history`
- Sticky breakout: LONG when close > prior N-day high, SHORT when close < prior N-day low, otherwise maintain (classic Donchian)
- Equal-weight vote aggregation per §8.1 locked

**`strategy/vol_targeting.py`** — volatility-targeting position sizing
- Constants locked per epic spec: `DEFAULT_PORTFOLIO_VOL_TARGET = 0.30`, `DEFAULT_MAX_LEVERAGE = 2.0`, `DEFAULT_MAX_POSITION_PCT = 0.20`, `DEFAULT_MIN_POSITION_USD = 50.0`, `TRADING_DAYS_PER_YEAR = 365`
- `compute_realized_vol_annualized`, `compute_position_size`, `apply_leverage_cap`, `compute_portfolio_positions`
- Close-to-close sample std × sqrt(365)
- Replaces R-multiple sizing (audit H4 root cause of bankruptcy under LRC)

## Tests

| File | Tests | Coverage |
|---|---:|---|
| `tests/test_donchian_ensemble.py` | 30 | channel, sticky direction history (LONG/SHORT/sticky/flip), ensemble vote (all-long/all-short/all-flat/majority/tied/partial-set/empty/invalid), history wrapper, ZARATTINI_LOOKBACKS constant |
| `tests/test_vol_targeting.py` | 39 | constants, realized vol (sample-std math + window + NaN + insufficient data), position sizing (vol-targeted math + caps + min order + nan vol + zero capital), leverage cap (within/at/over + signs + empty + single), end-to-end orchestrator (active count + leverage cap + per-symbol cap + missing vol + below-threshold) |
| **Total Phase 1A** | **69** | |

Full focused regression: **214/214 pass** including Phase 0 v1+v2 cost model, holdout isolation, overshoot cap, signal exit, trend pullback signal.

## What this PR does NOT do

- Does NOT modify `strategy/core.py` or `backtest.py` (Phase 1B + 1C)
- Does NOT add `cfg.regime_allocation_enabled` flag (Phase 1B)
- Does NOT touch `config.defaults.json` (deferred Phase 1D)
- Does NOT touch holdout (whitelist in `tests/test_holdout_isolation.py` unchanged)
- Does NOT integrate cost model v2 (Phase 1C)
- Does NOT add scanner integration (Phase 6 after holdout validation)

## Locked parameters baked in

Per §8 of epic #338 spec, fixed in modules as defaults / constants (not configurable to prevent drift):

- §8.1 Aggregation = equal-weight vote (only method supported; others raise NotImplementedError)
- §8.3 Vol target = 30% annualized
- §8.4 Lookbacks = 9 Zarattini exacts
- §8.6 Leverage cap = 2.0×

§8.2 (daily update freq), §8.5 (SHORT bidirectional), §8.7 (compute budget) are integration-level decisions for Phase 1B/1C — not encoded in these pure modules.

## References

- Epic #338
- Phase 1 issue: #342
- Phase 0 (prerequisite, merged): PR #341
- Epic spec §4.2 (signal) + §4.3 (sizing) + §8 (params): `docs/superpowers/specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md`
- Zarattini, Pagani & Barbon (2025) SSRN 5209907

## Test plan

- [x] 69/69 Phase 1A tests pass locally
- [x] 214/214 focused regression passes (Phase 0 + holdout + adjacent)
- [x] Pure functions only, no I/O, deterministic
- [ ] CI green (TBD on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)