### PR TITLE
feat(epic #338 Phase 1D): config.defaults.json regime_allocation block + CLAUDE.md docs (closes #342)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,38 @@ Binance API (Bybit fallback)
 ### Operational Model
 Signal generation is automatic; entry/close decisions require manual approval via CLI or frontend (Telegram is outbound only — no inbound bot for trade approval). Exclusions E2–E5 in `btc_scanner.py:305-335` are manual-check by design — see `docs/superpowers/specs/es/2026-05-01-operational-model-manual-gating.md` for the full classification and the backtest-vs-live distinction.
 
+### Cost model v2 (post-Phase 0 of epic #338)
+- **Slippage formula:** sqrt-participation (Almgren-Chriss family). `slippage_bps = base_bps + size_factor × sqrt(notional/liquidity_per_min)`, capped at `EXTREME_PARTICIPATION_CAP_BPS = 500` (5%) per fill. Migration from v1 linear in `backtest_costs.py` (PR #341). v1 linear path still available via `model='v1'` for parity testing.
+- **Anchor parity preserved:** at 0.1% participation, v2 and v1 produce identical total slippage per tier (calibration design invariant tested in `test_backtest_costs_v2.py::TestAnchorParity`).
+- **Funding-rate accounting:** per-tier conservative bps per 8h (`major=1.0`, `mid=2.0`, `small=5.0` in `costs_calibration.json`). Charged on every 8h funding interval the position is held (floor semantics: 7h pays 0, 8h pays 1, 24h pays 3). Conservative mode = always positive cost regardless of position direction.
+- **Forensic mitigation:** the DOGE -$30K single-trade case from audit H8 (#323) is mitigated >1000× under v2. v1 produced unbounded ~$19.8M per-fill cost on the catastrophically thin bar; v2 caps at $1,050. Vol-targeting in the new strategy class (below) prevents the $21K notional from being placed in the first place.
+- **Calibration sources cited in `costs_calibration.json`:** Almgren-Chriss (2001), Donier-Bonart (2015), Tóth et al (2011).
+
+### Regime-allocation strategy class (epic #338, post-Phase 1)
+Structurally distinct alternative strategy class to the LRC architecture. Mutually exclusive via `cfg.regime_allocation.enabled` (nested) or `cfg.regime_allocation_enabled` (flat, test convenience). Default **OFF** in `config.defaults.json` — opt-in only; not yet validated (Phase 2-6 pending).
+
+**Locked parameters** (§8 of epic spec):
+| Param | Value | Where |
+|---|---|---|
+| Signal | Equal-weight vote ensemble | `strategy/donchian_ensemble.py::ZARATTINI_LOOKBACKS = (5, 10, 20, 30, 60, 90, 150, 250, 360)` days |
+| Update frequency | Daily (23:00 UTC close) | `_simulate_strategy_regime_allocation` in `backtest.py` |
+| Portfolio vol target | 30% annualized | `cfg.regime_allocation.portfolio_vol_target` |
+| Sizing | Vol-targeting (replaces R-multiple) | `strategy/vol_targeting.py::compute_position_size` |
+| SHORT | Bidirectional rotational (requires perps + cross-margin) | dispatch direction sign from ensemble vote |
+| Max position per symbol | 20% of capital | `cfg.regime_allocation.max_position_pct` |
+| Leverage cap | 2x | `cfg.regime_allocation.max_leverage` (applied by portfolio orchestrator) |
+| Min position | $50 USD (Binance min) | `cfg.regime_allocation.min_position_usd` |
+| Exits | Signal-based (no SL/TP/TL) | `SIGNAL_FLIP` / `SIGNAL_EXIT` / `BANKRUPT` / `SIM_END` |
+
+**Architectural notes:**
+- When flag is on: `evaluate_signal` delegates to `_populate_regime_allocation_decision` (uses df1d only); `simulate_strategy` delegates to `_simulate_strategy_regime_allocation` (daily-update loop). LRC + trend-pullback paths are bypassed entirely.
+- When flag is off: LRC path is byte-identical (confirmed by `test_strategy_core` + `test_backtest_*` regression).
+- Single-symbol scope in `_simulate_strategy_regime_allocation`. Portfolio-level orchestration (n_active_symbols, leverage cap across symbols) is the caller's responsibility — not built in Phase 1.
+- Warmup: 390 daily bars required (longest lookback 360 + vol window 30). Symbols with shorter history return NONE with `regime_allocation_warmup` reason.
+- Cost model v2 + funding rate is the default for the regime-allocation path. Funding accrues per 8h interval the position is held (epic §8.5 SHORT bidirectional → perp dependency).
+
+**Authoritative spec doc:** `docs/superpowers/specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md` — read this before touching anything under the `regime_allocation` flag.
+
 ## Configuration
 
 **`config.json`** (root) — primary config read by both scanner and API:

--- a/backtest.py
+++ b/backtest.py
@@ -634,9 +634,21 @@ def _simulate_strategy_regime_allocation(
     )
 
     cfg = cfg or {}
-    portfolio_vol_target = float(cfg.get("portfolio_vol_target", DEFAULT_PORTFOLIO_VOL_TARGET))
-    max_position_pct = float(cfg.get("max_position_pct", DEFAULT_MAX_POSITION_PCT))
-    min_position_usd = float(cfg.get("min_position_usd", DEFAULT_MIN_POSITION_USD))
+    # Phase 1D: prefer nested `cfg.regime_allocation` block (production
+    # config.defaults.json shape), fall back to top-level keys (test convenience).
+    _ra_cfg = cfg.get("regime_allocation") if isinstance(cfg.get("regime_allocation"), dict) else {}
+
+    def _ra_param(key: str, default):
+        # nested wins if present; else top-level; else default
+        if key in _ra_cfg:
+            return _ra_cfg[key]
+        if key in cfg:
+            return cfg[key]
+        return default
+
+    portfolio_vol_target = float(_ra_param("portfolio_vol_target", DEFAULT_PORTFOLIO_VOL_TARGET))
+    max_position_pct = float(_ra_param("max_position_pct", DEFAULT_MAX_POSITION_PCT))
+    min_position_usd = float(_ra_param("min_position_usd", DEFAULT_MIN_POSITION_USD))
 
     # Cost setup — always-on by default per v2; flags allow opt-out for parity
     # testing or pure gross-PnL probes.
@@ -935,22 +947,32 @@ def simulate_strategy(df1h: pd.DataFrame, df4h: pd.DataFrame, df5m: pd.DataFrame
         Mutually exclusive with regime_thresholds.
     """
     # ── Early dispatch: regime-allocation path (epic #338 Phase 1C) ────────
-    # When `cfg.regime_allocation_enabled` is True, delegate entirely to the
+    # When regime-allocation is enabled, delegate entirely to the
     # regime-allocation simulator. LRC simulation below is bypassed.
-    if isinstance(cfg, dict) and cfg.get("regime_allocation_enabled", False):
-        return _simulate_strategy_regime_allocation(
-            df1h=df1h,
-            df1d=df1d,
-            symbol=symbol,
-            sim_start=sim_start,
-            sim_end=sim_end,
-            cfg=cfg,
-            enable_slippage=enable_slippage,
-            enable_spread=enable_spread,
-            enable_fees=enable_fees,
-            enable_funding=enable_funding,
-            cost_calibration=cost_calibration,
+    #
+    # Phase 1D: supports BOTH `cfg.regime_allocation.enabled` (nested,
+    # production config.defaults.json shape) and `cfg.regime_allocation_enabled`
+    # (flat, testing convenience).
+    if isinstance(cfg, dict):
+        _ra_nested = cfg.get("regime_allocation")
+        _ra_enabled = (
+            (isinstance(_ra_nested, dict) and _ra_nested.get("enabled", False))
+            or cfg.get("regime_allocation_enabled", False)
         )
+        if _ra_enabled:
+            return _simulate_strategy_regime_allocation(
+                df1h=df1h,
+                df1d=df1d,
+                symbol=symbol,
+                sim_start=sim_start,
+                sim_end=sim_end,
+                cfg=cfg,
+                enable_slippage=enable_slippage,
+                enable_spread=enable_spread,
+                enable_fees=enable_fees,
+                enable_funding=enable_funding,
+                cost_calibration=cost_calibration,
+            )
 
     if regime_disabled and regime_thresholds is not None:
         raise RegimeKwargError(

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -42,6 +42,13 @@
   "auto_tune": {
     "seed": 42
   },
+  "regime_allocation": {
+    "enabled": false,
+    "portfolio_vol_target": 0.30,
+    "max_position_pct": 0.20,
+    "min_position_usd": 50.0,
+    "max_leverage": 2.0
+  },
   "symbol_overrides": {
     "BTCUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 14, "max_participation_rate": 0.010,  "cooldown_hours": 14 },
     "ETHUSDT":    { "atr_sl_mult": 1.2, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 14, "max_participation_rate": 0.010,  "cooldown_hours": 14 },

--- a/strategy/core.py
+++ b/strategy/core.py
@@ -503,16 +503,27 @@ def evaluate_signal(
     decision = SignalDecision()
 
     # ── Regime-allocation dispatch (epic #338 Phase 1B) ────────────────────
-    # When `cfg.regime_allocation_enabled` is True, take the structurally
-    # distinct regime-allocation path (Donchian ensemble + vol-targeting prep
-    # via daily bars). LRC and trend-pullback paths are skipped entirely —
-    # per §0 of epic spec, regime-allocation is mutually exclusive with the
-    # legacy LRC architecture, not an overlay. Pure df1d-driven; df1h / df4h
-    # may be empty without affecting the regime-allocation outcome.
-    if isinstance(cfg, dict) and cfg.get("regime_allocation_enabled", False):
-        return _populate_regime_allocation_decision(
-            decision=decision, df1d=df1d, symbol=symbol,
+    # When regime-allocation is enabled, take the structurally distinct path
+    # (Donchian ensemble + vol-targeting prep via daily bars). LRC and
+    # trend-pullback paths are skipped entirely — per §0 of epic spec,
+    # regime-allocation is mutually exclusive with the legacy LRC architecture,
+    # not an overlay. Pure df1d-driven; df1h / df4h may be empty without
+    # affecting the regime-allocation outcome.
+    #
+    # Phase 1D: supports BOTH `cfg.regime_allocation.enabled` (nested,
+    # production config.defaults.json shape) and `cfg.regime_allocation_enabled`
+    # (flat, testing convenience for ad-hoc cfg dicts). Either path enables
+    # regime-allocation.
+    if isinstance(cfg, dict):
+        _ra_nested = cfg.get("regime_allocation")
+        _ra_enabled = (
+            (isinstance(_ra_nested, dict) and _ra_nested.get("enabled", False))
+            or cfg.get("regime_allocation_enabled", False)
         )
+        if _ra_enabled:
+            return _populate_regime_allocation_decision(
+                decision=decision, df1d=df1d, symbol=symbol,
+            )
 
     # Guard: not enough bars to compute anything useful (LRC path only).
     if len(df1h) == 0 or len(df4h) == 0:

--- a/tests/test_regime_allocation_config.py
+++ b/tests/test_regime_allocation_config.py
@@ -1,0 +1,279 @@
+"""Config integration tests for regime-allocation (epic #338 Phase 1D, part of #342).
+
+Verifies that:
+- `config.defaults.json` contains the `regime_allocation` block with the
+  expected schema and locked default values per §8 of epic spec
+- Dispatch in `evaluate_signal` and `simulate_strategy` accepts BOTH the
+  nested `cfg.regime_allocation.enabled` (production shape) AND the flat
+  `cfg.regime_allocation_enabled` (testing convenience)
+- Param resolution in `_simulate_strategy_regime_allocation` prefers nested
+  values over top-level (so production config.defaults.json is the source of
+  truth) but tolerates either shape
+"""
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+_DEFAULTS_PATH = (
+    Path(__file__).resolve().parent.parent / "config.defaults.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema: config.defaults.json has regime_allocation block with locked defaults
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDefaultsSchema:
+    def _load(self) -> dict:
+        with _DEFAULTS_PATH.open() as f:
+            return json.load(f)
+
+    def test_regime_allocation_block_present(self):
+        cfg = self._load()
+        assert "regime_allocation" in cfg
+        assert isinstance(cfg["regime_allocation"], dict)
+
+    def test_enabled_defaults_to_false(self):
+        """Production default is OFF — opt-in flag. Strategy class is not
+        yet validated (Phase 2-6 pending)."""
+        cfg = self._load()
+        assert cfg["regime_allocation"]["enabled"] is False
+
+    def test_portfolio_vol_target_locked_30pct(self):
+        """§8.3 locked 30% annualized."""
+        cfg = self._load()
+        assert cfg["regime_allocation"]["portfolio_vol_target"] == 0.30
+
+    def test_max_position_pct_locked_20pct(self):
+        """§4.3 hard cap per-symbol = 20% of capital."""
+        cfg = self._load()
+        assert cfg["regime_allocation"]["max_position_pct"] == 0.20
+
+    def test_min_position_usd_locked_50(self):
+        """Binance perp min order = $50."""
+        cfg = self._load()
+        assert cfg["regime_allocation"]["min_position_usd"] == 50.0
+
+    def test_max_leverage_locked_2x(self):
+        """§8.6 leverage cap = 2x (sum |positions| ≤ 2 × capital)."""
+        cfg = self._load()
+        assert cfg["regime_allocation"]["max_leverage"] == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Dispatch: nested cfg.regime_allocation.enabled enables the path
+# ---------------------------------------------------------------------------
+
+
+def _make_daily_df(n_days: int, closes: np.ndarray, start="2024-01-01"):
+    idx = pd.date_range(start, periods=n_days, freq="D", tz="UTC")
+    return pd.DataFrame(
+        {
+            "open": closes - 0.2,
+            "high": closes + 0.5,
+            "low": closes - 0.5,
+            "close": closes,
+            "volume": np.full(n_days, 1_000_000.0),
+        },
+        index=idx,
+    )
+
+
+def _make_hourly_df(n_hours: int, start="2024-01-01"):
+    idx = pd.date_range(start, periods=n_hours, freq="h", tz="UTC")
+    closes = np.full(n_hours, 200.0)
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": closes + 0.1,
+            "low": closes - 0.1,
+            "close": closes,
+            "volume": np.full(n_hours, 10_000.0),
+        },
+        index=idx,
+    )
+
+
+@pytest.fixture
+def daily_uptrend():
+    return _make_daily_df(500, np.arange(100.0, 600.0))
+
+
+@pytest.fixture
+def hourly_500days():
+    return _make_hourly_df(500 * 24)
+
+
+class TestNestedConfigDispatch:
+    """evaluate_signal accepts nested `cfg.regime_allocation.enabled`."""
+
+    def test_evaluate_signal_nested_true_takes_ra_path(self, daily_uptrend):
+        from strategy.core import evaluate_signal
+
+        decision = evaluate_signal(
+            df1h=pd.DataFrame(columns=["open", "high", "low", "close", "volume"]),
+            df4h=pd.DataFrame(columns=["open", "high", "low", "close", "volume"]),
+            df5m=pd.DataFrame(columns=["open", "high", "low", "close", "volume"]),
+            df1d=daily_uptrend,
+            symbol="BTCUSDT",
+            cfg={"regime_allocation": {"enabled": True}},
+            regime={"regime": "BULL"},
+        )
+        # Confirm RA path took it (regime_allocation_vote present)
+        assert "regime_allocation_vote" in decision.indicators
+        assert decision.direction == "LONG"
+
+    def test_evaluate_signal_nested_false_takes_lrc_path(self, daily_uptrend, hourly_500days):
+        from strategy.core import evaluate_signal
+
+        empty_4h = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+        empty_5m = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+        decision = evaluate_signal(
+            df1h=hourly_500days,
+            df4h=hourly_500days.iloc[::4].copy(),  # fake 4H from 1H
+            df5m=empty_5m,
+            df1d=daily_uptrend,
+            symbol="BTCUSDT",
+            cfg={"regime_allocation": {"enabled": False}},
+            regime={"regime": "BYPASS"},
+        )
+        # LRC path → no regime_allocation_vote
+        assert "regime_allocation_vote" not in decision.indicators
+        assert "lrc_pct" in decision.indicators
+
+    def test_simulate_strategy_nested_true_dispatches(self, daily_uptrend, hourly_500days):
+        from backtest import simulate_strategy
+
+        empty_4h = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+        empty_5m = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+        trades, equity = simulate_strategy(
+            df1h=hourly_500days, df4h=empty_4h, df5m=empty_5m,
+            df1d=daily_uptrend, symbol="BTCUSDT",
+            sim_start=daily_uptrend.index[391],
+            sim_end=daily_uptrend.index[-1],
+            cfg={"regime_allocation": {"enabled": True}},
+        )
+        # RA path produces trades shape
+        assert len(trades) >= 1
+        for t in trades:
+            # Regime-allocation exit reasons
+            assert t["exit_reason"] in {"SIGNAL_FLIP", "SIGNAL_EXIT", "BANKRUPT", "SIM_END"}
+            # No atr_*_mult_used (RA shape)
+            assert t["atr_sl_mult_used"] is None
+
+    def test_flat_flag_still_works_for_backward_compat(self, daily_uptrend, hourly_500days):
+        """Test convenience: `cfg.regime_allocation_enabled` (flat) still works
+        even though production config uses nested shape."""
+        from backtest import simulate_strategy
+
+        empty_4h = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+        empty_5m = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+        trades, equity = simulate_strategy(
+            df1h=hourly_500days, df4h=empty_4h, df5m=empty_5m,
+            df1d=daily_uptrend, symbol="BTCUSDT",
+            sim_start=daily_uptrend.index[391],
+            sim_end=daily_uptrend.index[-1],
+            cfg={"regime_allocation_enabled": True},  # flat — backward compat
+        )
+        assert len(trades) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Param resolution: nested params used when present
+# ---------------------------------------------------------------------------
+
+
+class TestParamResolution:
+    """`_simulate_strategy_regime_allocation` reads from nested block when
+    present, falls back to top-level keys otherwise."""
+
+    def test_nested_min_position_usd_used(self, daily_uptrend, hourly_500days):
+        """Passing nested min_position_usd changes when a trade fires.
+
+        Uses min_position_usd's cliff behavior: when the computed notional
+        falls below the threshold, the position is skipped entirely (size=0,
+        no trade). Setting min very high → no trades; setting min low →
+        trades fire. Cleaner cliff behavior than portfolio_vol_target which
+        can interact with caps.
+        """
+        from backtest import simulate_strategy
+
+        empty_4h = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+        empty_5m = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+        # min_position_usd ridiculously high → no trades fire (all positions
+        # below threshold). Confirms the nested param is being read.
+        trades_high_min, _ = simulate_strategy(
+            df1h=hourly_500days, df4h=empty_4h, df5m=empty_5m,
+            df1d=daily_uptrend, symbol="BTCUSDT",
+            sim_start=daily_uptrend.index[391], sim_end=daily_uptrend.index[-1],
+            cfg={
+                "regime_allocation": {
+                    "enabled": True,
+                    "min_position_usd": 1_000_000.0,  # impossibly high
+                }
+            },
+            enable_slippage=False, enable_spread=False, enable_fees=False,
+            enable_funding=False,
+        )
+        # min_position_usd default (50) → trades fire normally
+        trades_default_min, _ = simulate_strategy(
+            df1h=hourly_500days, df4h=empty_4h, df5m=empty_5m,
+            df1d=daily_uptrend, symbol="BTCUSDT",
+            sim_start=daily_uptrend.index[391], sim_end=daily_uptrend.index[-1],
+            cfg={"regime_allocation": {"enabled": True}},
+            enable_slippage=False, enable_spread=False, enable_fees=False,
+            enable_funding=False,
+        )
+        # High-min config → no trades fire (all below threshold)
+        assert trades_high_min == [], (
+            f"Expected zero trades with min_position_usd=$1M; got {len(trades_high_min)}"
+        )
+        # Default-min config → trades fire normally
+        assert len(trades_default_min) >= 1
+
+    def test_top_level_param_used_when_no_nested_block(self, daily_uptrend, hourly_500days):
+        """Without nested `regime_allocation` block, top-level keys are read."""
+        from backtest import simulate_strategy
+
+        empty_4h = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+        empty_5m = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+        trades, _ = simulate_strategy(
+            df1h=hourly_500days, df4h=empty_4h, df5m=empty_5m,
+            df1d=daily_uptrend, symbol="BTCUSDT",
+            sim_start=daily_uptrend.index[391], sim_end=daily_uptrend.index[-1],
+            cfg={
+                "regime_allocation_enabled": True,
+                "portfolio_vol_target": 0.40,  # top-level value
+            },
+            enable_slippage=False, enable_spread=False, enable_fees=False,
+            enable_funding=False,
+        )
+        assert trades  # should run successfully with top-level params
+
+    def test_defaults_when_no_overrides(self, daily_uptrend, hourly_500days):
+        """No nested, no top-level → falls back to module defaults
+        (30% vol, 20% per-symbol cap, $50 min)."""
+        from backtest import simulate_strategy
+
+        empty_4h = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+        empty_5m = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+        trades, _ = simulate_strategy(
+            df1h=hourly_500days, df4h=empty_4h, df5m=empty_5m,
+            df1d=daily_uptrend, symbol="BTCUSDT",
+            sim_start=daily_uptrend.index[391], sim_end=daily_uptrend.index[-1],
+            cfg={"regime_allocation_enabled": True},  # ONLY the flag, no params
+            enable_slippage=False, enable_spread=False, enable_fees=False,
+            enable_funding=False,
+        )
+        assert trades  # should run with defaults


### PR DESCRIPTION
## Summary

Phase 1D of epic #338 — final piece. Closes Phase 1 (#342) and the epic's infrastructure track.

## What this PR adds

**`config.defaults.json`** — nested `regime_allocation` block matching `kill_switch.v2` pattern:

```json
"regime_allocation": {
  "enabled": false,
  "portfolio_vol_target": 0.30,
  "max_position_pct": 0.20,
  "min_position_usd": 50.0,
  "max_leverage": 2.0
}
```

Production default = **OFF**. Opt-in only until Phase 5 holdout validation.

**Dispatch supports BOTH paths** (nested + flat) in `evaluate_signal` and `simulate_strategy`:
- `cfg.regime_allocation.enabled` (production shape)
- `cfg.regime_allocation_enabled` (backward compat for tests)

Param resolution precedence: nested → top-level → module defaults.

**CLAUDE.md** — two new sections:
1. Cost model v2 (post-Phase 0): sqrt-participation, anchor parity, funding rate, DOGE mitigation, academic citations
2. Regime-allocation strategy class: locked params table, dispatch semantics, architectural notes, spec pointer

## Tests

`tests/test_regime_allocation_config.py` — **13 new tests**:

| Class | Tests | Coverage |
|---|---:|---|
| TestConfigDefaultsSchema | 6 | block present, enabled=False default, all §8 locked values |
| TestNestedConfigDispatch | 4 | nested True dispatches; nested False = LRC; flat flag backward compat |
| TestParamResolution | 3 | nested cliff (min_position_usd), top-level fallback, bare flag defaults |

**Focused regression: 295/295 pass** including:
- Phase 1A donchian + vol-targeting (69)
- Phase 1B evaluate_signal integration (22)
- Phase 1C backtest simulation (21)
- Phase 1D config (13)
- Phase 0 cost v1+v2 (57)
- LRC core byte-identical (20)
- Holdout isolation (13)
- Plus signal_exit, trend_pullback, overshoot cap, bankruptcy regression

## Phase 1 deliverable status

Epic #338 Phase 1 is now **COMPLETE**:

- [x] Phase 0 — cost model v2 (PR #341)
- [x] Phase 1A — donchian + vol-targeting pure modules (PR #343)
- [x] Phase 1B — evaluate_signal dispatch (PR #344)
- [x] Phase 1C — backtest simulation path (PR #345)
- [x] **Phase 1D — config defaults + CLAUDE.md** (this PR)

## Next phase

**Phase 2** — pre-registration sub-spec (mirrors R1/R2/R3 pattern). Locks exact sub-window dates, primary success criterion + halt conditions, before Phase 3 sweep executes. Per epic §1.1, operator approval required before sweep.

Holdout (`data/holdout/`) remains untouched. #271 invitation guardrail still enforced under LRC; re-evaluable only if regime-allocation passes Phase 5 holdout (one-shot bala única).

## Closes

- Closes #342 (Phase 1 issue)
- Phase 1D-specific work done

## Test plan

- [x] 13/13 Phase 1D config tests pass
- [x] 295/295 focused regression pass
- [x] Nested + flat dispatch both work
- [x] LRC byte-identical via test_strategy_core
- [x] Holdout isolation unchanged
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)