### PR TITLE
feat(epic signal calibration Phase 1): observability + A1 subset + Phase 2/3/4 harness (#350)

### DIFF
--- a/data/retune/2026-05-15-signal-calibration/smoke_test.json
+++ b/data/retune/2026-05-15-signal-calibration/smoke_test.json
@@ -1,0 +1,39 @@
+{
+  "cell_args": {
+    "cutoff_iso": "2025-04-30T00:00:00+00:00",
+    "lookbacks_subset": [
+      5,
+      10,
+      20
+    ],
+    "sim_end_iso": "2022-07-01T00:00:00+00:00",
+    "sim_start_iso": "2022-04-01T00:00:00+00:00",
+    "sub_window": "A",
+    "symbol": "BTCUSDT",
+    "vol_target": 0.3
+  },
+  "cell_result": {
+    "bankruptcy_count": 0,
+    "clamped_trade_count": 0,
+    "insufficient_data": true,
+    "lookbacks_subset": [
+      5,
+      10,
+      20
+    ],
+    "max_drawdown_pct": -2.67,
+    "n_trades": 2,
+    "net_pnl_usd": 782.84,
+    "profit_factor": 6.01,
+    "sub_window": "A",
+    "symbol": "BTCUSDT",
+    "vol_target": 0.3,
+    "win_rate": 0.5
+  },
+  "code_commit": "b30f6af0b8fba6d57513fa257b5943da777f4312",
+  "elapsed_seconds": 3.53,
+  "harness_wiring_ok": true,
+  "phase": "smoke",
+  "schema_version": 1,
+  "spec_ref": "docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md"
+}

--- a/strategy/donchian_ensemble.py
+++ b/strategy/donchian_ensemble.py
@@ -264,3 +264,126 @@ def compute_ensemble_history(
     df["n_flat"] = n_lookbacks - df["n_long"] - df["n_short"]
 
     return df
+
+
+# ---------------------------------------------------------------------------
+# Epic C Phase 1 — observability instrumentation + A1 subset intervention
+# Pre-reg `docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md`
+#   §2.1 schema lock (lines 99-126) + Q-PR6 A1 subset = (5, 10, 20)
+# ---------------------------------------------------------------------------
+
+
+def emit_observability_metrics(history_df: pd.DataFrame) -> dict:
+    """Emit per-lookback + aggregate observability for Phase 2 diagnostic verdict.
+
+    Pre-reg §2.1 locks the output schema literal. Used to distinguish H-signal-A
+    (dilution: short-lookbacks fire but aggregate vote dampened by flat
+    long-lookbacks) from H-signal-B (no-firing-enough: signals barely fire at
+    any lookback). Schema rationale per pre-reg comment line 105: magnitude_*
+    fields under per_lookback are aggregate |sum| stats replicated for
+    ergonomic access — same value across all N.
+
+    Args:
+        history_df: output of `compute_ensemble_history`. Must contain
+            `dir_{N}` columns and a `vote` column.
+
+    Returns:
+        {
+            "per_lookback": {
+                N: {
+                    "lookback_days", "count_long", "count_short", "count_flat",
+                    "firing_count",
+                    "magnitude_mean", "magnitude_std",
+                    "magnitude_p50", "magnitude_p95",
+                },
+                ...
+            },
+            "sum_distribution": {
+                "mean", "std", "p25", "p50", "p75", "p95", "bars_total",
+            },
+        }
+
+    Raises:
+        ValueError: history_df is empty, missing `dir_N` columns, or missing `vote`.
+    """
+    if len(history_df) == 0:
+        raise ValueError("history_df is empty; need at least one bar")
+
+    dir_cols = [c for c in history_df.columns if c.startswith("dir_")]
+    if not dir_cols:
+        raise ValueError(
+            "history_df missing dir_N columns; pass output of compute_ensemble_history"
+        )
+
+    if "vote" not in history_df.columns:
+        raise ValueError(
+            "history_df missing 'vote' column; pass output of compute_ensemble_history"
+        )
+
+    lookbacks = sorted(int(c.removeprefix("dir_")) for c in dir_cols)
+
+    abs_vote = history_df["vote"].abs()
+    sum_distribution = {
+        "mean": float(abs_vote.mean()),
+        "std": float(abs_vote.std(ddof=0)),
+        "p25": float(abs_vote.quantile(0.25)),
+        "p50": float(abs_vote.quantile(0.50)),
+        "p75": float(abs_vote.quantile(0.75)),
+        "p95": float(abs_vote.quantile(0.95)),
+        "bars_total": int(len(history_df)),
+    }
+
+    per_lookback: dict[int, dict] = {}
+    for n in lookbacks:
+        col = history_df[f"dir_{n}"]
+        count_long = int((col == 1).sum())
+        count_short = int((col == -1).sum())
+        count_flat = int((col == 0).sum())
+        per_lookback[n] = {
+            "lookback_days": n,
+            "count_long": count_long,
+            "count_short": count_short,
+            "count_flat": count_flat,
+            "firing_count": count_long + count_short,
+            "magnitude_mean": sum_distribution["mean"],
+            "magnitude_std": sum_distribution["std"],
+            "magnitude_p50": sum_distribution["p50"],
+            "magnitude_p95": sum_distribution["p95"],
+        }
+
+    return {
+        "per_lookback": per_lookback,
+        "sum_distribution": sum_distribution,
+    }
+
+
+def apply_subset_lookbacks(
+    *,
+    closes: pd.Series,
+    highs: pd.Series,
+    lows: pd.Series,
+    lookbacks_subset: tuple[int, ...] = (5, 10, 20),
+) -> pd.DataFrame:
+    """A1 intervention: restrict Donchian ensemble to a subset of lookbacks.
+
+    Pre-reg Q-PR6 lock: default A1 subset = (5, 10, 20). Used in Phase 3 IF
+    Phase 2 verdict = A_DETECTED. Thin wrapper around `compute_ensemble_history`
+    that documents intent at the call site (epic C A-set intervention vs
+    general-purpose ensemble computation).
+
+    Args:
+        closes, highs, lows: same as `compute_ensemble_history`.
+        lookbacks_subset: tuple of lookbacks to use. Default `(5, 10, 20)` per
+            Q-PR6. Must be non-empty.
+
+    Returns:
+        DataFrame from `compute_ensemble_history(lookbacks=lookbacks_subset)`.
+
+    Raises:
+        ValueError: lookbacks_subset is empty.
+    """
+    if not lookbacks_subset:
+        raise ValueError("lookbacks_subset is empty; A1 requires ≥ 1 lookback")
+    return compute_ensemble_history(
+        closes=closes, highs=highs, lows=lows, lookbacks=lookbacks_subset,
+    )

--- a/tests/test_donchian_ensemble_observability.py
+++ b/tests/test_donchian_ensemble_observability.py
@@ -1,0 +1,346 @@
+"""Tests for emit_observability_metrics + apply_subset_lookbacks (epic C Phase 1).
+
+Locks pre-reg §2.1 schema literal + Q-PR6 A1 subset = (5, 10, 20).
+
+Schema reference (pre-reg `docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md` §2.1, lines 99-126):
+
+per_lookback[N] dict keys:
+  lookback_days, count_long, count_short, count_flat, firing_count,
+  magnitude_mean, magnitude_std, magnitude_p50, magnitude_p95
+
+sum_distribution dict keys:
+  mean, std, p25, p50, p75, p95, bars_total
+
+Magnitude fields under per_lookback are aggregate |sum| stats replicated (pre-reg
+comment line 105: `// mean of |sum| values`). Same value across all N.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from strategy.donchian_ensemble import (
+    ZARATTINI_LOOKBACKS,
+    apply_subset_lookbacks,
+    compute_ensemble_history,
+    emit_observability_metrics,
+)
+
+
+PER_LOOKBACK_KEYS = {
+    "lookback_days",
+    "count_long",
+    "count_short",
+    "count_flat",
+    "firing_count",
+    "magnitude_mean",
+    "magnitude_std",
+    "magnitude_p50",
+    "magnitude_p95",
+}
+
+SUM_DISTRIBUTION_KEYS = {
+    "mean",
+    "std",
+    "p25",
+    "p50",
+    "p75",
+    "p95",
+    "bars_total",
+}
+
+
+@pytest.fixture
+def daily_index_120():
+    """120 consecutive daily timestamps — enough for 90 + warmup tests."""
+    return pd.date_range("2024-01-01", periods=120, freq="D")
+
+
+@pytest.fixture
+def linear_uptrend_120(daily_index_120):
+    """Linear uptrend 100 → 219 over 120 days."""
+    closes = np.arange(100.0, 220.0)
+    return pd.DataFrame(
+        {"close": closes, "high": closes + 0.5, "low": closes - 0.5},
+        index=daily_index_120,
+    )
+
+
+@pytest.fixture
+def linear_downtrend_120(daily_index_120):
+    closes = np.arange(220.0, 100.0, -1.0)
+    return pd.DataFrame(
+        {"close": closes, "high": closes + 0.5, "low": closes - 0.5},
+        index=daily_index_120,
+    )
+
+
+@pytest.fixture
+def constant_price_120(daily_index_120):
+    return pd.DataFrame(
+        {"close": [100.0] * 120, "high": [100.0] * 120, "low": [100.0] * 120},
+        index=daily_index_120,
+    )
+
+
+@pytest.fixture
+def ensemble_history_uptrend(linear_uptrend_120):
+    """compute_ensemble_history output for a clean uptrend with 3 lookbacks."""
+    df = linear_uptrend_120
+    return compute_ensemble_history(
+        closes=df["close"], highs=df["high"], lows=df["low"],
+        lookbacks=(5, 10, 20),
+    )
+
+
+@pytest.fixture
+def ensemble_history_constant(constant_price_120):
+    df = constant_price_120
+    return compute_ensemble_history(
+        closes=df["close"], highs=df["high"], lows=df["low"],
+        lookbacks=(5, 10, 20),
+    )
+
+
+# ---------------------------------------------------------------------------
+# emit_observability_metrics — schema lock
+# ---------------------------------------------------------------------------
+
+
+class TestEmitObservabilityMetricsSchema:
+    def test_returns_dict_with_per_lookback_and_sum_distribution_keys(
+        self, ensemble_history_uptrend
+    ):
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        assert isinstance(out, dict)
+        assert "per_lookback" in out
+        assert "sum_distribution" in out
+
+    def test_per_lookback_keys_exact_match_schema(self, ensemble_history_uptrend):
+        """Schema locked verbatim from pre-reg §2.1 — set equality, no superset tolerance."""
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        for n, per_n in out["per_lookback"].items():
+            assert set(per_n.keys()) == PER_LOOKBACK_KEYS, (
+                f"per_lookback[{n}] keys mismatch: got {set(per_n.keys())}, "
+                f"expected {PER_LOOKBACK_KEYS}"
+            )
+
+    def test_sum_distribution_keys_exact_match_schema(self, ensemble_history_uptrend):
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        assert set(out["sum_distribution"].keys()) == SUM_DISTRIBUTION_KEYS
+
+    def test_per_lookback_includes_all_history_lookbacks(self, ensemble_history_uptrend):
+        """All dir_N columns in input df should produce a per_lookback[N] entry."""
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        assert set(out["per_lookback"].keys()) == {5, 10, 20}
+
+    def test_lookback_days_key_matches_dict_key(self, ensemble_history_uptrend):
+        """per_lookback[N]['lookback_days'] must equal N."""
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        for n, per_n in out["per_lookback"].items():
+            assert per_n["lookback_days"] == n
+
+
+# ---------------------------------------------------------------------------
+# Counts — per-lookback firing semantics
+# ---------------------------------------------------------------------------
+
+
+class TestCounts:
+    def test_constant_price_count_flat_dominant(self, ensemble_history_constant):
+        """Constant price never breaks any range → count_flat = bars_total per lookback."""
+        out = emit_observability_metrics(ensemble_history_constant)
+        bars_total = out["sum_distribution"]["bars_total"]
+        for n, per_n in out["per_lookback"].items():
+            assert per_n["count_flat"] == bars_total
+            assert per_n["count_long"] == 0
+            assert per_n["count_short"] == 0
+            assert per_n["firing_count"] == 0
+
+    def test_uptrend_count_long_dominant_post_warmup(self, ensemble_history_uptrend):
+        """In a clean linear uptrend, post-warmup all bars vote LONG."""
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        for n, per_n in out["per_lookback"].items():
+            assert per_n["count_long"] > 0
+            assert per_n["count_short"] == 0
+            assert per_n["count_long"] >= per_n["count_flat"], (
+                f"lookback {n}: expected count_long >= count_flat in uptrend; "
+                f"got long={per_n['count_long']} flat={per_n['count_flat']}"
+            )
+
+    def test_downtrend_count_short_dominant(self, linear_downtrend_120):
+        df = linear_downtrend_120
+        history = compute_ensemble_history(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+            lookbacks=(5, 10, 20),
+        )
+        out = emit_observability_metrics(history)
+        for n, per_n in out["per_lookback"].items():
+            assert per_n["count_short"] > 0
+            assert per_n["count_long"] == 0
+            assert per_n["count_short"] >= per_n["count_flat"]
+
+    def test_firing_count_equals_long_plus_short(self, ensemble_history_uptrend):
+        """firing_count := count_long + count_short (pre-reg §2.1 line 104)."""
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        for n, per_n in out["per_lookback"].items():
+            assert per_n["firing_count"] == per_n["count_long"] + per_n["count_short"]
+
+    def test_counts_sum_to_bars_total(self, ensemble_history_uptrend):
+        """count_long + count_short + count_flat == bars_total."""
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        bars_total = out["sum_distribution"]["bars_total"]
+        for n, per_n in out["per_lookback"].items():
+            total = per_n["count_long"] + per_n["count_short"] + per_n["count_flat"]
+            assert total == bars_total, f"lookback {n}: counts sum {total} != bars_total {bars_total}"
+
+
+# ---------------------------------------------------------------------------
+# Magnitudes — aggregate |sum| distribution semantics
+# ---------------------------------------------------------------------------
+
+
+class TestMagnitudes:
+    def test_constant_price_magnitude_zero(self, ensemble_history_constant):
+        """Constant price → vote always 0 → all magnitude stats are 0."""
+        out = emit_observability_metrics(ensemble_history_constant)
+        sd = out["sum_distribution"]
+        assert sd["mean"] == 0.0
+        assert sd["p25"] == 0.0
+        assert sd["p50"] == 0.0
+        assert sd["p75"] == 0.0
+        assert sd["p95"] == 0.0
+
+    def test_uptrend_aggregate_magnitude_max_lookback_count(self, ensemble_history_uptrend):
+        """3 lookbacks all LONG in uptrend → |sum| reaches max value 3."""
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        sd = out["sum_distribution"]
+        assert sd["p95"] == pytest.approx(3.0), (
+            f"Expected aggregate p95 == 3 (all 3 lookbacks LONG); got {sd['p95']}"
+        )
+
+    def test_magnitudes_replicated_in_per_lookback_dicts(self, ensemble_history_uptrend):
+        """Per-reg §2.1 schema: magnitude_* in per_lookback are aggregate |sum| stats replicated.
+
+        per_lookback[N]['magnitude_mean'] must equal sum_distribution['mean'] for all N.
+        Similarly for std, p50, p95.
+        """
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        sd = out["sum_distribution"]
+        for n, per_n in out["per_lookback"].items():
+            assert per_n["magnitude_mean"] == pytest.approx(sd["mean"]), f"lookback {n}"
+            assert per_n["magnitude_std"] == pytest.approx(sd["std"]), f"lookback {n}"
+            assert per_n["magnitude_p50"] == pytest.approx(sd["p50"]), f"lookback {n}"
+            assert per_n["magnitude_p95"] == pytest.approx(sd["p95"]), f"lookback {n}"
+
+    def test_bars_total_equals_dataframe_length(self, ensemble_history_uptrend):
+        out = emit_observability_metrics(ensemble_history_uptrend)
+        assert out["sum_distribution"]["bars_total"] == len(ensemble_history_uptrend)
+
+    def test_p25_le_p50_le_p75_le_p95(self, ensemble_history_uptrend):
+        """Percentiles must be ordered monotonically."""
+        sd = emit_observability_metrics(ensemble_history_uptrend)["sum_distribution"]
+        assert sd["p25"] <= sd["p50"] <= sd["p75"] <= sd["p95"]
+
+
+# ---------------------------------------------------------------------------
+# apply_subset_lookbacks — A1 intervention wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestApplySubsetLookbacks:
+    def test_default_subset_is_5_10_20(self, linear_uptrend_120):
+        """Q-PR6 lock: A1 default subset = (5, 10, 20)."""
+        df = linear_uptrend_120
+        out = apply_subset_lookbacks(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+        )
+        for n in (5, 10, 20):
+            assert f"dir_{n}" in out.columns
+        # Should NOT include larger lookbacks from ZARATTINI default
+        for n in (30, 60, 90, 150, 250, 360):
+            assert f"dir_{n}" not in out.columns
+
+    def test_custom_subset_propagates(self, linear_uptrend_120):
+        df = linear_uptrend_120
+        out = apply_subset_lookbacks(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+            lookbacks_subset=(10, 30),
+        )
+        assert "dir_10" in out.columns
+        assert "dir_30" in out.columns
+        assert "dir_5" not in out.columns
+
+    def test_subset_aggregate_vote_uses_only_subset(self, linear_uptrend_120):
+        """vote column == sum of subset dir_N only (max |vote| == len(subset))."""
+        df = linear_uptrend_120
+        out = apply_subset_lookbacks(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+            lookbacks_subset=(5, 10, 20),
+        )
+        # In linear uptrend, terminal bar has all 3 subset lookbacks LONG
+        assert out["vote"].iloc[-1] == 3
+        assert out["confidence"].iloc[-1] == pytest.approx(1.0)
+        assert out["direction"].iloc[-1] == 1
+
+    def test_empty_subset_raises(self, linear_uptrend_120):
+        df = linear_uptrend_120
+        with pytest.raises(ValueError, match="empty"):
+            apply_subset_lookbacks(
+                closes=df["close"], highs=df["high"], lows=df["low"],
+                lookbacks_subset=(),
+            )
+
+    def test_subset_must_be_subset_of_zarattini_or_arbitrary(self, linear_uptrend_120):
+        """Function accepts ANY tuple of valid lookbacks ≥ 2 (not limited to ZARATTINI).
+
+        Permits A2/A3/A4 future override paths per pre-reg §4.5 self-policing.
+        """
+        df = linear_uptrend_120
+        # Arbitrary lookback not in ZARATTINI default — should still work
+        out = apply_subset_lookbacks(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+            lookbacks_subset=(7, 14, 28),
+        )
+        assert "dir_7" in out.columns
+        assert "dir_14" in out.columns
+        assert "dir_28" in out.columns
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_emit_on_empty_dataframe_raises(self):
+        """Empty DataFrame is a programming error — explicit raise."""
+        empty = pd.DataFrame(columns=["dir_5", "dir_10", "dir_20", "vote"])
+        with pytest.raises(ValueError, match="empty"):
+            emit_observability_metrics(empty)
+
+    def test_emit_without_dir_columns_raises(self, daily_index_120):
+        """DataFrame missing dir_N columns is a malformed input — explicit raise."""
+        df = pd.DataFrame({"vote": [0, 1, -1]}, index=daily_index_120[:3])
+        with pytest.raises(ValueError, match="dir_"):
+            emit_observability_metrics(df)
+
+    def test_emit_without_vote_column_raises(self, daily_index_120):
+        """DataFrame missing 'vote' column → magnitudes undefined → explicit raise."""
+        df = pd.DataFrame(
+            {"dir_5": [0, 1, -1], "dir_10": [0, 1, -1]},
+            index=daily_index_120[:3],
+        )
+        with pytest.raises(ValueError, match="vote"):
+            emit_observability_metrics(df)
+
+    def test_emit_with_zarattini_9_lookbacks_all_present(self, linear_uptrend_120):
+        """Full ZARATTINI ensemble (9 lookbacks) — emit covers all 9 per_lookback entries."""
+        df = linear_uptrend_120
+        history = compute_ensemble_history(
+            closes=df["close"], highs=df["high"], lows=df["low"],
+            # Use ZARATTINI_LOOKBACKS default
+        )
+        out = emit_observability_metrics(history)
+        assert set(out["per_lookback"].keys()) == set(ZARATTINI_LOOKBACKS)
+        for n in ZARATTINI_LOOKBACKS:
+            assert out["per_lookback"][n]["lookback_days"] == n

--- a/tests/test_signal_calibration_sweep.py
+++ b/tests/test_signal_calibration_sweep.py
@@ -420,3 +420,93 @@ class TestDiagnosticRunner:
         assert cells[0]["symbol"] == "BTCUSDT"
         assert cells[0]["sum_distribution"]["p50"] == 1.5
         assert cells[1]["sum_distribution"]["p50"] == 1.8
+
+
+# ---------------------------------------------------------------------------
+# Module 4: signal_calibration_sweep.py — Phase 3 + Phase 4 runner unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSweepRunner:
+    def test_phase3_primary_jobs_8_cells_window_a_a1_vol30(self):
+        """Pre-reg §2.5 Phase 3 primary: 8 × Window A × A1 × vol=30%."""
+        from tools.signal_calibration_sweep import (
+            A1_SUBSET, build_phase3_primary_jobs,
+        )
+
+        jobs = build_phase3_primary_jobs(app_config_path="fake/path.json")
+        assert len(jobs) == 8
+        assert all(j["sub_window"] == "A" for j in jobs)
+        assert all(j["vol_target"] == 0.30 for j in jobs)
+        assert all(tuple(j["lookbacks_subset"]) == A1_SUBSET for j in jobs)
+        # A1 subset is exactly (5, 10, 20) per Q-PR6 lock
+        assert A1_SUBSET == (5, 10, 20)
+
+    def test_phase3_sensitivity_jobs_32_cells_4_vol_targets(self):
+        """Pre-reg §2.5 Phase 3 sensitivity: 8 × 4 vol_target = 32 cells."""
+        from tools.signal_calibration_sweep import (
+            SENSITIVITY_VOL_TARGETS, build_phase3_sensitivity_jobs,
+        )
+
+        jobs = build_phase3_sensitivity_jobs(app_config_path="fake/path.json")
+        assert len(jobs) == 32
+        # 4 distinct vol_targets
+        assert {j["vol_target"] for j in jobs} == set(SENSITIVITY_VOL_TARGETS)
+
+    def test_phase4_primary_jobs_17_cells_b_plus_c(self):
+        """Pre-reg §2.5 Phase 4 primary: 8 in B + 9 in C × A1 × vol=30% = 17 cells."""
+        from tools.signal_calibration_sweep import build_phase4_primary_jobs
+
+        jobs = build_phase4_primary_jobs(app_config_path="fake/path.json")
+        assert len(jobs) == 17
+        b_jobs = [j for j in jobs if j["sub_window"] == "B"]
+        c_jobs = [j for j in jobs if j["sub_window"] == "C"]
+        assert len(b_jobs) == 8
+        assert len(c_jobs) == 9
+        # Pre-reg §3 — PENDLE NOT in B (first bar AFTER B end), IS in C
+        b_symbols = {j["symbol"] for j in b_jobs}
+        c_symbols = {j["symbol"] for j in c_jobs}
+        assert "PENDLEUSDT" not in b_symbols
+        assert "PENDLEUSDT" in c_symbols
+
+    def test_aggregate_window_summary_counts_primary_passing_cells(self):
+        """aggregate_window_summary counts cells satisfying §4.2 PRIMARY conditions."""
+        from tools.signal_calibration_sweep import aggregate_window_summary
+
+        cells = [
+            # 6 cells PASS in Window B (n_trades=10, no bankruptcy, win_rate=0.40)
+            {"symbol": s, "sub_window": "B", "vol_target": 0.30,
+             "n_trades": 10, "bankruptcy_count": 0, "win_rate": 0.40}
+            for s in ("BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT", "UNIUSDT")
+        ] + [
+            # 2 cells FAIL (n_trades < 5)
+            {"symbol": s, "sub_window": "B", "vol_target": 0.30,
+             "n_trades": 2, "bankruptcy_count": 0, "win_rate": 0.40}
+            for s in ("XLMUSDT", "RUNEUSDT")
+        ]
+        summary = aggregate_window_summary(cells, "B")
+        assert summary["n_pass"] == 6
+        assert summary["n_in_coverage"] == 8
+        # 6/8 = 0.75 → just at threshold
+
+    def test_smoke_job_btc_window_a_a1(self):
+        """--smoke produces a single BTC × Window A × A1 × vol=30% job."""
+        from tools.signal_calibration_sweep import A1_SUBSET, build_smoke_job
+
+        job = build_smoke_job(app_config_path="fake/path.json")
+        assert job["symbol"] == "BTCUSDT"
+        assert job["sub_window"] == "A"
+        assert job["vol_target"] == 0.30
+        assert tuple(job["lookbacks_subset"]) == A1_SUBSET
+
+    def test_normalize_win_rate_percent_to_fraction(self):
+        """backtest returns 50.0 for 50%; normalize to 0.50 fraction for verdict layer."""
+        from tools.signal_calibration_sweep import _normalize_win_rate_to_fraction
+
+        assert _normalize_win_rate_to_fraction(50.0) == 0.50
+        assert _normalize_win_rate_to_fraction(100.0) == 1.0
+        assert _normalize_win_rate_to_fraction(0.0) == 0.0
+        # Already-fraction values are passed through (defensive, won't surface
+        # with current backtest but protects against future contract change)
+        assert _normalize_win_rate_to_fraction(0.40) == 0.40
+        assert _normalize_win_rate_to_fraction(0.30) == 0.30

--- a/tests/test_signal_calibration_sweep.py
+++ b/tests/test_signal_calibration_sweep.py
@@ -1,0 +1,333 @@
+"""Tests for tools/signal_calibration_{verdict,diagnostic,sweep}.py (epic C Phase 1).
+
+Pre-reg `docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md` §6
+locks this as the single test file covering 3 production modules. Tests are
+grouped by module:
+  - TestPhase2VerdictLogic / TestPhase3VerdictLogic / TestPhase4VerdictLogic /
+    TestAsymmetricHaltGuard   — module 2 (verdict.py, §4.1/§4.2/§4.3/§4.6)
+  - TestDiagnosticRunner      — module 3 (diagnostic.py)
+  - TestSweepRunner / TestSmoke — module 4 (sweep.py + --smoke flag)
+
+Thresholds reference (pre-reg §8 summary table + Q-PR locks):
+  T_COUNTS_FIRING       = 5     (Q-PR1)
+  P50_MAGNITUDE_MAX     = 2.0   (Q-PR2, strict `<`)
+  WIN_RATE_FLOOR        = 0.30  (Q-PR3)
+  WIN_RATE_DEGRADATION  = 0.50  (Q-PR4, intervention < 50% of baseline)
+  A1_SUBSET             = (5, 10, 20)  (Q-PR6)
+  AGGREGATE_MATCH_FRAC  = 0.75  (≥75% símbolos satisfy criterion; heredar #338)
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.signal_calibration_verdict import (
+    AGGREGATE_MATCH_FRACTION,
+    P50_MAGNITUDE_MAX,
+    T_COUNTS_FIRING,
+    WIN_RATE_DEGRADATION,
+    WIN_RATE_FLOOR,
+    apply_asymmetric_halt_guard,
+    classify_phase2_verdict,
+    classify_phase3_verdict,
+    classify_phase4_verdict,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic Phase 2 / Phase 3 / Phase 4 cell shapes
+# ---------------------------------------------------------------------------
+
+
+def _phase2_cell(symbol: str, *, firings: dict[int, int], p50_mag: float) -> dict:
+    """Construct a synthetic Phase 2 observability cell for verdict tests.
+
+    Args:
+        symbol: ticker label
+        firings: {N: firing_count} for each short-lookback in {5, 10, 20}
+        p50_mag: aggregate p50(|sum|) value over the window
+    """
+    return {
+        "symbol": symbol,
+        "per_lookback": {
+            n: {"firing_count": firings.get(n, 0)} for n in (5, 10, 20)
+        },
+        "sum_distribution": {"p50": p50_mag},
+    }
+
+
+def _phase3_cell(
+    symbol: str,
+    *,
+    n_trades: int,
+    bankruptcy_count: int,
+    win_rate: float,
+    vol_target: float = 0.30,
+) -> dict:
+    return {
+        "symbol": symbol,
+        "vol_target": vol_target,
+        "n_trades": n_trades,
+        "bankruptcy_count": bankruptcy_count,
+        "win_rate": win_rate,
+    }
+
+
+def _phase4_window_pass_summary(window_id: str, n_pass: int, n_in_coverage: int) -> dict:
+    """Summary of a single Phase 4 walk-forward window."""
+    return {
+        "window_id": window_id,
+        "n_pass": n_pass,
+        "n_in_coverage": n_in_coverage,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 verdict (§4.1 decision tree)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase2VerdictLogic:
+    def test_a_detected_8_of_8_show_both_evidence_types(self):
+        """Counts ≥5 per N∈{5,10,20} ∧ p50(|sum|) < 2 in all 8 in-coverage symbols."""
+        cells = [
+            _phase2_cell(s, firings={5: 10, 10: 8, 20: 6}, p50_mag=1.5)
+            for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE")
+        ]
+        result = classify_phase2_verdict(cells, in_coverage_count=8, halt=False)
+        assert result["verdict"] == "A_DETECTED"
+        assert result["n_symbols_a_evidence"] == 8
+
+    def test_b_detected_8_of_8_show_neither_evidence(self):
+        """Counts <5 in at least one short-lookback ∧ p50(|sum|) ≥ 2 in all 8."""
+        cells = [
+            _phase2_cell(s, firings={5: 2, 10: 1, 20: 0}, p50_mag=3.0)
+            for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE")
+        ]
+        result = classify_phase2_verdict(cells, in_coverage_count=8, halt=False)
+        assert result["verdict"] == "B_DETECTED"
+
+    def test_ambiguous_4_of_8_split(self):
+        """Pre-reg §4.1 line 290 worked example: 4 show A-evidence, 4 don't → AMBIGUOUS.
+
+        Derives from "else" clause: doesn't satisfy ≥6/8 for either A_DETECTED
+        or B_DETECTED.
+        """
+        a_cells = [
+            _phase2_cell(s, firings={5: 10, 10: 8, 20: 6}, p50_mag=1.5)
+            for s in ("BTC", "ETH", "ADA", "AVAX")
+        ]
+        b_cells = [
+            _phase2_cell(s, firings={5: 1, 10: 0, 20: 0}, p50_mag=4.0)
+            for s in ("DOGE", "UNI", "XLM", "RUNE")
+        ]
+        result = classify_phase2_verdict(a_cells + b_cells, in_coverage_count=8, halt=False)
+        assert result["verdict"] == "AMBIGUOUS"
+
+    def test_phase2_insufficient_data_when_halt_fired(self):
+        """If halt fires in Phase 2 (e.g., universal bankruptcy), verdict =
+        PHASE_2_INSUFFICIENT_DATA regardless of naive evidence pattern."""
+        cells = [
+            _phase2_cell(s, firings={5: 10, 10: 8, 20: 6}, p50_mag=1.5)
+            for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE")
+        ]
+        result = classify_phase2_verdict(cells, in_coverage_count=8, halt=True)
+        assert result["verdict"] == "PHASE_2_INSUFFICIENT_DATA"
+
+    def test_a_detected_at_exactly_6_of_8_boundary(self):
+        """≥75% threshold = ≥6 of 8 in-coverage symbols. Exactly 6 → A_DETECTED."""
+        a_cells = [
+            _phase2_cell(s, firings={5: 10, 10: 8, 20: 6}, p50_mag=1.5)
+            for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI")
+        ]
+        # 2 symbols with mixed/missing evidence
+        other_cells = [
+            _phase2_cell("XLM", firings={5: 1, 10: 0, 20: 0}, p50_mag=4.0),
+            _phase2_cell("RUNE", firings={5: 10, 10: 8, 20: 6}, p50_mag=4.0),  # counts but no mag
+        ]
+        result = classify_phase2_verdict(a_cells + other_cells, in_coverage_count=8, halt=False)
+        assert result["verdict"] == "A_DETECTED"
+        assert result["n_symbols_a_evidence"] == 6
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 verdict (§4.2 decision tree + Q-PR4 H-C4 halt)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase3VerdictLogic:
+    def test_phase3_a_pass_strong_6_of_8_with_3_of_4_sensitivity(self):
+        """≥6/8 primary PASS ∧ ≥3/4 sensitivity PASS → PHASE_3_A_PASS."""
+        primary = [
+            _phase3_cell(s, n_trades=10, bankruptcy_count=0, win_rate=0.40)
+            for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE")
+        ]
+        sensitivity = []
+        # 3/4 vol_target PASS, 1/4 FAIL
+        for vt, win_rate in zip((0.25, 0.30, 0.35, 0.40), (0.40, 0.40, 0.40, 0.20)):
+            for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE"):
+                sensitivity.append(
+                    _phase3_cell(s, n_trades=10, bankruptcy_count=0, win_rate=win_rate, vol_target=vt)
+                )
+        baseline_win_rates = {s: 0.40 for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE")}
+        result = classify_phase3_verdict(
+            primary_cells=primary,
+            sensitivity_cells=sensitivity,
+            baseline_win_rates=baseline_win_rates,
+            in_coverage_count=8,
+            halt=False,
+        )
+        assert result["verdict"] == "PHASE_3_A_PASS"
+
+    def test_a_intervention_insufficient_when_5_of_8_below_threshold(self):
+        """5/8 < 6/8 ≥75% threshold → A_INTERVENTION_INSUFFICIENT."""
+        primary = [
+            _phase3_cell(s, n_trades=10, bankruptcy_count=0, win_rate=0.40)
+            for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE")
+        ] + [
+            _phase3_cell(s, n_trades=2, bankruptcy_count=0, win_rate=0.40)  # FAIL: n_trades < 5
+            for s in ("UNI", "XLM", "RUNE")
+        ]
+        result = classify_phase3_verdict(
+            primary_cells=primary,
+            sensitivity_cells=[],
+            baseline_win_rates={s: 0.40 for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE")},
+            in_coverage_count=8,
+            halt=False,
+        )
+        assert result["verdict"] == "A_INTERVENTION_INSUFFICIENT"
+
+    def test_a_intervention_harmful_h_c3_when_bankruptcy_in_1_symbol(self):
+        """H-C3: ≥1 bankruptcy → A_INTERVENTION_HARMFUL (zero-tolerance, §10.4)."""
+        primary = [
+            _phase3_cell(s, n_trades=10, bankruptcy_count=0, win_rate=0.40)
+            for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM")
+        ] + [
+            _phase3_cell("RUNE", n_trades=10, bankruptcy_count=1, win_rate=0.40),  # bankruptcy
+        ]
+        result = classify_phase3_verdict(
+            primary_cells=primary,
+            sensitivity_cells=[],
+            baseline_win_rates={s: 0.40 for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE")},
+            in_coverage_count=8,
+            halt=False,
+        )
+        assert result["verdict"] == "A_INTERVENTION_HARMFUL"
+        assert "h_c3" in result["halt_trigger"].lower()
+
+    def test_a_intervention_harmful_h_c4_when_win_rate_degraded_in_4_of_8(self):
+        """H-C4 (Q-PR4): A1 win_rate < 50% of baseline in ≥4/8 símbolos."""
+        # Baseline win_rate = 0.40 for all; A1 < 0.20 for 4 symbols (degradation)
+        primary = [
+            _phase3_cell(s, n_trades=10, bankruptcy_count=0, win_rate=0.40)
+            for s in ("BTC", "ETH", "ADA", "AVAX")
+        ] + [
+            _phase3_cell(s, n_trades=10, bankruptcy_count=0, win_rate=0.15)  # < 50% of 0.40
+            for s in ("DOGE", "UNI", "XLM", "RUNE")
+        ]
+        result = classify_phase3_verdict(
+            primary_cells=primary,
+            sensitivity_cells=[],
+            baseline_win_rates={s: 0.40 for s in ("BTC", "ETH", "ADA", "AVAX", "DOGE", "UNI", "XLM", "RUNE")},
+            in_coverage_count=8,
+            halt=False,
+        )
+        assert result["verdict"] == "A_INTERVENTION_HARMFUL"
+        assert "h_c4" in result["halt_trigger"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 verdict (§4.3 conjunctive over Windows B + C)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase4VerdictLogic:
+    def test_phase4_pass_strong_both_b_and_c_with_strong_sensitivity(self):
+        """B PASS ∧ C PASS ∧ sensitivity 3-4/4 in both → PHASE_4_A_PASS_STRONG."""
+        window_summaries = {
+            "B": _phase4_window_pass_summary("B", n_pass=7, n_in_coverage=8),  # 7/8 ≥75%
+            "C": _phase4_window_pass_summary("C", n_pass=8, n_in_coverage=9),  # 8/9 ≥75%
+        }
+        sensitivity_per_window = {
+            "B": {"n_pass_out_of_4": 4, "n_available_out_of_4": 4},
+            "C": {"n_pass_out_of_4": 3, "n_available_out_of_4": 4},
+        }
+        result = classify_phase4_verdict(
+            window_summaries=window_summaries,
+            sensitivity_per_window=sensitivity_per_window,
+            halt=False,
+        )
+        assert result["verdict"] == "PHASE_4_A_PASS_STRONG"
+
+    def test_phase4_fail_clean_neither_window_passes(self):
+        """B FAIL ∧ C FAIL → PHASE_4_A_FAIL_CLEAN."""
+        window_summaries = {
+            "B": _phase4_window_pass_summary("B", n_pass=3, n_in_coverage=8),
+            "C": _phase4_window_pass_summary("C", n_pass=4, n_in_coverage=9),
+        }
+        sensitivity_per_window = {
+            "B": {"n_pass_out_of_4": 0, "n_available_out_of_4": 4},
+            "C": {"n_pass_out_of_4": 0, "n_available_out_of_4": 4},
+        }
+        result = classify_phase4_verdict(
+            window_summaries=window_summaries,
+            sensitivity_per_window=sensitivity_per_window,
+            halt=False,
+        )
+        assert result["verdict"] == "PHASE_4_A_FAIL_CLEAN"
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric halt-guard (§4.6 mirror)
+# ---------------------------------------------------------------------------
+
+
+class TestAsymmetricHaltGuard:
+    def test_favorable_verdict_overridden_when_halt_partial(self):
+        """Favorable naive verdict + halt + partial windows → *_INSUFFICIENT_DATA."""
+        # Phase 3 favorable (PHASE_3_A_PASS) overridden under halt
+        guarded = apply_asymmetric_halt_guard(
+            naive_verdict="PHASE_3_A_PASS",
+            halt=True,
+            n_windows_available=1,
+            n_windows_expected=1,  # Phase 3 = 1 window (A)
+            phase=3,
+        )
+        # For Phase 3, halt is what triggers override even with 1/1 window
+        assert guarded == "PHASE_3_INSUFFICIENT_DATA"
+
+    def test_negative_verdict_preserved_under_halt(self):
+        """Negative naive verdicts (FAIL_*) preserved under halt — §4.6 + R3."""
+        # FAIL_CLEAN preserved
+        guarded = apply_asymmetric_halt_guard(
+            naive_verdict="PHASE_4_A_FAIL_CLEAN",
+            halt=True,
+            n_windows_available=1,
+            n_windows_expected=2,
+            phase=4,
+        )
+        assert guarded == "PHASE_4_A_FAIL_CLEAN"
+
+        # A_INTERVENTION_INSUFFICIENT preserved
+        guarded2 = apply_asymmetric_halt_guard(
+            naive_verdict="A_INTERVENTION_INSUFFICIENT",
+            halt=True,
+            n_windows_available=1,
+            n_windows_expected=1,
+            phase=3,
+        )
+        assert guarded2 == "A_INTERVENTION_INSUFFICIENT"
+
+
+# ---------------------------------------------------------------------------
+# Threshold constants exported (sanity)
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdConstants:
+    def test_thresholds_match_q_pr_locks(self):
+        """Constants in module must equal Q-PR locked values."""
+        assert T_COUNTS_FIRING == 5  # Q-PR1
+        assert P50_MAGNITUDE_MAX == 2.0  # Q-PR2
+        assert WIN_RATE_FLOOR == 0.30  # Q-PR3
+        assert WIN_RATE_DEGRADATION == 0.50  # Q-PR4
+        assert AGGREGATE_MATCH_FRACTION == 0.75  # heredar #338 ≥75%

--- a/tests/test_signal_calibration_sweep.py
+++ b/tests/test_signal_calibration_sweep.py
@@ -510,3 +510,7 @@ class TestSweepRunner:
         # with current backtest but protects against future contract change)
         assert _normalize_win_rate_to_fraction(0.40) == 0.40
         assert _normalize_win_rate_to_fraction(0.30) == 0.30
+        # Boundary case docstring-locked: 1.0 exact is ambiguous (could be 1% or 100%).
+        # Strict `>` operator treats 1.0 as fraction (preserved as-is). Locking this
+        # behavior prevents future refactors from silently flipping the semantic.
+        assert _normalize_win_rate_to_fraction(1.0) == 1.0

--- a/tests/test_signal_calibration_sweep.py
+++ b/tests/test_signal_calibration_sweep.py
@@ -331,3 +331,92 @@ class TestThresholdConstants:
         assert WIN_RATE_FLOOR == 0.30  # Q-PR3
         assert WIN_RATE_DEGRADATION == 0.50  # Q-PR4
         assert AGGREGATE_MATCH_FRACTION == 0.75  # heredar #338 ≥75%
+
+
+# ---------------------------------------------------------------------------
+# Module 3: signal_calibration_diagnostic.py — Phase 2 runner unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticRunner:
+    def test_phase2_jobs_window_a_only_8_cells(self):
+        """build_phase2_jobs produces exactly 8 cells, all Window A, vol_target=30%."""
+        from tools.signal_calibration_diagnostic import build_phase2_jobs
+
+        jobs = build_phase2_jobs(app_config_path="fake/path.json")
+        assert len(jobs) == 8
+        assert all(j["sub_window"] == "A" for j in jobs)
+        assert all(j["vol_target"] == 0.30 for j in jobs)
+
+    def test_phase2_jobs_exclude_pendle_jup(self):
+        """Pre-reg §5.1 — PENDLE + JUP NOT in Window A coverage (warmup-fail)."""
+        from tools.signal_calibration_diagnostic import build_phase2_jobs
+
+        jobs = build_phase2_jobs(app_config_path="fake/path.json")
+        symbols = {j["symbol"] for j in jobs}
+        assert "PENDLEUSDT" not in symbols
+        assert "JUPUSDT" not in symbols
+        # Sanity: BTC + ETH ARE in coverage
+        assert "BTCUSDT" in symbols
+        assert "ETHUSDT" in symbols
+
+    def test_phase2_halt_fires_at_6_of_8_bankrupt(self):
+        """Pre-reg §10.4 — ≥6/8 bankrupt → halt=True."""
+        from tools.signal_calibration_diagnostic import check_phase2_halt
+
+        results = [
+            {"symbol": s, "sub_window": "A", "bankruptcy_count": 1, "n_trades": 0, "net_pnl_usd": -10000}
+            for s in ("BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT", "UNIUSDT")
+        ] + [
+            {"symbol": s, "sub_window": "A", "bankruptcy_count": 0, "n_trades": 5, "net_pnl_usd": 100}
+            for s in ("XLMUSDT", "RUNEUSDT")
+        ]
+        halt_diag = check_phase2_halt(results)
+        assert halt_diag["halt"] is True
+        assert halt_diag["n_symbols_bankrupt"] == 6
+
+    def test_phase2_halt_does_not_fire_at_5_of_8(self):
+        """5 < 6 threshold → halt=False."""
+        from tools.signal_calibration_diagnostic import check_phase2_halt
+
+        results = [
+            {"symbol": s, "sub_window": "A", "bankruptcy_count": 1, "n_trades": 0, "net_pnl_usd": -10000}
+            for s in ("BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT")
+        ] + [
+            {"symbol": s, "sub_window": "A", "bankruptcy_count": 0, "n_trades": 5, "net_pnl_usd": 100}
+            for s in ("UNIUSDT", "XLMUSDT", "RUNEUSDT")
+        ]
+        halt_diag = check_phase2_halt(results)
+        assert halt_diag["halt"] is False
+        assert halt_diag["n_symbols_bankrupt"] == 5
+
+    def test_aggregate_observability_cells_passes_through(self):
+        """aggregate_observability_cells extracts per_lookback + sum_distribution.
+
+        Used to feed classify_phase2_verdict downstream.
+        """
+        from tools.signal_calibration_diagnostic import aggregate_observability_cells
+
+        results = [
+            {
+                "symbol": "BTCUSDT",
+                "observability": {
+                    "per_lookback": {5: {"firing_count": 10}, 10: {"firing_count": 8}},
+                    "sum_distribution": {"p50": 1.5},
+                },
+            },
+            {
+                "symbol": "ETHUSDT",
+                "observability": {
+                    "per_lookback": {5: {"firing_count": 12}, 10: {"firing_count": 9}},
+                    "sum_distribution": {"p50": 1.8},
+                },
+            },
+            # Cell with no observability (e.g., error path) — should be skipped
+            {"symbol": "ADAUSDT", "observability": {}, "error": "fetch failed"},
+        ]
+        cells = aggregate_observability_cells(results)
+        assert len(cells) == 2  # ADA skipped
+        assert cells[0]["symbol"] == "BTCUSDT"
+        assert cells[0]["sum_distribution"]["p50"] == 1.5
+        assert cells[1]["sum_distribution"]["p50"] == 1.8

--- a/tools/signal_calibration_diagnostic.py
+++ b/tools/signal_calibration_diagnostic.py
@@ -119,6 +119,17 @@ def _finite_or(value, fallback: float) -> float:
     return v if math.isfinite(v) else fallback
 
 
+def _normalize_win_rate_to_fraction(value: float) -> float:
+    """backtest.calculate_metrics returns win_rate as percent (0-100); the verdict
+    layer (`WIN_RATE_FLOOR = 0.30`) expects fraction. Normalize at worker boundary.
+
+    Duplicated from tools/signal_calibration_sweep.py per Q-PR2 copy-modify lock
+    (modules independent at boundary). See sweep.py docstring for boundary-case
+    rationale.
+    """
+    return value / 100.0 if value > 1.0 else value
+
+
 def _get_cached_data_with_retry(symbol, timeframe, start_date):
     """get_cached_data with exponential backoff. Multiprocessing-safe (re-imports)."""
     from backtest import get_cached_data
@@ -232,6 +243,10 @@ def _process_phase2_cell(args: dict) -> dict:
     except Exception as exc:  # noqa: BLE001
         err = f"{type(exc).__name__}: {exc}"
 
+    win_rate_fraction = _normalize_win_rate_to_fraction(
+        _finite_or(metrics.get("win_rate", 0.0), 0.0)
+    )
+
     out = {
         "symbol": symbol,
         "sub_window": WINDOW_A_ID,
@@ -241,7 +256,7 @@ def _process_phase2_cell(args: dict) -> dict:
         "profit_factor": round(
             _finite_or(metrics.get("profit_factor", 0.0), _PROFIT_FACTOR_INF_SENTINEL), 4,
         ),
-        "win_rate": round(_finite_or(metrics.get("win_rate", 0.0), 0.0), 4),
+        "win_rate": round(win_rate_fraction, 4),
         "max_drawdown_pct": round(
             _finite_or(metrics.get("max_drawdown_pct", 0.0), 0.0), 4,
         ),

--- a/tools/signal_calibration_diagnostic.py
+++ b/tools/signal_calibration_diagnostic.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Signal calibration Phase 2 diagnostic runner (epic C Phase 1, module 3 of 4).
+
+Pre-reg: docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md
+
+Runs the Phase 2 diagnostic over Window A only with equal-weight Donchian-9
+baseline (heredado #338 §8.1 + §8.4) + observability emission per cell. Used
+to distinguish H-signal-A (dilution) from H-signal-B (no-firing-enough).
+
+## Sweep structure (pre-reg §2.5, Phase 2)
+  Window A only: 8 in-coverage cells × baseline equal-weight × vol_target=30%
+
+## Halt detection (pre-reg §10.4 + §4.1 row 4)
+  Universal bankruptcy: ≥6/8 in-coverage cells bankrupt → halt=True
+  Triggers verdict = PHASE_2_INSUFFICIENT_DATA via classify_phase2_verdict.
+
+## Output (data/retune/2026-05-15-signal-calibration/)
+  - phase2_diagnostic.json                 # per-cell metrics + observability
+  - observability_<symbol>_<window>.json   # 8 sidecar files
+  - phase2_verdict.json                    # verdict via classify_phase2_verdict
+  - halt_diagnostic.json                   # ALWAYS written; halt=True when fired
+  - manifest.json                          # cutoff, commit, sub-window, coverage
+
+## Usage
+  python tools/signal_calibration_diagnostic.py
+
+Exit codes:
+  0 — clean completion (or halt fired as expected)
+  1 — missing inputs / harness wiring error
+
+Copy-modified from tools/regime_allocation_sweep.py per pre-reg §11 + Q-PR2
+operator lock: helpers and constants duplicated rather than imported, to keep
+epic C and epic D independent at the module boundary.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from multiprocessing import Pool, cpu_count
+from pathlib import Path
+from typing import Final
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants — pre-reg §3 + §8 carry-forward from #338 + epic C locks
+# ─────────────────────────────────────────────────────────────────────────────
+
+WARMUP_DAILY_BARS: Final[int] = 390
+PRIMARY_VOL_TARGET: Final[float] = 0.30
+
+# Pre-reg §3 — Phase 2 runs only Window A.
+WINDOW_A_ID: Final[str] = "A"
+WINDOW_A_START_ISO: Final[str] = "2022-04-01T00:00:00+00:00"
+WINDOW_A_END_ISO: Final[str] = "2022-07-01T00:00:00+00:00"
+
+CUTOFF_ISO: Final[str] = "2025-04-30T00:00:00+00:00"
+
+# Pre-reg §3 + §5.1 — Window A coverage (8 symbols; PENDLE+JUP excluded).
+WINDOW_A_COVERAGE: Final[tuple[str, ...]] = (
+    "BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT",
+    "UNIUSDT", "XLMUSDT", "RUNEUSDT",
+)
+
+N_TRADES_MIN_FOR_ELIGIBILITY: Final[int] = 5
+
+# Pre-reg §10.4 + §4.1 row 4 — Phase 2 halt threshold (universal bankruptcy ≥75% in coverage).
+HALT_FRACTION_THRESHOLD: Final[float] = 0.75
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+OUTPUT_DIR: Final[Path] = (
+    REPO_ROOT / "data" / "retune" / "2026-05-15-signal-calibration"
+)
+APP_CONFIG_PATH_DEFAULT: Final[Path] = REPO_ROOT / "config.defaults.json"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_FETCH_RETRY_MAX_ATTEMPTS: Final[int] = 6
+_FETCH_RETRY_BASE_BACKOFF_SEC: Final[float] = 3.0
+_PROFIT_FACTOR_INF_SENTINEL: Final[float] = 99999.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers (copy-modified from regime_allocation_sweep.py per Q-PR2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _iso_to_utc_dt(iso: str) -> datetime:
+    return datetime.fromisoformat(iso).astimezone(timezone.utc)
+
+
+def _halt_count_threshold(n_in_coverage: int) -> int:
+    """`ceil(n × 0.75)` — same rounding as #338 §10.4."""
+    return math.ceil(n_in_coverage * HALT_FRACTION_THRESHOLD)
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, text=True,
+        ).strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _save_json(path: Path, payload):
+    """Write `payload` as JSON. NaN/Inf raise rather than serialize."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True, default=str, allow_nan=False)
+
+
+def _finite_or(value, fallback: float) -> float:
+    v = float(value)
+    return v if math.isfinite(v) else fallback
+
+
+def _get_cached_data_with_retry(symbol, timeframe, start_date):
+    """get_cached_data with exponential backoff. Multiprocessing-safe (re-imports)."""
+    from backtest import get_cached_data
+    from data.providers.base import AllProvidersFailedError
+
+    last_err = None
+    for attempt in range(1, _FETCH_RETRY_MAX_ATTEMPTS + 1):
+        try:
+            return get_cached_data(symbol, timeframe, start_date=start_date)
+        except AllProvidersFailedError as exc:
+            last_err = exc
+            if attempt < _FETCH_RETRY_MAX_ATTEMPTS:
+                wait = _FETCH_RETRY_BASE_BACKOFF_SEC * (2 ** (attempt - 1))
+                time.sleep(wait)
+    raise last_err
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2 worker — sim + ensemble history + observability emit
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _process_phase2_cell(args: dict) -> dict:
+    """Worker: one (symbol, Window A) Phase 2 cell.
+
+    Runs:
+      1. Loads df1h + df1d with warmup.
+      2. simulate_strategy with `cfg.regime_allocation.enabled = True` + baseline
+         9 lookbacks (no A1 subset). Returns trades + metrics + per-cell P&L.
+      3. Resamples df1h to daily + runs compute_ensemble_history (ZARATTINI 9).
+      4. Slices history to [sim_start, sim_end) + emits observability metrics.
+      5. Returns cell with metrics + nested `observability` sub-dict.
+    """
+    import pandas as pd
+    from dateutil.relativedelta import relativedelta
+
+    from backtest import calculate_metrics, simulate_strategy
+    from strategy.donchian_ensemble import (
+        compute_ensemble_history,
+        emit_observability_metrics,
+    )
+
+    symbol = args["symbol"]
+    sim_start = _iso_to_utc_dt(args["sim_start_iso"])
+    sim_end = _iso_to_utc_dt(args["sim_end_iso"])
+    cutoff = _iso_to_utc_dt(args["cutoff_iso"])
+    app_config_path = args["app_config_path"]
+
+    sim_start = sim_start.replace(tzinfo=None) if sim_start.tzinfo else sim_start
+    sim_end = sim_end.replace(tzinfo=None) if sim_end.tzinfo else sim_end
+
+    with open(app_config_path) as f:
+        app_config = json.load(f)
+
+    cfg = dict(app_config)
+    ra_block = dict(cfg.get("regime_allocation", {}))
+    ra_block["enabled"] = True
+    ra_block["portfolio_vol_target"] = PRIMARY_VOL_TARGET
+    cfg["regime_allocation"] = ra_block
+
+    empty_ohlcv = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+    err = None
+    trades: list[dict] = []
+    metrics: dict = {}
+    df1d = pd.DataFrame()
+    observability: dict = {}
+
+    try:
+        df1h = _get_cached_data_with_retry(
+            symbol, "1h", sim_start - relativedelta(months=14),
+        )
+        df1d = _get_cached_data_with_retry(
+            symbol, "1d", sim_start - relativedelta(months=14),
+        )
+
+        cutoff_naive = cutoff.replace(tzinfo=None) if cutoff.tzinfo else cutoff
+        if not df1h.empty:
+            idx = df1h.index.tz_localize(None) if df1h.index.tz is not None else df1h.index
+            df1h = df1h[idx < cutoff_naive]
+        if not df1d.empty:
+            idx = df1d.index.tz_localize(None) if df1d.index.tz is not None else df1d.index
+            df1d = df1d[idx < cutoff_naive]
+
+        if df1d.empty or len(df1d) < WARMUP_DAILY_BARS:
+            err = f"insufficient daily bars: {len(df1d)} < {WARMUP_DAILY_BARS}"
+        else:
+            trades, equity_curve = simulate_strategy(
+                df1h=df1h, df4h=empty_ohlcv, df5m=empty_ohlcv,
+                df1d=df1d, symbol=symbol,
+                sim_start=sim_start, sim_end=sim_end,
+                cfg=cfg,
+                enable_slippage=True, enable_spread=True,
+                enable_fees=True, enable_funding=True,
+            )
+            metrics = calculate_metrics(trades, equity_curve) if trades else {
+                "total_trades": 0, "net_pnl": 0.0,
+                "profit_factor": 0.0, "win_rate": 0.0,
+                "max_drawdown_pct": 0.0, "bankruptcy_count": 0,
+                "clamped_trade_count": 0,
+            }
+
+            history_df = compute_ensemble_history(
+                closes=df1d["close"], highs=df1d["high"], lows=df1d["low"],
+            )
+            in_window = history_df[
+                (history_df.index >= sim_start) & (history_df.index < sim_end)
+            ]
+            if not in_window.empty:
+                observability = emit_observability_metrics(in_window)
+    except Exception as exc:  # noqa: BLE001
+        err = f"{type(exc).__name__}: {exc}"
+
+    out = {
+        "symbol": symbol,
+        "sub_window": WINDOW_A_ID,
+        "vol_target": PRIMARY_VOL_TARGET,
+        "n_trades": int(metrics.get("total_trades", 0)),
+        "net_pnl_usd": round(float(metrics.get("net_pnl", 0.0)), 4),
+        "profit_factor": round(
+            _finite_or(metrics.get("profit_factor", 0.0), _PROFIT_FACTOR_INF_SENTINEL), 4,
+        ),
+        "win_rate": round(_finite_or(metrics.get("win_rate", 0.0), 0.0), 4),
+        "max_drawdown_pct": round(
+            _finite_or(metrics.get("max_drawdown_pct", 0.0), 0.0), 4,
+        ),
+        "bankruptcy_count": int(metrics.get("bankruptcy_count", 0)),
+        "clamped_trade_count": int(metrics.get("clamped_trade_count", 0)),
+        "insufficient_data": (
+            err is None
+            and int(metrics.get("total_trades", 0)) < N_TRADES_MIN_FOR_ELIGIBILITY
+        ),
+        "observability": observability,
+    }
+    if err is not None:
+        out["error"] = err
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Job builder + halt detection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def build_phase2_jobs(app_config_path: str) -> list[dict]:
+    """Pre-reg §2.5 Phase 2 — 8 cells × Window A × baseline equal-weight."""
+    jobs = []
+    for sym in WINDOW_A_COVERAGE:
+        jobs.append({
+            "symbol": sym,
+            "sub_window": WINDOW_A_ID,
+            "vol_target": PRIMARY_VOL_TARGET,
+            "sim_start_iso": WINDOW_A_START_ISO,
+            "sim_end_iso": WINDOW_A_END_ISO,
+            "cutoff_iso": CUTOFF_ISO,
+            "app_config_path": app_config_path,
+        })
+    return jobs
+
+
+def check_phase2_halt(phase2_results: list[dict]) -> dict:
+    """Pre-reg §10.4 + §4.1 row 4 — Phase 2 universal-bankruptcy halt.
+
+    Triggers verdict = PHASE_2_INSUFFICIENT_DATA when ≥75% of in-coverage cells
+    have at least one BANKRUPT event in the baseline run.
+    """
+    n_in_cov = len(WINDOW_A_COVERAGE)
+    threshold = _halt_count_threshold(n_in_cov)  # ≥6 of 8
+
+    a_cells = [r for r in phase2_results if r.get("sub_window") == WINDOW_A_ID]
+    bankrupt_symbols = sorted(
+        r["symbol"] for r in a_cells if int(r.get("bankruptcy_count", 0)) > 0
+    )
+    halt = len(bankrupt_symbols) >= threshold
+
+    return {
+        "halt": halt,
+        "halt_reasons": ["H_universal_bankruptcy"] if halt else [],
+        "window_evaluated": WINDOW_A_ID,
+        "vol_target_evaluated": PRIMARY_VOL_TARGET,
+        "n_in_coverage": n_in_cov,
+        "halt_count_threshold": threshold,
+        "halt_fraction_threshold": HALT_FRACTION_THRESHOLD,
+        "n_symbols_bankrupt": len(bankrupt_symbols),
+        "symbols_bankrupt": bankrupt_symbols,
+        "per_symbol_a_cell": {
+            r["symbol"]: {
+                "n_trades": r.get("n_trades", 0),
+                "bankruptcy_count": r.get("bankruptcy_count", 0),
+                "net_pnl_usd": r.get("net_pnl_usd", 0.0),
+            } for r in a_cells
+        },
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Aggregation: build observability cells list for verdict input
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def aggregate_observability_cells(phase2_results: list[dict]) -> list[dict]:
+    """Extract observability sub-dicts from each cell, keyed by symbol.
+
+    Output shape matches what `classify_phase2_verdict` expects: list of dicts
+    with `symbol`, `per_lookback` (keyed by int N), and `sum_distribution`.
+    """
+    cells = []
+    for r in phase2_results:
+        obs = r.get("observability") or {}
+        if not obs:
+            continue
+        cells.append({
+            "symbol": r["symbol"],
+            "per_lookback": obs.get("per_lookback", {}),
+            "sum_distribution": obs.get("sum_distribution", {}),
+        })
+    return cells
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--app-config", default=str(APP_CONFIG_PATH_DEFAULT),
+        help="Path to config.defaults.json (default: repo root)",
+    )
+    p.add_argument(
+        "--workers", type=int, default=min(8, cpu_count()),
+        help="Multiprocessing pool size (default: min(8, cpu_count()))",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    from tools.signal_calibration_verdict import classify_phase2_verdict
+
+    args = _parse_args()
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    jobs = build_phase2_jobs(args.app_config)
+    print(f"[phase2] {len(jobs)} cells × Window A × baseline equal-weight Donchian-9")
+
+    t_start = time.monotonic()
+    with Pool(processes=args.workers) as pool:
+        results = pool.map(_process_phase2_cell, jobs)
+    elapsed = time.monotonic() - t_start
+    print(f"[phase2] sweep done in {elapsed:.1f}s")
+
+    # Write per-cell observability sidecars
+    for r in results:
+        obs = r.get("observability") or {}
+        if obs:
+            sidecar_path = OUTPUT_DIR / f"observability_{r['symbol']}_{WINDOW_A_ID}.json"
+            _save_json(sidecar_path, obs)
+
+    # Write aggregate phase2_diagnostic.json (cell metrics + nested observability)
+    _save_json(OUTPUT_DIR / "phase2_diagnostic.json", results)
+
+    # Halt detection
+    halt_diag = check_phase2_halt(results)
+    _save_json(OUTPUT_DIR / "halt_diagnostic.json", halt_diag)
+
+    # Verdict
+    observability_cells = aggregate_observability_cells(results)
+    verdict_result = classify_phase2_verdict(
+        observability_cells,
+        in_coverage_count=len(WINDOW_A_COVERAGE),
+        halt=halt_diag["halt"],
+    )
+    _save_json(OUTPUT_DIR / "phase2_verdict.json", verdict_result)
+
+    # Manifest
+    _save_json(OUTPUT_DIR / "manifest.json", {
+        "schema_version": 1,
+        "spec_ref": "docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md",
+        "phase": 2,
+        "cutoff_iso": CUTOFF_ISO,
+        "code_commit": _git_commit(),
+        "sub_window": WINDOW_A_ID,
+        "sub_window_start_iso": WINDOW_A_START_ISO,
+        "sub_window_end_iso": WINDOW_A_END_ISO,
+        "in_coverage": list(WINDOW_A_COVERAGE),
+        "n_in_coverage": len(WINDOW_A_COVERAGE),
+        "vol_target": PRIMARY_VOL_TARGET,
+        "warmup_daily_bars": WARMUP_DAILY_BARS,
+        "elapsed_seconds": round(elapsed, 1),
+    })
+
+    print(
+        f"[phase2] verdict: {verdict_result['verdict']} "
+        f"(n_a={verdict_result.get('n_symbols_a_evidence', 0)}, "
+        f"n_not_a={verdict_result.get('n_symbols_no_a_evidence', 0)}, "
+        f"halt={halt_diag['halt']})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/signal_calibration_sweep.py
+++ b/tools/signal_calibration_sweep.py
@@ -403,8 +403,12 @@ def build_smoke_job(app_config_path: str) -> dict:
 def aggregate_window_summary(cells: list[dict], window_id: str) -> dict:
     """For Phase 4 verdict, count `n_pass` over in-coverage cells in a window.
 
-    PRIMARY conditions per cell: n_trades ≥ 5 ∧ no bankruptcies ∧ win_rate ≥ 30%.
+    Delegates PRIMARY conditions (n_trades ≥ 5 ∧ no bankruptcies ∧ win_rate ≥ 30%)
+    to `signal_calibration_verdict.primary_cell_passes` — single source of truth
+    keeps WIN_RATE_FLOOR drift impossible if tuning later changes Q-PR3 lock.
     """
+    from tools.signal_calibration_verdict import primary_cell_passes
+
     in_cov = set(COVERAGE_BY_WINDOW[window_id])
     eligible = [
         c for c in cells
@@ -412,12 +416,7 @@ def aggregate_window_summary(cells: list[dict], window_id: str) -> dict:
         and c.get("symbol") in in_cov
         and abs(float(c.get("vol_target", 0.0)) - PRIMARY_VOL_TARGET) < 1e-9
     ]
-    n_pass = sum(
-        1 for c in eligible
-        if c.get("n_trades", 0) >= 5
-        and c.get("bankruptcy_count", 0) == 0
-        and c.get("win_rate", 0.0) >= 0.30
-    )
+    n_pass = sum(1 for c in eligible if primary_cell_passes(c))
     return {
         "window_id": window_id,
         "n_pass": n_pass,
@@ -430,7 +429,12 @@ def aggregate_sensitivity_per_window(
     sensitivity_cells: list[dict],
     window_id: str,
 ) -> dict:
-    """For Phase 4 sensitivity verdict input — count vol_target PASS in this window."""
+    """For Phase 4 sensitivity verdict input — count vol_target PASS in this window.
+
+    Delegates PRIMARY conditions to `primary_cell_passes` (see aggregate_window_summary).
+    """
+    from tools.signal_calibration_verdict import primary_cell_passes
+
     in_cov = set(COVERAGE_BY_WINDOW[window_id])
     threshold = _halt_count_threshold(len(in_cov))
 
@@ -443,12 +447,7 @@ def aggregate_sensitivity_per_window(
 
     n_pass = 0
     for cells_at_vt in by_vt.values():
-        n_cells_pass = sum(
-            1 for c in cells_at_vt
-            if c.get("n_trades", 0) >= 5
-            and c.get("bankruptcy_count", 0) == 0
-            and c.get("win_rate", 0.0) >= 0.30
-        )
+        n_cells_pass = sum(1 for c in cells_at_vt if primary_cell_passes(c))
         if n_cells_pass >= threshold:
             n_pass += 1
     return {
@@ -567,6 +566,29 @@ def _run_phase4(args) -> int:
     from tools.signal_calibration_verdict import classify_phase4_verdict
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Sequencing check: Phase 4 walk-forward requires Phase 3 PASS verdict on disk.
+    # Mirrors #349 BLOCK #2 discipline + pre-reg §4.5 operator gating. Operator
+    # override = delete phase3_verdict.json (signals explicit decision to bypass).
+    phase3_verdict_path = OUTPUT_DIR / "phase3_verdict.json"
+    if not phase3_verdict_path.exists():
+        sys.stderr.write(
+            f"ERROR: {phase3_verdict_path} missing. Phase 4 walk-forward requires "
+            "Phase 3 PASS verdict; run --phase 3 first.\n"
+        )
+        return 1
+    with open(phase3_verdict_path) as f:
+        phase3_verdict_data = json.load(f)
+    phase3_verdict_label = phase3_verdict_data.get("verdict")
+    pass_set = {"PHASE_3_A_PASS", "PHASE_3_A_PASS_CONDITIONAL"}
+    if phase3_verdict_label not in pass_set:
+        sys.stderr.write(
+            f"ERROR: Phase 3 verdict = {phase3_verdict_label!r}; Phase 4 only valid "
+            f"after PASS verdicts {pass_set}. Operator override = delete "
+            "phase3_verdict.json + open sub-spec doc per pre-reg §4.5 self-policing.\n"
+        )
+        return 1
+    print(f"[phase4] Phase 3 verdict OK: {phase3_verdict_label}")
 
     primary_jobs = build_phase4_primary_jobs(args.app_config)
     print(f"[phase4] primary: {len(primary_jobs)} cells (B + C walk-forward)")

--- a/tools/signal_calibration_sweep.py
+++ b/tools/signal_calibration_sweep.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+"""Signal calibration Phase 3 + Phase 4 sweep runner (epic C Phase 1, module 4 of 4).
+
+Pre-reg: docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md
+
+Runs the Phase 3 sweep (8 + 32 cells over Window A with A1 subset {5,10,20})
+and the Phase 4 walk-forward sweep (17 + 68 cells over Windows B + C).
+Conditional on Phase 2 verdict = A_DETECTED (operator-gated via --phase). The
+--smoke flag runs a single-cell wiring check (~5-30s wall-clock) without
+touching the full sweep.
+
+## Sweep structure (pre-reg §2.5)
+
+Phase 3 primary:        8 (Window A × A1 × vol=30%)
+Phase 3 sensitivity:   32 (8 × A × A1 × 4 vol_targets)
+Phase 4 primary:       17 (8 in B + 9 in C × A1 × vol=30%)
+Phase 4 sensitivity:   68 (17 × 4 vol_targets)
+
+## Halt detection (pre-reg §10.4)
+
+H-C3 (zero-tolerance bankruptcy) and H-C4 (win_rate < 50% baseline in ≥4/8 cells)
+are evaluated by `tools/signal_calibration_verdict.py::classify_phase3_verdict`
+post-sweep. The sweep itself unconditionally writes halt_diagnostic.json.
+
+## Output (data/retune/2026-05-15-signal-calibration/)
+
+  Phase 3:
+    sweep_primary_A.json
+    sweep_sensitivity_A.json
+    phase3_verdict.json
+  Phase 4:
+    walkforward_primary_{B,C}.json
+    walkforward_sensitivity_{B,C}.json
+    walkforward_verdict.json
+  Always:
+    halt_diagnostic.json
+    manifest.json
+    smoke_test.json  (only if --smoke)
+
+## Usage
+
+  python tools/signal_calibration_sweep.py --phase 3        # Phase 3 only
+  python tools/signal_calibration_sweep.py --phase 4        # Phase 4 only
+  python tools/signal_calibration_sweep.py --smoke          # 1-cell harness check
+
+Exit codes:
+  0 — clean completion or halt fired as expected
+  1 — missing inputs / harness wiring error
+
+## A1 wiring caveat
+
+A1 subset = (5, 10, 20) is propagated through
+`cfg["regime_allocation"]["lookbacks_subset"]`. The current backtest.py path
+reads ZARATTINI_LOOKBACKS by default; whether it honors `lookbacks_subset` is
+a separate Phase 3 execution PR scope per pre-reg §6 (backtest.py out of
+Phase 1 scope). Phase 1 ships the harness; Phase 3 execution PR validates
+A1 propagation with evidence.
+
+Copy-modified from tools/regime_allocation_sweep.py per Q-PR2 operator lock.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from multiprocessing import Pool, cpu_count
+from pathlib import Path
+from typing import Final
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants — pre-reg §3 + §8 carry-forward + Q-PR6 A1 lock
+# ─────────────────────────────────────────────────────────────────────────────
+
+WARMUP_DAILY_BARS: Final[int] = 390
+PRIMARY_VOL_TARGET: Final[float] = 0.30
+SENSITIVITY_VOL_TARGETS: Final[tuple[float, ...]] = (0.25, 0.30, 0.35, 0.40)
+
+# Pre-reg Q-PR6 — A1 default intervention subset.
+A1_SUBSET: Final[tuple[int, ...]] = (5, 10, 20)
+
+# Pre-reg §3 — Phase 3 = Window A; Phase 4 = Windows B + C.
+SUB_WINDOWS: Final[dict[str, tuple[str, str]]] = {
+    "A": ("2022-04-01T00:00:00+00:00", "2022-07-01T00:00:00+00:00"),
+    "B": ("2023-04-01T00:00:00+00:00", "2023-07-01T00:00:00+00:00"),
+    "C": ("2025-01-30T00:00:00+00:00", "2025-04-30T00:00:00+00:00"),
+}
+
+CUTOFF_ISO: Final[str] = "2025-04-30T00:00:00+00:00"
+
+# Pre-reg §3 + §5.1 — coverage table.
+COVERAGE_BY_WINDOW: Final[dict[str, tuple[str, ...]]] = {
+    "A": (
+        "BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT",
+        "UNIUSDT", "XLMUSDT", "RUNEUSDT",
+    ),
+    "B": (
+        "BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT",
+        "UNIUSDT", "XLMUSDT", "RUNEUSDT",
+    ),
+    "C": (
+        "BTCUSDT", "ETHUSDT", "ADAUSDT", "AVAXUSDT", "DOGEUSDT",
+        "UNIUSDT", "XLMUSDT", "PENDLEUSDT", "RUNEUSDT",
+    ),
+}
+
+N_TRADES_MIN_FOR_ELIGIBILITY: Final[int] = 5
+HALT_FRACTION_THRESHOLD: Final[float] = 0.75
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+OUTPUT_DIR: Final[Path] = (
+    REPO_ROOT / "data" / "retune" / "2026-05-15-signal-calibration"
+)
+APP_CONFIG_PATH_DEFAULT: Final[Path] = REPO_ROOT / "config.defaults.json"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_FETCH_RETRY_MAX_ATTEMPTS: Final[int] = 6
+_FETCH_RETRY_BASE_BACKOFF_SEC: Final[float] = 3.0
+_PROFIT_FACTOR_INF_SENTINEL: Final[float] = 99999.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers (copy-modified from tools/regime_allocation_sweep.py)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _iso_to_utc_dt(iso: str) -> datetime:
+    return datetime.fromisoformat(iso).astimezone(timezone.utc)
+
+
+def _halt_count_threshold(n_in_coverage: int) -> int:
+    return math.ceil(n_in_coverage * HALT_FRACTION_THRESHOLD)
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, text=True,
+        ).strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _save_json(path: Path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True, default=str, allow_nan=False)
+
+
+def _finite_or(value, fallback: float) -> float:
+    v = float(value)
+    return v if math.isfinite(v) else fallback
+
+
+def _normalize_win_rate_to_fraction(value: float) -> float:
+    """backtest.calculate_metrics returns win_rate as percent (0-100); the verdict
+    layer (`WIN_RATE_FLOOR = 0.30`) expects fraction. Normalize at worker boundary
+    so units are consistent across the pipeline.
+
+    Boundary case `win_rate == 1.0`: ambiguous (could be "1%" or "100%"). With
+    `>` strict the value is preserved as-is, treating 1.0 as fraction. This is
+    safer than the inverse (treating 1.0 as percent would map 1% to fraction
+    0.01, FAILing the WIN_RATE_FLOOR check spuriously). Empirically backtest
+    returns either 0.0 (no trades won) or values like 50.0, 100.0 — boundary
+    case `win_rate == 1.0` exact is degenerate and unlikely.
+    """
+    return value / 100.0 if value > 1.0 else value
+
+
+def _get_cached_data_with_retry(symbol, timeframe, start_date):
+    from backtest import get_cached_data
+    from data.providers.base import AllProvidersFailedError
+
+    last_err = None
+    for attempt in range(1, _FETCH_RETRY_MAX_ATTEMPTS + 1):
+        try:
+            return get_cached_data(symbol, timeframe, start_date=start_date)
+        except AllProvidersFailedError as exc:
+            last_err = exc
+            if attempt < _FETCH_RETRY_MAX_ATTEMPTS:
+                wait = _FETCH_RETRY_BASE_BACKOFF_SEC * (2 ** (attempt - 1))
+                time.sleep(wait)
+    raise last_err
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cell worker — single parameterized worker for Phase 3 and Phase 4
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _process_sweep_cell(args: dict) -> dict:
+    """Worker: one (symbol, sub_window, vol_target) cell with A1 subset.
+
+    Propagates A1 via `cfg["regime_allocation"]["lookbacks_subset"]`. backtest.py
+    honor of that key is out of Phase 1 scope (Phase 3 execution PR).
+    """
+    import pandas as pd
+    from dateutil.relativedelta import relativedelta
+
+    from backtest import calculate_metrics, simulate_strategy
+
+    symbol = args["symbol"]
+    window_id = args["sub_window"]
+    vol_target = float(args["vol_target"])
+    sim_start = _iso_to_utc_dt(args["sim_start_iso"])
+    sim_end = _iso_to_utc_dt(args["sim_end_iso"])
+    cutoff = _iso_to_utc_dt(args["cutoff_iso"])
+    lookbacks_subset = tuple(args["lookbacks_subset"])
+    app_config_path = args["app_config_path"]
+
+    sim_start = sim_start.replace(tzinfo=None) if sim_start.tzinfo else sim_start
+    sim_end = sim_end.replace(tzinfo=None) if sim_end.tzinfo else sim_end
+
+    with open(app_config_path) as f:
+        app_config = json.load(f)
+
+    cfg = dict(app_config)
+    ra_block = dict(cfg.get("regime_allocation", {}))
+    ra_block["enabled"] = True
+    ra_block["portfolio_vol_target"] = vol_target
+    ra_block["lookbacks_subset"] = list(lookbacks_subset)  # JSON-serializable
+    cfg["regime_allocation"] = ra_block
+
+    empty_ohlcv = pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
+    err = None
+    trades: list[dict] = []
+    metrics: dict = {}
+    df1d = pd.DataFrame()
+
+    try:
+        df1h = _get_cached_data_with_retry(
+            symbol, "1h", sim_start - relativedelta(months=14),
+        )
+        df1d = _get_cached_data_with_retry(
+            symbol, "1d", sim_start - relativedelta(months=14),
+        )
+
+        cutoff_naive = cutoff.replace(tzinfo=None) if cutoff.tzinfo else cutoff
+        if not df1h.empty:
+            idx = df1h.index.tz_localize(None) if df1h.index.tz is not None else df1h.index
+            df1h = df1h[idx < cutoff_naive]
+        if not df1d.empty:
+            idx = df1d.index.tz_localize(None) if df1d.index.tz is not None else df1d.index
+            df1d = df1d[idx < cutoff_naive]
+
+        if df1d.empty or len(df1d) < WARMUP_DAILY_BARS:
+            err = f"insufficient daily bars: {len(df1d)} < {WARMUP_DAILY_BARS}"
+        else:
+            trades, equity_curve = simulate_strategy(
+                df1h=df1h, df4h=empty_ohlcv, df5m=empty_ohlcv,
+                df1d=df1d, symbol=symbol,
+                sim_start=sim_start, sim_end=sim_end,
+                cfg=cfg,
+                enable_slippage=True, enable_spread=True,
+                enable_fees=True, enable_funding=True,
+            )
+            metrics = calculate_metrics(trades, equity_curve) if trades else {
+                "total_trades": 0, "net_pnl": 0.0,
+                "profit_factor": 0.0, "win_rate": 0.0,
+                "max_drawdown_pct": 0.0, "bankruptcy_count": 0,
+                "clamped_trade_count": 0,
+            }
+    except Exception as exc:  # noqa: BLE001
+        err = f"{type(exc).__name__}: {exc}"
+
+    win_rate_fraction = _normalize_win_rate_to_fraction(
+        _finite_or(metrics.get("win_rate", 0.0), 0.0)
+    )
+
+    out = {
+        "symbol": symbol,
+        "sub_window": window_id,
+        "vol_target": vol_target,
+        "lookbacks_subset": list(lookbacks_subset),
+        "n_trades": int(metrics.get("total_trades", 0)),
+        "net_pnl_usd": round(float(metrics.get("net_pnl", 0.0)), 4),
+        "profit_factor": round(
+            _finite_or(metrics.get("profit_factor", 0.0), _PROFIT_FACTOR_INF_SENTINEL), 4,
+        ),
+        "win_rate": round(win_rate_fraction, 4),
+        "max_drawdown_pct": round(
+            _finite_or(metrics.get("max_drawdown_pct", 0.0), 0.0), 4,
+        ),
+        "bankruptcy_count": int(metrics.get("bankruptcy_count", 0)),
+        "clamped_trade_count": int(metrics.get("clamped_trade_count", 0)),
+        "insufficient_data": (
+            err is None
+            and int(metrics.get("total_trades", 0)) < N_TRADES_MIN_FOR_ELIGIBILITY
+        ),
+    }
+    if err is not None:
+        out["error"] = err
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Job builders
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def build_phase3_primary_jobs(app_config_path: str) -> list[dict]:
+    """Pre-reg §2.5 Phase 3 primary — 8 cells × Window A × A1 × vol=30%."""
+    start_iso, end_iso = SUB_WINDOWS["A"]
+    return [
+        {
+            "symbol": sym,
+            "sub_window": "A",
+            "vol_target": PRIMARY_VOL_TARGET,
+            "sim_start_iso": start_iso,
+            "sim_end_iso": end_iso,
+            "cutoff_iso": CUTOFF_ISO,
+            "lookbacks_subset": list(A1_SUBSET),
+            "app_config_path": app_config_path,
+        }
+        for sym in COVERAGE_BY_WINDOW["A"]
+    ]
+
+
+def build_phase3_sensitivity_jobs(app_config_path: str) -> list[dict]:
+    """Pre-reg §2.5 Phase 3 sensitivity — 8 × A × 4 vol_target × A1 = 32 cells."""
+    start_iso, end_iso = SUB_WINDOWS["A"]
+    return [
+        {
+            "symbol": sym,
+            "sub_window": "A",
+            "vol_target": float(vt),
+            "sim_start_iso": start_iso,
+            "sim_end_iso": end_iso,
+            "cutoff_iso": CUTOFF_ISO,
+            "lookbacks_subset": list(A1_SUBSET),
+            "app_config_path": app_config_path,
+        }
+        for sym in COVERAGE_BY_WINDOW["A"]
+        for vt in SENSITIVITY_VOL_TARGETS
+    ]
+
+
+def build_phase4_primary_jobs(app_config_path: str) -> list[dict]:
+    """Pre-reg §2.5 Phase 4 primary — (8 in B + 9 in C) × A1 × vol=30% = 17 cells."""
+    jobs = []
+    for window_id in ("B", "C"):
+        start_iso, end_iso = SUB_WINDOWS[window_id]
+        for sym in COVERAGE_BY_WINDOW[window_id]:
+            jobs.append({
+                "symbol": sym,
+                "sub_window": window_id,
+                "vol_target": PRIMARY_VOL_TARGET,
+                "sim_start_iso": start_iso,
+                "sim_end_iso": end_iso,
+                "cutoff_iso": CUTOFF_ISO,
+                "lookbacks_subset": list(A1_SUBSET),
+                "app_config_path": app_config_path,
+            })
+    return jobs
+
+
+def build_phase4_sensitivity_jobs(app_config_path: str) -> list[dict]:
+    """Pre-reg §2.5 Phase 4 sensitivity — 17 × 4 vol_target = 68 cells."""
+    jobs = []
+    for window_id in ("B", "C"):
+        start_iso, end_iso = SUB_WINDOWS[window_id]
+        for sym in COVERAGE_BY_WINDOW[window_id]:
+            for vt in SENSITIVITY_VOL_TARGETS:
+                jobs.append({
+                    "symbol": sym,
+                    "sub_window": window_id,
+                    "vol_target": float(vt),
+                    "sim_start_iso": start_iso,
+                    "sim_end_iso": end_iso,
+                    "cutoff_iso": CUTOFF_ISO,
+                    "lookbacks_subset": list(A1_SUBSET),
+                    "app_config_path": app_config_path,
+                })
+    return jobs
+
+
+def build_smoke_job(app_config_path: str) -> dict:
+    """--smoke: single cell BTC × Window A × vol=30% × A1 (~5-30s wall-clock)."""
+    start_iso, end_iso = SUB_WINDOWS["A"]
+    return {
+        "symbol": "BTCUSDT",
+        "sub_window": "A",
+        "vol_target": PRIMARY_VOL_TARGET,
+        "sim_start_iso": start_iso,
+        "sim_end_iso": end_iso,
+        "cutoff_iso": CUTOFF_ISO,
+        "lookbacks_subset": list(A1_SUBSET),
+        "app_config_path": app_config_path,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Aggregation: build window summary for Phase 4 verdict input
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def aggregate_window_summary(cells: list[dict], window_id: str) -> dict:
+    """For Phase 4 verdict, count `n_pass` over in-coverage cells in a window.
+
+    PRIMARY conditions per cell: n_trades ≥ 5 ∧ no bankruptcies ∧ win_rate ≥ 30%.
+    """
+    in_cov = set(COVERAGE_BY_WINDOW[window_id])
+    eligible = [
+        c for c in cells
+        if c.get("sub_window") == window_id
+        and c.get("symbol") in in_cov
+        and abs(float(c.get("vol_target", 0.0)) - PRIMARY_VOL_TARGET) < 1e-9
+    ]
+    n_pass = sum(
+        1 for c in eligible
+        if c.get("n_trades", 0) >= 5
+        and c.get("bankruptcy_count", 0) == 0
+        and c.get("win_rate", 0.0) >= 0.30
+    )
+    return {
+        "window_id": window_id,
+        "n_pass": n_pass,
+        "n_in_coverage": len(in_cov),
+        "n_cells_evaluated": len(eligible),
+    }
+
+
+def aggregate_sensitivity_per_window(
+    sensitivity_cells: list[dict],
+    window_id: str,
+) -> dict:
+    """For Phase 4 sensitivity verdict input — count vol_target PASS in this window."""
+    in_cov = set(COVERAGE_BY_WINDOW[window_id])
+    threshold = _halt_count_threshold(len(in_cov))
+
+    by_vt: dict[float, list[dict]] = {}
+    for c in sensitivity_cells:
+        if c.get("sub_window") != window_id or c.get("symbol") not in in_cov:
+            continue
+        vt = float(c.get("vol_target", 0.0))
+        by_vt.setdefault(vt, []).append(c)
+
+    n_pass = 0
+    for cells_at_vt in by_vt.values():
+        n_cells_pass = sum(
+            1 for c in cells_at_vt
+            if c.get("n_trades", 0) >= 5
+            and c.get("bankruptcy_count", 0) == 0
+            and c.get("win_rate", 0.0) >= 0.30
+        )
+        if n_cells_pass >= threshold:
+            n_pass += 1
+    return {
+        "n_pass_out_of_4": n_pass,
+        "n_available_out_of_4": len(by_vt),
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--phase", type=int, choices=(3, 4), default=3,
+        help="Sweep phase to run (3 = Window A primary+sens; 4 = walk-forward B+C)",
+    )
+    p.add_argument(
+        "--smoke", action="store_true",
+        help="Single-cell wiring check (BTC × Window A × A1 × vol=30%%, ~5-30s)",
+    )
+    p.add_argument(
+        "--skip-sensitivity", action="store_true",
+        help="Only run primary pass (skip 4 vol_target sweep)",
+    )
+    p.add_argument(
+        "--app-config", default=str(APP_CONFIG_PATH_DEFAULT),
+        help="Path to config.defaults.json (default: repo root)",
+    )
+    p.add_argument(
+        "--workers", type=int, default=min(8, cpu_count()),
+        help="Multiprocessing pool size (default: min(8, cpu_count()))",
+    )
+    return p.parse_args()
+
+
+def _run_smoke(args) -> int:
+    """1-cell wiring check. Writes smoke_test.json with stdout summary."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    job = build_smoke_job(args.app_config)
+    print(f"[smoke] running 1 cell: {job['symbol']} × Window {job['sub_window']} "
+          f"× vol_target={job['vol_target']} × A1={tuple(job['lookbacks_subset'])}")
+
+    t_start = time.monotonic()
+    result = _process_sweep_cell(job)
+    elapsed = time.monotonic() - t_start
+
+    smoke_payload = {
+        "schema_version": 1,
+        "spec_ref": "docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md",
+        "phase": "smoke",
+        "cell_args": {k: v for k, v in job.items() if k != "app_config_path"},
+        "cell_result": result,
+        "elapsed_seconds": round(elapsed, 2),
+        "code_commit": _git_commit(),
+        "harness_wiring_ok": "error" not in result,
+    }
+    _save_json(OUTPUT_DIR / "smoke_test.json", smoke_payload)
+
+    status = "OK" if smoke_payload["harness_wiring_ok"] else "FAIL"
+    print(f"[smoke] {status} in {elapsed:.1f}s — n_trades={result.get('n_trades', 0)}, "
+          f"net_pnl=${result.get('net_pnl_usd', 0):.2f}, "
+          f"error={result.get('error', 'none')}")
+    return 0 if smoke_payload["harness_wiring_ok"] else 1
+
+
+def _run_phase3(args) -> int:
+    from tools.signal_calibration_verdict import classify_phase3_verdict
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    primary_jobs = build_phase3_primary_jobs(args.app_config)
+    print(f"[phase3] primary: {len(primary_jobs)} cells")
+    t_start = time.monotonic()
+    with Pool(processes=args.workers) as pool:
+        primary_results = pool.map(_process_sweep_cell, primary_jobs)
+    print(f"[phase3] primary done in {time.monotonic() - t_start:.1f}s")
+    _save_json(OUTPUT_DIR / "sweep_primary_A.json", primary_results)
+
+    sensitivity_results: list[dict] = []
+    if not args.skip_sensitivity:
+        sens_jobs = build_phase3_sensitivity_jobs(args.app_config)
+        print(f"[phase3] sensitivity: {len(sens_jobs)} cells")
+        t_start = time.monotonic()
+        with Pool(processes=args.workers) as pool:
+            sensitivity_results = pool.map(_process_sweep_cell, sens_jobs)
+        print(f"[phase3] sensitivity done in {time.monotonic() - t_start:.1f}s")
+    _save_json(OUTPUT_DIR / "sweep_sensitivity_A.json", sensitivity_results)
+
+    # Load Phase 2 win_rates as Phase 3 baseline (for H-C4 check)
+    phase2_diag_path = OUTPUT_DIR / "phase2_diagnostic.json"
+    baseline_win_rates: dict[str, float] = {}
+    if phase2_diag_path.exists():
+        with open(phase2_diag_path) as f:
+            phase2_cells = json.load(f)
+        for c in phase2_cells:
+            baseline_win_rates[c["symbol"]] = float(c.get("win_rate", 0.0))
+
+    verdict_result = classify_phase3_verdict(
+        primary_results, sensitivity_results,
+        baseline_win_rates=baseline_win_rates,
+        in_coverage_count=len(COVERAGE_BY_WINDOW["A"]),
+        halt=False,  # H-C3/H-C4 checked internally by classifier
+    )
+    _save_json(OUTPUT_DIR / "phase3_verdict.json", verdict_result)
+
+    print(f"[phase3] verdict: {verdict_result['verdict']} "
+          f"(n_primary_pass={verdict_result.get('n_primary_pass', 0)}/8, "
+          f"sens_pass={verdict_result.get('n_sensitivity_vol_target_pass', 0)}/4)")
+    return 0
+
+
+def _run_phase4(args) -> int:
+    from tools.signal_calibration_verdict import classify_phase4_verdict
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    primary_jobs = build_phase4_primary_jobs(args.app_config)
+    print(f"[phase4] primary: {len(primary_jobs)} cells (B + C walk-forward)")
+    t_start = time.monotonic()
+    with Pool(processes=args.workers) as pool:
+        primary_results = pool.map(_process_sweep_cell, primary_jobs)
+    print(f"[phase4] primary done in {time.monotonic() - t_start:.1f}s")
+    # Split by window for spec-aligned output naming
+    by_window: dict[str, list[dict]] = {"B": [], "C": []}
+    for r in primary_results:
+        by_window.setdefault(r["sub_window"], []).append(r)
+    _save_json(OUTPUT_DIR / "walkforward_primary_B.json", by_window["B"])
+    _save_json(OUTPUT_DIR / "walkforward_primary_C.json", by_window["C"])
+
+    sensitivity_results: list[dict] = []
+    if not args.skip_sensitivity:
+        sens_jobs = build_phase4_sensitivity_jobs(args.app_config)
+        print(f"[phase4] sensitivity: {len(sens_jobs)} cells")
+        t_start = time.monotonic()
+        with Pool(processes=args.workers) as pool:
+            sensitivity_results = pool.map(_process_sweep_cell, sens_jobs)
+        print(f"[phase4] sensitivity done in {time.monotonic() - t_start:.1f}s")
+    sens_by_window: dict[str, list[dict]] = {"B": [], "C": []}
+    for r in sensitivity_results:
+        sens_by_window.setdefault(r["sub_window"], []).append(r)
+    _save_json(OUTPUT_DIR / "walkforward_sensitivity_B.json", sens_by_window["B"])
+    _save_json(OUTPUT_DIR / "walkforward_sensitivity_C.json", sens_by_window["C"])
+
+    window_summaries = {
+        "B": aggregate_window_summary(primary_results, "B"),
+        "C": aggregate_window_summary(primary_results, "C"),
+    }
+    sensitivity_per_window = {
+        "B": aggregate_sensitivity_per_window(sensitivity_results, "B"),
+        "C": aggregate_sensitivity_per_window(sensitivity_results, "C"),
+    }
+    verdict_result = classify_phase4_verdict(
+        window_summaries=window_summaries,
+        sensitivity_per_window=sensitivity_per_window,
+        halt=False,
+    )
+    _save_json(OUTPUT_DIR / "walkforward_verdict.json", verdict_result)
+
+    print(f"[phase4] verdict: {verdict_result['verdict']} "
+          f"(b_pass={verdict_result.get('b_pass')}, c_pass={verdict_result.get('c_pass')})")
+    return 0
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.smoke:
+        return _run_smoke(args)
+    if args.phase == 3:
+        return _run_phase3(args)
+    if args.phase == 4:
+        return _run_phase4(args)
+    sys.stderr.write(f"Unsupported phase: {args.phase}\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/signal_calibration_verdict.py
+++ b/tools/signal_calibration_verdict.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Signal calibration verdict calculator (epic C Phase 1, module 2 of 4).
+
+Pre-reg: docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md
+
+Implements verdict logic for Phase 2 (§4.1), Phase 3 (§4.2), and Phase 4 (§4.3)
+of epic C signal calibration. Mirrors the asymmetric halt-guard pattern (§4.6)
+from #338 Phase 3 verdict (`tools/regime_allocation_verdict.py`).
+
+## Phase 2 verdict (§4.1)
+  Diagnostic step over equal-weight Donchian-9 baseline in Window A:
+    A_DETECTED:                 counts_A ∧ magnitudes_A in ≥ 6/8 símbolos
+    B_DETECTED:                 ¬counts_A ∧ ¬magnitudes_A in ≥ 6/8 símbolos
+    AMBIGUOUS:                  mixed evidence (else clause; includes 4/8 split)
+    PHASE_2_INSUFFICIENT_DATA:  Phase 2 sweep halted (e.g., universal bankruptcy)
+
+## Phase 3 verdict (§4.2)
+  After A1 intervention (Q-PR6 lock: subset {5, 10, 20}) over Window A:
+    PHASE_3_A_PASS:               ≥ 6/8 primary PASS ∧ ≥ 3/4 sensitivity PASS
+    PHASE_3_A_PASS_CONDITIONAL:   ≥ 6/8 ∧ 2/4 sensitivity PASS
+    SWEET_SPOT_ARTIFACT:          ≥ 6/8 ∧ ≤ 1/4 sensitivity (calibration overfit)
+    A_INTERVENTION_INSUFFICIENT:  < 6/8 ∧ no halt
+    A_INTERVENTION_HARMFUL:       H-C3 (bankruptcy) ∨ H-C4 (win_rate degraded)
+    PHASE_3_INSUFFICIENT_DATA:    halt ∧ favorable naive (§4.6 guard)
+
+## Phase 4 verdict (§4.3)
+  Walk-forward over Windows B + C (conjunctive PASS):
+    PHASE_4_A_PASS_STRONG:        B PASS ∧ C PASS ∧ sensitivity 3-4/4 in both
+    PHASE_4_A_PASS_ROBUST:        B PASS ∧ C PASS ∧ sensitivity 2/4 in both
+    PHASE_4_A_PASS_PARTIAL:       B XOR C PASS (only one window passes)
+    PHASE_4_A_FAIL_CLEAN:         neither window PASS
+    PHASE_4_INSUFFICIENT_DATA:    halt ∧ favorable naive ∧ partial (§4.6 guard)
+
+## §4.6 asymmetric halt-guard
+  Favorable naive verdicts are overridden to PHASE_X_INSUFFICIENT_DATA under
+  halt. Negative naive verdicts are preserved. Phase 2/3 are single-window
+  (halt alone = partial). Phase 4 additionally requires partial windows
+  (n_windows_available < n_windows_expected).
+
+## Thresholds (Q-PR locks)
+  T_COUNTS_FIRING         = 5     (Q-PR1)
+  P50_MAGNITUDE_MAX       = 2.0   (Q-PR2, strict `<`)
+  WIN_RATE_FLOOR          = 0.30  (Q-PR3)
+  WIN_RATE_DEGRADATION    = 0.50  (Q-PR4, intervention < 50% of baseline)
+  AGGREGATE_MATCH_FRACTION = 0.75 (≥ 75% símbolos satisfy criterion)
+
+This module exposes the verdict classifiers as pure functions for unit testing
+and for orchestration by tools/signal_calibration_diagnostic.py (Phase 2 runner)
+and tools/signal_calibration_sweep.py (Phase 3 + Phase 4 runner). A CLI main
+is also provided for post-hoc verdict computation over sweep outputs.
+"""
+from __future__ import annotations
+
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Final
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Constants — Q-PR locks (pre-reg §8)
+# ─────────────────────────────────────────────────────────────────────────────
+
+T_COUNTS_FIRING: Final[int] = 5
+P50_MAGNITUDE_MAX: Final[float] = 2.0
+WIN_RATE_FLOOR: Final[float] = 0.30
+WIN_RATE_DEGRADATION: Final[float] = 0.50
+AGGREGATE_MATCH_FRACTION: Final[float] = 0.75
+
+SHORT_LOOKBACKS_FOR_COUNTS: Final[tuple[int, ...]] = (5, 10, 20)
+
+# Pre-reg §10.4 halt thresholds
+H_C3_BANKRUPTCY_THRESHOLD: Final[int] = 1
+H_C4_DEGRADED_CELL_COUNT: Final[int] = 4
+
+# Pre-reg §4.6 — favorable verdicts overridable under halt
+FAVORABLE_VERDICTS_OVERRIDABLE: Final[frozenset[str]] = frozenset({
+    "A_DETECTED",
+    "PHASE_3_A_PASS",
+    "PHASE_3_A_PASS_CONDITIONAL",
+    "PHASE_4_A_PASS_STRONG",
+    "PHASE_4_A_PASS_ROBUST",
+    "PHASE_4_A_PASS_PARTIAL",
+})
+
+# Output dir for verdict.json artifact (when invoked via CLI main)
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+OUTPUT_DIR: Final[Path] = (
+    REPO_ROOT / "data" / "retune" / "2026-05-15-signal-calibration"
+)
+
+
+def _aggregate_match_threshold(in_coverage_count: int) -> int:
+    """`ceil(AGGREGATE_MATCH_FRACTION × in_coverage_count)`, minimum 1.
+
+    Example: 8 in-coverage → 6; 9 in-coverage → 7. Matches pre-reg §4.3
+    coverage table thresholds (B≥6, C≥7).
+    """
+    return max(1, math.ceil(AGGREGATE_MATCH_FRACTION * in_coverage_count))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2 verdict (§4.1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _counts_a_evidence_per_cell(cell: dict) -> bool:
+    """Pre-reg §4.1 + Q-PR1: firing_count(N) ≥ T for N ∈ {5, 10, 20}, conjunctive."""
+    per_lookback = cell.get("per_lookback", {})
+    for n in SHORT_LOOKBACKS_FOR_COUNTS:
+        if per_lookback.get(n, {}).get("firing_count", 0) < T_COUNTS_FIRING:
+            return False
+    return True
+
+
+def _magnitudes_a_evidence_per_cell(cell: dict) -> bool:
+    """Pre-reg §4.1 + Q-PR2: p50(|sum|) < 2 over window (strict `<`)."""
+    p50 = cell.get("sum_distribution", {}).get("p50", float("inf"))
+    return p50 < P50_MAGNITUDE_MAX
+
+
+def classify_phase2_verdict(
+    observability_cells: list[dict],
+    *,
+    in_coverage_count: int,
+    halt: bool,
+) -> dict:
+    """Phase 2 diagnostic verdict (pre-reg §4.1).
+
+    Args:
+        observability_cells: list of per-symbol observability dicts. Each must
+            have keys `symbol`, `per_lookback` (with `firing_count` per N), and
+            `sum_distribution` (with `p50`).
+        in_coverage_count: total in-coverage symbols expected (e.g., 8 for Window A).
+        halt: True if Phase 2 sweep halted before completion.
+
+    Returns dict with `verdict`, `naive_verdict`, `n_symbols_a_evidence`,
+    `n_symbols_no_a_evidence`, `n_symbols_total`, `threshold`, `halt`,
+    `halt_guard_applied`.
+    """
+    if halt:
+        return {
+            "verdict": "PHASE_2_INSUFFICIENT_DATA",
+            "naive_verdict": None,
+            "n_symbols_a_evidence": 0,
+            "n_symbols_no_a_evidence": 0,
+            "n_symbols_total": len(observability_cells),
+            "threshold": _aggregate_match_threshold(in_coverage_count),
+            "halt": True,
+            "halt_guard_applied": True,
+        }
+
+    threshold = _aggregate_match_threshold(in_coverage_count)
+
+    n_a = 0
+    n_not_a = 0
+    for cell in observability_cells:
+        counts_a = _counts_a_evidence_per_cell(cell)
+        mag_a = _magnitudes_a_evidence_per_cell(cell)
+        if counts_a and mag_a:
+            n_a += 1
+        elif (not counts_a) and (not mag_a):
+            n_not_a += 1
+
+    if n_a >= threshold:
+        naive = "A_DETECTED"
+    elif n_not_a >= threshold:
+        naive = "B_DETECTED"
+    else:
+        naive = "AMBIGUOUS"
+
+    return {
+        "verdict": naive,
+        "naive_verdict": naive,
+        "n_symbols_a_evidence": n_a,
+        "n_symbols_no_a_evidence": n_not_a,
+        "n_symbols_total": len(observability_cells),
+        "threshold": threshold,
+        "halt": False,
+        "halt_guard_applied": False,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3 verdict (§4.2 + H-C3/H-C4 from §10.4)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _primary_cell_passes(cell: dict) -> bool:
+    """Pre-reg §4.2 PRIMARY conditions per cell:
+      n_trades ≥ 5 ∧ no bankruptcies ∧ win_rate ≥ 30% (Q-PR3).
+    """
+    return (
+        cell.get("n_trades", 0) >= 5
+        and cell.get("bankruptcy_count", 0) == 0
+        and cell.get("win_rate", 0.0) >= WIN_RATE_FLOOR
+    )
+
+
+def _check_h_c3(primary_cells: list[dict]) -> int:
+    """Pre-reg §10.4 H-C3: zero-tolerance bankruptcy. Returns count of bankrupt cells."""
+    return sum(1 for c in primary_cells if c.get("bankruptcy_count", 0) > 0)
+
+
+def _check_h_c4(
+    primary_cells: list[dict],
+    baseline_win_rates: dict[str, float],
+) -> int:
+    """Pre-reg §10.4 H-C4 + Q-PR4: count of cells where intervention win_rate < 50% of baseline."""
+    n = 0
+    for cell in primary_cells:
+        baseline = baseline_win_rates.get(cell.get("symbol", ""), 0.0)
+        if baseline > 0 and cell.get("win_rate", 0.0) < WIN_RATE_DEGRADATION * baseline:
+            n += 1
+    return n
+
+
+def _count_sensitivity_vol_target_pass(
+    sensitivity_cells: list[dict],
+    in_coverage_count: int,
+) -> int:
+    """For each vol_target, count if ≥ 75% cells PASS primary; return count out of 4."""
+    threshold = _aggregate_match_threshold(in_coverage_count)
+    by_vt: dict[float, list[dict]] = {}
+    for cell in sensitivity_cells:
+        vt = cell.get("vol_target", 0.0)
+        by_vt.setdefault(vt, []).append(cell)
+
+    n_pass = 0
+    for cells in by_vt.values():
+        n_cells_pass = sum(1 for c in cells if _primary_cell_passes(c))
+        if n_cells_pass >= threshold:
+            n_pass += 1
+    return n_pass
+
+
+def classify_phase3_verdict(
+    primary_cells: list[dict],
+    sensitivity_cells: list[dict],
+    *,
+    baseline_win_rates: dict[str, float],
+    in_coverage_count: int,
+    halt: bool,
+) -> dict:
+    """Phase 3 verdict after A1 intervention (pre-reg §4.2).
+
+    Order of checks:
+      1. H-C3 (bankruptcy in primary) → A_INTERVENTION_HARMFUL
+      2. H-C4 (win_rate degradation ≥ 4 cells) → A_INTERVENTION_HARMFUL
+      3. External halt → asymmetric guard
+      4. Standard verdict logic (primary ≥ 6/8 + sensitivity tier)
+
+    Args:
+        primary_cells: in-coverage cells × Window A × vol_target=0.30.
+        sensitivity_cells: in-coverage × Window A × 4 vol_target.
+        baseline_win_rates: `{symbol → equal-weight baseline win_rate}` from Phase 2.
+        in_coverage_count: expected coverage (e.g., 8 for Window A).
+        halt: external halt signal.
+    """
+    n_bankrupt = _check_h_c3(primary_cells)
+    if n_bankrupt >= H_C3_BANKRUPTCY_THRESHOLD:
+        return {
+            "verdict": "A_INTERVENTION_HARMFUL",
+            "naive_verdict": "A_INTERVENTION_HARMFUL",
+            "halt_trigger": "H_C3_bankruptcy",
+            "halt_guard_applied": False,
+            "n_bankrupt_cells": n_bankrupt,
+            "n_primary_pass": 0,
+            "n_sensitivity_vol_target_pass": 0,
+            "halt": halt,
+        }
+
+    n_degraded = _check_h_c4(primary_cells, baseline_win_rates)
+    if n_degraded >= H_C4_DEGRADED_CELL_COUNT:
+        return {
+            "verdict": "A_INTERVENTION_HARMFUL",
+            "naive_verdict": "A_INTERVENTION_HARMFUL",
+            "halt_trigger": "H_C4_win_rate_degradation",
+            "halt_guard_applied": False,
+            "n_degraded_cells": n_degraded,
+            "n_primary_pass": 0,
+            "n_sensitivity_vol_target_pass": 0,
+            "halt": halt,
+        }
+
+    threshold = _aggregate_match_threshold(in_coverage_count)
+    n_pass = sum(1 for c in primary_cells if _primary_cell_passes(c))
+    n_sens_pass = _count_sensitivity_vol_target_pass(sensitivity_cells, in_coverage_count)
+
+    if n_pass >= threshold:
+        if n_sens_pass >= 3:
+            naive = "PHASE_3_A_PASS"
+        elif n_sens_pass == 2:
+            naive = "PHASE_3_A_PASS_CONDITIONAL"
+        else:
+            naive = "SWEET_SPOT_ARTIFACT"
+    else:
+        naive = "A_INTERVENTION_INSUFFICIENT"
+
+    final_verdict = apply_asymmetric_halt_guard(
+        naive_verdict=naive,
+        halt=halt,
+        n_windows_available=1,
+        n_windows_expected=1,
+        phase=3,
+    )
+
+    return {
+        "verdict": final_verdict,
+        "naive_verdict": naive,
+        "halt_guard_applied": final_verdict != naive,
+        "halt_trigger": None,
+        "n_primary_pass": n_pass,
+        "n_sensitivity_vol_target_pass": n_sens_pass,
+        "threshold": threshold,
+        "halt": halt,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 4 verdict (§4.3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _window_pass(summary: dict) -> bool:
+    """Pre-reg §4.3 — single-window PASS: `n_pass / n_in_coverage ≥ 0.75`."""
+    n_in_cov = summary.get("n_in_coverage", 0)
+    if n_in_cov == 0:
+        return False
+    n_pass = summary.get("n_pass", 0)
+    return (n_pass / n_in_cov) >= AGGREGATE_MATCH_FRACTION
+
+
+def classify_phase4_verdict(
+    *,
+    window_summaries: dict[str, dict],
+    sensitivity_per_window: dict[str, dict],
+    halt: bool,
+) -> dict:
+    """Phase 4 walk-forward verdict over Windows B + C (pre-reg §4.3).
+
+    Args:
+        window_summaries: `{window_id → {"n_pass", "n_in_coverage"}}`. Keys B/C.
+        sensitivity_per_window: `{window_id → {"n_pass_out_of_4", "n_available_out_of_4"}}`.
+        halt: external halt signal.
+    """
+    available_windows = sorted(window_summaries.keys())
+    n_windows_available = len(available_windows)
+    n_windows_expected = 2  # B + C
+
+    b_pass = "B" in window_summaries and _window_pass(window_summaries["B"])
+    c_pass = "C" in window_summaries and _window_pass(window_summaries["C"])
+
+    if b_pass and c_pass:
+        b_sens = sensitivity_per_window.get("B", {}).get("n_pass_out_of_4", 0)
+        c_sens = sensitivity_per_window.get("C", {}).get("n_pass_out_of_4", 0)
+        if b_sens >= 3 and c_sens >= 3:
+            naive = "PHASE_4_A_PASS_STRONG"
+        elif b_sens >= 2 and c_sens >= 2:
+            naive = "PHASE_4_A_PASS_ROBUST"
+        else:
+            naive = "PHASE_4_A_PASS_PARTIAL"
+    elif b_pass or c_pass:
+        naive = "PHASE_4_A_PASS_PARTIAL"
+    else:
+        naive = "PHASE_4_A_FAIL_CLEAN"
+
+    final_verdict = apply_asymmetric_halt_guard(
+        naive_verdict=naive,
+        halt=halt,
+        n_windows_available=n_windows_available,
+        n_windows_expected=n_windows_expected,
+        phase=4,
+    )
+
+    return {
+        "verdict": final_verdict,
+        "naive_verdict": naive,
+        "halt_guard_applied": final_verdict != naive,
+        "n_windows_available": n_windows_available,
+        "n_windows_expected": n_windows_expected,
+        "b_pass": b_pass,
+        "c_pass": c_pass,
+        "halt": halt,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# §4.6 asymmetric halt-guard
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def apply_asymmetric_halt_guard(
+    *,
+    naive_verdict: str,
+    halt: bool,
+    n_windows_available: int,
+    n_windows_expected: int,
+    phase: int,
+) -> str:
+    """Pre-reg §4.6 — favorable verdicts overridden under halt + partial windows.
+
+    Phase 2/3 are single-window: halt alone triggers override on favorable naive.
+    Phase 4 requires halt + `n_windows_available < n_windows_expected`.
+    Negative verdicts are preserved in both cases.
+
+    Args:
+        naive_verdict: pre-guard verdict label.
+        halt: external halt signal.
+        n_windows_available: windows actually evaluated.
+        n_windows_expected: windows expected at this phase.
+        phase: 2, 3, or 4.
+    """
+    if not halt:
+        return naive_verdict
+    if naive_verdict not in FAVORABLE_VERDICTS_OVERRIDABLE:
+        return naive_verdict
+    if phase in (2, 3):
+        return f"PHASE_{phase}_INSUFFICIENT_DATA"
+    if phase == 4 and n_windows_available < n_windows_expected:
+        return "PHASE_4_INSUFFICIENT_DATA"
+    return naive_verdict
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI main — verdict.json emitter from sweep outputs
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _load_json(name: str):
+    path = OUTPUT_DIR / name
+    if not path.exists():
+        return None
+    with open(path) as f:
+        return json.load(f)
+
+
+def main() -> int:
+    """Compute verdict from sweep outputs in OUTPUT_DIR. Writes verdict.json.
+
+    Exit codes:
+      0 — verdict computed
+      1 — required inputs missing
+    """
+    phase2_diag = _load_json("phase2_diagnostic.json")
+    phase3_primary = _load_json("sweep_primary_A.json")
+    phase3_sensitivity = _load_json("sweep_sensitivity_A.json")
+    halt_diag = _load_json("halt_diagnostic.json")
+    halt = bool(halt_diag.get("halt", False)) if isinstance(halt_diag, dict) else False
+
+    out: dict = {
+        "schema_version": 1,
+        "spec_ref": "docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md",
+        "halt_fired": halt,
+        "halt_diagnostic_loaded": halt_diag is not None,
+    }
+
+    if phase2_diag is not None and isinstance(phase2_diag, list):
+        phase2_result = classify_phase2_verdict(
+            phase2_diag, in_coverage_count=8, halt=halt,
+        )
+        out["phase2"] = phase2_result
+
+    if phase3_primary is not None and isinstance(phase3_primary, list):
+        phase3_result = classify_phase3_verdict(
+            phase3_primary,
+            phase3_sensitivity if isinstance(phase3_sensitivity, list) else [],
+            baseline_win_rates={},
+            in_coverage_count=8,
+            halt=halt,
+        )
+        out["phase3"] = phase3_result
+
+    if not out.get("phase2") and not out.get("phase3"):
+        sys.stderr.write(
+            "ERROR: no Phase 2 or Phase 3 sweep results found in "
+            f"{OUTPUT_DIR}. Run tools/signal_calibration_diagnostic.py "
+            "or tools/signal_calibration_sweep.py first.\n"
+        )
+        return 1
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    with open(OUTPUT_DIR / "verdict.json", "w") as f:
+        json.dump(out, f, indent=2, sort_keys=True, default=str, allow_nan=False)
+    print(f"Wrote {OUTPUT_DIR / 'verdict.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/signal_calibration_verdict.py
+++ b/tools/signal_calibration_verdict.py
@@ -186,7 +186,7 @@ def classify_phase2_verdict(
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _primary_cell_passes(cell: dict) -> bool:
+def primary_cell_passes(cell: dict) -> bool:
     """Pre-reg §4.2 PRIMARY conditions per cell:
       n_trades ≥ 5 ∧ no bankruptcies ∧ win_rate ≥ 30% (Q-PR3).
     """
@@ -228,7 +228,7 @@ def _count_sensitivity_vol_target_pass(
 
     n_pass = 0
     for cells in by_vt.values():
-        n_cells_pass = sum(1 for c in cells if _primary_cell_passes(c))
+        n_cells_pass = sum(1 for c in cells if primary_cell_passes(c))
         if n_cells_pass >= threshold:
             n_pass += 1
     return n_pass
@@ -284,7 +284,7 @@ def classify_phase3_verdict(
         }
 
     threshold = _aggregate_match_threshold(in_coverage_count)
-    n_pass = sum(1 for c in primary_cells if _primary_cell_passes(c))
+    n_pass = sum(1 for c in primary_cells if primary_cell_passes(c))
     n_sens_pass = _count_sensitivity_vol_target_pass(sensitivity_cells, in_coverage_count)
 
     if n_pass >= threshold:
@@ -462,10 +462,20 @@ def main() -> int:
         out["phase2"] = phase2_result
 
     if phase3_primary is not None and isinstance(phase3_primary, list):
+        # Load baseline win_rates from Phase 2 diagnostic so H-C4 (intervention
+        # win_rate < 50% of baseline) can fire if applicable. Without this load
+        # the CLI silently disabled H-C4 — sweep tool's _run_phase3 does the same
+        # extraction (single source of truth: phase2_diagnostic.json).
+        baseline_win_rates: dict[str, float] = {}
+        if phase2_diag is not None and isinstance(phase2_diag, list):
+            for c in phase2_diag:
+                if isinstance(c, dict) and "symbol" in c:
+                    baseline_win_rates[c["symbol"]] = float(c.get("win_rate", 0.0))
+
         phase3_result = classify_phase3_verdict(
             phase3_primary,
             phase3_sensitivity if isinstance(phase3_sensitivity, list) else [],
-            baseline_win_rates={},
+            baseline_win_rates=baseline_win_rates,
             in_coverage_count=8,
             halt=halt,
         )


### PR DESCRIPTION
## Summary

Phase 1 of epic C (signal calibration, #350) — single PR per pre-reg §9.4 lock. Ships the observability instrumentation + A1 subset wrapper in `strategy/donchian_ensemble.py` plus the three new orchestration tools (`signal_calibration_{verdict,diagnostic,sweep}.py`) + 49 new tests + smoke evidence.

**No code execution beyond `--smoke` wiring check.** Phase 2/3/4 sweeps are blocked behind operator approval (separate PRs).

## Pre-reg traceability

| Deliverable | Pre-reg section | Lock |
|---|---|---|
| `emit_observability_metrics` schema | §2.1 lines 99-126 (literal) | per-lookback + sum_distribution dicts, magnitude_* replicated |
| `apply_subset_lookbacks` default | Q-PR6 | A1 = (5, 10, 20) |
| Single PR delivery | §9.4 | Path (a) locked 2026-05-15 |
| Counts threshold T | Q-PR1 | `T_COUNTS_FIRING = 5` |
| Magnitude threshold | Q-PR2 | `P50_MAGNITUDE_MAX = 2.0` strict `<` |
| Win-rate floor | Q-PR3 | `WIN_RATE_FLOOR = 0.30` fraction |
| Win-rate degradation H-C4 | Q-PR4 | `WIN_RATE_DEGRADATION = 0.50` × baseline |
| Aggregate ≥75% match | heredar #338 §10.4 | `AGGREGATE_MATCH_FRACTION = 0.75` |
| Phase 2 verdict §4.1 | classify_phase2_verdict | A_DETECTED / B_DETECTED / AMBIGUOUS / INSUFFICIENT_DATA + 4/8 split worked example line 290 |
| Phase 3 verdict §4.2 | classify_phase3_verdict | PHASE_3_A_PASS / *_CONDITIONAL / SWEET_SPOT_ARTIFACT / INSUFFICIENT / HARMFUL (H-C3 ∨ H-C4) |
| Phase 4 verdict §4.3 | classify_phase4_verdict | STRONG / ROBUST / PARTIAL / FAIL_CLEAN conjunctive B ∧ C |
| §4.6 asymmetric halt-guard | apply_asymmetric_halt_guard | Favorable overridden under halt; negative preserved |
| Copy-modify from #338 | Q-PR2 | helpers + constants duplicated, epic C/D independent at module boundary |
| Smoke flag | Q-PR3 (smoke check) | `--smoke` runs 1 BTC × Window A × A1 × 30% vol cell |

## Files

- `strategy/donchian_ensemble.py` — +123 LOC (2 new functions, no signatures touched)
- `tools/signal_calibration_verdict.py` — 490 LOC (Phase 2/3/4 classifiers + asymmetric guard + CLI main)
- `tools/signal_calibration_diagnostic.py` — 439 LOC (Phase 2 runner: 8 cells × Window A × baseline + observability emit)
- `tools/signal_calibration_sweep.py` — 631 LOC (Phase 3 + Phase 4 runner + `--smoke` flag)
- `tests/test_donchian_ensemble_observability.py` — 346 LOC (24 tests)
- `tests/test_signal_calibration_sweep.py` — 512 LOC (25 tests covering 3 production modules per §6)
- `data/retune/2026-05-15-signal-calibration/smoke_test.json` — evidence artifact

## Smoke evidence

```
[smoke] running 1 cell: BTCUSDT × Window A × vol_target=0.3 × A1=(5, 10, 20)
[smoke] OK in 3.5s — n_trades=2, net_pnl=$782.84, error=none
```

n_trades=2 is consistent with the #338 Phase 3 H2 firing pattern (8/8 cells had n_trades < 5 over Window A under baseline equal-weight). Whether A1 propagation through backtest.py changes this is a Phase 3 execution PR question (backtest.py out of Phase 1 scope per §1.2 line 69).

## Decision hooks documented in commit messages

- Schema interpretation of magnitude_* under per-lookback (§2.1 line 105 comment cited literally)
- Win-rate convention normalization at worker boundary (backtest returns percent; verdict expects fraction)
- A1 propagation via `cfg[\"regime_allocation\"][\"lookbacks_subset\"]` — actual honor by backtest.py deferred to Phase 3 execution PR

## Test plan

- [x] 13/13 `tests/test_holdout_isolation.py` (hard block #246 preserved)
- [x] 30/30 `tests/test_donchian_ensemble.py` (legacy, no regression after module changes)
- [x] 24/24 `tests/test_donchian_ensemble_observability.py` (NEW)
- [x] 25/25 `tests/test_signal_calibration_sweep.py` (NEW)
- [x] 91/91 `tests/test_regime_allocation_sweep.py` (#338 Phase 3 regression)
- [x] 20/20 `tests/test_strategy_core.py` (downstream consumer sanity)
- [x] 3/3 `tests/test_strategy_core_precision.py`
- [x] 8/8 `tests/test_import_boundaries.py` (no new circular imports)
- [x] Manual `--smoke` run completes (3.5s, harness_wiring_ok=true)

Combined: 214/214 PASS in 37.84s.

## Backwards compatibility

- No existing function signatures modified in `strategy/donchian_ensemble.py` — only additions.
- No config defaults changed; `cfg.regime_allocation.enabled` remains default OFF in `config.defaults.json` (no production promotion).
- No `backtest.py` / `strategy/core.py` / `strategy/vol_targeting.py` modifications (Phase 1 scope per pre-reg §1.2 line 69).
- New `cfg.regime_allocation.lookbacks_subset` key is read by sweep tool only; absence from existing configs is a no-op.

## NOT in this PR

- Phase 2 / 3 / 4 sweep execution (separate PRs, gated on operator review of this Phase 1)
- `backtest.py` A1 honor (Phase 3 execution PR scope)
- Holdout (Phase 5, gated joint with epic D per Q5 lock)
- `config.defaults.json` promotion of `regime_allocation.enabled` or any A1 default
- A2/A3/A4 interventions (Q-PR6 lock locks A1 only; operator override per §4.5 self-policing)

## Refs

- Tracking: #350 (epic C tracker)
- Parent: #338 (regime-allocation strategy pivot)
- Pre-reg: `docs/superpowers/plans/2026-05-15-signal-calibration-pre-reg.md`
- Epic spec: `docs/superpowers/specs/es/2026-05-15-epic-signal-calibration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)