### PR TITLE
feat(rule_a_check): CLI veto-only Rule A check (Option 1 implementation)

### DIFF
--- a/tests/test_rule_a_check.py
+++ b/tests/test_rule_a_check.py
@@ -1,0 +1,186 @@
+"""Tests for tools/rule_a_check.py (Rule A veto-only CLI)."""
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tools.rule_a_check import (
+    CLOSE_POSITION_BLOCK_THRESHOLD,
+    CLOSE_POSITION_EXIT_THRESHOLD,
+    compute_rule_a,
+    get_most_recent_closed_bar,
+    load_position,
+)
+
+
+def _bar(o: float, h: float, l: float, c: float) -> dict:
+    return {"open_time": 0, "open": o, "high": h, "low": l, "close": c}
+
+
+class TestThresholdConstants:
+    def test_block_threshold(self):
+        assert CLOSE_POSITION_BLOCK_THRESHOLD == 0.7
+
+    def test_exit_threshold(self):
+        assert CLOSE_POSITION_EXIT_THRESHOLD == 0.5
+
+
+class TestRuleALongHold:
+    def test_green_strong_bar_triggers_hold(self):
+        """Bar green AND close near top → HOLD (the green-bar bias trigger)."""
+        bar = _bar(100, 105, 99, 104)  # green, close at top
+        # close_position = (104-99)/(105-99) = 5/6 ≈ 0.83 > 0.7
+        ruling = compute_rule_a(bar, "LONG")
+        assert ruling["recommendation"] == "HOLD"
+        assert ruling["bar_color"] == "green"
+        assert ruling["close_position"] == pytest.approx(0.8333, abs=0.001)
+        assert "veto active" in ruling["reasoning"].lower()
+
+    def test_green_bar_close_at_literal_top(self):
+        bar = _bar(100, 105, 99, 105)  # close == high
+        ruling = compute_rule_a(bar, "LONG")
+        assert ruling["recommendation"] == "HOLD"
+        assert ruling["close_position"] == 1.0
+
+
+class TestRuleALongExit:
+    def test_red_bar_triggers_exit_ok(self):
+        bar = _bar(100, 102, 95, 96)  # red, close in lower range
+        ruling = compute_rule_a(bar, "LONG")
+        assert ruling["recommendation"] == "EXIT_OK"
+        assert ruling["bar_color"] == "red"
+
+    def test_green_bar_close_low_triggers_exit_ok(self):
+        """Green bar but close_position < 0.5 also triggers EXIT_OK."""
+        bar = _bar(100, 110, 99, 102)  # green, but close_pos = 3/11 ≈ 0.27 < 0.5
+        ruling = compute_rule_a(bar, "LONG")
+        assert ruling["recommendation"] == "EXIT_OK"
+        assert ruling["bar_color"] == "green"
+        assert ruling["close_position"] < CLOSE_POSITION_EXIT_THRESHOLD
+
+
+class TestRuleALongAmbiguous:
+    def test_green_bar_mid_range_is_ambiguous(self):
+        """Green bar with close_position in [0.5, 0.7] gray zone."""
+        bar = _bar(100, 105, 99, 102.5)  # green, close_pos = 3.5/6 ≈ 0.58
+        ruling = compute_rule_a(bar, "LONG")
+        assert ruling["recommendation"] == "AMBIGUOUS"
+        assert CLOSE_POSITION_EXIT_THRESHOLD <= ruling["close_position"] <= CLOSE_POSITION_BLOCK_THRESHOLD
+
+    def test_doji_zero_range_bar(self):
+        bar = _bar(100, 100, 100, 100)
+        ruling = compute_rule_a(bar, "LONG")
+        assert ruling["recommendation"] == "AMBIGUOUS"
+        assert ruling["bar_color"] == "doji"
+        assert ruling["close_position"] is None
+
+
+class TestRuleAShortNotApplicable:
+    def test_short_position_not_applicable(self):
+        """Per findings §5: Rule A LONG-only, SHORT exits had no green-bar bias."""
+        bar = _bar(100, 102, 98, 101)
+        ruling = compute_rule_a(bar, "SHORT")
+        assert ruling["recommendation"] == "NOT_APPLICABLE"
+        assert ruling["rule_a_applicable"] is False
+        assert "short" in ruling["reasoning"].lower()
+
+
+class TestRuleAUnknownDirection:
+    def test_invalid_direction_not_applicable(self):
+        bar = _bar(100, 102, 98, 101)
+        ruling = compute_rule_a(bar, "FLAT")
+        assert ruling["recommendation"] == "NOT_APPLICABLE"
+
+
+# ---------------------------------------------------------------------------
+# DB integration with synthetic SQLite fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def synthetic_signals_db(tmp_path: Path) -> Path:
+    """positions table with sample LONG open + closed positions."""
+    db_path = tmp_path / "signals.db"
+    con = sqlite3.connect(db_path)
+    con.execute("""
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY,
+            symbol TEXT, direction TEXT, status TEXT,
+            entry_price REAL, entry_ts TEXT,
+            sl_price REAL, tp_price REAL, size_usd REAL,
+            exit_price REAL, exit_ts TEXT, exit_reason TEXT,
+            pnl_usd REAL, pnl_pct REAL
+        )
+    """)
+    con.executemany("""
+        INSERT INTO positions
+        (id, symbol, direction, status, entry_price, entry_ts, size_usd)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, [
+        (1, "BTCUSDT", "LONG", "open", 80000.0, "2026-05-15T10:00:00+00:00", 500),
+        (2, "ETHUSDT", "LONG", "open", 2300.0, "2026-05-15T11:00:00+00:00", 300),
+        (3, "BTCUSDT", "SHORT", "open", 81000.0, "2026-05-15T12:00:00+00:00", 400),
+    ])
+    con.commit()
+    con.close()
+    return db_path
+
+
+@pytest.fixture
+def synthetic_ohlcv_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "ohlcv.db"
+    con = sqlite3.connect(db_path)
+    con.execute("""
+        CREATE TABLE ohlcv (
+            symbol TEXT, timeframe TEXT, open_time INTEGER,
+            open REAL, high REAL, low REAL, close REAL, volume REAL,
+            provider TEXT, fetched_at INTEGER
+        )
+    """)
+    # BTC 1h bar with green-strong pattern (HOLD trigger)
+    base_ts_ms = int(datetime(2026, 5, 15, 12, 0, tzinfo=timezone.utc).timestamp() * 1000)
+    con.executemany(
+        "INSERT INTO ohlcv VALUES (?,?,?,?,?,?,?,?,?,?)",
+        [
+            ("BTCUSDT", "1h", base_ts_ms, 80000.0, 80500.0, 79900.0, 80400.0, 0.0, "synth", 0),
+            ("BTCUSDT", "1h", base_ts_ms + 3600 * 1000, 80400.0, 80800.0, 80300.0, 80700.0, 0.0, "synth", 0),
+        ],
+    )
+    con.commit()
+    con.close()
+    return db_path
+
+
+class TestLoadPosition:
+    def test_load_by_id(self, synthetic_signals_db: Path):
+        pos = load_position(synthetic_signals_db, position_id=1, symbol=None)
+        assert pos is not None
+        assert pos["id"] == 1
+        assert pos["symbol"] == "BTCUSDT"
+
+    def test_load_by_symbol_returns_open(self, synthetic_signals_db: Path):
+        pos = load_position(synthetic_signals_db, position_id=None, symbol="ETHUSDT")
+        assert pos["id"] == 2
+
+    def test_no_match_returns_none(self, synthetic_signals_db: Path):
+        pos = load_position(synthetic_signals_db, position_id=999, symbol=None)
+        assert pos is None
+
+
+class TestGetMostRecentClosedBar:
+    def test_returns_most_recent(self, synthetic_ohlcv_db: Path):
+        # as_of well after both bars closed
+        as_of = datetime(2026, 5, 15, 15, 0, tzinfo=timezone.utc)
+        bar = get_most_recent_closed_bar(synthetic_ohlcv_db, "BTCUSDT", as_of=as_of)
+        assert bar is not None
+        # Second bar (13:00-14:00) should be closed by 15:00
+        expected_ms = int(datetime(2026, 5, 15, 13, 0, tzinfo=timezone.utc).timestamp() * 1000)
+        assert bar["open_time"] == expected_ms
+
+    def test_no_bar_returns_none_for_unknown_symbol(self, synthetic_ohlcv_db: Path):
+        as_of = datetime(2026, 5, 15, 15, 0, tzinfo=timezone.utc)
+        bar = get_most_recent_closed_bar(synthetic_ohlcv_db, "UNKNOWN", as_of=as_of)
+        assert bar is None

--- a/tools/rule_a_check.py
+++ b/tools/rule_a_check.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Rule A check — veto-only alert for premature LONG exits.
+
+Origin: data/retune/2026-05-15-manual-exit-market-context/findings.md (PR #359).
+Hypothesis (n=16 sample, single bull regime): operator's MANUAL LONG closes on
+green bars with close_position > 0.7 are systematically premature (6 of 6
+PREMATURE in 4h post-exit hindsight). Rule A vetoes such exits.
+
+## Rule A logic
+
+For a given LONG position:
+  GIVEN current 1h bar B (the most recent fully-closed bar for the symbol):
+
+  color = "green" if B.close > B.open else "red"
+  close_position = (B.close - B.low) / (B.high - B.low)
+
+  IF color == "green" AND close_position > 0.7:
+    RECOMMENDATION = "HOLD" (Rule A veto active)
+    Rationale: green-strong bar pattern correlates with premature exit
+    historically (6 of 6 LONG winners with this pattern continued favorable
+    ≥1% in next 4h).
+
+  ELIF color == "red" OR close_position < 0.5:
+    RECOMMENDATION = "EXIT_OK" (Rule A clear)
+    Rationale: stall/reversal signal present — operator's historical pattern
+    when this fires correctly catches turns.
+
+  ELSE:
+    RECOMMENDATION = "AMBIGUOUS" (Rule A neither blocks nor confirms)
+    Rationale: bar is green with close_position in [0.5, 0.7] gray zone.
+
+For SHORT positions: Rule A does NOT apply per findings §5 (SHORT timing was
+empirically GOOD in n=4 sample). Tool returns "NOT_APPLICABLE" for SHORTs.
+
+## Usage
+
+  python tools/rule_a_check.py --position-id 47 --signals-db PATH
+  python tools/rule_a_check.py --symbol BTCUSDT --signals-db PATH --ohlcv-db PATH
+
+## Caveats (do NOT skip)
+
+- Rule A is **hypothesis-only** based on n=16 single-regime sample. NO statistical validation.
+- Tool is veto-ONLY: emits recommendation, does NOT execute any trade.
+- Requires up-to-date OHLCV cache. Run scanner periodically to refresh.
+- Bear/sideways regime may invalidate the green-bar bias. Re-check if regime changes.
+- Out-of-sample test pending (Phase 2 — see follow-up issue).
+
+## NOT in this tool
+
+- Telegram/webhook integration (Phase 2)
+- Scanner.py integration (Phase 2)
+- Auto-close logic (never — Rule A is veto-only by design)
+- Live OHLCV provider calls (relies on data/ohlcv.db cache)
+- Complementary exit trigger logic (Phase 2)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Final
+
+# Rule A thresholds (Phase 1, locked by findings PR #359)
+CLOSE_POSITION_BLOCK_THRESHOLD: Final[float] = 0.7  # > this on green bar = HOLD
+CLOSE_POSITION_EXIT_THRESHOLD: Final[float] = 0.5   # < this = EXIT_OK
+LIVE_BAR_TIMEFRAME: Final[str] = "1h"
+LIVE_BAR_LOOKBACK_HOURS: Final[int] = 3  # query bars in last 3h to find most-recent closed
+
+REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+DEFAULT_SIGNALS_DB: Final[Path] = REPO_ROOT / "signals.db"
+DEFAULT_OHLCV_DB: Final[Path] = REPO_ROOT / "data" / "ohlcv.db"
+
+
+def load_position(signals_db: Path, position_id: int | None, symbol: str | None) -> dict | None:
+    """Load a single OPEN position. If position_id given, use that. Else load
+    most-recent open position for symbol."""
+    con = sqlite3.connect(signals_db)
+    con.row_factory = sqlite3.Row
+    con.text_factory = lambda x: x.decode("utf-8", errors="replace")
+    if position_id is not None:
+        row = con.execute("""
+            SELECT id, symbol, direction, status, entry_price, entry_ts,
+                   sl_price, tp_price, size_usd, pnl_usd, pnl_pct, exit_reason
+            FROM positions WHERE id = ?
+        """, (position_id,)).fetchone()
+    elif symbol is not None:
+        row = con.execute("""
+            SELECT id, symbol, direction, status, entry_price, entry_ts,
+                   sl_price, tp_price, size_usd, pnl_usd, pnl_pct, exit_reason
+            FROM positions WHERE symbol = ? AND status = 'open'
+            ORDER BY entry_ts DESC LIMIT 1
+        """, (symbol,)).fetchone()
+    else:
+        row = None
+    con.close()
+    return dict(row) if row else None
+
+
+def get_most_recent_closed_bar(
+    ohlcv_db: Path,
+    symbol: str,
+    timeframe: str = LIVE_BAR_TIMEFRAME,
+    as_of: datetime | None = None,
+) -> dict | None:
+    """Most recent fully-closed bar for symbol/timeframe at/before `as_of`.
+
+    A bar is "fully closed" when current time >= bar.open_time + timeframe_duration.
+    If as_of is None, uses datetime.now(UTC).
+    """
+    if as_of is None:
+        as_of = datetime.now(timezone.utc)
+    # 1h timeframe — bar is closed when as_of >= bar.open_time + 3600s
+    cutoff_ms = int(as_of.timestamp() * 1000) - 3600 * 1000
+    con = sqlite3.connect(ohlcv_db)
+    row = con.execute("""
+        SELECT open_time, open, high, low, close, volume
+        FROM ohlcv
+        WHERE symbol = ? AND timeframe = ? AND open_time <= ?
+        ORDER BY open_time DESC LIMIT 1
+    """, (symbol, timeframe, cutoff_ms)).fetchone()
+    con.close()
+    if not row:
+        return None
+    return {
+        "open_time": row[0],
+        "open": row[1],
+        "high": row[2],
+        "low": row[3],
+        "close": row[4],
+        "volume": row[5],
+    }
+
+
+def compute_rule_a(bar: dict, direction: str) -> dict:
+    """Apply Rule A check to a bar + position direction.
+
+    Returns dict with:
+      - recommendation: HOLD / EXIT_OK / AMBIGUOUS / NOT_APPLICABLE
+      - reasoning: human-readable explanation
+      - bar_color: green / red / doji
+      - close_position: float in [0, 1] (NaN-safe; None if bar.range == 0)
+      - rule_a_applicable: bool
+    """
+    if direction not in ("LONG", "SHORT"):
+        return {
+            "recommendation": "NOT_APPLICABLE",
+            "reasoning": f"Unknown direction {direction!r}. Rule A applies to LONG positions only.",
+            "bar_color": None,
+            "close_position": None,
+            "rule_a_applicable": False,
+        }
+    if direction == "SHORT":
+        return {
+            "recommendation": "NOT_APPLICABLE",
+            "reasoning": (
+                "Rule A does NOT apply to SHORT positions (findings §5: SHORT exit "
+                "timing empirically GOOD in n=4 sample, no green-bar bias)."
+            ),
+            "bar_color": None,
+            "close_position": None,
+            "rule_a_applicable": False,
+        }
+
+    o = bar["open"]
+    h = bar["high"]
+    l = bar["low"]
+    c = bar["close"]
+    bar_range = h - l
+    if bar_range <= 0:
+        # Degenerate bar (high == low): doji-like, no close_position info
+        return {
+            "recommendation": "AMBIGUOUS",
+            "reasoning": "Bar has zero range (high == low). Cannot compute close_position.",
+            "bar_color": "doji",
+            "close_position": None,
+            "rule_a_applicable": True,
+        }
+    close_position = (c - l) / bar_range
+    bar_color = "green" if c > o else ("red" if c < o else "doji")
+
+    # Rule A logic
+    if bar_color == "green" and close_position > CLOSE_POSITION_BLOCK_THRESHOLD:
+        return {
+            "recommendation": "HOLD",
+            "reasoning": (
+                f"Rule A veto active. Current bar is green ({c:.4f} > {o:.4f}) AND "
+                f"close_position {close_position:.2f} > {CLOSE_POSITION_BLOCK_THRESHOLD}. "
+                f"Historical pattern: 6/6 LONG winners with this signature exited prematurely "
+                f"(median +2.74% additional upside continued in next 4h). "
+                f"Recommend HOLD."
+            ),
+            "bar_color": bar_color,
+            "close_position": round(close_position, 4),
+            "rule_a_applicable": True,
+        }
+    if bar_color == "red" or close_position < CLOSE_POSITION_EXIT_THRESHOLD:
+        return {
+            "recommendation": "EXIT_OK",
+            "reasoning": (
+                f"Rule A clear. Bar color {bar_color}, close_position {close_position:.2f}. "
+                f"Historical pattern: 2/2 LONG REVERSAL_CAUGHT exits had this signature "
+                f"(red bar OR close near bottom of range). Exit timing supported."
+            ),
+            "bar_color": bar_color,
+            "close_position": round(close_position, 4),
+            "rule_a_applicable": True,
+        }
+    # Gray zone: green AND close_position in [0.5, 0.7]
+    return {
+        "recommendation": "AMBIGUOUS",
+        "reasoning": (
+            f"Bar is {bar_color}, close_position {close_position:.2f} in gray zone "
+            f"[{CLOSE_POSITION_EXIT_THRESHOLD}, {CLOSE_POSITION_BLOCK_THRESHOLD}]. "
+            f"Rule A neither vetoes nor confirms exit. Operator discretion."
+        ),
+        "bar_color": bar_color,
+        "close_position": round(close_position, 4),
+        "rule_a_applicable": True,
+    }
+
+
+def format_report(position: dict, bar: dict | None, ruling: dict) -> str:
+    """Human-readable report for CLI stdout."""
+    lines = []
+    lines.append("=" * 70)
+    lines.append(f"Rule A check — position id={position['id']} {position['symbol']} {position['direction']}")
+    lines.append("=" * 70)
+    lines.append(f"Status: {position['status']}")
+    lines.append(f"Entry: ${position['entry_price']} @ {position['entry_ts']}")
+    if position.get("size_usd"):
+        lines.append(f"Size: ${position['size_usd']:.2f}")
+    if bar:
+        bar_dt = datetime.fromtimestamp(bar["open_time"] / 1000, tz=timezone.utc)
+        lines.append(f"\nCurrent 1h bar @ {bar_dt.isoformat()}:")
+        lines.append(f"  open={bar['open']:.4f}  high={bar['high']:.4f}  low={bar['low']:.4f}  close={bar['close']:.4f}")
+        lines.append(f"  color={ruling['bar_color']}  close_position={ruling['close_position']}")
+    else:
+        lines.append("\n(no OHLCV bar available for symbol — cannot evaluate)")
+    lines.append(f"\n=== RECOMMENDATION: {ruling['recommendation']} ===")
+    lines.append(f"\n{ruling['reasoning']}")
+    if ruling["recommendation"] == "HOLD":
+        lines.append("\n(Operator may still override — Rule A is veto-only, not auto-action)")
+    return "\n".join(lines)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    grp = p.add_mutually_exclusive_group(required=True)
+    grp.add_argument("--position-id", type=int, help="Specific position id to check")
+    grp.add_argument("--symbol", help="Symbol — checks most-recent OPEN position for this symbol")
+    p.add_argument("--signals-db", default=str(DEFAULT_SIGNALS_DB))
+    p.add_argument("--ohlcv-db", default=str(DEFAULT_OHLCV_DB))
+    p.add_argument("--json", action="store_true", help="Output JSON instead of human-readable")
+    p.add_argument("--as-of", help="ISO timestamp (UTC) to evaluate as-of. Default: now.")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    signals_db = Path(args.signals_db)
+    ohlcv_db = Path(args.ohlcv_db)
+    if not signals_db.exists():
+        sys.stderr.write(f"ERROR: signals.db not found at {signals_db}\n")
+        return 1
+    if not ohlcv_db.exists():
+        sys.stderr.write(f"ERROR: ohlcv.db not found at {ohlcv_db}\n")
+        return 1
+    as_of = None
+    if args.as_of:
+        as_of = datetime.fromisoformat(args.as_of)
+        if as_of.tzinfo is None:
+            as_of = as_of.replace(tzinfo=timezone.utc)
+
+    position = load_position(signals_db, args.position_id, args.symbol)
+    if position is None:
+        sys.stderr.write("ERROR: no matching position found\n")
+        return 1
+
+    bar = get_most_recent_closed_bar(ohlcv_db, position["symbol"], as_of=as_of)
+    if bar is None:
+        ruling = {
+            "recommendation": "NOT_APPLICABLE",
+            "reasoning": "No OHLCV bar available for symbol (cache may be stale). Refresh OHLCV before re-checking.",
+            "bar_color": None,
+            "close_position": None,
+            "rule_a_applicable": False,
+        }
+    else:
+        ruling = compute_rule_a(bar, position["direction"])
+
+    if args.json:
+        out = {
+            "position": {
+                "id": position["id"],
+                "symbol": position["symbol"],
+                "direction": position["direction"],
+                "status": position["status"],
+                "entry_price": position["entry_price"],
+                "entry_ts": position["entry_ts"],
+            },
+            "current_bar": bar,
+            "ruling": ruling,
+            "thresholds": {
+                "close_position_block": CLOSE_POSITION_BLOCK_THRESHOLD,
+                "close_position_exit": CLOSE_POSITION_EXIT_THRESHOLD,
+            },
+            "tool_version": 1,
+            "source_findings": "data/retune/2026-05-15-manual-exit-market-context/findings.md (PR #359)",
+        }
+        print(json.dumps(out, indent=2, default=str))
+    else:
+        print(format_report(position, bar, ruling))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Option 1 implementation per PR #359 findings §9 — lowest-cost intervention to operationalize the empirical green-bar bias finding.

Standalone CLI tool: operator invokes manually before considering MANUAL exit on LONG positions. Tool reads current 1h bar, evaluates Rule A trigger, returns HOLD / EXIT_OK / AMBIGUOUS recommendation with reasoning.

**Veto-only by design**: NO automated trade execution. NO scanner.py modification. Operator retains full discretion.

## Rule A logic (locked from PR #359 findings)

```
GIVEN LONG position + current 1h bar:
  IF bar is green AND close_position > 0.7  → HOLD (veto premature exit)
  ELIF bar is red OR close_position < 0.5   → EXIT_OK (stall/reversal)
  ELSE                                       → AMBIGUOUS (gray zone)

SHORTs: NOT_APPLICABLE (Rule A is LONG-only per findings §5)
```

## Demo on papá's open positions

Tested on the 2 currently-open positions in papá's backup (snapshot 2026-05-07):

| id | symbol | dir | bar color | close_pos | Recommendation |
|---:|---|---|---|---:|---|
| 44 | ETHUSDT | LONG | green | 0.73 | **HOLD** (Rule A veto active) |
| 46 | BTCUSDT | LONG | green | 0.31 | **EXIT_OK** (close near bottom = stall) |

Tool correctly differentiates the two positions per current bar pattern.

## Usage

```bash
# By position id
python tools/rule_a_check.py --position-id 47

# By symbol (most-recent OPEN position)
python tools/rule_a_check.py --symbol BTCUSDT

# JSON output for integration
python tools/rule_a_check.py --position-id 44 --json

# Historical evaluation
python tools/rule_a_check.py --position-id 44 --as-of "2026-05-07T12:00:00"
```

## Caveats

- **n=16 hypothesis sample**, NO statistical validation
- Single bull regime context (Mar-May 2026)
- Out-of-sample test pending (Phase 2 issue to be opened)
- Bear/sideways regime may invalidate green-bar bias — re-check if regime changes
- Requires up-to-date OHLCV cache — run scanner periodically to refresh

## Test plan

- [x] 15 synthetic-fixture tests in tests/test_rule_a_check.py pass
- [x] 13/13 holdout isolation pass
- [x] Demo run on papá's 2 open positions produces sensible differential recommendations
- [x] SHORT positions correctly return NOT_APPLICABLE
- [x] Doji (zero-range bar) handled gracefully
- [x] Missing OHLCV (uncached symbol) returns informative NOT_APPLICABLE
- [x] Papá's signals.db NOT committed (sandbox path preserved)

## NOT in this PR (Phase 2 scope, separate issue)

- Scanner.py integration with config flag
- Telegram/webhook alerting (proactive vs operator-invoked)
- Live OHLCV provider calls (currently relies on cache)
- Complementary exit trigger logic (Rule A only vetoes; doesn't define when TO exit)
- Formal out-of-sample test on extended data
- Walk-forward simulation of Rule A vs no-Rule-A counterfactual

## Refs

- Origin findings: PR #359 (manual-exit market context, green-bar bias pattern)
- Predecessor: PR #358 (manual-exit EDA, capture rate / hold time analysis)
- Direction A Phase D2: PR #357 draft (verdict EDGE_WEAK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)