### PR TITLE
feat(multi-tenant B.5 follow-up): notifications + signals/performance endpoint enforcement

### DIFF
--- a/api/notifications.py
+++ b/api/notifications.py
@@ -1,14 +1,21 @@
 """Notifications API — thin router wrapper.
 
 Extracted from btc_api.py in PR6 of the api+db refactor (2026-04-27).
+
+## Multi-tenancy (B.5 follow-up #258 — 2026-05-15)
+
+All endpoints use Depends(get_current_tenant_id) — tenant scoped from JWT,
+never from request. Strict filter: NULL tenant_id rows invisible per
+established B.5 pattern (PR #363).
 """
 from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.deps import verify_api_key
+from auth.dependencies import get_current_tenant_id
 from db.connection import get_db
 
 log = logging.getLogger("api.notifications")
@@ -21,45 +28,63 @@ def get_notifications(
     unread: bool = True,
     limit: int = Query(50, ge=1, le=200,
                         description="Max rows returned (capped to prevent unbounded scans)"),
+    tenant_id: int = Depends(get_current_tenant_id),
 ):
     """List notifications recorded by the notifier.
 
     By default returns only unread entries; pass ?unread=false to include
-    read ones too. Sorted most-recent-first.
+    read ones too. Sorted most-recent-first. B.5 #258: scoped to tenant_id
+    from JWT — pre-backfill (NULL tenant_id) notifications invisible.
     """
     from notifier._storage import list_unread
     if not unread:
-        # Full list (both read + unread) — use a direct query since list_unread
-        # filters on read_at IS NULL.
+        # Full list (both read + unread) — direct query (list_unread filters on read_at).
         con = get_db()
         try:
             rows = con.execute(
                 """SELECT id, event_type, event_key, priority, payload_json,
                           channels_sent, delivery_status, sent_at, read_at, error_log
                    FROM notifications_sent
+                   WHERE tenant_id = ?
                    ORDER BY sent_at DESC
                    LIMIT ?""",
-                (limit,),
+                (tenant_id, limit),
             ).fetchall()
         finally:
             con.close()
         cols = ("id", "event_type", "event_key", "priority", "payload_json",
                 "channels_sent", "delivery_status", "sent_at", "read_at", "error_log")
         return {"notifications": [dict(zip(cols, r)) for r in rows]}
-    return {"notifications": list_unread(limit=limit)}
+    return {"notifications": list_unread(limit=limit, tenant_id=tenant_id)}
 
 
 @router.post("/{notif_id}/read", dependencies=[Depends(verify_api_key)])
-def post_notification_read(notif_id: int):
-    """Mark a single notification as read."""
+def post_notification_read(
+    notif_id: int,
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    """Mark a single notification as read. B.5 #258: ownership-enforced.
+
+    Returns 404 if notification does not belong to current tenant (IDOR
+    protection — same response as 'not found').
+    """
     from notifier._storage import mark_read
-    mark_read(notif_id)
+    updated = mark_read(notif_id, tenant_id=tenant_id)
+    if not updated:
+        raise HTTPException(
+            status_code=404, detail=f"Notification #{notif_id} not found",
+        )
     return {"ok": True, "id": notif_id}
 
 
 @router.post("/read-all", dependencies=[Depends(verify_api_key)])
-def post_notifications_read_all():
-    """Mark all currently-unread notifications as read. Returns how many were updated."""
+def post_notifications_read_all(
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    """Mark all currently-unread notifications for current tenant as read.
+
+    B.5 #258: scope-limited to tenant_id — affects only current user's queue.
+    """
     from notifier._storage import mark_all_read
-    n = mark_all_read()
+    n = mark_all_read(tenant_id=tenant_id)
     return {"ok": True, "marked": n}

--- a/api/signals.py
+++ b/api/signals.py
@@ -15,10 +15,11 @@ import os
 from datetime import datetime, timezone
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.config import load_config
 from api.deps import verify_api_key
+from auth.dependencies import get_current_tenant_id
 from api.telegram import build_telegram_message
 from db.connection import get_db
 from db.signals import (
@@ -229,14 +230,23 @@ def list_signals(
 
 
 @router.get("/performance", summary="Métricas de éxito de las señales históricas")
-def get_signals_performance():
+def get_signals_performance(
+    tenant_id: int = Depends(get_current_tenant_id),
+):
     """
     Calcula estadísticas de acierto de las señales procesadas (status='completed').
     Win Rate se define como: precio 24h > precio señal (para LONG).
+
+    B.5 #258: scoped to tenant_id from JWT. Pre-backfill signal_outcomes
+    (tenant_id=NULL) are invisible. Each user sees their own performance
+    tracking.
     """
     con = get_db()
-    # Solo señales completadas (24h de historia)
-    rows = con.execute("SELECT * FROM signal_outcomes WHERE status = 'completed'").fetchall()
+    # Solo señales completadas (24h de historia) — filtradas por tenant
+    rows = con.execute(
+        "SELECT * FROM signal_outcomes WHERE status = 'completed' AND tenant_id = ?",
+        (tenant_id,),
+    ).fetchall()
     con.close()
 
     if not rows:

--- a/notifier/_storage.py
+++ b/notifier/_storage.py
@@ -1,12 +1,23 @@
 """Thin wrapper around signals.db for notification records.
 
 Uses btc_api.get_db() so tests monkeypatching DB_FILE work transparently.
+
+## Multi-tenancy (B.5 follow-up #258 — 2026-05-15)
+
+All functions accept optional `tenant_id: int | None = None`:
+- `None` (default) — legacy behavior; system broadcasts inserted with tenant_id=NULL
+- `int` — strict filter (rows match exact tenant_id, NULL rows invisible)
+
+Caveat: scanner-emitted notifications (system-level) call record_delivery
+without tenant context → inserted as NULL → invisible to authenticated
+per-user listings. B.4 (signal subscriptions + notification routing) is
+the proper home for fan-out logic to per-user notifications.
 """
 from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Optional
 
 
 def _now_iso() -> str:
@@ -26,19 +37,20 @@ def record_delivery(
     channels_sent: list[str],
     delivery_status: str,
     error_log: str | None = None,
+    tenant_id: Optional[int] = None,
 ) -> int:
     conn = _conn()
     try:
         cur = conn.execute(
             """INSERT INTO notifications_sent
                (event_type, event_key, priority, payload_json,
-                channels_sent, delivery_status, sent_at, error_log)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                channels_sent, delivery_status, sent_at, error_log, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 event_type, event_key, priority,
                 json.dumps(payload, default=str),
                 ",".join(channels_sent), delivery_status,
-                _now_iso(), error_log,
+                _now_iso(), error_log, tenant_id,
             ),
         )
         conn.commit()
@@ -47,18 +59,32 @@ def record_delivery(
         conn.close()
 
 
-def list_unread(limit: int = 50) -> list[dict[str, Any]]:
+def list_unread(
+    limit: int = 50,
+    tenant_id: Optional[int] = None,
+) -> list[dict[str, Any]]:
     conn = _conn()
     try:
-        rows = conn.execute(
-            """SELECT id, event_type, event_key, priority, payload_json,
-                      channels_sent, delivery_status, sent_at, read_at, error_log
-               FROM notifications_sent
-               WHERE read_at IS NULL
-               ORDER BY sent_at DESC
-               LIMIT ?""",
-            (limit,),
-        ).fetchall()
+        if tenant_id is None:
+            rows = conn.execute(
+                """SELECT id, event_type, event_key, priority, payload_json,
+                          channels_sent, delivery_status, sent_at, read_at, error_log
+                   FROM notifications_sent
+                   WHERE read_at IS NULL
+                   ORDER BY sent_at DESC
+                   LIMIT ?""",
+                (limit,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                """SELECT id, event_type, event_key, priority, payload_json,
+                          channels_sent, delivery_status, sent_at, read_at, error_log
+                   FROM notifications_sent
+                   WHERE read_at IS NULL AND tenant_id = ?
+                   ORDER BY sent_at DESC
+                   LIMIT ?""",
+                (tenant_id, limit),
+            ).fetchall()
     finally:
         conn.close()
     cols = ["id", "event_type", "event_key", "priority", "payload_json",
@@ -66,25 +92,49 @@ def list_unread(limit: int = 50) -> list[dict[str, Any]]:
     return [dict(zip(cols, r)) for r in rows]
 
 
-def mark_read(notification_id: int) -> None:
+def mark_read(
+    notification_id: int,
+    tenant_id: Optional[int] = None,
+) -> bool:
+    """Mark notification as read. Ownership-enforced when tenant_id provided.
+
+    Returns True if a row was updated, False if not (e.g., IDOR: trying to
+    mark another user's notification).
+    """
     conn = _conn()
     try:
-        conn.execute(
-            "UPDATE notifications_sent SET read_at = ? WHERE id = ?",
-            (_now_iso(), notification_id),
-        )
+        if tenant_id is None:
+            cur = conn.execute(
+                "UPDATE notifications_sent SET read_at = ? WHERE id = ?",
+                (_now_iso(), notification_id),
+            )
+        else:
+            cur = conn.execute(
+                "UPDATE notifications_sent SET read_at = ? "
+                "WHERE id = ? AND tenant_id = ?",
+                (_now_iso(), notification_id, tenant_id),
+            )
         conn.commit()
+        return cur.rowcount > 0
     finally:
         conn.close()
 
 
-def mark_all_read() -> int:
+def mark_all_read(tenant_id: Optional[int] = None) -> int:
+    """Mark all unread as read. Scope-limited by tenant_id when provided."""
     conn = _conn()
     try:
-        cur = conn.execute(
-            "UPDATE notifications_sent SET read_at = ? WHERE read_at IS NULL",
-            (_now_iso(),),
-        )
+        if tenant_id is None:
+            cur = conn.execute(
+                "UPDATE notifications_sent SET read_at = ? WHERE read_at IS NULL",
+                (_now_iso(),),
+            )
+        else:
+            cur = conn.execute(
+                "UPDATE notifications_sent SET read_at = ? "
+                "WHERE read_at IS NULL AND tenant_id = ?",
+                (_now_iso(), tenant_id),
+            )
         conn.commit()
         return cur.rowcount
     finally:

--- a/tests/test_multi_tenant_b5_enforcement.py
+++ b/tests/test_multi_tenant_b5_enforcement.py
@@ -308,3 +308,109 @@ class TestBackfillRestoresVisibility:
         results = db_get_positions(tenant_id=1)
         assert len(results) == 1
         assert results[0]["symbol"] == "BTC"
+
+
+# ---------------------------------------------------------------------------
+# B.5 follow-up: notifier._storage tenant enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestNotifierStorageTenantEnforcement:
+    def test_record_delivery_persists_tenant_id(self, initialized_db):
+        from notifier._storage import record_delivery
+        import sqlite3
+        nid = record_delivery(
+            event_type="signal", event_key="signal:BTC", priority="info",
+            payload={"symbol": "BTC"}, channels_sent=["telegram"],
+            delivery_status="ok", tenant_id=42,
+        )
+        con = sqlite3.connect(initialized_db)
+        row = con.execute(
+            "SELECT tenant_id FROM notifications_sent WHERE id=?", (nid,)
+        ).fetchone()
+        con.close()
+        assert row[0] == 42
+
+    def test_list_unread_filters_by_tenant(self, initialized_db):
+        from notifier._storage import list_unread, record_delivery
+        record_delivery(
+            event_type="signal", event_key="signal:BTC", priority="info",
+            payload={}, channels_sent=["telegram"], delivery_status="ok",
+            tenant_id=1,
+        )
+        record_delivery(
+            event_type="signal", event_key="signal:ETH", priority="info",
+            payload={}, channels_sent=["telegram"], delivery_status="ok",
+            tenant_id=2,
+        )
+        user1_notifs = list_unread(tenant_id=1)
+        user2_notifs = list_unread(tenant_id=2)
+        assert len(user1_notifs) == 1
+        assert user1_notifs[0]["event_key"] == "signal:BTC"
+        assert len(user2_notifs) == 1
+        assert user2_notifs[0]["event_key"] == "signal:ETH"
+
+    def test_mark_read_idor_returns_false(self, initialized_db):
+        """User 2 cannot mark user 1's notification as read."""
+        from notifier._storage import mark_read, record_delivery, list_unread
+        nid = record_delivery(
+            event_type="signal", event_key="signal:BTC", priority="info",
+            payload={}, channels_sent=["telegram"], delivery_status="ok",
+            tenant_id=1,
+        )
+        # User 2 tries to mark user 1's notification
+        ok = mark_read(nid, tenant_id=2)
+        assert ok is False
+        # Verify notif is still unread for user 1
+        user1_unread = list_unread(tenant_id=1)
+        assert len(user1_unread) == 1
+
+    def test_mark_read_owner_succeeds(self, initialized_db):
+        from notifier._storage import mark_read, record_delivery
+        nid = record_delivery(
+            event_type="signal", event_key="signal:BTC", priority="info",
+            payload={}, channels_sent=["telegram"], delivery_status="ok",
+            tenant_id=1,
+        )
+        ok = mark_read(nid, tenant_id=1)
+        assert ok is True
+
+    def test_mark_all_read_scope_limited_to_tenant(self, initialized_db):
+        """mark_all_read affects only current tenant's notifications."""
+        from notifier._storage import mark_all_read, record_delivery, list_unread
+        # 2 unread for user 1
+        for i in range(2):
+            record_delivery(
+                event_type="signal", event_key=f"signal:U1_{i}", priority="info",
+                payload={}, channels_sent=["telegram"], delivery_status="ok",
+                tenant_id=1,
+            )
+        # 1 unread for user 2
+        record_delivery(
+            event_type="signal", event_key="signal:U2", priority="info",
+            payload={}, channels_sent=["telegram"], delivery_status="ok",
+            tenant_id=2,
+        )
+
+        marked_for_user1 = mark_all_read(tenant_id=1)
+        assert marked_for_user1 == 2
+
+        # User 2's notification still unread
+        user2_unread = list_unread(tenant_id=2)
+        assert len(user2_unread) == 1
+        assert user2_unread[0]["event_key"] == "signal:U2"
+
+    def test_legacy_null_tenant_invisible_to_filter(self, initialized_db):
+        """Notifications without tenant_id (system broadcasts) invisible to per-user filter."""
+        from notifier._storage import list_unread, record_delivery
+        record_delivery(
+            event_type="signal", event_key="system:broadcast", priority="info",
+            payload={}, channels_sent=["telegram"], delivery_status="ok",
+            # No tenant_id → NULL
+        )
+        # User 1 sees nothing (strict filter)
+        user1_unread = list_unread(tenant_id=1)
+        assert user1_unread == []
+        # Legacy unfiltered listing sees it
+        all_unread = list_unread()
+        assert len(all_unread) == 1

--- a/tests/test_notifications_endpoints.py
+++ b/tests/test_notifications_endpoints.py
@@ -14,8 +14,13 @@ def client(tmp_path, monkeypatch):
     return TestClient(btc_api.app)
 
 
-def _seed(n_unread=3, n_read=2):
-    """Insert notifications directly via the storage helper."""
+def _seed(n_unread=3, n_read=2, tenant_id: int = 0):
+    """Insert notifications directly via the storage helper.
+
+    B.5 follow-up #258: tenant_id=0 matches synthetic test user
+    (auth.middleware._synthetic_test_user). Without explicit tenant_id,
+    strict filter excludes rows post-B.5-follow-up.
+    """
     from notifier._storage import record_delivery, mark_read
     ids = []
     for i in range(n_unread):
@@ -23,14 +28,16 @@ def _seed(n_unread=3, n_read=2):
             event_type="signal", event_key=f"signal:SYM{i}", priority="info",
             payload={"symbol": f"SYM{i}"}, channels_sent=["telegram"],
             delivery_status="ok",
+            tenant_id=tenant_id,
         ))
     for i in range(n_read):
         nid = record_delivery(
             event_type="health", event_key=f"health:R{i}", priority="warning",
             payload={"symbol": f"R{i}"}, channels_sent=["telegram"],
             delivery_status="ok",
+            tenant_id=tenant_id,
         )
-        mark_read(nid)
+        mark_read(nid, tenant_id=tenant_id)
     return ids
 
 


### PR DESCRIPTION
## Summary

Extends B.5 #258 JWT enforcement (PR #363) to the remaining existing endpoints reading per-user tables. Same pattern, same pre-reg.

## Endpoints updated (4)

| File | Endpoint | Change |
|---|---|---|
| api/notifications.py | GET / | \`Depends(get_current_tenant_id)\` + filtered list_unread |
| api/notifications.py | POST /{id}/read | Ownership-enforced — 404 on IDOR |
| api/notifications.py | POST /read-all | Scope-limited to tenant |
| api/signals.py | GET /signals/performance | \`Depends(get_current_tenant_id)\` + SQL filter on signal_outcomes |

## notifier/_storage.py — 4 functions accept optional tenant_id

Non-breaking pattern matching B.5 positions:

| Function | Change |
|---|---|
| \`record_delivery(..., tenant_id=None)\` | Persists tenant_id |
| \`list_unread(limit, tenant_id=None)\` | Strict filter when provided |
| \`mark_read(id, tenant_id=None) -> bool\` | Ownership-enforced; **return type changed** to bool (True/False) |
| \`mark_all_read(tenant_id=None) -> int\` | Scope-limited |

\`mark_read\` signature note: was \`-> None\`, now \`-> bool\`. False signals IDOR (caller not owner or row absent). API endpoint raises 404 on False. No external callers besides this PR's endpoint.

## Strict filter consistent with B.5 positions

- NULL tenant_id rows invisible to per-user queries
- System-broadcast notifications (scanner-emitted without user context) → NULL → invisible to authenticated listings
- B.4 (signal subscriptions + notification routing, #257) is the proper home for fan-out logic to per-user notifications

## Test plan

- [x] **6 new tests** in \`tests/test_multi_tenant_b5_enforcement.py\`:
  - record_delivery persists tenant_id
  - list_unread filters by tenant (cross-tenant isolation)
  - mark_read IDOR returns False
  - mark_read owner succeeds
  - mark_all_read scope-limited
  - legacy NULL invisible to filter + visible to legacy unfiltered call
- [x] \`tests/test_notifications_endpoints.py\` fixture updated to pass tenant_id=0 (synthetic test user)
- [x] **46/46 regression PASS** across B.5 enforcement (23) + notifications endpoints (9) + positions parity (1) + holdout isolation (13)

## NOT in this PR (separate)

- New endpoints for capital + user_preferences (B.5 follow-up B / B.2)
- db_delete_position primitive refactor
- record_delivery system-broadcast fan-out logic (B.4 #257)
- IDOR test suite proper (B.7 #260)

## Refs

- Epic B: #253
- B.5 main: PR #363 merged 74cc613
- Pre-reg: docs/superpowers/plans/2026-05-15-multi-tenant-b5-api-enforcement-pre-reg.md (B.5 main pre-reg covers this pattern; no separate pre-reg needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)