### PR TITLE
chore(dev-env): configurable ports + auto-load .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,15 @@
 # trading-spacial — environment template
 # Copy to .env and fill in values. .env is gitignored.
+# btc_api.py auto-loads .env via python-dotenv at startup.
+
+# ── btc_api bind ────────────────────────────────────────────────
+# Override the default host/port the FastAPI server binds to.
+# Default: 0.0.0.0:8000. Set TRADING_API_PORT=8001 (or any free port) if
+# 8000 is occupied by another local project (e.g., a Docker container).
+# Frontend dev proxy must point at the same port — see VITE_API_PROXY_TARGET
+# below.
+TRADING_API_HOST=0.0.0.0
+TRADING_API_PORT=8000
 
 # JWT signing secret. REQUIRED — app refuses to boot without it.
 # Regenerate with: python -c 'import secrets; print(secrets.token_urlsafe(64))'
@@ -78,3 +88,13 @@ AUTH_INITIAL_ADMIN_PASSWORD=
 
 # Set to "1" to disable the web setup form (CLI is the only path).
 AUTH_DISABLE_WEB_SETUP=
+
+# ── Frontend dev (frontend/.env, NOT this file) ─────────────────
+# The Vite dev server reads its own .env from frontend/. Documented here
+# for discoverability — copy to frontend/.env.local (gitignored):
+#
+#   VITE_DEV_PORT=5173
+#   VITE_API_PROXY_TARGET=http://localhost:8000
+#
+# If TRADING_API_PORT above is non-default, set VITE_API_PROXY_TARGET to
+# match (e.g., http://localhost:8001).

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,15 @@
 config.json
 config.secrets.json
 
+# ── Env vars (AUTH_JWT_SECRET, port overrides, etc.) ──────────
+# .env.example IS committed as documentation — .env is your local copy
+.env
+.env.local
+.env.*.local
+frontend/.env
+frontend/.env.local
+frontend/.env.*.local
+
 # ── Datos de backtesting (descargados de Binance) ────────────
 data/backtest/
 data/regime_cache.json

--- a/btc_api.py
+++ b/btc_api.py
@@ -12,6 +12,16 @@ import sys
 from contextlib import asynccontextmanager
 from typing import Optional
 
+# Load .env (if present) BEFORE any module reads env vars. python-dotenv is a
+# dev-quality-of-life: production deployments set vars at the process level.
+try:
+    from dotenv import load_dotenv  # type: ignore
+    load_dotenv()
+except ImportError:
+    # python-dotenv not installed → fall back to plain os.environ.
+    # Same path the prod systemd unit uses (no .env file, env set via unit).
+    pass
+
 import requests as req_lib  # tests patch btc_api.req_lib.post (test_api.py); also used directly at line 187
 from fastapi import Depends, FastAPI, Query
 from fastapi.middleware.cors import CORSMiddleware
@@ -92,8 +102,8 @@ from scanner.runtime import (
 
 DATA_DIR = os.path.join(SCRIPT_DIR, "data")  # noqa: F841 — patched by tests
 LOGS_DIR = os.path.join(SCRIPT_DIR, "logs")  # noqa: F841 — patched by tests
-API_HOST = "0.0.0.0"
-API_PORT = 8000
+API_HOST = os.environ.get("TRADING_API_HOST", "0.0.0.0")
+API_PORT = int(os.environ.get("TRADING_API_PORT", "8000"))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)-8s  %(message)s",
                     datefmt="%Y-%m-%d %H:%M:%S")

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,22 +1,38 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      // En desarrollo local: /api/* → http://localhost:8000/*
-      '/api': {
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+//
+// Env vars (read from frontend/.env, .env.local, etc. via loadEnv with empty
+// prefix so non-VITE_ names also surface):
+//
+//   VITE_DEV_PORT             default 5173 — port for the Vite dev server
+//   VITE_API_PROXY_TARGET     default http://localhost:8000
+//                             where /api/* gets proxied in dev mode.
+//                             Set to http://localhost:8001 if port 8000 is
+//                             occupied by something else.
+//
+// In production the React bundle is served by nginx; this proxy block is
+// dev-only. nginx config still hard-routes /api/ → btc_api on the prod box.
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const devPort = Number(env.VITE_DEV_PORT || 5173)
+  const apiTarget = env.VITE_API_PROXY_TARGET || 'http://localhost:8000'
+  return {
+    plugins: [react()],
+    server: {
+      port: devPort,
+      proxy: {
+        '/api': {
+          target: apiTarget,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
       },
     },
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: false,
-  },
+    build: {
+      outDir: 'dist',
+      sourcemap: false,
+    },
+  }
 })


### PR DESCRIPTION
## Summary

Local dev quality-of-life — orthogonal to feature work. Production deploys unaffected (they set env vars via the systemd unit, not via `.env` files).

## What changes

| File | Change |
|---|---|
| `btc_api.py` | `TRADING_API_HOST` / `TRADING_API_PORT` from env (defaults `0.0.0.0:8000` preserved). `python-dotenv` auto-loads `.env` at import — best-effort: falls back to plain `os.environ` if dotenv is absent (the prod systemd-unit path). |
| `frontend/vite.config.ts` | `loadEnv()` reads `VITE_API_PROXY_TARGET` (default `http://localhost:8000`) + `VITE_DEV_PORT` (default `5173`) from `frontend/.env*`. |
| `.gitignore` | Excludes `.env` / `.env.local` / `.env.*.local` in both repo root and `frontend/`. |
| `.env.example` | Documents the new `TRADING_API_*` vars + a `frontend/.env.local` block. |

## Why

Today the API hardcodes `8000`. If anything else on a dev machine grabs that port (e.g., a Docker container running another project), there's no way to override without editing `btc_api.py`. After this PR, `TRADING_API_PORT=8001` in `.env` + `VITE_API_PROXY_TARGET=http://localhost:8001` in `frontend/.env.local` is all that's needed.

Also: today `AUTH_JWT_SECRET` has to be set every shell session because nothing loads `.env`. After this PR, `.env` is read once at process start.

## Production safety

- All env vars have the same defaults as the previous hardcoded values. A prod box that doesn't set any new env var behaves byte-identically.
- `python-dotenv` import is wrapped in `try/except ImportError` — if it's not installed (or prod systemd unit doesn't want it), the fallback to `os.environ` keeps current behavior.
- `.env.example` is documentation only; no behavior change there.

## Test plan

- [x] Local: `TRADING_API_PORT=8001` in `.env` → `python btc_api.py` binds to `:8001`
- [x] Local: `VITE_API_PROXY_TARGET=http://localhost:8001` → Vite proxies `/api/*` to `:8001` (smoke `curl http://localhost:5173/api/symbols` → 401 from btc_api auth middleware, not 404 from the wrong target)
- [x] Local: no `.env` present → `python btc_api.py` binds to `:8000` (default preserved)
- [ ] CI green (unrelated `test_setup.py::test_5/6/9` may still fail on bcrypt env — pre-existing on main, not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)