### PR TITLE
feat(symbols): add live_price field for between-bar dashboard refresh

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -293,21 +293,32 @@ def root():
 @app.get("/symbols", summary="Estado actual de cada par monitoreado")
 def list_symbols():
     """Retorna el último escaneo de cada símbolo, ordenado por señal y score."""
+    import json as _json  # noqa: PLC0415 — local import keeps the module-level surface unchanged
     symbols = _scanner_state.get("symbols_active") or get_active_symbols()
     rows    = get_signals_summary()
     by_sym  = {r["symbol"]: r for r in rows}
     result  = []
     for sym in symbols:
         row = by_sym.get(sym)
+        # `price` is the 1H close (decision-time price for SL/TP/sizing).
+        # `live_price` (lives in payload JSON) is the 5m close — refreshes every
+        # scan so the dashboard doesn't appear stuck between 1H bar closes.
+        live_price = None
+        if row and row.get("payload"):
+            try:
+                live_price = _json.loads(row["payload"]).get("live_price")
+            except (ValueError, TypeError):
+                live_price = None
         result.append({
-            "symbol":  sym,
-            "estado":  row["estado"]        if row else "Sin datos aun",
-            "price":   row["price"]         if row else None,
-            "lrc_pct": row["lrc_pct"]       if row else None,
-            "score":   row["score"]         if row else None,
-            "señal":   bool(row["señal"])   if row else False,
-            "gatillo": bool(row["gatillo"]) if row else False,
-            "ts":      row["ts"]            if row else None,
+            "symbol":     sym,
+            "estado":     row["estado"]        if row else "Sin datos aun",
+            "price":      row["price"]         if row else None,
+            "live_price": live_price,
+            "lrc_pct":    row["lrc_pct"]       if row else None,
+            "score":      row["score"]         if row else None,
+            "señal":      bool(row["señal"])   if row else False,
+            "gatillo":    bool(row["gatillo"]) if row else False,
+            "ts":         row["ts"]            if row else None,
         })
     return {"total": len(result), "symbols": result}
 

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -223,7 +223,15 @@ def scan(symbol: str = None):
     df5  = md.get_klines(symbol, "5m",  limit=210)   # gatillo
     df1h = md.get_klines(symbol, "1h",  limit=210)   # señal principal
     df4h = md.get_klines(symbol, "4h",  limit=150)   # contexto macro
-    price = df1h["close"].iloc[-1]   # precio de cierre de la última vela 1H
+    price = df1h["close"].iloc[-1]   # precio de cierre de la última vela 1H (decisión / SL / TP / sizing)
+    # live_price = close de la vela 5m más reciente. Solo para display — refresca
+    # con cada scan (~5 min) en vez de quedarse pegado al cierre 1H (~1 h).
+    # No alimenta scoring / SL / TP / sizing, esos siguen usando `price`.
+    try:
+        live_price = float(df5["close"].iloc[-1])
+    except Exception:
+        live_price = float(price)
+    rep["live_price"] = round(live_price, 8)
 
     # ── Load config (reused for regime_mode + symbol_overrides) ─────────────
     _cfg_path = os.path.join(SCRIPT_DIR, "config.json")

--- a/frontend/src/components/ChartModal.tsx
+++ b/frontend/src/components/ChartModal.tsx
@@ -247,7 +247,7 @@ const ChartModal: React.FC<ChartModalProps> = ({ symbol, onClose }) => {
 
   if (!symbol) return null;
 
-  const displayPrice = hoverPrice ?? symbol.price ?? 0;
+  const displayPrice = hoverPrice ?? symbol.live_price ?? symbol.price ?? 0;
   const lrc          = symbol.lrc_pct;
   const score        = symbol.score ?? 0;
   const lrcColor     = lrc != null && lrc <= 25 ? C_GREEN : C_RED;

--- a/frontend/src/components/OpenPositionModal.tsx
+++ b/frontend/src/components/OpenPositionModal.tsx
@@ -26,10 +26,11 @@ const OpenPositionModal: React.FC<OpenPositionModalProps> = ({
   const [saving,     setSaving]     = useState(false);
   const [error,      setError]      = useState<string | null>(null);
 
-  // When symbol changes, fill entry price from current price
+  // When symbol changes, fill entry price from current price (prefer live).
   useEffect(() => {
     const sym = symbols.find(s => s.symbol === symbol);
-    if (sym?.price && !prefill?.price) setEntryPrice(String(sym.price));
+    const current = sym?.live_price ?? sym?.price;
+    if (current && !prefill?.price) setEntryPrice(String(current));
   }, [symbol, symbols, prefill]);
 
   // Derived calculations

--- a/frontend/src/components/PositionsPanel.tsx
+++ b/frontend/src/components/PositionsPanel.tsx
@@ -19,7 +19,8 @@ interface PositionsPanelProps {
 function priceMap(symbols: SymbolStatus[]): Record<string, number> {
   const map: Record<string, number> = {};
   for (const s of symbols) {
-    if (s.price != null) map[s.symbol] = s.price;
+    const p = s.live_price ?? s.price;
+    if (p != null) map[s.symbol] = p;
   }
   return map;
 }

--- a/frontend/src/components/SymbolCard.tsx
+++ b/frontend/src/components/SymbolCard.tsx
@@ -43,7 +43,7 @@ const SymbolCard: React.FC<SymbolCardProps> = ({ symbol, onClick }) => {
 
   const lrc    = symbol.lrc_pct ?? 0;
   const score  = symbol.score   ?? 0;
-  const price  = symbol.price   ?? 0;
+  const price  = symbol.live_price ?? symbol.price ?? 0;
 
   // Clamp lrc_pct to 0–100 for bar display
   const lrcBarPct   = Math.min(100, Math.max(0, lrc));
@@ -109,7 +109,7 @@ const SymbolCard: React.FC<SymbolCardProps> = ({ symbol, onClick }) => {
       <div className="card-price">
         <span className="price-currency">$</span>
         <span className="price-value">
-          {symbol.price != null ? formatPrice(price) : '—'}
+          {(symbol.live_price ?? symbol.price) != null ? formatPrice(price) : '—'}
         </span>
       </div>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,7 +19,10 @@ export interface Sizing1h {
 export interface SymbolStatus {
   symbol: string;
   estado: string;
+  /** Decision-time price (1H close). Used by SL/TP/sizing on the backend; stable across 5-min scans within an hour. */
   price: number | null;
+  /** Display price (5m close). Refreshes every scan. Prefer this for rendering; fall back to `price`. */
+  live_price?: number | null;
   lrc_pct: number | null;
   score: number | null;
   señal: boolean;

--- a/tests/_baselines/scan_btcusdt.json
+++ b/tests/_baselines/scan_btcusdt.json
@@ -95,6 +95,7 @@
     "vela_5m_alcista": false
   },
   "gatillo_activo": false,
+  "live_price": 76622.47,
   "lrc_1h": {
     "lower": 76374.26,
     "mid": 77440.95,


### PR DESCRIPTION
## Summary

`/symbols` returned `price` = close of the last completed **1H** bar, so with the 5-min scanner cadence the dashboard showed the same value for ~12 consecutive scans before it ever ticked. To users this looked like the prices were frozen.

This PR adds a parallel **`live_price`** field sourced from the **5m** close — refreshes every scan. `price` is unchanged and still drives SL / TP / sizing / scoring, so backtest parity is preserved.

### What changes

| Layer | Field | Source | Updates every |
|---|---|---|---|
| Backend (strategy logic — unchanged) | `price` | `df1h["close"].iloc[-1]` | 1H bar close |
| Backend (new, display only) | `live_price` | `df5["close"].iloc[-1]` | scan (5 min) |

### Files

- `btc_scanner.py` — compute `live_price` right after the existing 1H assignment; stash in `rep["live_price"]`. `df5` is already fetched for the trigger so no extra HTTP cost.
- `btc_api.py` `/symbols` — parse the existing `payload` JSON column to surface `live_price` as a separate response field. Defaults to `None` for rows written before this commit; frontend falls back to `price`.
- `frontend/src/types.ts` — add optional `live_price?: number | null` to `SymbolStatus` with docstrings explaining the contract.
- `SymbolCard.tsx`, `ChartModal.tsx`, `OpenPositionModal.tsx`, `PositionsPanel.tsx` — prefer `live_price ?? price` for display, entry-price prefill, and the current-price map used by unrealized PnL.

### Why no schema migration

`live_price` rides in the existing `payload` JSON column of `scans`. Adding a column would have been the more relational option but the field is purely a display artifact (not queried by strategy / backtests / outcome tracking), so keeping it in the JSON envelope avoids both the migration and the operational coordination.

### Side benefit: real precision for cheap coins

`price` was rounded to 2 decimals → ADA / DOGE / XLM / JUP all displayed as `0.26 / 0.11 / 0.15 / 0.20` regardless of actual value. `live_price` rounds to 8 decimals so the dashboard now shows `0.2569 / 0.11186 / 0.1522 / 0.2002`.

## Verification

```
=== latest scan per symbol: price (1H) vs live_price (5m) ===
ADAUSDT       price(1H)=        0.26   live(5m)=0.2569    Δ=-0.0031
AVAXUSDT      price(1H)=        9.36   live(5m)=9.37      Δ=+0.0100
BTCUSDT       price(1H)=    78415.99   live(5m)=78390.34  Δ=-25.65
DOGEUSDT      price(1H)=        0.11   live(5m)=0.11186   Δ=+0.00186
ETHUSDT       price(1H)=      2192.0   live(5m)=2192.59   Δ=+0.59
```

## Test plan

- [x] `python -m pytest tests/test_api.py::TestAPIEndpoints tests/test_scanner.py` → 110 passed
- [x] Backend restart, scan cycle completes, `live_price` present in DB payload + `/symbols` response
- [ ] Reviewer: load dashboard, confirm cheap-coin pairs display real precision and prices visibly change across scan cycles instead of every hour
- [ ] Reviewer: open the position modal, confirm entry-price prefill picks up `live_price`

🤖 Generated with [Claude Code](https://claude.com/claude-code)