### PR TITLE
chore(ci): bump Node 20 → 22 on workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 


### PR DESCRIPTION
## Summary
- `actions/setup-node@v4` was pinned to Node 20, which GitHub is deprecating (forced removal Sept 2026).
- Bumped both `ci.yml` and `deploy.yml` to Node 22 (current LTS).
- Local dev is already on Node 24, so this narrows the gap.

## Test plan
- [ ] CI Backend (pytest) green
- [ ] CI Frontend (tsc + vitest + build) green
- [ ] Deploy to Production succeeds and health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)