### PR TITLE
feat(deploy): atomic deploys via releases/<sha> + symlink swap

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,89 @@
+# One-shot workflow para correr scripts/bootstrap-atomic-deploy.sh en el
+# server vía SSH usando los mismos secrets que deploy.yml. Es de disparo
+# manual (workflow_dispatch) — NO se ejecuta automáticamente.
+#
+# Uso:
+#   1. Desde el web UI: Actions → Bootstrap atomic deploy → Run workflow
+#      → seleccionar mode = "dry-run" o "apply"
+#   2. Desde CLI:
+#        gh workflow run "Bootstrap atomic deploy" -f mode=dry-run
+#        gh workflow run "Bootstrap atomic deploy" -f mode=apply
+#
+# El primer paso recomendado es siempre "dry-run" para ver el diff del
+# systemd unit y la lista de archivos que se moverían. Después, "apply".
+#
+# Es idempotente: si el bootstrap ya corrió, el script detecta /current
+# y sale limpio sin tocar nada.
+
+name: Bootstrap atomic deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'dry-run = preview sin aplicar; apply = ejecuta el bootstrap'
+        required: true
+        type: choice
+        default: dry-run
+        options:
+          - dry-run
+          - apply
+
+# Sin concurrency group: queremos que cada dispatch corra independiente.
+# Si alguien dispara dos al hilo, GitHub los serializa por defecto pero
+# tampoco hay riesgo (script es idempotente).
+
+jobs:
+  bootstrap:
+    name: Bootstrap server (mode=${{ inputs.mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HOST:    ${{ secrets.DEPLOY_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Upload bootstrap script to server
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          scp -i ~/.ssh/deploy_key \
+            scripts/bootstrap-atomic-deploy.sh \
+            ubuntu@${HOST}:/tmp/bootstrap-atomic-deploy.sh
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} \
+            "chmod +x /tmp/bootstrap-atomic-deploy.sh"
+
+      - name: Run bootstrap (${{ inputs.mode }})
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          if [ "$MODE" = "dry-run" ]; then
+            FLAG="--dry-run"
+          else
+            FLAG="--yes"
+          fi
+          echo "::group::Running bootstrap with $FLAG"
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} \
+            "/tmp/bootstrap-atomic-deploy.sh $FLAG"
+          echo "::endgroup::"
+
+      - name: Cleanup remote script
+        if: always()
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} \
+            "rm -f /tmp/bootstrap-atomic-deploy.sh" || true
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,29 @@
-# Deploy in-place. Trade-off conocido: si el rsync de frontend falla
-# después del rsync de backend, el sistema queda con backend nuevo y
-# frontend viejo hasta el siguiente deploy. Aceptable mientras el sistema
-# sea single-user sin capital real. Para capital real, migrar a deploy
-# atómico con symlink swap (releases/<sha> → /var/www/trading current).
+# Atomic deploy con symlink swap.
 #
-# Bootstrap manual del server requerido ANTES del primer deploy:
-#   docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md §6
-# El step "Verify .env exists" abajo falla fast si no se hizo.
+# Layout en el server (creado por scripts/bootstrap-atomic-deploy.sh):
+#
+#   /var/www/trading/
+#   ├── current → releases/<sha>     (symlink al release activo)
+#   ├── releases/
+#   │   ├── <sha-N>/                  (copy completo de la app por deploy)
+#   │   │   ├── btc_api.py / ...
+#   │   │   ├── dist/                 (frontend build)
+#   │   │   ├── .env    → ../../shared/.env
+#   │   │   ├── .venv   → ../../shared/.venv
+#   │   │   └── data    → ../../shared/data
+#   │   └── <sha-N-1>/                (release anterior — para rollback)
+#   └── shared/                       (persiste entre deploys)
+#       ├── .env
+#       ├── .venv/
+#       └── data/
+#
+# El cutover es atómico (mv -Tf sobre el symlink usa rename(2) atómico de
+# Linux). Si el health check falla, se hace rollback automático al release
+# anterior antes de devolver exit 1.
+#
+# Bootstrap manual requerido ANTES del primer deploy con este workflow:
+#   docs/atomic-deploy-migration.md
+# El step "Verify atomic layout" abajo falla fast si no se hizo.
 
 name: Deploy to Production
 
@@ -52,19 +69,58 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
-      - name: Verify .env exists on server (fail-fast if bootstrap missing)
+      - name: Verify atomic layout (fail-fast if bootstrap missing)
+        # Chequeo de que el server ya corrió scripts/bootstrap-atomic-deploy.sh.
+        # Sin esto, los rsync/symlink subsiguientes romperían el deploy
+        # actual del server. Fail fast antes de tocar nada.
         env:
           HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
-          if ! ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "test -f /var/www/trading/.env"; then
-            echo "::error::/var/www/trading/.env no existe en el server."
-            echo "::error::Ejecutar bootstrap manual primero (ver docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md §6)."
+          if ! ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "
+            test -L /var/www/trading/current &&
+            test -d /var/www/trading/releases &&
+            test -d /var/www/trading/shared &&
+            test -f /var/www/trading/shared/.env &&
+            test -d /var/www/trading/shared/.venv
+          "; then
+            echo "::error::Server no está migrado al layout atómico."
+            echo "::error::Ejecutar scripts/bootstrap-atomic-deploy.sh primero."
+            echo "::error::Ver docs/atomic-deploy-migration.md"
             exit 1
           fi
 
-      - name: rsync backend source
+      - name: Compute release paths
+        id: paths
+        run: |
+          SHA=${GITHUB_SHA::12}
+          echo "sha=$SHA"                                   >> $GITHUB_OUTPUT
+          echo "release_dir=/var/www/trading/releases/$SHA" >> $GITHUB_OUTPUT
+
+      - name: Capture previous release (for rollback)
+        # Leemos el target del symlink current ANTES de tocarlo. Si el health
+        # check post-cutover falla, hacemos `ln -sfn $PREV current` para volver.
+        id: prev
         env:
           HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          PREV=$(ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "readlink /var/www/trading/current || echo ''")
+          echo "prev=$PREV" >> $GITHUB_OUTPUT
+          echo "Previous release symlink target: $PREV"
+
+      - name: Stage release directory
+        env:
+          HOST:        ${{ secrets.DEPLOY_HOST }}
+          RELEASE_DIR: ${{ steps.paths.outputs.release_dir }}
+        run: |
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "
+            mkdir -p ${RELEASE_DIR} &&
+            mkdir -p ${RELEASE_DIR}/dist
+          "
+
+      - name: rsync backend source to release dir
+        env:
+          HOST:        ${{ secrets.DEPLOY_HOST }}
+          RELEASE_DIR: ${{ steps.paths.outputs.release_dir }}
         run: |
           rsync -az --delete \
             -e "ssh -i ~/.ssh/deploy_key" \
@@ -76,39 +132,104 @@ jobs:
             --exclude='Dashboard/' --exclude='docs/' --exclude='*.bat' \
             --exclude='*.ps1' --exclude='.env' --exclude='.env.*' \
             --exclude='.claude/' \
-            --exclude='data/*.json' --exclude='data/*.csv' \
-            --exclude='data/*.xlsx' --exclude='data/backtest/' \
-            ./ ubuntu@${HOST}:/var/www/trading/
+            --exclude='data/' \
+            --exclude='dist/' \
+            ./ ubuntu@${HOST}:${RELEASE_DIR}/
 
-      - name: rsync frontend dist
+      - name: rsync frontend dist to release dir
         env:
-          HOST: ${{ secrets.DEPLOY_HOST }}
+          HOST:        ${{ secrets.DEPLOY_HOST }}
+          RELEASE_DIR: ${{ steps.paths.outputs.release_dir }}
         run: |
           rsync -az --delete \
             -e "ssh -i ~/.ssh/deploy_key" \
-            frontend/dist/ ubuntu@${HOST}:/var/www/trading/dist/
+            frontend/dist/ ubuntu@${HOST}:${RELEASE_DIR}/dist/
 
-      - name: pip install + restart service
+      - name: Link shared resources into release
+        # .env, .venv, data/ viven en shared/ y se linkean dentro del release.
+        # Esto garantiza que los releases comparten el mismo virtualenv (sin
+        # reinstalar pip deps salvo que requirements cambie) y la misma DB.
+        env:
+          HOST:        ${{ secrets.DEPLOY_HOST }}
+          RELEASE_DIR: ${{ steps.paths.outputs.release_dir }}
+        run: |
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "
+            cd ${RELEASE_DIR} &&
+            ln -sfn ../../shared/.env  .env &&
+            ln -sfn ../../shared/.venv .venv &&
+            ln -sfn ../../shared/data  data
+          "
+
+      - name: pip install in new release
+        env:
+          HOST:        ${{ secrets.DEPLOY_HOST }}
+          RELEASE_DIR: ${{ steps.paths.outputs.release_dir }}
+        run: |
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "
+            cd ${RELEASE_DIR} &&
+            .venv/bin/pip install --upgrade -r requirements.txt
+          "
+
+      - name: Atomic cutover (swap symlink + restart)
+        # `mv -Tf` sobre un symlink existente usa rename(2) que es atómico en
+        # Linux: el proceso del kernel garantiza que ningún lector ve un
+        # estado intermedio. `ln -sfn current.new current` también funciona
+        # pero `mv -T` es más explícitamente atómico.
+        env:
+          HOST:        ${{ secrets.DEPLOY_HOST }}
+          RELEASE_DIR: ${{ steps.paths.outputs.release_dir }}
+        run: |
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "
+            cd /var/www/trading &&
+            ln -sfn releases/$(basename ${RELEASE_DIR}) current.new &&
+            mv -Tf current.new current &&
+            sudo systemctl restart trading-spacial
+          "
+
+      - name: Health check + auto-rollback on failure
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          PREV: ${{ steps.prev.outputs.prev }}
+        run: |
+          sleep 15
+          if ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "curl -fsS http://localhost:8100/health"; then
+            echo "::notice::Deploy OK. Release activo: ${{ steps.paths.outputs.sha }}"
+            exit 0
+          fi
+
+          echo "::error::Health check falló post-cutover."
+          if [ -n "$PREV" ]; then
+            echo "::warning::Rolling back a $PREV..."
+            ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "
+              cd /var/www/trading &&
+              ln -sfn $PREV current.new &&
+              mv -Tf current.new current &&
+              sudo systemctl restart trading-spacial
+            "
+            sleep 10
+            if ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "curl -fsS http://localhost:8100/health"; then
+              echo "::warning::Rollback OK. Release activo: $PREV"
+            else
+              echo "::error::Rollback también falló. Estado del server desconocido."
+              ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "sudo journalctl -u trading-spacial -n 80 --no-pager"
+            fi
+          else
+            echo "::error::No hay release previo registrado para rollback."
+          fi
+          exit 1
+
+      - name: Cleanup old releases (keep last 5)
+        # Sólo si el deploy fue exitoso. Si falló y rolled back, mantenemos
+        # el release fallido para inspección manual.
+        if: success()
         env:
           HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
           ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "
-            cd /var/www/trading &&
-            .venv/bin/pip install --upgrade -r requirements.txt &&
-            sudo systemctl restart trading-spacial
+            cd /var/www/trading/releases &&
+            ls -1t | tail -n +6 | xargs -r rm -rf
           "
 
-      - name: Health check
-        env:
-          HOST: ${{ secrets.DEPLOY_HOST }}
-        run: |
-          sleep 15
-          if ! ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "curl -fsS http://localhost:8100/health"; then
-            echo "::error::Health check falló. Logs del servicio:"
-            ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "sudo journalctl -u trading-spacial -n 80 --no-pager"
-            exit 1
-          fi
-
-      - name: Cleanup
+      - name: Cleanup SSH key
         if: always()
         run: rm -f ~/.ssh/deploy_key

--- a/docs/atomic-deploy-migration.md
+++ b/docs/atomic-deploy-migration.md
@@ -1,0 +1,179 @@
+# Migración al deploy atómico — guía operativa
+
+Esta es una migración **one-time** del layout actual del server
+(`/var/www/trading/` plano) al layout con `releases/<sha>` + symlink
+`current` que permite deploys atómicos con rollback.
+
+## Por qué
+
+El `deploy.yml` previo hacía rsync directo a `/var/www/trading/`. Trade-off
+conocido:
+- Si rsync del backend pasaba pero rsync del frontend fallaba, el sistema
+  quedaba con backend nuevo + frontend viejo hasta el próximo deploy.
+- Si el `systemctl restart` no levantaba la app, no había rollback fácil
+  — había que re-rsync de un commit anterior o restaurar a mano.
+
+El nuevo flujo:
+1. Cada deploy va a `releases/<sha>/` (sin tocar el activo).
+2. Pip install corre dentro del release nuevo.
+3. **Cutover atómico**: `mv -Tf current.new current` (rename(2) es atómico
+   en Linux). Antes del swap el sistema está 100% en el release anterior;
+   después del swap está 100% en el nuevo. No hay estado intermedio.
+4. Health check → si falla, **rollback automático** al release anterior.
+5. Se mantienen los últimos 5 releases para rollback manual si hace falta.
+
+## Layout objetivo
+
+```
+/var/www/trading/
+├── current → releases/abc123def4    (symlink, el target apunta al release activo)
+├── releases/
+│   ├── abc123def4/                   (release activo)
+│   │   ├── btc_api.py / ...          (código copiado por rsync)
+│   │   ├── dist/                     (frontend build)
+│   │   ├── .env    → ../../shared/.env
+│   │   ├── .venv   → ../../shared/.venv
+│   │   └── data    → ../../shared/data
+│   ├── 789ghi456789/                 (release anterior)
+│   └── ...                           (hasta 5 releases)
+└── shared/                           (persiste entre deploys)
+    ├── .env                          (config — NO se commitea, NO se rsync)
+    ├── .venv/                        (virtualenv compartido)
+    └── data/                         (signals.db, logs, etc)
+```
+
+Por qué linkear `.env`, `.venv`, `data/` en vez de tenerlos por-release:
+- **`.env`**: secrets / config. Tiene que sobrevivir al deploy.
+- **`.venv`**: tarda 30-60s en recrearse. Compartirlo evita esa latencia
+  por deploy. El `pip install --upgrade -r requirements.txt` se ejecuta
+  pero solo aplica deltas.
+- **`data/`**: la DB y los logs. Obvio que no podemos tirarlos cada deploy.
+
+## Pasos del bootstrap (una vez, en el server)
+
+### 0. Pre-requisitos
+
+- Acceso SSH al server como `ubuntu`.
+- Permisos `sudo` (para `systemctl` y escribir en `/etc/systemd/system/`).
+- El service `trading-spacial` está corriendo en el layout viejo
+  (`/var/www/trading/btc_api.py`, etc).
+
+### 1. Subir el script al server
+
+Desde tu máquina (la que tiene SSH key):
+
+```bash
+scp scripts/bootstrap-atomic-deploy.sh ubuntu@<DEPLOY_HOST>:/tmp/
+ssh ubuntu@<DEPLOY_HOST>
+```
+
+### 2. Ejecutar el bootstrap
+
+```bash
+cd /tmp
+chmod +x bootstrap-atomic-deploy.sh
+./bootstrap-atomic-deploy.sh
+```
+
+El script:
+
+1. **Sanity checks** — chequea que `/var/www/trading/.env`, `/var/www/trading/.venv/`
+   y el systemd unit existen. Si `current` ya existe, sale sin tocar nada.
+2. `systemctl stop trading-spacial` — pausa la app durante la migración.
+3. Crea `shared/` y mueve `.env`, `.venv`, `data/` ahí.
+4. Crea `releases/<initial-sha>/` y mueve todo lo demás (código backend,
+   `dist/`, etc) ahí.
+5. Crea los symlinks `.env`, `.venv`, `data` dentro del release inicial
+   apuntando a `../../shared/*`.
+6. Crea el symlink `current → releases/<initial-sha>`.
+7. **Reescribe el systemd unit** con `perl -i` reemplazando `/var/www/trading`
+   por `/var/www/trading/current` (con lookahead para no doble-prefijar
+   paths que ya empiezan con `releases/`, `shared/` o `current`).
+   Hace un `.bak.<timestamp>` antes.
+8. Muestra el diff del unit y **pide confirmación interactiva**.
+9. `systemctl daemon-reload && systemctl start trading-spacial`.
+10. `curl -fsS http://localhost:8100/health` — si falla, imprime los
+    comandos para revertir manualmente.
+
+### 3. Verificación post-bootstrap
+
+```bash
+# El service tiene que estar activo
+sudo systemctl status trading-spacial
+
+# El symlink apunta al release inicial
+ls -la /var/www/trading/current
+
+# .env y .venv son symlinks a shared/
+ls -la /var/www/trading/current/.env
+ls -la /var/www/trading/current/.venv
+
+# El health check responde
+curl http://localhost:8100/health
+
+# Logs limpios sin tracebacks
+sudo journalctl -u trading-spacial -n 50 --no-pager
+```
+
+### 4. Mergear el PR del deploy atómico
+
+Con el server ya migrado, mergear el PR de
+`.github/workflows/deploy.yml` (deploy atómico).
+
+El primer deploy con el flujo nuevo:
+- Tomará el SHA del commit que mergeó el PR.
+- Creará `releases/<ese-sha>/` con la copia.
+- Cutover atómico al nuevo release.
+- Health check.
+
+Si todo OK, vas a ver dos releases en `releases/`: el inicial del bootstrap
++ el primer release auto-generado.
+
+## Rollback manual (después de bootstrapped)
+
+Si un deploy auto-completa pero el comportamiento de la app es malo (no
+es un health check failure, sino un bug funcional), podés rollback a mano:
+
+```bash
+ssh ubuntu@<DEPLOY_HOST>
+cd /var/www/trading
+ls -1t releases/ | head -5            # ver últimos 5 releases
+ln -sfn releases/<sha-anterior> current.new
+mv -Tf current.new current
+sudo systemctl restart trading-spacial
+```
+
+El rollback es atómico también.
+
+## Rollback del bootstrap (volver al layout viejo)
+
+Si el bootstrap falla y querés volver al layout plano, el script imprime
+los comandos exactos al final del error. Resumen:
+
+```bash
+sudo systemctl stop trading-spacial
+sudo cp /etc/systemd/system/trading-spacial.service.bak.<timestamp> \
+        /etc/systemd/system/trading-spacial.service
+sudo mv /var/www/trading/releases/<initial-sha>/* /var/www/trading/
+sudo mv /var/www/trading/shared/.env  /var/www/trading/.env
+sudo mv /var/www/trading/shared/.venv /var/www/trading/.venv
+sudo mv /var/www/trading/shared/data  /var/www/trading/data
+sudo rm -rf /var/www/trading/{current,releases,shared}
+sudo systemctl daemon-reload
+sudo systemctl start trading-spacial
+```
+
+## Notas y limitaciones
+
+- **Rolling release window**: el flujo de CI mantiene los últimos 5 releases.
+  Si querés más historia, ajustar `tail -n +6` en el step "Cleanup old
+  releases" del `deploy.yml`.
+- **Concurrent deploys**: el `concurrency.group: deploy-production` con
+  `cancel-in-progress: true` cancela cualquier deploy en curso si llega
+  uno nuevo. Si el nuevo cancela uno que ya rsync-eó pero no hizo cutover,
+  el release queda en `releases/` pero no activo. Cleanup lo barre tras
+  el próximo deploy exitoso.
+- **DB migrations**: este flujo NO contempla migraciones de schema. Si
+  agregás SQLAlchemy + Alembic o similar, hay que insertar un step
+  `.venv/bin/alembic upgrade head` ANTES del cutover (dentro del release
+  nuevo, antes del swap).

--- a/docs/atomic-deploy-migration.md
+++ b/docs/atomic-deploy-migration.md
@@ -49,30 +49,53 @@ Por qué linkear `.env`, `.venv`, `data/` en vez de tenerlos por-release:
   pero solo aplica deltas.
 - **`data/`**: la DB y los logs. Obvio que no podemos tirarlos cada deploy.
 
-## Pasos del bootstrap (una vez, en el server)
+## Pasos del bootstrap
 
-### 0. Pre-requisitos
+Hay dos formas de correr el bootstrap. Elegí la que aplique a tu situación.
+
+### Opción A — Via GitHub Actions (sin SSH key local)
+
+Si NO tenés SSH key al server pero sí acceso al repo en GitHub:
+
+1. Ir a **Actions → "Bootstrap atomic deploy" → Run workflow**.
+2. Primer dispatch: `mode = dry-run`. Mira el log — especialmente el diff
+   del systemd unit y la lista de archivos que se moverían. Si todo se ve
+   razonable, seguí al paso 3.
+3. Segundo dispatch: `mode = apply`. Esto ejecuta el bootstrap completo
+   (sin confirmaciones interactivas, ya las hiciste vos al revisar el
+   dry-run). Termina con un health check; si falla, los logs te muestran
+   los comandos para revertir manualmente.
+
+Equivalente vía CLI:
+
+```bash
+gh workflow run "Bootstrap atomic deploy" -f mode=dry-run
+gh run watch    # mirá el log del dry-run
+gh workflow run "Bootstrap atomic deploy" -f mode=apply
+gh run watch    # confirmá que apply completó OK
+```
+
+El workflow usa los mismos secrets `DEPLOY_SSH_KEY` + `DEPLOY_HOST` que
+`deploy.yml`. Es idempotente: si `current` ya existe, sale sin tocar nada.
+
+### Opción B — Via SSH directo (interactivo)
+
+Pre-requisitos:
 
 - Acceso SSH al server como `ubuntu`.
 - Permisos `sudo` (para `systemctl` y escribir en `/etc/systemd/system/`).
 - El service `trading-spacial` está corriendo en el layout viejo
   (`/var/www/trading/btc_api.py`, etc).
 
-### 1. Subir el script al server
-
-Desde tu máquina (la que tiene SSH key):
-
 ```bash
 scp scripts/bootstrap-atomic-deploy.sh ubuntu@<DEPLOY_HOST>:/tmp/
 ssh ubuntu@<DEPLOY_HOST>
-```
-
-### 2. Ejecutar el bootstrap
-
-```bash
 cd /tmp
 chmod +x bootstrap-atomic-deploy.sh
-./bootstrap-atomic-deploy.sh
+./bootstrap-atomic-deploy.sh                # default: pide confirmación tras mostrar el diff
+# o:
+./bootstrap-atomic-deploy.sh --dry-run      # solo preview
+./bootstrap-atomic-deploy.sh --yes          # apply sin prompts
 ```
 
 El script:

--- a/scripts/bootstrap-atomic-deploy.sh
+++ b/scripts/bootstrap-atomic-deploy.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# bootstrap-atomic-deploy.sh — migración one-time del layout actual del
+# server (todo en /var/www/trading/) al layout atómico con releases/<sha>
+# + shared/ + symlink current.
+#
+# Ejecutar como usuario `ubuntu` en el server de producción.
+# Requiere sudo para tocar systemd.
+#
+# Pre-condición:
+#   /var/www/trading/                   contiene la app actual deployada
+#   /var/www/trading/.env               existe (creado durante bootstrap original)
+#   /var/www/trading/.venv/             existe (virtualenv del sistema)
+#
+# Post-condición:
+#   /var/www/trading/current → releases/<initial-sha>
+#   /var/www/trading/shared/.env, shared/.venv/, shared/data/
+#   /var/www/trading/releases/<initial-sha>/  con copia del estado actual
+#   systemd unit `trading-spacial` apuntando a /var/www/trading/current
+#
+# El script es idempotente: si /var/www/trading/current ya existe, sale
+# limpio sin tocar nada.
+
+set -euo pipefail
+
+BASE=/var/www/trading
+INITIAL_SHA="${1:-pre-atomic-$(date +%Y%m%d-%H%M%S)}"
+UNIT_FILE=/etc/systemd/system/trading-spacial.service
+
+# ── 0. Sanity checks ─────────────────────────────────────────
+
+if [ ! -d "$BASE" ]; then
+  echo "::error::$BASE no existe — ¿bootstrap original completado?"
+  exit 1
+fi
+
+if [ -L "$BASE/current" ]; then
+  echo "==> $BASE/current ya existe. Layout atómico ya está bootstrapped."
+  echo "==> Release activo: $(readlink $BASE/current)"
+  exit 0
+fi
+
+for f in .env .venv; do
+  if [ ! -e "$BASE/$f" ]; then
+    echo "::error::$BASE/$f no existe. Bootstrap original incompleto."
+    exit 1
+  fi
+done
+
+if [ ! -f "$UNIT_FILE" ]; then
+  echo "::error::$UNIT_FILE no existe. Bootstrap original incompleto."
+  exit 1
+fi
+
+echo "==> Bootstrap atómico: BASE=$BASE INITIAL_SHA=$INITIAL_SHA"
+echo
+
+# ── 1. Pausar service ────────────────────────────────────────
+
+echo "==> Pausando trading-spacial..."
+sudo systemctl stop trading-spacial
+
+# ── 2. Crear shared/ y mover .env, .venv, data/ ──────────────
+
+echo "==> Creando $BASE/shared/..."
+sudo mkdir -p "$BASE/shared"
+
+echo "==> Moviendo .env, .venv, data/ a shared/..."
+sudo mv "$BASE/.env"  "$BASE/shared/.env"
+sudo mv "$BASE/.venv" "$BASE/shared/.venv"
+if [ -d "$BASE/data" ]; then
+  sudo mv "$BASE/data" "$BASE/shared/data"
+else
+  sudo mkdir -p "$BASE/shared/data"
+fi
+
+# ── 3. Crear releases/<initial-sha>/ con el resto ────────────
+
+echo "==> Creando $BASE/releases/$INITIAL_SHA/ con el estado actual..."
+sudo mkdir -p "$BASE/releases/$INITIAL_SHA"
+
+cd "$BASE"
+# Mover todo lo que no sea releases/, shared/, current al release inicial.
+for f in *; do
+  case "$f" in
+    releases|shared|current) ;;
+    *) sudo mv "$f" "releases/$INITIAL_SHA/" ;;
+  esac
+done
+
+# ── 4. Linkear shared/* dentro del release inicial ───────────
+
+echo "==> Linkeando shared/* dentro del release inicial..."
+sudo ln -sfn ../../shared/.env  "$BASE/releases/$INITIAL_SHA/.env"
+sudo ln -sfn ../../shared/.venv "$BASE/releases/$INITIAL_SHA/.venv"
+sudo ln -sfn ../../shared/data  "$BASE/releases/$INITIAL_SHA/data"
+
+# ── 5. Symlink current → release inicial ─────────────────────
+
+echo "==> Creando symlink $BASE/current → releases/$INITIAL_SHA..."
+sudo ln -sfn "releases/$INITIAL_SHA" "$BASE/current"
+
+# ── 6. Actualizar systemd unit ───────────────────────────────
+
+echo "==> Backup del systemd unit en ${UNIT_FILE}.bak.$(date +%s)..."
+sudo cp "$UNIT_FILE" "${UNIT_FILE}.bak.$(date +%s)"
+
+echo "==> Reescribiendo paths del systemd unit (/var/www/trading → /var/www/trading/current)..."
+# Reemplazo cuidadoso: solo paths que empiezan con /var/www/trading/ seguido
+# de algo distinto a "current", "releases", "shared". Usa lookahead negativo
+# vía dos pases (Perl) para evitar /var/www/trading/current/current/.
+sudo perl -i -pe 's|/var/www/trading(?!/(?:current|releases|shared))(\b)|/var/www/trading/current\1|g' "$UNIT_FILE"
+
+echo "==> Diff del unit (revisar antes de continuar):"
+sudo diff "${UNIT_FILE}.bak."*[0-9] "$UNIT_FILE" || true
+echo
+echo "==> ¿OK? Presioná Enter para continuar, Ctrl+C para abortar."
+read -r _
+
+sudo systemctl daemon-reload
+
+# ── 7. Restart + health check ────────────────────────────────
+
+echo "==> Arrancando trading-spacial con el nuevo layout..."
+sudo systemctl start trading-spacial
+
+echo "==> Esperando 8s y verificando health..."
+sleep 8
+
+if curl -fsS http://localhost:8100/health > /dev/null; then
+  echo
+  echo "==> ✓ Bootstrap completado."
+  echo "==> Release activo: $INITIAL_SHA"
+  echo "==> Layout:"
+  echo "      current     → $(readlink $BASE/current)"
+  echo "      shared/.env → $(ls -la $BASE/shared/.env | awk '{print $NF}')"
+  echo
+  echo "==> Próximos deploys vía CI usarán el flujo atómico de .github/workflows/deploy.yml"
+else
+  echo "::error::Health check falló. El service no levantó con el nuevo layout."
+  echo "::error::Logs:"
+  sudo journalctl -u trading-spacial -n 60 --no-pager
+  echo
+  echo "::error::Para revertir manualmente:"
+  echo "  sudo systemctl stop trading-spacial"
+  echo "  sudo cp ${UNIT_FILE}.bak.* ${UNIT_FILE}"
+  echo "  sudo mv $BASE/releases/$INITIAL_SHA/* $BASE/"
+  echo "  sudo mv $BASE/shared/.env $BASE/.env"
+  echo "  sudo mv $BASE/shared/.venv $BASE/.venv"
+  echo "  sudo mv $BASE/shared/data $BASE/data 2>/dev/null || true"
+  echo "  sudo rm -rf $BASE/{current,releases,shared}"
+  echo "  sudo systemctl daemon-reload"
+  echo "  sudo systemctl start trading-spacial"
+  exit 1
+fi

--- a/scripts/bootstrap-atomic-deploy.sh
+++ b/scripts/bootstrap-atomic-deploy.sh
@@ -19,14 +19,73 @@
 #
 # El script es idempotente: si /var/www/trading/current ya existe, sale
 # limpio sin tocar nada.
+#
+# ── Flags ──────────────────────────────────────────────────────
+#   --dry-run    Muestra todo lo que se haría sin ejecutar nada destructivo.
+#                Calcula el diff del systemd unit pero NO lo escribe.
+#                Implica --yes (no pide confirmación interactiva).
+#   --yes        Skip la confirmación interactiva después del diff del unit.
+#                Pensado para ejecución no-interactiva (CI). Con esto el
+#                script aplica TODO sin pausas. Combinarlo con --dry-run
+#                primero para revisar el plan.
+#   --sha=<id>   ID custom para el release inicial (default: pre-atomic-<ts>).
+#
+# ── Ejemplos ───────────────────────────────────────────────────
+#   Interactivo (default):       ./bootstrap-atomic-deploy.sh
+#   Preview no-destructivo:      ./bootstrap-atomic-deploy.sh --dry-run
+#   Aplicar sin prompts (CI):    ./bootstrap-atomic-deploy.sh --yes
 
 set -euo pipefail
 
+# ── Parse flags ──────────────────────────────────────────────
+
+DRY_RUN=0
+ASSUME_YES=0
+INITIAL_SHA=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)  DRY_RUN=1; ASSUME_YES=1 ;;
+    --yes)      ASSUME_YES=1 ;;
+    --sha=*)    INITIAL_SHA="${arg#--sha=}" ;;
+    -h|--help)
+      sed -n '1,/^set -e/p' "$0" | sed 's/^# \?//' | head -n -1
+      exit 0
+      ;;
+    *)
+      echo "::error::Flag desconocido: $arg"
+      echo "Usage: $0 [--dry-run] [--yes] [--sha=<id>]"
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$INITIAL_SHA" ]; then
+  INITIAL_SHA="pre-atomic-$(date +%Y%m%d-%H%M%S)"
+fi
+
 BASE=/var/www/trading
-INITIAL_SHA="${1:-pre-atomic-$(date +%Y%m%d-%H%M%S)}"
 UNIT_FILE=/etc/systemd/system/trading-spacial.service
 
-# ── 0. Sanity checks ─────────────────────────────────────────
+# ── Helpers ──────────────────────────────────────────────────
+
+# `run` ejecuta el comando si no estamos en dry-run; si sí, lo imprime.
+run() {
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "  [dry-run] would run: $*"
+  else
+    "$@"
+  fi
+}
+
+# ── 0. Sanity checks (siempre se ejecutan) ───────────────────
+
+echo "==> Bootstrap atómico"
+echo "    BASE         = $BASE"
+echo "    INITIAL_SHA  = $INITIAL_SHA"
+echo "    DRY_RUN      = $DRY_RUN"
+echo "    ASSUME_YES   = $ASSUME_YES"
+echo
 
 if [ ! -d "$BASE" ]; then
   echo "::error::$BASE no existe — ¿bootstrap original completado?"
@@ -51,77 +110,119 @@ if [ ! -f "$UNIT_FILE" ]; then
   exit 1
 fi
 
-echo "==> Bootstrap atómico: BASE=$BASE INITIAL_SHA=$INITIAL_SHA"
+echo "==> Sanity checks OK."
 echo
 
 # ── 1. Pausar service ────────────────────────────────────────
 
-echo "==> Pausando trading-spacial..."
-sudo systemctl stop trading-spacial
+echo "==> Step 1: Pausar trading-spacial"
+run sudo systemctl stop trading-spacial
+echo
 
 # ── 2. Crear shared/ y mover .env, .venv, data/ ──────────────
 
-echo "==> Creando $BASE/shared/..."
-sudo mkdir -p "$BASE/shared"
-
-echo "==> Moviendo .env, .venv, data/ a shared/..."
-sudo mv "$BASE/.env"  "$BASE/shared/.env"
-sudo mv "$BASE/.venv" "$BASE/shared/.venv"
+echo "==> Step 2: Crear $BASE/shared/ y mover .env, .venv, data/"
+run sudo mkdir -p "$BASE/shared"
+run sudo mv "$BASE/.env"  "$BASE/shared/.env"
+run sudo mv "$BASE/.venv" "$BASE/shared/.venv"
 if [ -d "$BASE/data" ]; then
-  sudo mv "$BASE/data" "$BASE/shared/data"
+  run sudo mv "$BASE/data" "$BASE/shared/data"
 else
-  sudo mkdir -p "$BASE/shared/data"
+  run sudo mkdir -p "$BASE/shared/data"
 fi
+echo
 
 # ── 3. Crear releases/<initial-sha>/ con el resto ────────────
 
-echo "==> Creando $BASE/releases/$INITIAL_SHA/ con el estado actual..."
-sudo mkdir -p "$BASE/releases/$INITIAL_SHA"
+echo "==> Step 3: Crear $BASE/releases/$INITIAL_SHA/ con el estado actual"
+run sudo mkdir -p "$BASE/releases/$INITIAL_SHA"
 
 cd "$BASE"
-# Mover todo lo que no sea releases/, shared/, current al release inicial.
-for f in *; do
-  case "$f" in
-    releases|shared|current) ;;
-    *) sudo mv "$f" "releases/$INITIAL_SHA/" ;;
-  esac
-done
+# En dry-run mostramos la lista de archivos que se moverían.
+if [ "$DRY_RUN" = "1" ]; then
+  echo "  [dry-run] would move these entries from $BASE to releases/$INITIAL_SHA/:"
+  for f in *; do
+    case "$f" in
+      releases|shared|current) ;;
+      *) echo "    - $f" ;;
+    esac
+  done
+else
+  for f in *; do
+    case "$f" in
+      releases|shared|current) ;;
+      *) sudo mv "$f" "releases/$INITIAL_SHA/" ;;
+    esac
+  done
+fi
+echo
 
 # ── 4. Linkear shared/* dentro del release inicial ───────────
 
-echo "==> Linkeando shared/* dentro del release inicial..."
-sudo ln -sfn ../../shared/.env  "$BASE/releases/$INITIAL_SHA/.env"
-sudo ln -sfn ../../shared/.venv "$BASE/releases/$INITIAL_SHA/.venv"
-sudo ln -sfn ../../shared/data  "$BASE/releases/$INITIAL_SHA/data"
+echo "==> Step 4: Linkear shared/.env, shared/.venv, shared/data en el release"
+run sudo ln -sfn ../../shared/.env  "$BASE/releases/$INITIAL_SHA/.env"
+run sudo ln -sfn ../../shared/.venv "$BASE/releases/$INITIAL_SHA/.venv"
+run sudo ln -sfn ../../shared/data  "$BASE/releases/$INITIAL_SHA/data"
+echo
 
 # ── 5. Symlink current → release inicial ─────────────────────
 
-echo "==> Creando symlink $BASE/current → releases/$INITIAL_SHA..."
-sudo ln -sfn "releases/$INITIAL_SHA" "$BASE/current"
+echo "==> Step 5: Crear symlink $BASE/current → releases/$INITIAL_SHA"
+run sudo ln -sfn "releases/$INITIAL_SHA" "$BASE/current"
+echo
 
 # ── 6. Actualizar systemd unit ───────────────────────────────
 
-echo "==> Backup del systemd unit en ${UNIT_FILE}.bak.$(date +%s)..."
-sudo cp "$UNIT_FILE" "${UNIT_FILE}.bak.$(date +%s)"
-
-echo "==> Reescribiendo paths del systemd unit (/var/www/trading → /var/www/trading/current)..."
-# Reemplazo cuidadoso: solo paths que empiezan con /var/www/trading/ seguido
-# de algo distinto a "current", "releases", "shared". Usa lookahead negativo
-# vía dos pases (Perl) para evitar /var/www/trading/current/current/.
-sudo perl -i -pe 's|/var/www/trading(?!/(?:current|releases|shared))(\b)|/var/www/trading/current\1|g' "$UNIT_FILE"
-
-echo "==> Diff del unit (revisar antes de continuar):"
-sudo diff "${UNIT_FILE}.bak."*[0-9] "$UNIT_FILE" || true
+echo "==> Step 6: Reescribir paths del systemd unit"
+echo "    /var/www/trading  →  /var/www/trading/current"
 echo
-echo "==> ¿OK? Presioná Enter para continuar, Ctrl+C para abortar."
-read -r _
 
-sudo systemctl daemon-reload
+# Calculamos el nuevo contenido del unit usando perl con lookahead negativo
+# para no doble-prefijar paths que ya empiezan con current/, releases/, o shared/.
+ORIGINAL_UNIT_CONTENT=$(sudo cat "$UNIT_FILE")
+NEW_UNIT_CONTENT=$(echo "$ORIGINAL_UNIT_CONTENT" | perl -pe 's|/var/www/trading(?!/(?:current|releases|shared))(\b)|/var/www/trading/current\1|g')
+
+echo "    Diff del systemd unit:"
+echo "    ──────────────────────"
+diff <(echo "$ORIGINAL_UNIT_CONTENT") <(echo "$NEW_UNIT_CONTENT") | sed 's/^/    /' || true
+echo "    ──────────────────────"
+echo
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "  [dry-run] would back up $UNIT_FILE → ${UNIT_FILE}.bak.<timestamp>"
+  echo "  [dry-run] would write the diff above to $UNIT_FILE"
+  echo "  [dry-run] would run: sudo systemctl daemon-reload"
+else
+  BAK="${UNIT_FILE}.bak.$(date +%s)"
+  echo "==> Backup del unit en $BAK"
+  sudo cp "$UNIT_FILE" "$BAK"
+
+  if [ "$ASSUME_YES" = "0" ]; then
+    echo "==> ¿OK el diff de arriba?"
+    echo "    Enter para aplicar · Ctrl+C para abortar."
+    read -r _
+  fi
+
+  echo "==> Reescribiendo $UNIT_FILE"
+  echo "$NEW_UNIT_CONTENT" | sudo tee "$UNIT_FILE" > /dev/null
+
+  echo "==> systemctl daemon-reload"
+  sudo systemctl daemon-reload
+fi
+echo
 
 # ── 7. Restart + health check ────────────────────────────────
 
-echo "==> Arrancando trading-spacial con el nuevo layout..."
-sudo systemctl start trading-spacial
+echo "==> Step 7: Arrancar trading-spacial con el nuevo layout"
+run sudo systemctl start trading-spacial
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "  [dry-run] would wait 8s then curl http://localhost:8100/health"
+  echo
+  echo "==> Dry-run completado. Para aplicar:"
+  echo "       $0 --yes"
+  exit 0
+fi
 
 echo "==> Esperando 8s y verificando health..."
 sleep 8
@@ -130,9 +231,10 @@ if curl -fsS http://localhost:8100/health > /dev/null; then
   echo
   echo "==> ✓ Bootstrap completado."
   echo "==> Release activo: $INITIAL_SHA"
-  echo "==> Layout:"
-  echo "      current     → $(readlink $BASE/current)"
-  echo "      shared/.env → $(ls -la $BASE/shared/.env | awk '{print $NF}')"
+  echo "==> Layout final:"
+  echo "      current       → $(readlink $BASE/current)"
+  echo "      shared/.env   → $(ls -la $BASE/shared/.env 2>/dev/null | awk '{print $NF}')"
+  echo "      shared/.venv  → $(ls -la $BASE/shared/.venv 2>/dev/null | awk '{print $NF}')"
   echo
   echo "==> Próximos deploys vía CI usarán el flujo atómico de .github/workflows/deploy.yml"
 else
@@ -144,9 +246,9 @@ else
   echo "  sudo systemctl stop trading-spacial"
   echo "  sudo cp ${UNIT_FILE}.bak.* ${UNIT_FILE}"
   echo "  sudo mv $BASE/releases/$INITIAL_SHA/* $BASE/"
-  echo "  sudo mv $BASE/shared/.env $BASE/.env"
+  echo "  sudo mv $BASE/shared/.env  $BASE/.env"
   echo "  sudo mv $BASE/shared/.venv $BASE/.venv"
-  echo "  sudo mv $BASE/shared/data $BASE/data 2>/dev/null || true"
+  echo "  sudo mv $BASE/shared/data  $BASE/data 2>/dev/null || true"
   echo "  sudo rm -rf $BASE/{current,releases,shared}"
   echo "  sudo systemctl daemon-reload"
   echo "  sudo systemctl start trading-spacial"


### PR DESCRIPTION
> **DRAFT — no mergear hasta haber corrido el bootstrap en el server.**
> Ver `docs/atomic-deploy-migration.md` para la guía operativa.

## Summary

Reemplaza el flujo de rsync in-place por un layout release-per-deploy con symlink atómico.

### Antes
```
/var/www/trading/{btc_api.py, frontend/, .env, .venv, data/}
```
rsync directo + restart. Si el rsync del frontend fallaba después del backend, el sistema quedaba en estado mixto.

### Después
```
/var/www/trading/
├── current → releases/<sha>       (cutover atómico vía mv -Tf)
├── releases/<sha-N>/...            (últimos 5)
└── shared/{.env, .venv, data}/     (persiste entre deploys)
```

Cada deploy:
1. Stage de un release dir nuevo en el server
2. rsync backend + frontend ahí
3. Link de `shared/.env`, `.venv`, `data` dentro del release
4. `pip install` dentro del release nuevo
5. **Cutover atómico**: `ln -sfn` + `mv -Tf current.new current` (rename(2) es atómico en Linux)
6. Restart del service
7. Health check; **auto-rollback** al release anterior si falla
8. Cleanup: prune releases > últimos 5

## Archivos nuevos

- `scripts/bootstrap-atomic-deploy.sh` — migración one-time del server. Idempotente: si `current` ya existe, sale limpio. Hace backup del systemd unit y reescribe los paths via `perl` con lookahead negativo para no doble-prefijar.
- `docs/atomic-deploy-migration.md` — guía operativa: prereqs, pasos, verificación post-bootstrap, rollback manual, rollback del propio bootstrap si falla.

## Fail-safe

El `deploy.yml` nuevo tiene un step **"Verify atomic layout"** que falla fast si el server sigue en layout viejo (chequea que `current`, `releases/`, `shared/.env`, `shared/.venv` existan). Si mergeás este PR antes de bootstrappear, el deploy abortará sin tocar nada en el server.

## Orden recomendado

1. Mergear primero #375 (Node 22) y #376 (vitest realign) — este PR tiene conflictos con ellos en `deploy.yml`. Una vez merged, rebase este branch contra main.
2. Correr `scripts/bootstrap-atomic-deploy.sh` en el server (yo no puedo SSH desde Windows — coordinar con el otro agente o vos).
3. Verificar post-bootstrap (`systemctl status`, `curl /health`, `ls -la current`).
4. Mergear este PR. El primer deploy automático creará `releases/<merge-commit-sha>` y hará cutover atómico.

## Test plan
- [ ] Bootstrap script corre limpio en el server (idempotente)
- [ ] Health check post-bootstrap verde
- [ ] Primer deploy con flow nuevo: release dir creado, cutover OK, health check OK
- [ ] Forzar un failure (ej. health check temporal) y verificar rollback automático
- [ ] Después de 6+ deploys, verificar que `releases/` tiene exactamente 5 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)