### PR TITLE
chore(deploy): disable atomic bootstrap after PR #377 closed

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,18 +1,33 @@
+# ============================================================================
+# DISABLED — atomic deploy migration was reverted (PR #377 closed)
+# ============================================================================
+# Este workflow está retenido como herramienta diagnóstica pero el approach
+# de atomic deploy fue revertido. Tres bloqueos no resueltos:
+#   1. Shebangs del venv (status=203/EXEC) tras mover .venv
+#   2. ReadWritePaths vs symlinks → SQLite readonly
+#   3. SQLite WAL + cwd-vía-symlink → "attempt to write a readonly database"
+# Ver el closing comment de PR #377 para el análisis completo y las 3
+# opciones forward (PYTHONPATH v3, eliminar WAL, migrar a Postgres).
+#
+# Los modos apply/repair/rollback están bloqueados por un gate explícito.
+# Solo diagnose y dry-run son ejecutables sin override.
+# ============================================================================
+#
 # One-shot workflow para correr scripts/bootstrap-atomic-deploy.sh en el
 # server vía SSH usando los mismos secrets que deploy.yml. Es de disparo
 # manual (workflow_dispatch) — NO se ejecuta automáticamente.
 #
 # Modos:
-#   dry-run = preview de qué haría el bootstrap sin ejecutarlo
-#   apply   = ejecuta el bootstrap (migración del layout)
-#   repair  = post-bootstrap fix: crea symlink legacy /var/www/trading/.venv
-#             → shared/.venv para que los shebangs del venv resuelvan.
-#             También resetea el restart-counter del service y lo restartea.
+#   diagnose = print server state (read-only, siempre safe)
+#   dry-run  = preview de qué haría el bootstrap sin ejecutarlo
+#   apply    = ejecuta el bootstrap (DISABLED — requiere ack explícito)
+#   repair   = post-bootstrap fix (DISABLED — requiere ack explícito)
+#   rollback = revierte al layout flat (DISABLED — requiere ack explícito)
 #
 # Uso:
-#   gh workflow run "Bootstrap atomic deploy" -f mode=dry-run
-#   gh workflow run "Bootstrap atomic deploy" -f mode=apply
-#   gh workflow run "Bootstrap atomic deploy" -f mode=repair
+#   gh workflow run "Bootstrap atomic deploy" -f mode=diagnose
+#   gh workflow run "Bootstrap atomic deploy" -f mode=apply \
+#     -f i_understand_pr_377_was_closed=yes
 
 name: Bootstrap atomic deploy
 
@@ -20,16 +35,21 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: 'dry-run = preview; apply = ejecuta; repair = fix post-apply; rollback = revierte; diagnose = print server state'
+        description: 'diagnose = read-only state; dry-run = preview; apply/repair/rollback = DISABLED unless ack'
         required: true
         type: choice
-        default: dry-run
+        default: diagnose
         options:
+          - diagnose
           - dry-run
           - apply
           - repair
           - rollback
-          - diagnose
+      i_understand_pr_377_was_closed:
+        description: 'Required for apply/repair/rollback. Set to "yes" to override the disabled gate.'
+        required: false
+        type: string
+        default: 'no'
 
 jobs:
   bootstrap:
@@ -38,6 +58,31 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+
+      - name: Disabled gate — block apply/repair/rollback without ack
+        env:
+          MODE: ${{ inputs.mode }}
+          ACK: ${{ inputs.i_understand_pr_377_was_closed }}
+        run: |
+          case "$MODE" in
+            diagnose|dry-run)
+              echo "::notice::Mode '$MODE' is read-only/preview — gate bypassed."
+              exit 0
+              ;;
+            apply|repair|rollback)
+              if [ "$ACK" != "yes" ]; then
+                echo "::error::Mode '$MODE' is DISABLED. Atomic deploy migration was reverted (PR #377 closed)."
+                echo "::error::To override, re-run with i_understand_pr_377_was_closed=yes."
+                echo "::error::See PR #377 closing comment for the 3 forward options before re-enabling."
+                exit 1
+              fi
+              echo "::warning::Override accepted for mode '$MODE'. Proceeding despite PR #377 being closed."
+              ;;
+            *)
+              echo "::error::Unknown mode: $MODE"
+              exit 1
+              ;;
+          esac
 
       - name: Setup SSH
         env:
@@ -69,7 +114,7 @@ jobs:
           if [ "$MODE" = "dry-run" ]; then
             FLAG="--dry-run"
           else
-            FLAG="--yes"
+            FLAG="--yes --i-understand-pr-377-was-closed"
           fi
           echo "::group::Running bootstrap with $FLAG"
           ssh -i ~/.ssh/deploy_key ubuntu@${HOST} \

--- a/docs/atomic-deploy-migration.md
+++ b/docs/atomic-deploy-migration.md
@@ -1,5 +1,28 @@
 # Migración al deploy atómico — guía operativa
 
+> **⚠️ DISABLED — PR #377 fue cerrado tras varios intentos fallidos.**
+>
+> Tres bloqueos no resueltos:
+> 1. Shebangs del venv (`status=203/EXEC`) tras mover `.venv`.
+> 2. `ReadWritePaths` vs symlinks → SQLite readonly.
+> 3. SQLite WAL + `cwd`-vía-symlink → `attempt to write a readonly database`.
+>
+> El workflow (`bootstrap.yml`) y el script (`bootstrap-atomic-deploy.sh`)
+> quedan retenidos como herramienta diagnóstica. Los modos destructivos
+> (`apply`/`repair`/`rollback`) están bloqueados por un gate explícito que
+> requiere pasar `i_understand_pr_377_was_closed=yes` (workflow) o
+> `--i-understand-pr-377-was-closed` (script). `diagnose` y `dry-run` siguen
+> sin override.
+>
+> **Tres opciones forward** documentadas en el closing comment de PR #377:
+> 1. PYTHONPATH v3 (cwd sin symlink, código vía PYTHONPATH).
+> 2. Eliminar `PRAGMA journal_mode=WAL` en `db/schema.py`.
+> 3. Migrar a Postgres (epic separado).
+>
+> El resto de este doc describe el approach intentado, por valor histórico.
+
+---
+
 Esta es una migración **one-time** del layout actual del server
 (`/var/www/trading/` plano) al layout con `releases/<sha>` + symlink
 `current` que permite deploys atómicos con rollback.

--- a/scripts/bootstrap-atomic-deploy.sh
+++ b/scripts/bootstrap-atomic-deploy.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 # bootstrap-atomic-deploy.sh — migración al layout atómico (v2, simplificado).
 #
+# ============================================================================
+# DISABLED — atomic deploy migration was reverted (PR #377 closed)
+# ============================================================================
+# Este script está retenido como referencia. El approach fue revertido por
+# tres bloqueos no resueltos:
+#   1. Shebangs del venv (status=203/EXEC) tras mover .venv
+#   2. ReadWritePaths vs symlinks → SQLite readonly
+#   3. SQLite WAL + cwd-vía-symlink → "attempt to write a readonly database"
+# Ver closing comment de PR #377 para análisis + 3 opciones forward
+# (PYTHONPATH v3, eliminar WAL, migrar a Postgres).
+#
+# Para correr de todas formas (NO recomendado sin haber resuelto uno de los
+# tres bloqueos), pasar --i-understand-pr-377-was-closed.
+# --dry-run sigue funcionando sin override (solo preview, no destructivo).
+# ============================================================================
+#
 # Diseño:
 #
 #   /var/www/trading/
@@ -25,9 +41,10 @@
 # Idempotente: si /var/www/trading/current ya existe, sale sin hacer nada.
 #
 # Flags:
-#   --dry-run   Preview sin destruir. Implica --yes.
-#   --yes       Skip prompt interactivo después del diff del unit.
-#   --sha=<id>  ID para el release inicial (default pre-atomic-<ts>).
+#   --dry-run                            Preview sin destruir. Implica --yes.
+#   --yes                                Skip prompt interactivo después del diff del unit.
+#   --sha=<id>                           ID para el release inicial (default pre-atomic-<ts>).
+#   --i-understand-pr-377-was-closed     Override del gate de DISABLED.
 
 set -euo pipefail
 
@@ -36,23 +53,41 @@ set -euo pipefail
 DRY_RUN=0
 ASSUME_YES=0
 INITIAL_SHA=""
+OVERRIDE_DISABLED=0
 
 for arg in "$@"; do
   case "$arg" in
-    --dry-run)  DRY_RUN=1; ASSUME_YES=1 ;;
-    --yes)      ASSUME_YES=1 ;;
-    --sha=*)    INITIAL_SHA="${arg#--sha=}" ;;
+    --dry-run)                        DRY_RUN=1; ASSUME_YES=1 ;;
+    --yes)                            ASSUME_YES=1 ;;
+    --sha=*)                          INITIAL_SHA="${arg#--sha=}" ;;
+    --i-understand-pr-377-was-closed) OVERRIDE_DISABLED=1 ;;
     -h|--help)
       sed -n '1,/^set -e/p' "$0" | sed 's/^# \?//' | head -n -1
       exit 0
       ;;
     *)
       echo "::error::Flag desconocido: $arg"
-      echo "Usage: $0 [--dry-run] [--yes] [--sha=<id>]"
+      echo "Usage: $0 [--dry-run] [--yes] [--sha=<id>] [--i-understand-pr-377-was-closed]"
       exit 2
       ;;
   esac
 done
+
+# ── Disabled gate ────────────────────────────────────────────
+# Bloquea acciones destructivas si no se pasó el override.
+# --dry-run es siempre safe (no modifica nada) y no requiere override.
+
+if [ "$DRY_RUN" -eq 0 ] && [ "$OVERRIDE_DISABLED" -eq 0 ]; then
+  echo "::error::This script is DISABLED. Atomic deploy migration was reverted (PR #377 closed)."
+  echo "::error::Three unresolved blockers: venv shebangs, ReadWritePaths vs symlinks, SQLite WAL + cwd-symlink."
+  echo "::error::To override and run anyway, pass --i-understand-pr-377-was-closed."
+  echo "::error::To preview without running, use --dry-run."
+  exit 1
+fi
+
+if [ "$OVERRIDE_DISABLED" -eq 1 ]; then
+  echo "::warning::Override accepted. Proceeding despite PR #377 being closed."
+fi
 
 if [ -z "$INITIAL_SHA" ]; then
   INITIAL_SHA="pre-atomic-$(date +%Y%m%d-%H%M%S)"


### PR DESCRIPTION
## Summary

PR #377 (atomic deploy migration) fue cerrado por 3 bloqueos no resueltos:
1. Shebangs del venv (`status=203/EXEC`) tras mover `.venv`
2. `ReadWritePaths` vs symlinks → SQLite readonly
3. SQLite WAL + cwd-vía-symlink → `attempt to write a readonly database`

El workflow + script + doc quedan retenidos como referencia/herramienta diagnóstica, pero los modos destructivos (`apply`/`repair`/`rollback`) ahora requieren ack explícito.

### Cambios

- **`bootstrap.yml`**: gate step bloquea `apply`/`repair`/`rollback` salvo que se pase `i_understand_pr_377_was_closed=yes`. Default mode pasa a `diagnose`.
- **`bootstrap-atomic-deploy.sh`**: gate análogo, flag `--i-understand-pr-377-was-closed`. `--dry-run` sigue sin override (read-only).
- **`atomic-deploy-migration.md`**: callout DISABLED al tope con las 3 opciones forward citadas en el closing comment de PR #377.

### Server state

Ya verificado en server (commit anterior limpió los 2 `.bak` files del unit):
- Layout flat in-place ✓
- `trading-spacial.service` activo y healthy ✓
- No quedan residuos del intento atomic ✓

## Test plan
- [ ] YAML del workflow es válido (`python3 -c "import yaml; yaml.safe_load(...)"`) — ya verificado local.
- [ ] Bash syntax del script válido (`bash -n`) — ya verificado local.
- [ ] Workflow trigger en modo `diagnose` (default) sigue funcionando sin ack.
- [ ] Workflow trigger en modo `apply` sin ack falla con mensaje claro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)