### PR TITLE
fix(scanner): tolerate ' UTC' suffix in signal_outcomes.signal_ts

### DIFF
--- a/scanner/runtime.py
+++ b/scanner/runtime.py
@@ -153,7 +153,12 @@ def check_pending_signal_outcomes(current_prices: dict[str, float]):
 
     for r in [dict(row) for row in rows]:
         try:
-            sig_ts = datetime.fromisoformat(r["signal_ts"])
+            # signal_outcomes.signal_ts is written by btc_scanner.py:219 as
+            # '%Y-%m-%d %H:%M:%S UTC'. fromisoformat doesn't accept the literal
+            # ' UTC' suffix — strip it before parsing.
+            ts_raw = (r["signal_ts"] or "").strip()
+            clean  = ts_raw.removesuffix(" UTC").strip().replace(" ", "T")
+            sig_ts = datetime.fromisoformat(clean)
             if sig_ts.tzinfo is None:
                 sig_ts = sig_ts.replace(tzinfo=timezone.utc)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1713,6 +1713,55 @@ class TestSignalPerformance:
         con.close()
         assert row["price_1h"] == 61500.0
 
+    def test_check_pending_handles_utc_suffix_format(self, caplog):
+        """signal_outcomes.signal_ts is written by btc_scanner.py as
+        '%Y-%m-%d %H:%M:%S UTC' (display format with literal UTC suffix).
+        Regression: check_pending_signal_outcomes must parse it without
+        raising 'Invalid isoformat string' warnings.
+        """
+        import logging
+        import btc_api
+        from unittest.mock import patch
+
+        ts_2h_ago = (datetime.now(timezone.utc) - timedelta(hours=2)).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+
+        con = btc_api.get_db()
+        con.execute("""
+            INSERT INTO signal_outcomes
+            (scan_id, symbol, signal_ts, signal_price, score, status)
+            VALUES (300, 'BTCUSDT', ?, 60000.0, 5, 'pending')
+        """, (ts_2h_ago,))
+        con.commit()
+        con.close()
+
+        with patch.object(btc_api.md, "get_klines") as mock_klines:
+            import pandas as pd
+            mock_klines.return_value = pd.DataFrame({
+                "open": [59000.0], "high": [62000.0],
+                "low": [58000.0], "close": [61000.0],
+                "volume": [100.0], "taker_buy_base": [50.0],
+            })
+            with caplog.at_level(logging.WARNING, logger="scanner.runtime"):
+                btc_api.check_pending_signal_outcomes({"BTCUSDT": 61500.0})
+
+        bad_warnings = [
+            rec for rec in caplog.records
+            if "Invalid isoformat" in rec.getMessage()
+        ]
+        assert not bad_warnings, (
+            f"check_pending_signal_outcomes raised isoformat warnings for "
+            f"production timestamp format: {[r.getMessage() for r in bad_warnings]}"
+        )
+
+        con = btc_api.get_db()
+        row = con.execute("SELECT * FROM signal_outcomes WHERE scan_id = 300").fetchone()
+        con.close()
+        assert row["price_1h"] == 61500.0, (
+            "Row update was skipped — fix did not reach the update branch"
+        )
+
     def test_check_pending_groups_by_symbol(self):
         """Multiple pending signals for same symbol share one klines call."""
         import btc_api


### PR DESCRIPTION
## Summary

`scanner/runtime.check_pending_signal_outcomes` venía calling `datetime.fromisoformat()` sobre `signal_outcomes.signal_ts`, que `btc_scanner.py:219` escribe con el display format `'%Y-%m-%d %H:%M:%S UTC'` (sufijo literal ` UTC`). `fromisoformat` no acepta ese sufijo, así que cada ciclo (~300s) producía ~20 warnings:

```
WARNING  Error trackeando performance de RUNEUSDT (id=3441):
         Invalid isoformat string: '2026-05-18 19:31:30 UTC'
```

**Effect**: el performance tracking silenciosamente saltaba cada señal pending — las columnas `price_1h/4h/24h` y `max_runup_pct/max_drawdown_pct` no se actualizaban para señales que tuvieran ese formato.

## Fix

`scanner/runtime.py:156-159`: strip ` UTC` suffix + replace space con `T` antes de `fromisoformat`. Backward-compatible con ISO strings (los tests existentes siguen pasando).

## Discovery

Aparece en logs de producción cada ciclo del scanner. Detectado durante diagnose del server post-PR #377 closure.

## Test plan
- [x] Regression test reproduce el warning con formato producción (RED).
- [x] Fix → test pasa (GREEN).
- [x] Suites completas `tests/test_api.py` + `tests/test_scanner.py`: 216/216 pass.
- [ ] Post-merge: verificar journal del server que los warnings desaparezcan en el próximo ciclo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)