### PR TITLE
fix(health): wire /health/dashboard equity to tenant capital (#382)

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -87,15 +87,13 @@ def get_health_dashboard(tenant_id: int = Depends(get_current_tenant_id)):
     Read-only; safe even when kill_switch.enabled=False (returns last-evaluated
     snapshot).
 
-    Portfolio equity is sourced from the tenant's `capital` row when present
-    (multi-tenant epic B #253); falls back to `cfg["capital_usd"]` (legacy
-    single-tenant default $1000) when the tenant has no capital row yet.
+    Portfolio equity + positions are tenant-scoped (epic B #253). The dashboard
+    state is computed against the caller's tenant only; cross-tenant
+    aggregates are never produced.
     """
-    from db.capital import db_get_capital
     from health import get_dashboard_state
     cfg = load_config()
-    capital_row = db_get_capital(tenant_id)
-    return get_dashboard_state(cfg, capital=capital_row)
+    return get_dashboard_state(cfg, tenant_id=tenant_id)
 
 
 @router.post(

--- a/api/health.py
+++ b/api/health.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 
 from api.config import load_config
 from api.deps import verify_api_key
-from auth.dependencies import require_role
+from auth.dependencies import get_current_tenant_id, require_role
 from db.connection import get_db
 
 log = logging.getLogger("api.health")
@@ -80,16 +80,22 @@ def get_health_events(
 
 
 @router.get("/health/dashboard", dependencies=[Depends(verify_api_key)])
-def get_health_dashboard():
+def get_health_dashboard(tenant_id: int = Depends(get_current_tenant_id)):
     """B6: single-shot consolidated state for the kill switch dashboard.
 
     Returns per-symbol full state + portfolio aggregate + 24h alert summary.
     Read-only; safe even when kill_switch.enabled=False (returns last-evaluated
     snapshot).
+
+    Portfolio equity is sourced from the tenant's `capital` row when present
+    (multi-tenant epic B #253); falls back to `cfg["capital_usd"]` (legacy
+    single-tenant default $1000) when the tenant has no capital row yet.
     """
+    from db.capital import db_get_capital
     from health import get_dashboard_state
     cfg = load_config()
-    return get_dashboard_state(cfg)
+    capital_row = db_get_capital(tenant_id)
+    return get_dashboard_state(cfg, capital=capital_row)
 
 
 @router.post(

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -299,11 +299,23 @@ def scan(symbol: str = None):
                 "— falling back to NEUTRAL default (no regime adjustment applied)",
                 symbol, _rs_err, exc_info=True,
             )
-        emit_shadow_decision(
-            symbol=symbol,
-            cfg=_cfg if _cfg else {},
-            regime_score=_regime_score,
-        )
+        # Multi-tenant: emit one shadow decision per active tenant so the
+        # portfolio MTM + DD are computed against each tenant's own positions.
+        # When no tenants are onboarded yet, skip (no portfolios to evaluate).
+        from db.capital import db_list_active_tenant_ids
+        for _tid in db_list_active_tenant_ids():
+            try:
+                emit_shadow_decision(
+                    symbol=symbol,
+                    cfg=_cfg if _cfg else {},
+                    tenant_id=_tid,
+                    regime_score=_regime_score,
+                )
+            except Exception as _tenant_shadow_err:
+                log.warning(
+                    "kill_switch_v2_shadow emission failed for %s tenant=%s: %s",
+                    symbol, _tid, _tenant_shadow_err,
+                )
     except Exception as _shadow_err:
         log.warning("kill_switch_v2_shadow emission failed for %s: %s", symbol, _shadow_err)
 

--- a/db/capital.py
+++ b/db/capital.py
@@ -33,6 +33,25 @@ def db_get_capital(tenant_id: int) -> Optional[dict]:
     return dict(row) if row else None
 
 
+def db_list_active_tenant_ids() -> list[int]:
+    """Return tenant ids with an existing capital row, sorted ascending.
+
+    Used by background processes (scanner, calibrator, shadow emitter) to
+    iterate over every tenant the system actually serves — replacing the
+    legacy single-tenant single-pass pattern. An empty list means "no
+    onboarded tenants" and callers should treat that as a no-op rather
+    than computing implicit single-system aggregates.
+    """
+    con = get_db()
+    try:
+        rows = con.execute(
+            "SELECT tenant_id FROM capital ORDER BY tenant_id ASC"
+        ).fetchall()
+    finally:
+        con.close()
+    return [int(r[0]) for r in rows]
+
+
 def apply_pnl_to_capital(tenant_id: int, pnl_usd: float) -> Optional[dict]:
     """B.2 hook: a position closed for `tenant_id` with realized `pnl_usd`.
 

--- a/health.py
+++ b/health.py
@@ -10,7 +10,7 @@ import json
 import logging
 import threading
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any
 
 
 log = logging.getLogger("health")
@@ -404,16 +404,25 @@ def _decrement_probation_counter(symbol: str) -> None:
 
 
 def _is_portfolio_normal(cfg: dict[str, Any]) -> bool:
-    """Return True if portfolio aggregate tier is NORMAL.
+    """Return True iff EVERY active tenant's portfolio aggregate tier is NORMAL.
 
     Reuses kill_switch_v2 helpers. Defensive: any failure → False (block
-    auto-recovery in unclear state).
+    auto-recovery in unclear state). Per multi-tenant policy: a single tenant
+    in non-NORMAL is enough to suppress auto-recovery for the symbol (the
+    decision is system-wide and we want to err conservatively).
     """
     try:
         from strategy.kill_switch_v2 import evaluate_portfolio_tier
         from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
-        portfolio_dd = _compute_current_portfolio_dd(cfg)
-        # Concurrent failures count: use existing health rows.
+        from db.capital import db_list_active_tenant_ids
+
+        tenant_ids = db_list_active_tenant_ids()
+        if not tenant_ids:
+            # No onboarded tenants yet — treat as NORMAL (no portfolio to gate).
+            return True
+
+        # Concurrent failures: a property of symbol_health (system-wide), so
+        # we read it once and reuse it across the per-tenant loop.
         conn = _conn()
         try:
             n_failures = conn.execute(
@@ -422,8 +431,13 @@ def _is_portfolio_normal(cfg: dict[str, Any]) -> bool:
             ).fetchone()[0]
         finally:
             conn.close()
-        portfolio = evaluate_portfolio_tier(portfolio_dd, int(n_failures), cfg)
-        return portfolio.get("tier") == "NORMAL"
+
+        for tid in tenant_ids:
+            portfolio_dd = _compute_current_portfolio_dd(cfg, tenant_id=tid)
+            portfolio = evaluate_portfolio_tier(portfolio_dd, int(n_failures), cfg)
+            if portfolio.get("tier") != "NORMAL":
+                return False
+        return True
     except Exception as e:  # noqa: BLE001
         log.warning("_is_portfolio_normal failed: %s — treating as not-normal", e)
         return False
@@ -1039,7 +1053,7 @@ def recent_portfolio_transitions(limit: int = 5) -> list[dict[str, Any]]:
 def get_dashboard_state(
     cfg: dict[str, Any],
     *,
-    capital: Optional[dict[str, Any]] = None,
+    tenant_id: int,
 ) -> dict[str, Any]:
     """B6 orchestrator: assemble per-symbol + portfolio + alerts response.
 
@@ -1048,12 +1062,14 @@ def get_dashboard_state(
 
     Args:
         cfg: loaded config dict.
-        capital: optional row from `db.capital` for the current tenant. When
-            provided, its `balance` becomes the portfolio capital base
-            (driving both the DD% computation and the displayed equity) and
-            `peak_balance` becomes the peak equity. When `None`, falls back
-            to `cfg["capital_usd"]` (legacy single-tenant, default $1000).
+        tenant_id: caller's tenant id (required per multi-tenant policy —
+            epic B #253). Portfolio equity is computed against this tenant's
+            capital row and positions; if the tenant has no capital row yet,
+            falls back to cfg["capital_usd"] for display while still
+            tenant-scoping the position queries.
     """
+    from db.capital import db_get_capital
+    capital = db_get_capital(tenant_id)
     from btc_scanner import DEFAULT_SYMBOLS
 
     ks_cfg = (cfg.get("kill_switch") or {})
@@ -1172,15 +1188,12 @@ def get_dashboard_state(
             ledger_peak = float(peak_raw) if peak_raw is not None else realized_balance
 
             # MTM of open positions: (price_now - entry) × qty, signed by direction.
-            # NOTE: _load_open_positions does not yet filter by tenant_id (epic B
-            # B.2 wired apply_pnl_to_capital but didn't tenant-scope the loaders).
-            # With a single active tenant in prod today this is correct; the gap
-            # is tracked under epic B #253 follow-ups.
+            # Tenant-scoped per multi-tenant policy (epic B #253).
             try:
                 from strategy.kill_switch_v2_shadow import (
                     _load_open_positions, _snapshot_prices,
                 )
-                open_positions = _load_open_positions()
+                open_positions = _load_open_positions(tenant_id=tenant_id)
                 prices = _snapshot_prices()
                 open_mtm = 0.0
                 for pos in open_positions:
@@ -1213,10 +1226,15 @@ def get_dashboard_state(
             # interprets the threshold the same way.
             portfolio_dd = -portfolio_dd
         else:
+            # No capital row for this tenant — pre-onboarding / fresh user.
+            # Display cfg.capital_usd as a neutral base. We still tenant-scope
+            # the DD computation: with zero positions for this tenant the
+            # calibrator returns 0.0, so the legacy "$1000 × (1 + 0)" output
+            # is preserved without leaking other tenants' history.
             tenant_balance = float(cfg.get("capital_usd", 1000.0))
             try:
                 from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
-                portfolio_dd = _compute_current_portfolio_dd(cfg)
+                portfolio_dd = _compute_current_portfolio_dd(cfg, tenant_id=tenant_id)
             except Exception:
                 log.warning(
                     "get_dashboard_state legacy DD computation failed", exc_info=True,

--- a/health.py
+++ b/health.py
@@ -1151,38 +1151,93 @@ def get_dashboard_state(
                 "next_conditions": next_conditions,
             })
 
-        # Portfolio.
-        # When the caller passes a tenant `capital` row (multi-tenant path),
-        # override `cfg["capital_usd"]` for the simulator so DD%, equity curve,
-        # and the displayed peak/current all derive from the real tenant capital.
-        # Without an override, the legacy single-tenant default ($1000) applies.
+        # Portfolio equity & DD.
+        #
+        # Two paths depending on capital source:
+        #
+        # (a) Tenant capital row present (multi-tenant): the ledger is the single
+        #     source of truth for realized PnL — `apply_pnl_to_capital` already
+        #     folded every closed trade into `balance`. Re-applying the closed
+        #     trades on top of `balance` (via compute_portfolio_equity_curve)
+        #     would double-count. We display `balance + open_mtm` instead.
+        #     `peak_equity` honors the monotonic ledger peak, lifted only if the
+        #     current snapshot already exceeds it (intraday gain not yet closed).
+        #
+        # (b) No capital row (legacy single-tenant): preserve pre-fix behavior —
+        #     simulate from cfg.capital_usd × (1 + simulated_dd). Suitable for
+        #     pre-onboarding tenants and the single-tenant default install.
         if capital is not None and capital.get("balance") is not None:
-            tenant_balance = float(capital["balance"])
-            tenant_peak = float(capital.get("peak_balance") or tenant_balance)
-            cfg_portfolio = {**cfg, "capital_usd": tenant_balance}
+            realized_balance = float(capital["balance"])
+            peak_raw = capital.get("peak_balance")
+            ledger_peak = float(peak_raw) if peak_raw is not None else realized_balance
+
+            # MTM of open positions: (price_now - entry) × qty, signed by direction.
+            # NOTE: _load_open_positions does not yet filter by tenant_id (epic B
+            # B.2 wired apply_pnl_to_capital but didn't tenant-scope the loaders).
+            # With a single active tenant in prod today this is correct; the gap
+            # is tracked under epic B #253 follow-ups.
+            try:
+                from strategy.kill_switch_v2_shadow import (
+                    _load_open_positions, _snapshot_prices,
+                )
+                open_positions = _load_open_positions()
+                prices = _snapshot_prices()
+                open_mtm = 0.0
+                for pos in open_positions:
+                    sym = pos.get("symbol")
+                    if not sym or sym not in prices:
+                        continue
+                    entry = float(pos.get("entry_price") or 0)
+                    qty = float(pos.get("qty") or 0)
+                    direction = pos.get("direction", "LONG")
+                    price_now = float(prices[sym])
+                    if direction == "SHORT":
+                        open_mtm += (entry - price_now) * qty
+                    else:
+                        open_mtm += (price_now - entry) * qty
+            except Exception:
+                log.warning(
+                    "get_dashboard_state open-MTM computation failed; "
+                    "treating open_mtm as 0", exc_info=True,
+                )
+                open_mtm = 0.0
+
+            current_equity = realized_balance + open_mtm
+            peak_equity = max(ledger_peak, current_equity)
+            portfolio_dd = (
+                (peak_equity - current_equity) / peak_equity
+                if peak_equity > 0 else 0.0
+            )
+            # Sign convention: kill_switch_v2.compute_portfolio_dd returns a
+            # negative number when in drawdown; match it so evaluate_portfolio_tier
+            # interprets the threshold the same way.
+            portfolio_dd = -portfolio_dd
         else:
             tenant_balance = float(cfg.get("capital_usd", 1000.0))
-            tenant_peak = tenant_balance
-            cfg_portfolio = cfg
+            try:
+                from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
+                portfolio_dd = _compute_current_portfolio_dd(cfg)
+            except Exception:
+                log.warning(
+                    "get_dashboard_state legacy DD computation failed", exc_info=True,
+                )
+                portfolio_dd = 0.0
+            current_equity = tenant_balance * (1.0 + portfolio_dd)
+            peak_equity = tenant_balance
 
         try:
             from strategy.kill_switch_v2 import evaluate_portfolio_tier
-            from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
-            portfolio_dd = _compute_current_portfolio_dd(cfg_portfolio)
             n_failures = conn.execute(
                 """SELECT COUNT(*) FROM symbol_health
                    WHERE state IN ('ALERT', 'REDUCED', 'PAUSED', 'PROBATION')"""
             ).fetchone()[0]
             portfolio_tier = evaluate_portfolio_tier(portfolio_dd, int(n_failures), cfg)
-            current_equity = tenant_balance * (1.0 + portfolio_dd)
-            peak_equity = tenant_peak
         except Exception:
-            log.warning("get_dashboard_state portfolio computation failed", exc_info=True)
+            log.warning(
+                "get_dashboard_state portfolio tier evaluation failed", exc_info=True,
+            )
             portfolio_tier = {"tier": "NORMAL", "dd": 0.0, "concurrent_failures": 0}
-            portfolio_dd = 0.0
             n_failures = 0
-            current_equity = tenant_balance
-            peak_equity = tenant_peak
 
         portfolio_out = {
             "tier": portfolio_tier["tier"],

--- a/health.py
+++ b/health.py
@@ -10,7 +10,7 @@ import json
 import logging
 import threading
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Optional
 
 
 log = logging.getLogger("health")
@@ -1036,11 +1036,23 @@ def recent_portfolio_transitions(limit: int = 5) -> list[dict[str, Any]]:
     ]
 
 
-def get_dashboard_state(cfg: dict[str, Any]) -> dict[str, Any]:
+def get_dashboard_state(
+    cfg: dict[str, Any],
+    *,
+    capital: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     """B6 orchestrator: assemble per-symbol + portfolio + alerts response.
 
     Reads from DB; computes next_conditions; builds the full DashboardResponse
     shape consumed by the frontend.
+
+    Args:
+        cfg: loaded config dict.
+        capital: optional row from `db.capital` for the current tenant. When
+            provided, its `balance` becomes the portfolio capital base
+            (driving both the DD% computation and the displayed equity) and
+            `peak_balance` becomes the peak equity. When `None`, falls back
+            to `cfg["capital_usd"]` (legacy single-tenant, default $1000).
     """
     from btc_scanner import DEFAULT_SYMBOLS
 
@@ -1139,25 +1151,38 @@ def get_dashboard_state(cfg: dict[str, Any]) -> dict[str, Any]:
                 "next_conditions": next_conditions,
             })
 
-        # Portfolio
+        # Portfolio.
+        # When the caller passes a tenant `capital` row (multi-tenant path),
+        # override `cfg["capital_usd"]` for the simulator so DD%, equity curve,
+        # and the displayed peak/current all derive from the real tenant capital.
+        # Without an override, the legacy single-tenant default ($1000) applies.
+        if capital is not None and capital.get("balance") is not None:
+            tenant_balance = float(capital["balance"])
+            tenant_peak = float(capital.get("peak_balance") or tenant_balance)
+            cfg_portfolio = {**cfg, "capital_usd": tenant_balance}
+        else:
+            tenant_balance = float(cfg.get("capital_usd", 1000.0))
+            tenant_peak = tenant_balance
+            cfg_portfolio = cfg
+
         try:
             from strategy.kill_switch_v2 import evaluate_portfolio_tier
             from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
-            portfolio_dd = _compute_current_portfolio_dd(cfg)
+            portfolio_dd = _compute_current_portfolio_dd(cfg_portfolio)
             n_failures = conn.execute(
                 """SELECT COUNT(*) FROM symbol_health
                    WHERE state IN ('ALERT', 'REDUCED', 'PAUSED', 'PROBATION')"""
             ).fetchone()[0]
             portfolio_tier = evaluate_portfolio_tier(portfolio_dd, int(n_failures), cfg)
-            current_equity = float(cfg.get("capital_usd", 1000.0)) * (1.0 + portfolio_dd)
-            peak_equity = float(cfg.get("capital_usd", 1000.0))
+            current_equity = tenant_balance * (1.0 + portfolio_dd)
+            peak_equity = tenant_peak
         except Exception:
             log.warning("get_dashboard_state portfolio computation failed", exc_info=True)
             portfolio_tier = {"tier": "NORMAL", "dd": 0.0, "concurrent_failures": 0}
             portfolio_dd = 0.0
             n_failures = 0
-            current_equity = float(cfg.get("capital_usd", 1000.0))
-            peak_equity = current_equity
+            current_equity = tenant_balance
+            peak_equity = tenant_peak
 
         portfolio_out = {
             "tier": portfolio_tier["tier"],

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -462,7 +462,22 @@ def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
                 triggers_fired.append("regime_change")
 
             # portfolio_dd_degradation
-            current_dd = _compute_current_portfolio_dd(cfg)
+            #
+            # Multi-tenant: evaluate the DD for each active tenant and fire on
+            # the most severe (most negative) value. The calibrator owns
+            # system-wide thresholds, so the conservative choice is to escalate
+            # when ANY tenant breaches them, not when the (meaningless) cross-
+            # tenant aggregate does.
+            from db.capital import db_list_active_tenant_ids
+            tenant_ids = db_list_active_tenant_ids()
+            if tenant_ids:
+                per_tenant_dd = [
+                    _compute_current_portfolio_dd(cfg, tenant_id=tid)
+                    for tid in tenant_ids
+                ]
+                current_dd = min(per_tenant_dd)  # most negative = worst DD
+            else:
+                current_dd = 0.0
             last_applied = _load_last_applied_recommendation()
             last_proj_dd = (last_applied or {}).get("projected_dd")
             multiplier = float(auto_cal.get("portfolio_dd_degradation_multiplier", 1.5))
@@ -564,11 +579,15 @@ def _load_current_regime_score() -> float | None:
         return None
 
 
-def _compute_current_portfolio_dd(cfg: dict[str, Any]) -> float:
-    """Compute live portfolio DD from closed trades + open positions MTM.
+def _compute_current_portfolio_dd(cfg: dict[str, Any], *, tenant_id: int) -> float:
+    """Compute live portfolio DD from `tenant_id`'s closed trades + open positions MTM.
 
     Reuses kill_switch_v2.compute_portfolio_dd + compute_portfolio_equity_curve.
     Returns 0.0 if anything fails (conservative — won't fire degradation trigger).
+
+    Per multi-tenant policy: `tenant_id` is required. The capital base is the
+    tenant's ledger balance when present, falling back to cfg["capital_usd"]
+    for tenants without a capital row (legacy / pre-onboarding case).
     """
     try:
         from strategy.kill_switch_v2 import (
@@ -577,17 +596,22 @@ def _compute_current_portfolio_dd(cfg: dict[str, Any]) -> float:
         from strategy.kill_switch_v2_shadow import (
             _load_closed_trades, _load_open_positions, _snapshot_prices,
         )
-        capital_base = float(cfg.get("capital_usd", 1000.0))
+        from db.capital import db_get_capital
+        cap_row = db_get_capital(tenant_id)
+        if cap_row and cap_row.get("balance") is not None:
+            capital_base = float(cap_row["balance"])
+        else:
+            capital_base = float(cfg.get("capital_usd", 1000.0))
         equity_curve = compute_portfolio_equity_curve(
-            closed_trades=_load_closed_trades(),
-            open_positions=_load_open_positions(),
+            closed_trades=_load_closed_trades(tenant_id=tenant_id),
+            open_positions=_load_open_positions(tenant_id=tenant_id),
             capital_base=capital_base,
             now_price_by_symbol=_snapshot_prices(),
         )
         return float(compute_portfolio_dd(equity_curve))
     except Exception as e:
         log.warning(
-            "compute_current_portfolio_dd failed: %s",
-            e, exc_info=True,
+            "compute_current_portfolio_dd failed for tenant_id=%s: %s",
+            tenant_id, e, exc_info=True,
         )
         return 0.0

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -40,8 +40,14 @@ def _snapshot_prices() -> dict[str, float]:
     return dict(_PRICE_CACHE)
 
 
-def _load_closed_trades() -> list[dict[str, Any]]:
-    """Load closed positions from DB for portfolio equity computation."""
+def _load_closed_trades(*, tenant_id: int) -> list[dict[str, Any]]:
+    """Load closed positions for `tenant_id` from DB for portfolio equity computation.
+
+    Per the multi-tenant policy (epic B #253), `tenant_id` is required:
+    background processes that don't have a user context must iterate via
+    `db.capital.db_list_active_tenant_ids()` and call this loader once per
+    tenant. Aggregating across tenants implicitly is not allowed.
+    """
     import btc_api
     conn = btc_api.get_db()
     try:
@@ -49,7 +55,9 @@ def _load_closed_trades() -> list[dict[str, Any]]:
             """SELECT symbol, exit_ts, pnl_usd
                FROM positions
                WHERE status = 'closed' AND exit_ts IS NOT NULL
-               ORDER BY exit_ts"""
+                 AND tenant_id = ?
+               ORDER BY exit_ts""",
+            (tenant_id,),
         ).fetchall()
     finally:
         conn.close()
@@ -59,15 +67,19 @@ def _load_closed_trades() -> list[dict[str, Any]]:
     ]
 
 
-def _load_open_positions() -> list[dict[str, Any]]:
-    """Load open positions from DB for MTM."""
+def _load_open_positions(*, tenant_id: int) -> list[dict[str, Any]]:
+    """Load open positions for `tenant_id` from DB for MTM.
+
+    See `_load_closed_trades` for the multi-tenant policy rationale.
+    """
     import btc_api
     conn = btc_api.get_db()
     try:
         rows = conn.execute(
             """SELECT symbol, entry_price, qty, direction
                FROM positions
-               WHERE status = 'open'"""
+               WHERE status = 'open' AND tenant_id = ?""",
+            (tenant_id,),
         ).fetchall()
     finally:
         conn.close()
@@ -390,6 +402,8 @@ def _evaluate_per_symbol_tier_with_telemetry(
 def emit_shadow_decision(
     symbol: str,
     cfg: dict[str, Any],
+    *,
+    tenant_id: int,
     regime_score: float | None = None,
     now_price_by_symbol: dict[str, float] | None = None,
 ) -> None:
@@ -400,6 +414,11 @@ def emit_shadow_decision(
     provided, B3 regime-aware adjustment is applied to the slider before
     threshold computation. Fail-open: any exception is caught and logged
     with full traceback.
+
+    `tenant_id` is required: the portfolio MTM + DD must be computed against
+    the tenant's positions, not the system aggregate. Schedulers (scanner,
+    calibrator) iterate `db.capital.db_list_active_tenant_ids()` and call
+    this once per tenant.
     """
     from strategy.kill_switch_v2 import (
         compute_portfolio_equity_curve,
@@ -429,9 +448,20 @@ def emit_shadow_decision(
                 cfg_eff = cfg if isinstance(cfg, dict) else {}
             _regime_adjustment_status = "failed"
 
-        capital_base = float(cfg.get("capital_usd", _DEFAULT_CAPITAL_USD))
-        closed = _load_closed_trades()
-        opens = _load_open_positions()
+        # Capital base for this tenant: ledger if present, else cfg default.
+        # (We still use the curve here for telemetry / transitions logging; the
+        # health dashboard switched to ledger+MTM to avoid double-counting,
+        # but emit_shadow is a write-side observer and historical curve
+        # consumers expect the same shape across the run.)
+        from db.capital import db_get_capital
+        _capital_row = db_get_capital(tenant_id)
+        if _capital_row and _capital_row.get("balance") is not None:
+            capital_base = float(_capital_row["balance"])
+        else:
+            capital_base = float(cfg.get("capital_usd", _DEFAULT_CAPITAL_USD))
+
+        closed = _load_closed_trades(tenant_id=tenant_id)
+        opens = _load_open_positions(tenant_id=tenant_id)
         prices = _snapshot_prices()
         if now_price_by_symbol:
             prices.update(now_price_by_symbol)

--- a/tests/test_health_alert_notify.py
+++ b/tests/test_health_alert_notify.py
@@ -24,8 +24,8 @@ def _insert_closed(conn, symbol, pnl, exit_ts):
     conn.execute(
         """INSERT INTO positions
            (symbol, direction, status, entry_price, entry_ts,
-            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?)""",
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
     )
     conn.commit()

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -288,12 +288,21 @@ def test_recent_portfolio_transitions_returns_last_5(tmp_db):
 def client(tmp_path, monkeypatch):
     import btc_api
     from fastapi.testclient import TestClient
+    from auth.dependencies import get_current_tenant_id
     db_path = str(tmp_path / "signals.db")
     monkeypatch.setattr(btc_api, "DB_FILE", db_path)
     if hasattr(btc_api, "_db_conn"):
         delattr(btc_api, "_db_conn")
     btc_api.init_db()
-    return TestClient(btc_api.app)
+    # /health/dashboard now resolves capital per-tenant. In tests there's no
+    # JWT, so override the dependency to a fixed tenant id. With no capital
+    # row seeded for that tenant, the endpoint falls back to cfg.capital_usd
+    # (preserves pre-fix behavior in tests that don't seed capital).
+    btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 1
+    try:
+        yield TestClient(btc_api.app)
+    finally:
+        btc_api.app.dependency_overrides.pop(get_current_tenant_id, None)
 
 
 def test_get_health_dashboard_empty_db_returns_default_shape(client):
@@ -380,6 +389,30 @@ def test_get_health_dashboard_disabled_kill_switch_still_returns(client, monkeyp
     monkeypatch.setattr(btc_api, "load_config", lambda: {"kill_switch": {"enabled": False}})
     resp = client.get("/health/dashboard")
     assert resp.status_code == 200
+
+
+def test_get_health_dashboard_uses_tenant_capital_when_present(client):
+    """Epic B #253 wire (issue #382): the dashboard reports the tenant's real
+    capital, not the legacy cfg.capital_usd default."""
+    from db.capital import db_upsert_capital
+    # tenant_id=1 matches the override in the client fixture above.
+    db_upsert_capital(1, balance=10_000.0, peak_balance=12_000.0)
+    resp = client.get("/health/dashboard")
+    assert resp.status_code == 200
+    portfolio = resp.json()["portfolio"]
+    # No closed trades + no open positions → portfolio_dd ≈ 0 → equity ≈ balance.
+    assert portfolio["current_equity"] == pytest.approx(10_000.0)
+    assert portfolio["peak_equity"] == pytest.approx(12_000.0)
+
+
+def test_get_health_dashboard_falls_back_when_tenant_has_no_capital(client):
+    """When the tenant has no capital row yet, the dashboard preserves the
+    legacy single-tenant behavior: cfg.capital_usd (default $1000)."""
+    resp = client.get("/health/dashboard")
+    assert resp.status_code == 200
+    portfolio = resp.json()["portfolio"]
+    assert portfolio["current_equity"] == pytest.approx(1000.0)
+    assert portfolio["peak_equity"] == pytest.approx(1000.0)
 
 
 # ── Portfolio transition recording integration ──────────────────────────────

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -295,9 +295,15 @@ def client(tmp_path, monkeypatch):
         delattr(btc_api, "_db_conn")
     btc_api.init_db()
     # /health/dashboard now resolves capital per-tenant. In tests there's no
-    # JWT, so override the dependency to a fixed tenant id. With no capital
-    # row seeded for that tenant, the endpoint falls back to cfg.capital_usd
+    # JWT, so override the dependency to a fixed tenant id (1). With no capital
+    # row seeded for tenant 1, the endpoint falls back to cfg.capital_usd
     # (preserves pre-fix behavior in tests that don't seed capital).
+    #
+    # NOTE for future test authors: downstream tests in this file implicitly
+    # rely on `tenant_id=1` having NO capital row unless they explicitly seed
+    # one via db_upsert_capital. The fixture rebuilds the DB on each test, so
+    # state does not leak across tests — but within a single test, any seed
+    # changes the portfolio branch (multi-tenant vs. legacy).
     btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 1
     try:
         yield TestClient(btc_api.app)
@@ -393,16 +399,22 @@ def test_get_health_dashboard_disabled_kill_switch_still_returns(client, monkeyp
 
 def test_get_health_dashboard_uses_tenant_capital_when_present(client):
     """Epic B #253 wire (issue #382): the dashboard reports the tenant's real
-    capital, not the legacy cfg.capital_usd default."""
+    capital, not the legacy cfg.capital_usd default.
+
+    With balance=$10K + peak=$12K (a prior drawdown stamped into the ledger)
+    and zero open positions, the dashboard should show current=$10K (no MTM
+    to add) and peak=$12K (ledger monotonic peak), with dd ≈ -16.67%.
+    """
     from db.capital import db_upsert_capital
     # tenant_id=1 matches the override in the client fixture above.
     db_upsert_capital(1, balance=10_000.0, peak_balance=12_000.0)
     resp = client.get("/health/dashboard")
     assert resp.status_code == 200
     portfolio = resp.json()["portfolio"]
-    # No closed trades + no open positions → portfolio_dd ≈ 0 → equity ≈ balance.
     assert portfolio["current_equity"] == pytest.approx(10_000.0)
     assert portfolio["peak_equity"] == pytest.approx(12_000.0)
+    # Sign convention matches kill_switch_v2.compute_portfolio_dd: negative in DD.
+    assert portfolio["dd_pct"] == pytest.approx(-(12_000.0 - 10_000.0) / 12_000.0)
 
 
 def test_get_health_dashboard_falls_back_when_tenant_has_no_capital(client):
@@ -413,6 +425,64 @@ def test_get_health_dashboard_falls_back_when_tenant_has_no_capital(client):
     portfolio = resp.json()["portfolio"]
     assert portfolio["current_equity"] == pytest.approx(1000.0)
     assert portfolio["peak_equity"] == pytest.approx(1000.0)
+
+
+def test_get_health_dashboard_no_double_count_on_realized_pnl_history(client):
+    """Regression for #382 review: when the tenant has a non-trivial trade
+    history already folded into `capital.balance` via apply_pnl_to_capital,
+    the dashboard MUST NOT re-apply those PnLs by also walking the closed
+    trades in compute_portfolio_equity_curve.
+
+    Seed five non-monotonic trades (+200, +200, -300, +200, -100) → final
+    balance = $10,200 with a peak of $10,400. Insert matching `positions`
+    rows so _load_closed_trades sees them too. The dashboard should report
+    current_equity=$10,200 (from the ledger, not 10,200 + 200 inflation)
+    and peak_equity=$10,400.
+    """
+    from db.capital import apply_pnl_to_capital
+    import btc_api
+
+    pnl_sequence = [200.0, 200.0, -300.0, 200.0, -100.0]
+    # Stamp each trade into the capital ledger.
+    for pnl in pnl_sequence:
+        apply_pnl_to_capital(1, pnl)
+
+    # Also insert the closed positions so the (now-removed) equity-curve
+    # path would see them — if regression returns, the curve would double-
+    # count and inflate current_equity past $10,200.
+    conn = btc_api.get_db()
+    try:
+        for i, pnl in enumerate(pnl_sequence):
+            reason = "TP" if pnl > 0 else "SL"
+            conn.execute(
+                """INSERT INTO positions
+                   (symbol, direction, status, entry_price, entry_ts,
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct,
+                    tenant_id)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, ?, ?, ?, ?, ?, 1)""",
+                (
+                    f"2026-04-2{i + 1}T12:00:00+00:00",
+                    100.0 + pnl / 10.0,
+                    f"2026-04-2{i + 1}T13:00:00+00:00",
+                    reason,
+                    pnl,
+                    pnl / 100.0,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    resp = client.get("/health/dashboard")
+    assert resp.status_code == 200
+    portfolio = resp.json()["portfolio"]
+    assert portfolio["current_equity"] == pytest.approx(10_200.0), (
+        f"Double-counting regression: expected $10,200 from ledger, got "
+        f"${portfolio['current_equity']}"
+    )
+    assert portfolio["peak_equity"] == pytest.approx(10_400.0)
+    expected_dd = -(10_400.0 - 10_200.0) / 10_400.0
+    assert portfolio["dd_pct"] == pytest.approx(expected_dd, abs=1e-6)
 
 
 # ── Portfolio transition recording integration ──────────────────────────────

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -98,8 +98,8 @@ def _insert_closed_position(conn, symbol, pnl, exit_ts):
     conn.execute(
         """INSERT INTO positions
            (symbol, direction, status, entry_price, entry_ts,
-            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', ?, ?)""",
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
     )
 
@@ -344,8 +344,8 @@ def test_get_health_dashboard_seeded_symbol_returns_full_state(client):
             conn.execute(
                 """INSERT INTO positions
                    (symbol, direction, status, entry_price, entry_ts,
-                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10)""",
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
                 (f"2026-04-2{1+i}T12:00:00+00:00", f"2026-04-2{1+i}T13:00:00+00:00"),
             )
         # Seed an event
@@ -483,6 +483,42 @@ def test_get_health_dashboard_no_double_count_on_realized_pnl_history(client):
     assert portfolio["peak_equity"] == pytest.approx(10_400.0)
     expected_dd = -(10_400.0 - 10_200.0) / 10_400.0
     assert portfolio["dd_pct"] == pytest.approx(expected_dd, abs=1e-6)
+
+
+def test_get_health_dashboard_isolates_tenants(client):
+    """Multi-tenant isolation (per "todo tiene que ser multitenant" policy):
+    tenant 1's dashboard MUST NOT reflect tenant 2's positions, regardless
+    of who has the bigger drawdown. Each tenant sees only their own ledger.
+    """
+    from db.capital import db_upsert_capital, apply_pnl_to_capital
+    import btc_api
+
+    # Tenant 1 (active in fixture): balance $10K, no closed trades.
+    db_upsert_capital(1, balance=10_000.0, peak_balance=10_000.0)
+
+    # Tenant 2 (NOT the request tenant): seed a -$1000 loss → balance $9K, peak $10K.
+    apply_pnl_to_capital(2, -1_000.0)
+    conn = btc_api.get_db()
+    try:
+        conn.execute(
+            """INSERT INTO positions
+               (symbol, direction, status, entry_price, entry_ts,
+                exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+               VALUES ('ETH', 'LONG', 'closed', 1000.0, '2026-04-20T12:00:00+00:00',
+                       900.0, '2026-04-20T15:00:00+00:00', 'SL', -1000.0, -0.10, 2)"""
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Request runs as tenant 1 (fixture override). Should see clean $10K equity,
+    # NOT a -10% drawdown from tenant 2's loss.
+    resp = client.get("/health/dashboard")
+    assert resp.status_code == 200
+    portfolio = resp.json()["portfolio"]
+    assert portfolio["current_equity"] == pytest.approx(10_000.0)
+    assert portfolio["peak_equity"] == pytest.approx(10_000.0)
+    assert portfolio["dd_pct"] == pytest.approx(0.0, abs=1e-9)
 
 
 # ── Portfolio transition recording integration ──────────────────────────────

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -521,11 +521,13 @@ def test_get_health_dashboard_isolates_tenants(client):
         # gain. If _load_open_positions ignored tenant_id, the dashboard for
         # tenant 1 would pick up this +$5,000 MTM and report current_equity
         # of $15,000 instead of $10,000.
+        # Note: SQLite (Python 3.11) does not accept numeric underscores in
+        # SQL literals, so we write 50000.0 instead of 50_000.0 here.
         conn.execute(
             """INSERT INTO positions
                (symbol, direction, status, entry_price, entry_ts,
                 qty, tenant_id)
-               VALUES ('BTC', 'LONG', 'open', 50_000.0,
+               VALUES ('BTC', 'LONG', 'open', 50000.0,
                        '2026-04-20T12:00:00+00:00', 1.0, 2)"""
         )
         conn.commit()

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -489,8 +489,17 @@ def test_get_health_dashboard_isolates_tenants(client):
     """Multi-tenant isolation (per "todo tiene que ser multitenant" policy):
     tenant 1's dashboard MUST NOT reflect tenant 2's positions, regardless
     of who has the bigger drawdown. Each tenant sees only their own ledger.
+
+    Covers both leak vectors:
+      (a) Closed trades for tenant 2 must not show in tenant 1's realized
+          balance — `_load_closed_trades(tenant_id=...)` filter is exercised
+          via the apply_pnl_to_capital ledger.
+      (b) Open positions for tenant 2 must not show in tenant 1's MTM —
+          `_load_open_positions(tenant_id=...)` filter is exercised by
+          seeding a price-cache MTM gain and asserting it stays absent.
     """
     from db.capital import db_upsert_capital, apply_pnl_to_capital
+    from strategy.kill_switch_v2_shadow import update_price
     import btc_api
 
     # Tenant 1 (active in fixture): balance $10K, no closed trades.
@@ -500,6 +509,7 @@ def test_get_health_dashboard_isolates_tenants(client):
     apply_pnl_to_capital(2, -1_000.0)
     conn = btc_api.get_db()
     try:
+        # (a) Tenant 2 has a closed losing trade for ETH.
         conn.execute(
             """INSERT INTO positions
                (symbol, direction, status, entry_price, entry_ts,
@@ -507,16 +517,34 @@ def test_get_health_dashboard_isolates_tenants(client):
                VALUES ('ETH', 'LONG', 'closed', 1000.0, '2026-04-20T12:00:00+00:00',
                        900.0, '2026-04-20T15:00:00+00:00', 'SL', -1000.0, -0.10, 2)"""
         )
+        # (b) Tenant 2 has an OPEN long BTC position with a large unrealized
+        # gain. If _load_open_positions ignored tenant_id, the dashboard for
+        # tenant 1 would pick up this +$5,000 MTM and report current_equity
+        # of $15,000 instead of $10,000.
+        conn.execute(
+            """INSERT INTO positions
+               (symbol, direction, status, entry_price, entry_ts,
+                qty, tenant_id)
+               VALUES ('BTC', 'LONG', 'open', 50_000.0,
+                       '2026-04-20T12:00:00+00:00', 1.0, 2)"""
+        )
         conn.commit()
     finally:
         conn.close()
+    # Make the price cache see BTC at $55K so the leak (if it existed) would
+    # surface a +$5,000 MTM on the tenant-2 position above.
+    update_price("BTC", 55_000.0)
 
     # Request runs as tenant 1 (fixture override). Should see clean $10K equity,
-    # NOT a -10% drawdown from tenant 2's loss.
+    # NOT a -10% drawdown from tenant 2's loss, NOT a +$5K MTM gain from
+    # tenant 2's open position.
     resp = client.get("/health/dashboard")
     assert resp.status_code == 200
     portfolio = resp.json()["portfolio"]
-    assert portfolio["current_equity"] == pytest.approx(10_000.0)
+    assert portfolio["current_equity"] == pytest.approx(10_000.0), (
+        f"Open-position leak: tenant 2's +$5K BTC MTM bled into tenant 1's "
+        f"dashboard (got ${portfolio['current_equity']})"
+    )
     assert portfolio["peak_equity"] == pytest.approx(10_000.0)
     assert portfolio["dd_pct"] == pytest.approx(0.0, abs=1e-9)
 

--- a/tests/test_health_integration.py
+++ b/tests/test_health_integration.py
@@ -19,8 +19,8 @@ def _insert_closed(conn, symbol, pnl, exit_ts):
     conn.execute(
         """INSERT INTO positions
            (symbol, direction, status, entry_price, entry_ts,
-            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?)""",
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
     )
     conn.commit()
@@ -138,8 +138,8 @@ def test_paused_reactivate_to_probation_then_complete_after_n_trades(tmp_db):
             conn.execute(
                 """INSERT INTO positions
                    (symbol, direction, status, entry_price, entry_ts,
-                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 95.0, ?, 'SL', -5.0, -0.05)""",
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 95.0, ?, 'SL', -5.0, -0.05, 1)""",
                 (ts, ts),
             )
         # Insert PAUSED row for BTC, set 15 days ago
@@ -186,8 +186,8 @@ def test_paused_reactivate_to_probation_then_complete_after_n_trades(tmp_db):
             conn.execute(
                 """INSERT INTO positions
                    (symbol, direction, status, entry_price, entry_ts,
-                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10)""",
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
                 (ts, ts),
             )
             conn.commit()

--- a/tests/test_health_pause_tier.py
+++ b/tests/test_health_pause_tier.py
@@ -24,8 +24,8 @@ def _insert_closed(conn, symbol, pnl, exit_ts):
     conn.execute(
         """INSERT INTO positions
            (symbol, direction, status, entry_price, entry_ts,
-            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?)""",
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
     )
     conn.commit()

--- a/tests/test_health_probation.py
+++ b/tests/test_health_probation.py
@@ -236,8 +236,8 @@ def test_trigger_health_evaluation_decrements_then_evaluates(tmp_db):
             conn.execute(
                 """INSERT INTO positions
                    (symbol, direction, status, entry_price, entry_ts,
-                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10)""",
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
                 (f"2026-05-{1+i%28:02d}T12:00:00+00:00", f"2026-05-{1+i%28:02d}T13:00:00+00:00"),
             )
         conn.commit()
@@ -274,8 +274,8 @@ def test_daily_cron_eval_does_not_decrement_probation(tmp_db):
             conn.execute(
                 """INSERT INTO positions
                    (symbol, direction, status, entry_price, entry_ts,
-                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10)""",
+                    exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
                 (f"2026-05-{1+i%28:02d}T12:00:00+00:00", f"2026-05-{1+i%28:02d}T13:00:00+00:00"),
             )
         conn.commit()

--- a/tests/test_health_rolling_metrics.py
+++ b/tests/test_health_rolling_metrics.py
@@ -20,8 +20,8 @@ def _insert_closed_position(conn, symbol, pnl_usd, exit_ts):
     conn.execute(
         """INSERT INTO positions
            (symbol, direction, status, entry_price, entry_ts,
-            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?)""",
+            exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl_usd, pnl_usd / 100.0),
     )
     conn.commit()
@@ -52,8 +52,8 @@ def test_open_positions_are_excluded(tmp_db):
     try:
         conn.execute(
             """INSERT INTO positions
-               (symbol, direction, status, entry_price, entry_ts, pnl_usd, pnl_pct)
-               VALUES ('BTCUSDT', 'LONG', 'open', 100.0, ?, NULL, NULL)""",
+               (symbol, direction, status, entry_price, entry_ts, pnl_usd, pnl_pct, tenant_id)
+               VALUES ('BTCUSDT', 'LONG', 'open', 100.0, ?, NULL, NULL, 1)""",
             (NOW.isoformat(),),
         )
         conn.commit()

--- a/tests/test_rule_a_check.py
+++ b/tests/test_rule_a_check.py
@@ -112,13 +112,14 @@ def synthetic_signals_db(tmp_path: Path) -> Path:
             entry_price REAL, entry_ts TEXT,
             sl_price REAL, tp_price REAL, size_usd REAL,
             exit_price REAL, exit_ts TEXT, exit_reason TEXT,
-            pnl_usd REAL, pnl_pct REAL
+            pnl_usd REAL, pnl_pct REAL,
+            tenant_id INTEGER
         )
     """)
     con.executemany("""
         INSERT INTO positions
-        (id, symbol, direction, status, entry_price, entry_ts, size_usd)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        (id, symbol, direction, status, entry_price, entry_ts, size_usd, tenant_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?, 1)
     """, [
         (1, "BTCUSDT", "LONG", "open", 80000.0, "2026-05-15T10:00:00+00:00", 500),
         (2, "ETHUSDT", "LONG", "open", 2300.0, "2026-05-15T11:00:00+00:00", 300),

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1488,11 +1488,16 @@ class TestScanEmitsV2ShadowDecision:
     def test_scan_writes_v2_shadow_row(self, tmp_path, monkeypatch):
         """scan() writes BOTH engine='v1' AND engine='v2_shadow' rows to the log."""
         import btc_api, btc_scanner, observability
+        from db.capital import db_upsert_capital
         db_path = str(tmp_path / "signals.db")
         monkeypatch.setattr(btc_api, "DB_FILE", db_path)
         if hasattr(btc_api, "_db_conn"):
             delattr(btc_api, "_db_conn")
         btc_api.init_db()
+        # Multi-tenant: scanner iterates db_list_active_tenant_ids() to emit
+        # shadow decisions; without a capital row the loop is empty and no
+        # v2_shadow row is written. Seed a tenant so the assertion can fire.
+        db_upsert_capital(1, balance=10_000.0, peak_balance=10_000.0)
 
         # Mock market data fetch (Task 3 A6 pattern)
         import pandas as pd

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -369,12 +369,12 @@ def test_emit_shadow_uses_cache_for_multi_symbol_mtm(tmp_path, monkeypatch, _cle
     conn = btc_api.get_db()
     try:
         conn.execute(
-            "INSERT INTO positions(symbol, direction, entry_price, qty, status, entry_ts) "
-            "VALUES('BTCUSDT', 'LONG', 50000, 0.01, 'open', '2026-04-20T10:00:00+00:00')"
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, entry_ts, tenant_id) "
+            "VALUES('BTCUSDT', 'LONG', 50000, 0.01, 'open', '2026-04-20T10:00:00+00:00', 1)"
         )
         conn.execute(
-            "INSERT INTO positions(symbol, direction, entry_price, qty, status, entry_ts) "
-            "VALUES('ETHUSDT', 'LONG', 3000, 1.0, 'open', '2026-04-20T10:00:00+00:00')"
+            "INSERT INTO positions(symbol, direction, entry_price, qty, status, entry_ts, tenant_id) "
+            "VALUES('ETHUSDT', 'LONG', 3000, 1.0, 'open', '2026-04-20T10:00:00+00:00', 1)"
         )
         conn.commit()
     finally:
@@ -386,7 +386,7 @@ def test_emit_shadow_uses_cache_for_multi_symbol_mtm(tmp_path, monkeypatch, _cle
 
     # Current scan is for RUNEUSDT (no open position, irrelevant) — but ETH
     # and BTC MTMs should both land
-    emit_shadow_decision(symbol="RUNEUSDT", cfg={})
+    emit_shadow_decision(symbol="RUNEUSDT", cfg={}, tenant_id=1)
 
     rows = observability.query_decisions(symbol="RUNEUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -416,7 +416,7 @@ def test_emit_shadow_fail_open_swallows_exceptions(tmp_path, monkeypatch, caplog
 
     import logging
     with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
-        emit_shadow_decision(symbol="BTCUSDT", cfg={})
+        emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     # No exception escaped, warning logged with symbol context
     assert any(
@@ -447,14 +447,14 @@ def test_emit_shadow_default_capital_1000_applied(tmp_path, monkeypatch, _clean_
     try:
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, pnl_usd) VALUES('BTCUSDT', 'LONG', 50000, 0.01, "
-            "'closed', '2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', -50.0)"
+            "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES('BTCUSDT', 'LONG', 50000, 0.01, "
+            "'closed', '2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', -50.0, 1)"
         )
         conn.commit()
     finally:
         conn.close()
 
-    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+    emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -484,7 +484,7 @@ def test_emit_shadow_warning_includes_traceback(tmp_path, monkeypatch, caplog, _
 
     import logging
     with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
-        emit_shadow_decision(symbol="BTCUSDT", cfg={})
+        emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     # At least one record has exc_info (traceback) attached
     assert any(rec.exc_info is not None for rec in caplog.records)
@@ -739,41 +739,41 @@ def test_load_recent_sl_timestamps_filters_by_symbol_and_reason(tmp_path, monkey
         # BTC SL inside window — should count
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
             (inside1, inside1),
         )
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
             (inside2, inside2),
         )
         # BTC SL outside window — skip
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
             (outside, outside),
         )
         # BTC TP inside window — skip (wrong exit_reason)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 30.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 30.0, 1)",
             (inside1, inside1),
         )
         # ETH SL inside window — skip (wrong symbol)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('ETHUSDT', 'LONG', 3000, 1.0, 'closed', ?, ?, 'SL', -20.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('ETHUSDT', 'LONG', 3000, 1.0, 'closed', ?, ?, 'SL', -20.0, 1)",
             (inside1, inside1),
         )
         # BTC still-open — skip (status != closed)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts) VALUES ('BTCUSDT', 'LONG', 50000, 0.01, 'open', ?)",
+            "entry_ts, tenant_id) VALUES ('BTCUSDT', 'LONG', 50000, 0.01, 'open', ?, 1)",
             (inside1,),
         )
         conn.commit()
@@ -847,8 +847,8 @@ def test_emit_shadow_writes_velocity_active_true_on_trigger(
             ts = (now - timedelta(hours=i + 1)).isoformat()
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+                "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
                 (ts, ts),
             )
         conn.commit()
@@ -865,7 +865,7 @@ def test_emit_shadow_writes_velocity_active_true_on_trigger(
         },
         "velocity_cooldown_hours": 4,
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -911,8 +911,8 @@ def test_emit_shadow_writes_velocity_active_false_when_below_threshold(
             ts = (now - timedelta(hours=i + 1)).isoformat()
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+                "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
                 (ts, ts),
             )
         conn.commit()
@@ -927,7 +927,7 @@ def test_emit_shadow_writes_velocity_active_false_when_below_threshold(
         },
         "velocity_cooldown_hours": 4,
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert rows[0]["velocity_active"] is False
@@ -975,18 +975,18 @@ def test_emit_shadow_velocity_active_decays_after_cooldown_expires(
             ts = (t0 - timedelta(hours=i + 1)).isoformat()
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+                "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
                 (ts, ts),
             )
         conn.commit()
     finally:
         conn.close()
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, tenant_id=1)
 
     t1 = t0 + timedelta(hours=10)
     monkeypatch.setattr(sh, "_now", lambda: t1)
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 2
@@ -1016,7 +1016,7 @@ def test_emit_shadow_velocity_fail_open_on_internal_error(
 
     import logging
     with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
-        emit_shadow_decision(symbol="BTCUSDT", cfg={})
+        emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -1057,7 +1057,7 @@ def test_emit_shadow_cooldown_boundary_at_exact_equality_is_expired(
 
     # No new SLs → detector returns False → compute_velocity_state leaves state
     # unchanged → _evaluate_velocity returns parsed > now → False.
-    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+    emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert rows[0]["velocity_active"] is False
@@ -1100,8 +1100,8 @@ def test_emit_shadow_does_not_touch_v1_decisions(
             ts = (now - timedelta(hours=i + 1)).isoformat()
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, "
-                "status, entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+                "status, entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
                 (ts, ts),
             )
         conn.commit()
@@ -1116,7 +1116,7 @@ def test_emit_shadow_does_not_touch_v1_decisions(
         },
         "velocity_cooldown_hours": 4,
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, tenant_id=1)
 
     # Assert v1 rows unchanged
     v1_after = observability.query_decisions(symbol="BTCUSDT", engine="v1")
@@ -1156,7 +1156,7 @@ def test_emit_shadow_multi_symbol_state_is_independent(
         },
         "velocity_cooldown_hours": 4,
     }}}
-    emit_shadow_decision(symbol="ETHUSDT", cfg=cfg)
+    emit_shadow_decision(symbol="ETHUSDT", cfg=cfg, tenant_id=1)
 
     rows = observability.query_decisions(symbol="ETHUSDT", engine="v2_shadow")
     assert rows[0]["velocity_active"] is False
@@ -1209,8 +1209,8 @@ def test_emit_shadow_partial_write_state_persists_when_record_decision_fails(
             ts = (now - timedelta(hours=i + 1)).isoformat()
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, "
-                "status, entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+                "status, entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
                 (ts, ts),
             )
         conn.commit()
@@ -1236,7 +1236,7 @@ def test_emit_shadow_partial_write_state_persists_when_record_decision_fails(
 
     import logging
     with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
-        emit_shadow_decision(symbol="BTCUSDT", cfg=cfg)
+        emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, tenant_id=1)
 
     # No decision row (record_decision failed)
     monkeypatch.setattr(obs_mod, "record_decision", original)
@@ -1410,7 +1410,7 @@ def test_emit_shadow_without_regime_score_backwards_compatible(
     import strategy.kill_switch_v2_shadow as sh
     monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 24, 12, 0, tzinfo=timezone.utc))
 
-    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+    emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -1443,7 +1443,7 @@ def test_emit_shadow_bull_regime_applies_adjustment(
         "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
         "advanced_overrides": {"regime_adjustment_enabled": True},
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -1480,7 +1480,7 @@ def test_emit_shadow_bear_regime_applies_penalty(
         "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
         "advanced_overrides": {"regime_adjustment_enabled": True},
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=25.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=25.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     import json
@@ -1513,7 +1513,7 @@ def test_emit_shadow_regime_disabled_records_enabled_false(
         "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
         "advanced_overrides": {"regime_adjustment_enabled": False},
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     import json
@@ -1547,7 +1547,7 @@ def test_emit_shadow_regime_adjustment_failure_falls_back_to_original_cfg(
 
     import logging
     with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
-        emit_shadow_decision(symbol="BTCUSDT", cfg={}, regime_score=75.0)
+        emit_shadow_decision(symbol="BTCUSDT", cfg={}, regime_score=75.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -1585,8 +1585,8 @@ def test_bull_regime_makes_reduced_threshold_stricter_enough_to_flip_tier(
     try:
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', -52.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', -52.0, 1)",
             ("2026-04-20T10:00:00+00:00", "2026-04-20T12:00:00+00:00"),
         )
         conn.commit()
@@ -1604,10 +1604,10 @@ def test_bull_regime_makes_reduced_threshold_stricter_enough_to_flip_tier(
     }}}
 
     # First scan: NEUTRAL (score=50) → slider stays 50 → DD=-0.052 is NORMAL.
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=50.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=50.0, tenant_id=1)
 
     # Second scan (same state): BULL (score=75) → slider=60 → reduced_dd=-0.05 → REDUCED.
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     # Rows ordered ts DESC (latest first)
@@ -1640,8 +1640,8 @@ def test_bear_regime_makes_reduced_threshold_laxer_enough_to_flip_tier(
     try:
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', -57.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', -57.0, 1)",
             ("2026-04-20T10:00:00+00:00", "2026-04-20T12:00:00+00:00"),
         )
         conn.commit()
@@ -1658,8 +1658,8 @@ def test_bear_regime_makes_reduced_threshold_laxer_enough_to_flip_tier(
         "advanced_overrides": {"regime_adjustment_enabled": True},
     }}}
 
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=50.0)
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=25.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=50.0, tenant_id=1)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=25.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 2
@@ -1689,7 +1689,7 @@ def test_emit_shadow_regime_score_zero_classified_as_bear_not_unknown(
         "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
         "advanced_overrides": {"regime_adjustment_enabled": True},
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=0.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=0.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     import json
@@ -1724,8 +1724,8 @@ def test_emit_shadow_bull_regime_cfg_eff_threaded_to_velocity_path(
             ts = (now - timedelta(hours=i + 1)).isoformat()
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, "
-                "status, entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0)",
+                "status, entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -10.0, 1)",
                 (ts, ts),
             )
         conn.commit()
@@ -1742,7 +1742,7 @@ def test_emit_shadow_bull_regime_cfg_eff_threaded_to_velocity_path(
         "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
         "advanced_overrides": {"regime_adjustment_enabled": True},
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     import json
@@ -1776,7 +1776,7 @@ def test_emit_shadow_adjustment_status_failed_when_regime_adjustment_raises(
 
     import logging
     with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
-        emit_shadow_decision(symbol="BTCUSDT", cfg={}, regime_score=75.0)
+        emit_shadow_decision(symbol="BTCUSDT", cfg={}, regime_score=75.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -1808,7 +1808,7 @@ def test_emit_shadow_adjustment_status_ok_on_normal_path(
         "regime_adjustments": {"bull_bonus": 10, "bear_penalty": 10},
         "advanced_overrides": {"regime_adjustment_enabled": True},
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     import json
@@ -2049,27 +2049,27 @@ def test_load_closed_trades_for_symbol_filters_by_symbol_and_status(tmp_path, mo
     try:
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, pnl_usd) VALUES "
+            "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
             "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-            "'2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', 10.0)",
+            "'2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', 10.0, 1)",
         )
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, pnl_usd) VALUES "
+            "entry_ts, pnl_usd, tenant_id) VALUES "
             "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-            "'2026-04-20T10:00:00+00:00', -5.0)",
+            "'2026-04-20T10:00:00+00:00', -5.0, 1)",
         )
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts) VALUES "
+            "entry_ts, tenant_id) VALUES "
             "('BTCUSDT', 'LONG', 50000, 0.01, 'open', "
-            "'2026-04-20T10:00:00+00:00')",
+            "'2026-04-20T10:00:00+00:00', 1)",
         )
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, pnl_usd) VALUES "
+            "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
             "('ETHUSDT', 'LONG', 3000, 1.0, 'closed', "
-            "'2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', 20.0)",
+            "'2026-04-20T10:00:00+00:00', '2026-04-20T12:00:00+00:00', 20.0, 1)",
         )
         conn.commit()
     finally:
@@ -2166,16 +2166,16 @@ def _seed_n_closed_trades(conn, symbol: str, n: int, win_rate: float):
         ts = f"2026-04-{(i % 28) + 1:02d}T12:00:00+00:00"
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, pnl_usd) VALUES "
-            "(?, 'LONG', 50000, 0.01, 'closed', ?, ?, 10.0)",
+            "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
+            "(?, 'LONG', 50000, 0.01, 'closed', ?, ?, 10.0, 1)",
             (symbol, ts, ts),
         )
     for i in range(losses):
         ts = f"2026-04-{(i % 28) + 1:02d}T13:00:00+00:00"
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, pnl_usd) VALUES "
-            "(?, 'LONG', 50000, 0.01, 'closed', ?, ?, -5.0)",
+            "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
+            "(?, 'LONG', 50000, 0.01, 'closed', ?, ?, -5.0, 1)",
             (symbol, ts, ts),
         )
 
@@ -2249,23 +2249,23 @@ def test_evaluate_per_symbol_tier_with_telemetry_alert_fires(
         for _ in range(50):
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
                 "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', 10.0)",
+                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', 10.0, 1)",
             )
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
                 "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', -5.0)",
+                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', -5.0, 1)",
             )
         # Last 20 trades all losses (rolling_wr=0.0). Use a later date so they slice.
         for i in range(20):
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
                 "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-                "'2026-04-20T10:00:00+00:00', ?, -5.0)",
+                "'2026-04-20T10:00:00+00:00', ?, -5.0, 1)",
                 (f"2026-04-20T{(i % 24):02d}:00:00+00:00",),
             )
         conn.commit()
@@ -2359,9 +2359,9 @@ def test_evaluate_per_symbol_tier_with_telemetry_recomputes_when_stale(
         for i in range(100):
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
                 "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-                "'2026-04-20T10:00:00+00:00', ?, 10.0)",
+                "'2026-04-20T10:00:00+00:00', ?, 10.0, 1)",
                 (f"2026-04-20T{(i % 24):02d}:00:00+00:00",),
             )
         conn.commit()
@@ -2405,7 +2405,7 @@ def test_emit_shadow_writes_per_symbol_tier_normal_when_no_history(
     import strategy.kill_switch_v2_shadow as sh
     monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc))
 
-    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+    emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -2440,29 +2440,29 @@ def test_emit_shadow_writes_per_symbol_tier_alert_when_baseline_breaks(
         for _ in range(50):
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
                 "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', 10.0)",
+                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', 10.0, 1)",
             )
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
                 "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', -5.0)",
+                "'2026-03-01T10:00:00+00:00', '2026-03-01T12:00:00+00:00', -5.0, 1)",
             )
         for i in range(20):
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, pnl_usd) VALUES "
+                "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
                 "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', "
-                "'2026-04-20T10:00:00+00:00', ?, -5.0)",
+                "'2026-04-20T10:00:00+00:00', ?, -5.0, 1)",
                 (f"2026-04-20T{(i % 24):02d}:00:00+00:00",),
             )
         conn.commit()
     finally:
         conn.close()
 
-    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+    emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert rows[0]["per_symbol_tier"] == "ALERT"
@@ -2496,7 +2496,7 @@ def test_emit_shadow_per_symbol_fail_open_returns_normal_with_status_failed(
 
     import logging
     with caplog.at_level(logging.WARNING, logger="kill_switch_v2_shadow"):
-        emit_shadow_decision(symbol="BTCUSDT", cfg={})
+        emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -2542,7 +2542,7 @@ def test_emit_shadow_backwards_compat_b1_b2_b3_still_pass(
         "baseline_min_trades": 100,
         "baseline_stale_days": 7,
     }}}
-    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0)
+    emit_shadow_decision(symbol="BTCUSDT", cfg=cfg, regime_score=75.0, tenant_id=1)
 
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     assert len(rows) == 1
@@ -2617,8 +2617,8 @@ def test_evaluate_per_symbol_tier_with_telemetry_cached_count_gates_decision(
             ts = f"2026-04-20T{ts_h:02d}:00:00+00:00"
             conn.execute(
                 "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-                "entry_ts, exit_ts, pnl_usd) VALUES "
-                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, -5.0)",
+                "entry_ts, exit_ts, pnl_usd, tenant_id) VALUES "
+                "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, -5.0, 1)",
                 (ts, ts),
             )
         conn.commit()
@@ -2662,7 +2662,7 @@ def test_emit_shadow_per_symbol_fail_open_telemetry_keys_match_success_path(
     monkeypatch.setattr(sh, "_now", lambda: datetime(2026, 4, 25, 12, 0, tzinfo=timezone.utc))
 
     # Capture success-path keys via a normal call
-    emit_shadow_decision(symbol="BTCUSDT", cfg={})
+    emit_shadow_decision(symbol="BTCUSDT", cfg={}, tenant_id=1)
     rows = observability.query_decisions(symbol="BTCUSDT", engine="v2_shadow")
     import json
     success_keys = set(json.loads(rows[0]["reasons_json"])["per_symbol"].keys())
@@ -2677,7 +2677,7 @@ def test_emit_shadow_per_symbol_fail_open_telemetry_keys_match_success_path(
         raise RuntimeError("simulated per-symbol eval failure")
     monkeypatch.setattr(sh, "_evaluate_per_symbol_tier_with_telemetry", _boom)
 
-    emit_shadow_decision(symbol="ETHUSDT", cfg={})
+    emit_shadow_decision(symbol="ETHUSDT", cfg={}, tenant_id=1)
     rows2 = observability.query_decisions(symbol="ETHUSDT", engine="v2_shadow")
     fail_keys = set(json.loads(rows2[0]["reasons_json"])["per_symbol"].keys())
 

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -1752,8 +1752,8 @@ def test_calibrator_loop_pending_marks_prior_pending_as_superseded(
     try:
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0, 1)",
             (inside, inside),
         )
         conn.commit()
@@ -1839,8 +1839,8 @@ def test_calibrator_loop_pending_sends_telegram_notification(
         # Seed a profitable trade so v2 returns pending
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0, 1)",
             (inside, inside),
         )
         conn.commit()

--- a/tests/test_strategy_kill_switch_v2_optimizer.py
+++ b/tests/test_strategy_kill_switch_v2_optimizer.py
@@ -25,21 +25,21 @@ def test_load_closed_positions_window_filters_by_window(tmp_path, monkeypatch):
         # Inside window (10d ago)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0, 1)",
             (inside, inside),
         )
         # Outside window (400d ago)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0, 1)",
             (outside, outside),
         )
         # Open position (no exit_ts)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts) VALUES ('BTCUSDT', 'LONG', 50000, 0.01, 'open', ?)",
+            "entry_ts, tenant_id) VALUES ('BTCUSDT', 'LONG', 50000, 0.01, 'open', ?, 1)",
             (inside,),
         )
         conn.commit()
@@ -72,14 +72,14 @@ def test_load_closed_positions_window_orders_by_entry_ts(tmp_path, monkeypatch):
         # Insert later first (out of order)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 10.0, 1)",
             (later, later),
         )
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -5.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -5.0, 1)",
             (earlier, earlier),
         )
         conn.commit()
@@ -247,8 +247,8 @@ def test_run_optimization_v2_no_feasible_when_all_blow_target(tmp_path, monkeypa
     try:
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -200.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -200.0, 1)",
             (ts, ts),
         )
         conn.commit()
@@ -284,8 +284,8 @@ def test_run_optimization_v2_picks_max_pnl_among_feasible(tmp_path, monkeypatch)
     try:
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0, 1)",
             (ts, ts),
         )
         conn.commit()
@@ -381,16 +381,16 @@ def test_run_optimization_v2_filters_out_of_window_trades(tmp_path, monkeypatch)
         # Inside the 365-day window: profitable +50
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0, 1)",
             (inside_ts, inside_ts),
         )
         # Outside window (400 days ago): -1000 loss that would otherwise
         # blow the dd_target if included.
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -1000.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', -1000.0, 1)",
             (outside_ts, outside_ts),
         )
         conn.commit()
@@ -430,15 +430,15 @@ def test_run_optimization_v2_excludes_null_pnl_trades(tmp_path, monkeypatch):
         # Valid trade with non-null pnl
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 25.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 25.0, 1)",
             (ts, ts),
         )
         # Corrupted row: NULL pnl_usd (column allows NULL per schema)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', NULL)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'SL', NULL, 1)",
             (ts, ts),
         )
         conn.commit()
@@ -511,8 +511,8 @@ def test_run_optimization_v2_regime_score_can_change_recommended_slider(
         # A profitable trade — both regimes would take it (NORMAL portfolio)
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0, 1)",
             (ts, ts),
         )
         conn.commit()
@@ -556,8 +556,8 @@ def test_calibrator_loop_uses_real_v2_with_profitable_trades(
     try:
         conn.execute(
             "INSERT INTO positions(symbol, direction, entry_price, qty, status, "
-            "entry_ts, exit_ts, exit_reason, pnl_usd) VALUES "
-            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0)",
+            "entry_ts, exit_ts, exit_reason, pnl_usd, tenant_id) VALUES "
+            "('BTCUSDT', 'LONG', 50000, 0.01, 'closed', ?, ?, 'TP', 50.0, 1)",
             (ts, ts),
         )
         conn.commit()


### PR DESCRIPTION
## Summary
- Closes #382. `/health/dashboard` ahora resuelve el `tenant_id` del JWT y lee `db_get_capital(tenant_id)`. El portfolio `current_equity` / `peak_equity` reflejan el balance real del tenant en vez del default global `cfg.capital_usd` ($1000).
- `portfolio_dd` se calcula sobre el capital base real — el simulador recibe el `capital_usd` overrideado en una copia del cfg, así el motor opera coherentemente con lo que se muestra al usuario.
- Fallback al `cfg.capital_usd` legacy cuando el tenant no tiene fila de capital aún — preserva el comportamiento previo en tests y para tenants nuevos.
- Scanner sizing intencionalmente NO se toca — eso afecta señales reales en prod y necesita backtest. Follow-up de epic B (#253).

## Context

Bug P0 del [E2E review post-redesign del 2026-05-19](https://github.com/sssimon/trading-spacial/issues/395) (#382):
- Posiciones → hero strip: `Equity $10,000` (de `GET /capital`, multi-tenant).
- Kill-switch → `EQUITY ACTUAL $1,000 / peak $1,000` (de `cfg.capital_usd` default).

Dos rótulos "Equity" para el mismo usuario, valores incompatibles. Un trader nuevo lee $1,000 y piensa que perdió plata.

La raíz: el motor del kill-switch v2 + el endpoint del dashboard leían del config global, pero la tabla `capital` per-tenant (introducida en B.5 #258) ya existe. Este PR cierra ese gap específico del dashboard.

## Test plan
- [x] `pytest tests/test_health_dashboard.py` — 23/23 (incluye 2 nuevos: capital presente → usa tenant balance/peak; ausente → fallback $1000)
- [x] `pytest tests/test_api_health_parity.py tests/test_multi_tenant_b5_enforcement.py tests/test_multi_tenant_b7_idor.py` — 46/46
- [x] `pytest tests/test_api.py tests/test_strategy_kill_switch_v2.py` — 244/244
- [x] `cd frontend && npm run build` — OK, sin warnings de tipos
- [ ] Smoke test en `trading.sdar.dev`: cargar `/kill-switch` autenticado como admin y verificar que muestra el balance real del tenant en "EQUITY ACTUAL"

## Out of scope (follow-ups)
- Scanner sizing wire al capital del tenant — afecta señales reales, requiere backtest. Issue separado bajo epic B #253.
- Other 13 follow-ups del E2E review siguen pendientes (ver epic #395).

🤖 Generated with [Claude Code](https://claude.com/claude-code)