### PR TITLE
fix(notifier): include lrc_pct in SignalEvent payload (#385)

### DIFF
--- a/api/telegram.py
+++ b/api/telegram.py
@@ -122,6 +122,15 @@ def push_telegram_direct(rep: dict, cfg: dict):
         log.warning("push_telegram_direct: health lookup failed for %s: %s", symbol, e)
         health_state = "NORMAL"
 
+    # LRC% lives under rep["lrc_1h"]["pct"] (scanner schema). If the scanner
+    # report omitted it (corrupted run, partial fixture), pass None and let
+    # the consumer render "?" instead of fabricating a value.
+    _lrc_raw = (rep.get("lrc_1h") or {}).get("pct")
+    try:
+        lrc_pct = float(_lrc_raw) if _lrc_raw is not None else None
+    except (TypeError, ValueError):
+        lrc_pct = None
+
     event = SignalEvent(
         symbol=symbol,
         score=int(rep.get("score", 0) or 0),
@@ -129,6 +138,7 @@ def push_telegram_direct(rep: dict, cfg: dict):
         entry=float(rep.get("price") or 0.0),
         sl=float((rep.get("sizing_1h") or {}).get("sl_precio") or 0.0),
         tp=float((rep.get("sizing_1h") or {}).get("tp_precio") or 0.0),
+        lrc_pct=lrc_pct,
         health_state=health_state,
     )
     # B.4 #257: per-user fan-out with symbol/min_score filtering + channel

--- a/notifier/events.py
+++ b/notifier/events.py
@@ -41,6 +41,12 @@ class SignalEvent(_BaseEvent):
     entry: float = 0.0
     sl: float = 0.0
     tp: float = 0.0
+    # LRC percentile within the 100-bar 1h channel (0..100). 0..25 = lower
+    # quartile (LONG zone); 75..100 = upper quartile (SHORT zone). Optional:
+    # callers that don't have it (legacy paths, tests) pass None and the
+    # frontend renders "?" instead of inventing a value. Surfacing this in
+    # the NotificationBell summary closes #385.
+    lrc_pct: float | None = None
     # Kill-switch context (#138): "NORMAL" | "ALERT" | "REDUCED" | "PAUSED".
     # Determines whether the template prepends a warning prefix.
     health_state: str = "NORMAL"

--- a/tests/test_health_shim_integration.py
+++ b/tests/test_health_shim_integration.py
@@ -72,3 +72,59 @@ def test_shim_unknown_symbol_defaults_to_normal(tmp_db):
     assert mock_post.call_count == 1, "no signal sent — later assertion would be misleading"
     sent_text = mock_post.call_args.kwargs["json"]["text"]
     assert not sent_text.startswith("⚠️"), f"unexpected prefix: {sent_text!r}"
+
+
+def test_shim_propagates_lrc_pct_from_rep_to_signal_event(tmp_db):
+    """#385: rep["lrc_1h"]["pct"] must land in the persisted notification
+    payload so the bell can render the percentage instead of '?'.
+    """
+    import btc_api, json
+    from notifier import _storage as storage
+
+    rep = {
+        "symbol": "PENDLE", "score": 5, "direction": "SHORT",
+        "price": 4.20,
+        "sizing_1h": {"sl_precio": 4.31, "tp_precio": 4.05},
+        "lrc_1h": {"pct": 87.3, "upper": 4.40, "lower": 3.90, "mid": 4.15},
+    }
+    fake_resp = MagicMock()
+    fake_resp.ok = True
+
+    with patch("notifier.channels.telegram.requests.post", return_value=fake_resp):
+        btc_api.push_telegram_direct(rep, _cfg())
+
+    # The notifier persists the SignalEvent payload to notifications_sent.
+    rows = storage.list_unread(tenant_id=None)
+    signal_rows = [r for r in rows if r["event_type"] == "signal"]
+    assert signal_rows, "no signal notification persisted"
+    payload = json.loads(signal_rows[0]["payload_json"])
+    assert payload.get("lrc_pct") == pytest.approx(87.3), (
+        f"lrc_pct missing from persisted payload — bell will still render '?'. "
+        f"Got payload keys: {list(payload.keys())}"
+    )
+
+
+def test_shim_handles_missing_lrc_gracefully(tmp_db):
+    """When the scanner report omits lrc_1h (corrupted run, partial fixture),
+    the persisted payload carries lrc_pct=None and the bell will render '?'
+    — never fabricates a value."""
+    import btc_api, json
+    from notifier import _storage as storage
+
+    rep = {
+        "symbol": "JUP", "score": 4, "direction": "LONG",
+        "price": 1.20,
+        "sizing_1h": {"sl_precio": 1.10, "tp_precio": 1.35},
+        # NO lrc_1h key on purpose
+    }
+    fake_resp = MagicMock()
+    fake_resp.ok = True
+
+    with patch("notifier.channels.telegram.requests.post", return_value=fake_resp):
+        btc_api.push_telegram_direct(rep, _cfg())
+
+    rows = storage.list_unread(tenant_id=None)
+    signal_rows = [r for r in rows if r["event_type"] == "signal"]
+    assert signal_rows, "no signal notification persisted"
+    payload = json.loads(signal_rows[0]["payload_json"])
+    assert payload.get("lrc_pct") is None

--- a/tests/test_notifier_events.py
+++ b/tests/test_notifier_events.py
@@ -21,6 +21,34 @@ def test_signal_event_required_fields():
     assert ev.dedupe_key == "signal:BTCUSDT"
 
 
+def test_signal_event_lrc_pct_optional_default_none():
+    """#385: lrc_pct is optional — callers that don't have it (legacy paths,
+    tests) pass None and the frontend renders '?' instead of fabricating."""
+    from notifier import SignalEvent
+    ev = SignalEvent(
+        symbol="BTCUSDT", score=6, direction="LONG",
+        entry=50_000.0, sl=49_000.0, tp=55_000.0,
+    )
+    assert ev.lrc_pct is None
+    assert ev.to_dict()["lrc_pct"] is None
+
+
+def test_signal_event_lrc_pct_persisted_in_payload():
+    """#385: when callers DO have an LRC percentile, it survives to_dict()
+    so notifier.storage can persist it for the bell."""
+    from notifier import SignalEvent
+    ev = SignalEvent(
+        symbol="RUNEUSDT", score=4, direction="SHORT",
+        entry=4.20, sl=4.31, tp=4.05,
+        lrc_pct=87.3,
+    )
+    payload = ev.to_dict()
+    assert payload["lrc_pct"] == 87.3
+    # Round-trip through json (the bell payload_json column is text)
+    import json
+    assert json.loads(json.dumps(payload))["lrc_pct"] == 87.3
+
+
 def test_health_event_required_fields():
     from notifier import HealthEvent
     ev = HealthEvent(


### PR DESCRIPTION
## Summary
- Closes #385. The bell summary `score X · LRC ?%` was rendering `?` for every signal because the backend never put `lrc_pct` in the payload.
- Fix: add optional `lrc_pct: float | None` to `SignalEvent`; `push_telegram_direct` reads it from `rep[\"lrc_1h\"][\"pct\"]`.
- Frontend unchanged — its `?? '?'` fallback already handled the None case; now it simply receives a real value.

## Root cause

`SignalEvent` dataclass had `symbol`, `score`, `direction`, `entry`, `sl`, `tp`, `health_state` — and that was the entire payload persisted to `notifications_sent.payload_json`. The bell template `summary()` in `NotificationBell.tsx:68` expected `p.lrc_pct` but the field never existed → falsy fallback to `'?'` triggered on every item.

## Test plan
- [x] `pytest tests/test_notifier_events.py tests/test_health_shim_integration.py` — 15/15 (2 new + 2 new respectively)
- [x] `pytest tests/test_notifier_*.py tests/test_multi_tenant_b4_signal_routing.py tests/test_api_telegram_unit.py` — 52/52
- [x] `cd frontend && npm run build` — OK
- [ ] Smoke on `trading.sdar.dev`: trigger a new signal (or wait for one) and verify the bell shows `score X · LRC 87.3%` instead of `?%`

## Out of scope

The shim path (`push_telegram_direct`) is the production hot path. Legacy direct-`notify(SignalEvent(...))` callers (some tests, future migrations) keep the field as None — frontend renders `?` for those, which is the honest behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)