### PR TITLE
chore(frontend): cleanup api.ts exports + wire test-webhook button (#391)

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -256,12 +256,12 @@ export async function closePosition(id: number, payload: PositionClosePayload): 
   });
 }
 
-// DELETE /positions/{id}
-export async function cancelPosition(id: number): Promise<{ ok: boolean; message: string }> {
-  return request<{ ok: boolean; message: string }>(`/positions/${id}`, {
-    method: 'DELETE',
-  });
-}
+// NOTE: `cancelPosition` (DELETE /positions/{id}, marks status='cancelled'
+// without computing PnL — distinct from POST /close) used to live here but
+// was removed in #391: no UI flow ever called it, and POST /close covers
+// the operator-driven exit case. The backend endpoint is still live so
+// curl/script callers continue to work; reintroduce the wrapper here only
+// when a real UX flow needs the cancel-without-PnL semantics.
 
 // ---- Auto-Tune -------------------------------------------------------
 
@@ -318,6 +318,12 @@ export async function markAllNotificationsRead(): Promise<{ ok: boolean; marked:
 }
 
 // ---- Kill switch observability (#187 phase 1) ---------------------------
+//
+// `getKillSwitchDecisions` and `getKillSwitchCurrentState` have no consumer
+// in the redesigned UI yet (the new KillSwitchView reads /health/dashboard,
+// the aggregated form). Decommission vs. building an admin panel is tracked
+// in #390 — kept here so the eventual panel doesn't have to recreate the
+// wrappers from scratch.
 
 export async function getKillSwitchDecisions(
   opts: {
@@ -373,6 +379,11 @@ export async function releaseKillSwitch(
 // do NOT accept tenant_id / user_id arguments. The JWT cookie is httpOnly
 // (set by /auth/login) and is automatically attached via credentials:'include'
 // in request(). Frontend cannot read it.
+//
+// `putCapital`, `getPreferences`, and `putPreferences` have unit tests in
+// api.test.ts but no component consumer yet — that UI is tracked in #389
+// (multi-tenant preferences panel + capital editor). Kept here so the panel
+// can land without recreating the contracts.
 
 export async function getCapital(): Promise<Capital> {
   return request<Capital>('/capital');

--- a/frontend/src/components/ConfigPanel.module.css
+++ b/frontend/src/components/ConfigPanel.module.css
@@ -138,6 +138,27 @@
   text-transform: uppercase;
 }
 .pillBull { color: var(--bull); border-color: var(--bull); }
+.pillBear { color: var(--bear); border-color: var(--bear); }
+.pillDim  { color: var(--nbc-fg-muted); border-color: var(--nbc-border-dim); }
+
+.webhookResult {
+  margin-top: 4px;
+  padding: 10px 12px;
+  border: 1px solid var(--nbc-border-dim);
+  background: var(--nbc-bg-elevated, rgba(255,255,255,0.02));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.webhookRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  font-size: 12px;
+}
+.webhookChannel { color: var(--nbc-fg-muted); font-family: var(--nbc-font-mono); font-size: 11px; }
+.webhookDetail  { color: var(--nbc-fg-muted); font-size: 11px; line-height: 1.4; }
 
 .dashed {
   font-family: inherit;

--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -7,8 +7,13 @@
 
 import React, { useEffect, useState } from 'react';
 import styles from './ConfigPanel.module.css';
-import type { SignalFilters, AppConfig } from '../types';
-import { getConfig, updateConfigFull } from '../api';
+import type {
+  SignalFilters,
+  AppConfig,
+  WebhookTestResponse,
+  WebhookTestChannelResult,
+} from '../types';
+import { getConfig, updateConfigFull, testWebhook } from '../api';
 
 interface ConfigPanelProps {
   open: boolean;
@@ -21,6 +26,12 @@ const DEFAULT_FILTERS: SignalFilters = {
   notify_setup: false,
 };
 
+type WebhookTestState =
+  | { status: 'idle' }
+  | { status: 'running' }
+  | { status: 'done'; result: WebhookTestResponse }
+  | { status: 'error'; message: string };
+
 const ConfigPanel: React.FC<ConfigPanelProps> = ({ open, onClose }) => {
   const [config, setConfig]   = useState<AppConfig | null>(null);
   const [filters, setFilters] = useState<SignalFilters>(DEFAULT_FILTERS);
@@ -28,6 +39,27 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ open, onClose }) => {
   const [saving, setSaving]   = useState(false);
   const [dirty, setDirty]     = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [webhookTest, setWebhookTest] = useState<WebhookTestState>({ status: 'idle' });
+
+  // Reset the webhook test status whenever the panel re-opens so the user
+  // sees a clean slate. (Otherwise the "OK" badge from a previous open
+  // would linger and create false confidence about the current config.)
+  useEffect(() => {
+    if (open) setWebhookTest({ status: 'idle' });
+  }, [open]);
+
+  const runWebhookTest = async () => {
+    setWebhookTest({ status: 'running' });
+    try {
+      const result = await testWebhook();
+      setWebhookTest({ status: 'done', result });
+    } catch (err) {
+      setWebhookTest({
+        status:  'error',
+        message: err instanceof Error ? err.message : 'Error inesperado',
+      });
+    }
+  };
 
   // Load config when opened.
   useEffect(() => {
@@ -131,6 +163,33 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ open, onClose }) => {
 
               <div className={styles.row}>
                 <div className={styles.rowLeft}>
+                  <div className={styles.rowLabel}>Probar entrega</div>
+                  <div className={`${styles.rowHint} prose`}>
+                    Envía un mensaje de prueba a Telegram y al webhook configurado.
+                  </div>
+                </div>
+                <div className={styles.rowRight}>
+                  <button
+                    type="button"
+                    className="btn btn--ghost btn--sm"
+                    onClick={runWebhookTest}
+                    disabled={webhookTest.status === 'running'}
+                  >
+                    <span className="btn__caret">▸</span>{' '}
+                    {webhookTest.status === 'running' ? 'probando…' : 'probar'}
+                  </button>
+                </div>
+              </div>
+
+              {webhookTest.status === 'done' && (
+                <WebhookTestResult result={webhookTest.result} />
+              )}
+              {webhookTest.status === 'error' && (
+                <div className={styles.error}>Falló: {webhookTest.message}</div>
+              )}
+
+              <div className={styles.row}>
+                <div className={styles.rowLeft}>
                   <div className={styles.rowLabel}>Intervalo de escaneo</div>
                   <div className={`${styles.rowHint} prose`}>Cada cuánto re-evalúa los pares.</div>
                 </div>
@@ -223,6 +282,48 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ open, onClose }) => {
         </footer>
       </aside>
     </>
+  );
+};
+
+// ─── WebhookTestResult ───
+// Renders the two-channel summary from GET /webhook/test. Each row is one
+// channel (telegram_directo, webhook_n8n). The pill color reflects ok/fail;
+// the error string (if any) is shown below in muted prose. We intentionally
+// don't conflate "no token configured" with "HTTP request failed" — both
+// arrive as ok=false but with distinct error messages from the backend.
+
+interface WebhookTestResultProps {
+  result: WebhookTestResponse;
+}
+const WebhookTestResult: React.FC<WebhookTestResultProps> = ({ result }) => {
+  const rows: Array<{ key: string; label: string; channel: WebhookTestChannelResult }> = [
+    { key: 'telegram', label: 'Telegram', channel: result.telegram_directo },
+    { key: 'webhook',  label: 'Webhook',  channel: result.webhook_n8n },
+  ];
+  return (
+    <div className={styles.webhookResult}>
+      {rows.map(({ key, label, channel }) => (
+        <div key={key} className={styles.webhookRow}>
+          <div>
+            <div>{label}</div>
+            {channel.error && (
+              <div className={`${styles.webhookDetail} prose`}>{channel.error}</div>
+            )}
+            {channel.url && (
+              <div className={styles.webhookChannel}>{channel.url}</div>
+            )}
+          </div>
+          <span
+            className={[
+              styles.pill,
+              channel.ok ? styles.pillBull : styles.pillBear,
+            ].join(' ')}
+          >
+            {channel.ok ? 'ok' : 'fail'}
+          </span>
+        </div>
+      ))}
+    </div>
   );
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -117,10 +117,20 @@ export interface ScanResponse {
   results: ScanResult[];
 }
 
-export interface WebhookTestResponse {
+// Backend returns one entry per channel under the keys it actually tried.
+// `error` is set when ok=false; `status_code` and `url` are present when the
+// channel did an HTTP call.
+export interface WebhookTestChannelResult {
   ok: boolean;
-  status_code: number;
-  url: string;
+  status_code?: number;
+  error?: string;
+  url?: string;
+}
+
+export interface WebhookTestResponse {
+  ok: boolean;  // overall: at least one channel succeeded
+  telegram_directo: WebhookTestChannelResult;
+  webhook_n8n: WebhookTestChannelResult;
 }
 
 export interface SignalsParams {


### PR DESCRIPTION
## Summary
Closes #391. Audited the 7 frontend `api.ts` exports flagged as "no consumer":

| Export | Decision | Rationale |
|---|---|---|
| `cancelPosition` | **Removed** | No UI flow uses it; `POST /close` covers exits. Backend endpoint stays for curl/scripts. |
| `testWebhook` | **Now wired** | New "Probar entrega" row in ConfigPanel. |
| `getKillSwitchDecisions` | Kept + comment → #390 | Admin-panel-or-decommission decision belongs to that ticket. |
| `getKillSwitchCurrentState` | Kept + comment → #390 | Same. |
| `putCapital` | Kept + comment → #389 | Multi-tenant prefs UI will consume it. |
| `getPreferences` | Kept + comment → #389 | Same. |
| `putPreferences` | Kept + comment → #389 | Same. |

## Bonus fix — WebhookTestResponse type

The previous `WebhookTestResponse` declared `{ ok, status_code, url }` but the backend actually returns `{ ok, telegram_directo, webhook_n8n }` (per-channel result). Type now matches the wire format; the new `WebhookTestChannelResult` carries the per-channel `ok / status_code / error / url` shape.

## New UI — "Probar entrega" row in ConfigPanel

- Lives under "general" in the same visual pattern as the existing Webhook row.
- Button toggles between `probar` / `probando…`; results render as a two-row card with `ok`/`fail` pill per channel + the error string when the backend supplies one (e.g. `telegram_bot_token no configurado`).
- Status auto-clears when the panel closes/reopens — no stale "OK" badge leaking into a later session.
- The endpoint is admin-only on the backend (`require_role('admin')`); non-admins will see the standard 401/403 surface via `request<...>()`.

## Test plan
- [x] `cd frontend && npm run build` — OK (tsc + vite).
- [x] `cd frontend && npm run test -- --run` — 80 passed / 7 skipped (existing NotificationToast test logs a deliberate "network" error to stderr; not a regression).
- [ ] Smoke on `trading.sdar.dev`: open ConfigPanel → click "probar" → verify both channels report their actual config status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)