### PR TITLE
feat(agent): Phase 0 foundation — kill leak, server-driven status (#400)

### DIFF
--- a/api/agent/__init__.py
+++ b/api/agent/__init__.py
@@ -1,0 +1,12 @@
+"""Agent / copiloto package.
+
+Owns the new /agent/* surface introduced by the production-grade rewrite.
+
+Pre-registro: docs/superpowers/specs/es/2026-05-19-trading-copilot-production-grade-pre-reg.md
+Epic: #400.
+
+Phase 0 (this commit) introduces the package + GET /agent/status only.
+Phase 1 adds the read-only tool layer + audit tables.
+Phase 2 delivers the conversation core (SSE streaming) that replaces
+/agent/chat. Phase 3 adds the propose/confirm side-effect tools.
+"""

--- a/api/agent/config.py
+++ b/api/agent/config.py
@@ -1,0 +1,59 @@
+"""Agent runtime configuration: feature flag + status resolution.
+
+Intentionally minimal in Phase 0 — owns the contract behind GET /agent/status
+documented in §4.4 of the pre-reg. Phase 2 will extend this module with the
+per-surface model whitelist, the daily/monthly token budget readers, and
+the AGENT_PROPOSAL_SECRET accessor used by HMAC proposal signing.
+
+Spec §6.3 + §13.5: this module NEVER leaks env-var names, .env paths, or
+operator-only configuration detail through any field it returns. The
+`reason` field is a closed enum of user-safe strings — anything else is
+a regression that must trip the no-leak test in tests/test_agent_status.py.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from api.config import load_config
+
+log = logging.getLogger("api.agent.config")
+
+
+# Closed enum of user-safe status reasons. Never expand this with an
+# operator-only string (env var name, path, secret name, etc).
+_REASON_OK = "ok"
+_REASON_DISABLED = "agent_disabled"
+
+
+@dataclass(frozen=True)
+class AgentStatus:
+    """Public status returned by GET /agent/status."""
+
+    enabled: bool
+    reason: str
+
+
+def get_agent_status(cfg: Optional[dict] = None) -> AgentStatus:
+    """Resolve the agent's runtime status.
+
+    Precedence (any disabling source wins):
+      1. cfg["agent"]["enabled"] is explicitly False  → operator-disabled
+      2. ANTHROPIC_API_KEY missing or empty            → treated identically
+         (we deliberately collapse "key missing" into the same reason as
+         "operator disabled" so the wire format never leaks the existence
+         of an env var named ANTHROPIC_API_KEY)
+      3. Otherwise                                     → enabled
+    """
+    cfg = cfg if cfg is not None else load_config()
+    agent_cfg = cfg.get("agent") or {}
+    if agent_cfg.get("enabled") is False:
+        return AgentStatus(enabled=False, reason=_REASON_DISABLED)
+
+    api_key = (os.environ.get("ANTHROPIC_API_KEY") or "").strip()
+    if not api_key:
+        return AgentStatus(enabled=False, reason=_REASON_DISABLED)
+
+    return AgentStatus(enabled=True, reason=_REASON_OK)

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -1,0 +1,49 @@
+"""Agent API router. Phase 0 owns GET /agent/status only.
+
+The /agent/* surface lands incrementally per the pre-reg's 6-phase plan:
+
+  Phase 0 (this commit):
+    GET  /agent/status                              — public, no auth
+
+  Phase 1:
+    (no new endpoints — tool registry + audit schema land internally)
+
+  Phase 2:
+    POST /agent/conversations/{conversation_id}/turn   — SSE streaming,
+                                                         JWT-authenticated
+
+  Phase 3:
+    POST /agent/proposals/{proposal_id}/confirm     — JWT-authenticated
+
+  Phase 5:
+    GET  /agent/metrics                             — admin role required
+
+GET /agent/status is intentionally unauthenticated: the frontend reads it
+on initial load (before login completes in some flows) to decide whether
+to render the copilot UI at all. Per pre-reg §3.3 / §4.4 / §13.5, the
+response body NEVER leaks env-var names, .env paths, or operator-only
+configuration detail.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter
+
+from api.agent.config import get_agent_status
+
+log = logging.getLogger("api.agent.router")
+
+router = APIRouter(tags=["agent"])
+
+
+@router.get("/agent/status", summary="Public agent feature status")
+def get_status():
+    """Return whether the copilot is currently available.
+
+    The shape is `{"enabled": bool, "reason": "ok" | "agent_disabled"}`.
+    The reason field is a closed enum — see api/agent/config.py for the
+    exhaustive list.
+    """
+    status = get_agent_status()
+    return {"enabled": status.enabled, "reason": status.reason}

--- a/btc_api.py
+++ b/btc_api.py
@@ -84,6 +84,7 @@ from api.signals import router as signals_router
 # push_webhook: called as btc_api.push_webhook in test_api.py (lines 521–575)
 from api.telegram import build_telegram_message, push_telegram_direct, push_webhook  # noqa: F401
 from api.tune import router as tune_router
+from api.agent.router import router as agent_router
 from btc_scanner import scan  # noqa: F401 — patch("btc_api.scan", ...) in test_api.py line 421
 from data import market_data as md  # used directly at line 145; patch.object(btc_api.md) in test_api.py
 # DB_FILE: monkeypatched as btc_api.DB_FILE by ~25 test files to redirect SQLite path
@@ -275,6 +276,7 @@ app.include_router(health_router)
 app.include_router(notifications_router)
 app.include_router(capital_router)
 app.include_router(user_preferences_router)
+app.include_router(agent_router)
 
 
 @app.get("/", summary="Bienvenida y estado general")
@@ -421,11 +423,13 @@ def agent_chat(body: _AgentRequest):
     """
     api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
     if not api_key:
+        # Pre-reg §3.3 / §11.7: never leak env-var names, .env paths, or
+        # operator-only configuration detail through the wire. The frontend
+        # gates the dock on GET /agent/status (same closed-enum reason),
+        # so this 503 is the defense-in-depth case where someone bypasses
+        # the status check and calls /agent/chat directly.
         from fastapi import HTTPException  # noqa: PLC0415
-        raise HTTPException(
-            status_code=503,
-            detail="ANTHROPIC_API_KEY not configured. Set it in .env and restart the API.",
-        )
+        raise HTTPException(status_code=503, detail="agent_disabled")
 
     payload = {
         "model":      "claude-haiku-4-5",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -85,23 +85,24 @@ import Ticker from './components/Ticker';
 import FocusPanel from './components/FocusPanel';
 import NotificationBell from './components/NotificationBell';
 import UserMenu from './components/UserMenu';
+import { useAgentEnabled } from './hooks/useAgentEnabled';
 
 import appStyles from './App.module.css';
 
 const REFRESH_INTERVAL_MS = 30_000;
-
-// Agent feature flag — same gate the SymbolDetail copilot uses. When off,
-// FocusPanel stays in the briefing slot and the AgentDock FAB is hidden.
-const AGENT_ENABLED: boolean = (() => {
-  const flag = (import.meta.env.VITE_AGENT_ENABLED ?? '').toString().trim().toLowerCase();
-  return flag !== '0' && flag !== 'false' && flag !== 'off';
-})();
 
 type OverlayKind = 'notifs' | 'settings' | 'user' | null;
 
 const App: React.FC = () => {
   const { user, logout } = useAuth();
   const mobile = useIsMobile();
+
+  // Agent feature gate — server-driven via GET /agent/status (epic #400,
+  // Phase 0). Replaces the compile-time `VITE_AGENT_ENABLED` env-var-only
+  // gate so operator-side disables propagate without redeploying the
+  // frontend. The hook still honors VITE_AGENT_ENABLED=0 as a local dev
+  // override.
+  const AGENT_ENABLED = useAgentEnabled();
 
   // ── data ───────────────────────────────────────────────
   // Raw symbols from /symbols. The exposed `symbols` (further down) overlays
@@ -768,6 +769,7 @@ const App: React.FC = () => {
         symbol={selectedSymbol}
         onClose={() => setSelectedSymbol(null)}
         onOpenPosition={handleOpenFromPreset}
+        agentEnabled={AGENT_ENABLED}
       />
 
       {AGENT_ENABLED && (

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -29,6 +29,7 @@ import type {
   CapitalPutPayload,
   UserPreferences,
   PreferencesPutPayload,
+  AgentStatus,
 } from './types';
 
 const BASE_URL = '/api';
@@ -262,6 +263,18 @@ export async function closePosition(id: number, payload: PositionClosePayload): 
 // the operator-driven exit case. The backend endpoint is still live so
 // curl/script callers continue to work; reintroduce the wrapper here only
 // when a real UX flow needs the cancel-without-PnL semantics.
+
+// ---- Agent (copilot) -------------------------------------------------
+//
+// Phase 0 of the production-grade copilot rewrite (epic #400). For now
+// the only exposed endpoint is GET /agent/status, which the frontend
+// polls to decide whether to render the copilot UI at all. Phase 2 will
+// add the SSE streaming `turn` endpoint; Phase 3 adds proposal confirm.
+
+// GET /agent/status
+export async function getAgentStatus(): Promise<AgentStatus> {
+  return request<AgentStatus>('/agent/status');
+}
 
 // ---- Auto-Tune -------------------------------------------------------
 

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -14,8 +14,10 @@
 //       <<<TOOL:position>>> → <PositionCard/>
 //       <<<TOOL:history>>>  → <HistoryCard/>
 //   - Agent backend: POST /agent/chat (proxies to Anthropic Haiku 4.5)
-//   - Feature flag: VITE_AGENT_ENABLED (default on). When off, the input
-//     row is hidden and only the synchronous greeting + setup card render.
+//   - Feature flag: server-driven via GET /agent/status (epic #400, Phase 0).
+//     App.tsx owns the polling (useAgentEnabled) and passes the resolved
+//     boolean down as `agentEnabled`. When false, the input row is hidden
+//     and only the synchronous greeting + setup card render.
 // ============================================================
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -50,14 +52,12 @@ interface SymbolDetailProps {
   symbol:          SymbolStatus | null;
   onClose:         () => void;
   onOpenPosition?: (preset: PositionPreset) => void;
+  // Server-driven feature flag — App.tsx owns the polling via
+  // useAgentEnabled() (epic #400 Phase 0). Pass `true` to enable the
+  // copilot input row, `false` to render the read-only fallback. This
+  // replaces the previous compile-time `VITE_AGENT_ENABLED` read.
+  agentEnabled:    boolean;
 }
-
-// Read the agent feature flag once at module load. Default ENABLED.
-// Disable with `VITE_AGENT_ENABLED=0` in `frontend/.env.local`.
-const AGENT_ENABLED: boolean = (() => {
-  const flag = (import.meta.env.VITE_AGENT_ENABLED ?? '').toString().trim().toLowerCase();
-  return flag !== '0' && flag !== 'false' && flag !== 'off';
-})();
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -125,7 +125,9 @@ const TIMEFRAMES: { v: Timeframe; l: string }[] = [
 // MAIN — SymbolDetail
 // ============================================================
 
-const SymbolDetail: React.FC<SymbolDetailProps> = ({ symbol, onClose, onOpenPosition }) => {
+const SymbolDetail: React.FC<SymbolDetailProps> = ({ symbol, onClose, onOpenPosition, agentEnabled }) => {
+  // Local alias keeps the rest of the file readable (rename-only change).
+  const AGENT_ENABLED = agentEnabled;
   const [tf, setTf] = useState<Timeframe>('1h');
 
   useEffect(() => {
@@ -214,7 +216,7 @@ const SymbolDetail: React.FC<SymbolDetailProps> = ({ symbol, onClose, onOpenPosi
             </div>
           </section>
 
-          <Copilot symbol={symbol} onOpenPosition={onOpenPosition} />
+          <Copilot symbol={symbol} onOpenPosition={onOpenPosition} agentEnabled={AGENT_ENABLED} />
         </div>
 
         {/* ── Footer ── */}
@@ -398,9 +400,12 @@ const SUGGESTIONS = [
 interface CopilotProps {
   symbol:          SymbolStatus;
   onOpenPosition?: (preset: PositionPreset) => void;
+  // Server-driven feature flag forwarded from <SymbolDetail/>.
+  agentEnabled:    boolean;
 }
 
-const Copilot: React.FC<CopilotProps> = ({ symbol, onOpenPosition }) => {
+const Copilot: React.FC<CopilotProps> = ({ symbol, onOpenPosition, agentEnabled }) => {
+  const AGENT_ENABLED = agentEnabled;
   const [msgs,    setMsgs]    = useState<CopilotMsg[]>([]);
   const [input,   setInput]   = useState('');
   const [loading, setLoading] = useState(false);
@@ -551,7 +556,7 @@ INSTRUCCIONES:
         </>
       ) : (
         <div className={styles.cpFlagOff}>
-          copiloto desactivado (VITE_AGENT_ENABLED=0). Modo solo-lectura.
+          copiloto desactivado. Modo solo-lectura.
         </div>
       )}
     </section>

--- a/frontend/src/hooks/useAgentEnabled.ts
+++ b/frontend/src/hooks/useAgentEnabled.ts
@@ -1,0 +1,67 @@
+// ============================================================
+// useAgentEnabled.ts
+//
+// Server-driven feature flag for the copilot UI. Polls GET /agent/status
+// on mount and every POLL_INTERVAL_MS afterwards, returning the latest
+// enabled-or-not boolean.
+//
+// Phase 0 of the production-grade copilot rewrite (epic #400). Replaces
+// the previous compile-time `VITE_AGENT_ENABLED` env-var-only gate so the
+// dashboard can react to operator-side disables without redeploying the
+// frontend.
+//
+// Compile-time override is preserved as a dev convenience: setting
+// VITE_AGENT_ENABLED=0/false/off in `frontend/.env.local` forces the
+// agent OFF regardless of what the backend says (useful for local
+// development without an ANTHROPIC_API_KEY).
+//
+// While the first poll is in flight the hook reports the server-driven
+// state as `null`, but the public boolean is optimistic (`true`) so the
+// UI does not flash "offline" on every refresh. The first poll resolves
+// in under a second on a healthy backend.
+// ============================================================
+
+import { useEffect, useState } from 'react';
+import { getAgentStatus } from '../api';
+
+// Compile-time dev override. Anything other than '0' / 'false' / 'off'
+// is treated as "respect the server".
+const COMPILE_TIME_OFF: boolean = (() => {
+  const flag = (import.meta.env.VITE_AGENT_ENABLED ?? '').toString().trim().toLowerCase();
+  return flag === '0' || flag === 'false' || flag === 'off';
+})();
+
+const POLL_INTERVAL_MS = 60_000;
+
+export function useAgentEnabled(): boolean {
+  const [serverEnabled, setServerEnabled] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (COMPILE_TIME_OFF) return;
+    let cancelled = false;
+
+    const tick = async () => {
+      try {
+        const status = await getAgentStatus();
+        if (!cancelled) setServerEnabled(status.enabled);
+      } catch {
+        // Network error or backend down → treat as disabled. Better to
+        // hide the dock than to show "ONLINE" while every turn 5xx's.
+        if (!cancelled) setServerEnabled(false);
+      }
+    };
+
+    void tick();
+    const id = window.setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  if (COMPILE_TIME_OFF) return false;
+  // Optimistic-on-load: while the first poll is in flight (`null`), we
+  // report enabled. The first poll typically resolves in <1s; the dock
+  // hides smoothly if the server reports off.
+  return serverEnabled !== false;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -127,6 +127,14 @@ export interface WebhookTestChannelResult {
   url?: string;
 }
 
+// Public agent feature status — served by GET /agent/status.
+// The `reason` field is a closed enum; never expand it with operator-only
+// strings (env-var names, paths, secret names). See api/agent/config.py.
+export interface AgentStatus {
+  enabled: boolean;
+  reason:  'ok' | 'agent_disabled';
+}
+
 export interface WebhookTestResponse {
   ok: boolean;  // overall: at least one channel succeeded
   telegram_directo: WebhookTestChannelResult;

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,9 @@ bcrypt>=4.0,<5
 email-validator>=2.0
 # Required by FastAPI Form() parsing (used in api/setup.py).
 python-multipart>=0.0.9
+
+# AI copilot (added 2026-05-19 — Phase 0 of #400).
+# Pinned to >=0.40 for prompt-caching beta header support + native SSE
+# streaming via client.messages.stream(). Bump deliberately post-Phase 5
+# with a live-model re-run (pre-reg §12.7 Buffers internos).
+anthropic>=0.40,<1.0

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -1,0 +1,167 @@
+"""GET /agent/status — no-leak contract + state precedence.
+
+Phase 0 of the production-grade copilot rewrite (epic #400). The status
+endpoint is the single source of truth the frontend reads to decide
+whether to render the copilot UI. Its body MUST NOT leak env-var names,
+.env paths, or any operator-only configuration detail — those strings
+would let an unauthenticated visitor map the server's deployment.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# Strings that must NEVER appear in the response body of /agent/status,
+# /agent/chat 503, or any other agent-related public surface. Lifted
+# verbatim from pre-reg §11.7.
+_FORBIDDEN_LEAK_STRINGS = (
+    "ANTHROPIC_API_KEY",
+    ".env",
+    "/.env",
+    "restart",
+    "configure",
+    "config.json",
+    "Set it in",
+)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Same DB-isolation pattern as tests/test_health_dashboard.py."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    return TestClient(btc_api.app)
+
+
+# ── /agent/status: enabled when ANTHROPIC_API_KEY is set ────────────────
+
+
+def test_agent_status_enabled_when_api_key_set(client, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
+    resp = client.get("/agent/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"enabled": True, "reason": "ok"}
+
+
+# ── /agent/status: disabled when ANTHROPIC_API_KEY is missing ───────────
+
+
+def test_agent_status_disabled_when_api_key_missing(client, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    resp = client.get("/agent/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"enabled": False, "reason": "agent_disabled"}
+
+
+def test_agent_status_disabled_when_api_key_empty(client, monkeypatch):
+    """Empty string is treated identically to missing — see config.py."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    resp = client.get("/agent/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"enabled": False, "reason": "agent_disabled"}
+
+
+def test_agent_status_disabled_when_api_key_whitespace(client, monkeypatch):
+    """Whitespace-only is treated as missing — operator typo guard."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+    resp = client.get("/agent/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"enabled": False, "reason": "agent_disabled"}
+
+
+# ── /agent/status: disabled when cfg.agent.enabled is False ─────────────
+
+
+def test_agent_status_disabled_when_cfg_disabled(client, monkeypatch):
+    """Operator-driven disable wins even if ANTHROPIC_API_KEY is set."""
+    import btc_api
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
+    monkeypatch.setattr(
+        btc_api, "load_config",
+        lambda: {"agent": {"enabled": False}},
+    )
+    # The router calls load_config via api.agent.config; patch that path too.
+    import api.agent.config as agent_cfg
+    monkeypatch.setattr(
+        agent_cfg, "load_config",
+        lambda: {"agent": {"enabled": False}},
+    )
+    resp = client.get("/agent/status")
+    assert resp.status_code == 200
+    assert resp.json() == {"enabled": False, "reason": "agent_disabled"}
+
+
+# ── No-leak contract (the load-bearing test for #381) ───────────────────
+
+
+def test_agent_status_body_never_leaks_env_var_names_or_paths(client, monkeypatch):
+    """The response body MUST NOT contain any of the forbidden leak strings
+    regardless of the state. This is the regression test for #381."""
+    for key_value in (None, "", "sk-ant-real-key"):
+        if key_value is None:
+            monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        else:
+            monkeypatch.setenv("ANTHROPIC_API_KEY", key_value)
+        resp = client.get("/agent/status")
+        body_text = resp.text
+        for forbidden in _FORBIDDEN_LEAK_STRINGS:
+            assert forbidden not in body_text, (
+                f"/agent/status leaked forbidden string {forbidden!r} "
+                f"with ANTHROPIC_API_KEY={key_value!r}. Body: {body_text!r}"
+            )
+
+
+def test_agent_chat_503_body_no_longer_leaks(client, monkeypatch):
+    """The legacy /agent/chat endpoint also stops leaking — pre-reg §3.3."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    resp = client.post(
+        "/agent/chat",
+        json={"system": "test", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 503
+    body_text = resp.text
+    for forbidden in _FORBIDDEN_LEAK_STRINGS:
+        assert forbidden not in body_text, (
+            f"/agent/chat 503 leaked forbidden string {forbidden!r}. "
+            f"Body: {body_text!r}"
+        )
+    # And it carries the closed-enum reason instead of the prose leak.
+    assert resp.json() == {"detail": "agent_disabled"}
+
+
+# ── Closed-enum invariant ───────────────────────────────────────────────
+
+
+def test_agent_status_reason_field_is_closed_enum(client, monkeypatch):
+    """`reason` must be one of the documented values. Anything else is a
+    regression — likely an operator-only string sneaking through."""
+    allowed = {"ok", "agent_disabled"}
+    for key_value in (None, "", "sk-ant-real-key"):
+        if key_value is None:
+            monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        else:
+            monkeypatch.setenv("ANTHROPIC_API_KEY", key_value)
+        resp = client.get("/agent/status")
+        reason = resp.json()["reason"]
+        assert reason in allowed, (
+            f"Unknown agent status reason {reason!r} — closed enum is {allowed}"
+        )
+
+
+# ── Unauthenticated access ──────────────────────────────────────────────
+
+
+def test_agent_status_does_not_require_auth(client, monkeypatch):
+    """The frontend reads /agent/status before login completes in some
+    flows; the endpoint must respond without an auth cookie."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
+    # No login, no cookies — should still succeed.
+    resp = client.get("/agent/status")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
Phase 0 del epic [#400](https://github.com/sssimon/trading-spacial/issues/400). Cierra el leak user-facing de \`ANTHROPIC_API_KEY\` reportado en [#381](https://github.com/sssimon/trading-spacial/issues/381) e introduce el nuevo paquete \`api/agent/\` con el contrato server-driven del status.

Esta fase **no rompe** la funcionalidad actual del copiloto: el legacy \`POST /agent/chat\` sigue vivo (per pre-reg §12 Phase 0) hasta que Phase 2 lo reemplace con el SSE streaming endpoint. Lo único que cambia para el usuario hoy es:
1. Si \`ANTHROPIC_API_KEY\` está mal/ausente, ya **no** se filtra el nombre de la env var ni el path del \`.env\`.
2. El \`AgentDock\` y el copiloto del \`SymbolDetail\` ahora se ocultan basados en \`GET /agent/status\` server-driven, no en el compile-time \`VITE_AGENT_ENABLED\`.

## Cambios

### Backend
- **\`api/agent/{__init__.py, config.py, router.py}\`** — nuevo paquete que va a crecer en las fases siguientes (tool registry, SSE turn endpoint, proposals).
- **\`GET /agent/status\`** (no auth) devuelve closed enum:
  ```json
  { \"enabled\": true | false, \"reason\": \"ok\" | \"agent_disabled\" }
  ```
  Source order: \`cfg.agent.enabled=False\` wins → \`ANTHROPIC_API_KEY\` missing/empty/whitespace → enabled. Cualquier otra string en \`reason\` rompe el closed-enum test.
- **\`btc_api.py\`** — montar \`agent_router\`; reemplazar el literal del 503 (\`\"ANTHROPIC_API_KEY not configured...\"\`) por \`{\"detail\": \"agent_disabled\"}\` sin leak.
- **\`requirements.txt\`** — pin \`anthropic>=0.40,<1.0\`. Estrategia de bump documentada inline (pre-reg §12.7).

### Frontend
- **\`types.ts\`** — \`AgentStatus\` type con closed enum.
- **\`api.ts\`** — \`getAgentStatus()\` cliente.
- **\`hooks/useAgentEnabled.ts\`** (nuevo) — polling 60s, retorna boolean reactivo. \`VITE_AGENT_ENABLED=0\` se mantiene como dev override (forces OFF). Optimistic-on-load para no flash \"offline\" en cada refresh.
- **\`App.tsx\`** — el const compile-time se reemplaza por el hook adentro del componente. Forwardeado a \`<SymbolDetail/>\` como prop.
- **\`SymbolDetail.tsx\`** — acepta \`agentEnabled\` prop, forward a \`<Copilot/>\` interno. Copy de \"modo solo-lectura\" sin mencionar la env var.

### Tests
**\`tests/test_agent_status.py\`** — 9 tests verde:
- Enabled cuando \`ANTHROPIC_API_KEY\` está set.
- Disabled cuando missing/empty/whitespace.
- Override por \`cfg.agent.enabled=False\`.
- Closed-enum invariant.
- **No-leak forbidden-string contract** (load-bearing test para #381) — verifica que el body NUNCA contiene \`ANTHROPIC_API_KEY\`, \`.env\`, \`/.env\`, \`restart\`, \`configure\`, \`config.json\`, \`Set it in\`.
- Mismo no-leak test en el legacy \`/agent/chat\` 503.
- Sin auth necessary.

## Lo que NO hace este PR (lands en fases siguientes per pre-reg §12)
- ❌ Construcción del cliente Anthropic SDK (Phase 1+).
- ❌ \`/agent/conversations/{id}/turn\` SSE endpoint (Phase 2).
- ❌ Tool registry + audit tables (Phase 1).
- ❌ Propose/confirm con AGENT_PROPOSAL_SECRET HMAC (Phase 3).
- ❌ AgentDock rewire de \`chatAgent\` a \`useAgentStream\` (Phase 2).

## Test plan
- [x] \`pytest tests/test_agent_status.py\` — 9/9 verde.
- [x] \`pytest tests/test_api.py tests/test_api_health_parity.py\` — 140/140 verde (sin regresiones del cambio en \`btc_api.py\`).
- [x] \`cd frontend && npm run build\` — OK.
- [x] \`cd frontend && npm run test -- --run\` — 80 passed / 7 skipped.
- [ ] Smoke en \`trading.sdar.dev\`: con \`ANTHROPIC_API_KEY\` ausente, abrir el dashboard → \`AgentDock\` oculto, sin badge \"ONLINE\" mintiendo. Y POST a \`/agent/chat\` por curl devuelve \`{\"detail\": \"agent_disabled\"}\` sin leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)