### PR TITLE
feat(agent): Phase 1 — tool layer + audit schema (#400)

### DIFF
--- a/api/agent/tools/__init__.py
+++ b/api/agent/tools/__init__.py
@@ -1,0 +1,18 @@
+"""Agent tool layer — Phase 1 of epic #400.
+
+This package owns the read-only tools the copilot can call. The pattern,
+locked in pre-reg §5:
+
+  - schemas.py  — Pydantic models for every tool's input.
+  - handlers.py — implementations. Every handler is keyword-only and
+                  REQUIRES `tenant_id: int`. Server-side wiring binds
+                  tenant_id from the JWT before dispatching; the model
+                  never sees nor supplies it.
+  - registry.py — catalog mapping tool name → (schema, handler, doc,
+                  surface allowlist). The Phase 2 conversation core
+                  reads this to build the per-turn tool list.
+
+Propose / side-effect tools (close_position, reactivate_symbol,
+apply_tune) land in Phase 3 as a separate sub-module so the security
+boundary is visually obvious.
+"""

--- a/api/agent/tools/handlers.py
+++ b/api/agent/tools/handlers.py
@@ -1,0 +1,322 @@
+"""Read-only tool handlers — Phase 1 of epic #400.
+
+Every handler:
+
+  1. Is keyword-only and REQUIRES `tenant_id: int`. Callers (Phase 2's
+     conversation core, the unit tests) construct them with the JWT-
+     resolved tenant_id bound. The model never sees nor supplies
+     tenant_id — adding it to the input schema is a regression.
+
+  2. Filters every DB read by tenant_id where the table is per-user
+     (positions, signal_outcomes, notifications_sent,
+     portfolio_health_events). System-wide reads (macro cache, scanner
+     state, kill-switch dashboard) flow through `get_dashboard_state`
+     which is already tenant-aware as of PR #396.
+
+  3. Returns a plain `dict` (or list of dicts). The conversation core
+     serializes them as tool_result content; the Anthropic API accepts
+     stringified JSON, so we json.dumps at the dispatch boundary, not
+     here.
+
+  4. On ownership mismatch or missing-row, returns `{"error": "not_found"}`.
+     Never raises — the model handles error blocks via the
+     `is_error: true` convention.
+
+Pre-reg §5.1 and §8.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from db.connection import get_db
+
+log = logging.getLogger("api.agent.tools.handlers")
+
+
+# ── Internal helpers ────────────────────────────────────────────────────
+
+
+def _row_to_dict(row: Any) -> dict:
+    if row is None:
+        return {}
+    return dict(row)
+
+
+def _position_to_summary(pos: dict) -> dict:
+    """Project a positions row down to the user-relevant fields. Drops
+    internal columns the model has no business reasoning about."""
+    return {
+        "id":          pos.get("id"),
+        "symbol":      pos.get("symbol"),
+        "direction":   pos.get("direction"),
+        "status":      pos.get("status"),
+        "entry_price": pos.get("entry_price"),
+        "entry_ts":    pos.get("entry_ts"),
+        "sl_price":    pos.get("sl_price"),
+        "tp_price":    pos.get("tp_price"),
+        "size_usd":    pos.get("size_usd"),
+        "exit_price":  pos.get("exit_price"),
+        "exit_ts":     pos.get("exit_ts"),
+        "exit_reason": pos.get("exit_reason"),
+        "pnl_usd":     pos.get("pnl_usd"),
+        "pnl_pct":     pos.get("pnl_pct"),
+    }
+
+
+def _normalize_symbol(s: str) -> str:
+    """Accept 'BTC' and return 'BTCUSDT'; pass through tickers already
+    ending in USDT. Defensive only — the model usually sends the full
+    ticker because the system prompt shows them that way."""
+    s = (s or "").upper().strip()
+    if not s:
+        return s
+    if s.endswith("USDT"):
+        return s
+    return f"{s}USDT"
+
+
+# ── Read-only handlers ──────────────────────────────────────────────────
+
+
+def get_portfolio_overview(*, tenant_id: int) -> dict:
+    """Aggregate snapshot: open positions count + notional + DD + macro.
+
+    Reuses get_dashboard_state's portfolio block (already tenant-aware
+    as of PR #396) for the equity / DD numbers; the open-positions
+    section comes from db.positions.db_get_positions with tenant_id.
+    """
+    from db.positions import db_get_positions
+    from health import get_dashboard_state
+    from api.config import load_config
+
+    open_positions = db_get_positions(status="open", tenant_id=tenant_id)
+    open_count = len(open_positions)
+    total_notional = sum(float(p.get("size_usd") or 0) for p in open_positions)
+
+    try:
+        dashboard = get_dashboard_state(load_config(), tenant_id=tenant_id)
+        portfolio = dashboard.get("portfolio", {})
+    except Exception:  # noqa: BLE001
+        log.warning("get_portfolio_overview: dashboard fetch failed", exc_info=True)
+        portfolio = {}
+
+    return {
+        "open_positions_count":  open_count,
+        "open_positions_notional_usd": round(total_notional, 2),
+        "current_equity_usd":    portfolio.get("current_equity"),
+        "peak_equity_usd":       portfolio.get("peak_equity"),
+        "drawdown_pct":          portfolio.get("dd_pct"),
+        "portfolio_tier":        portfolio.get("tier"),
+    }
+
+
+def get_positions(*, tenant_id: int) -> dict:
+    """Currently open positions, summarized."""
+    from db.positions import db_get_positions
+    rows = db_get_positions(status="open", tenant_id=tenant_id)
+    return {"positions": [_position_to_summary(p) for p in rows]}
+
+
+def get_position_detail(*, tenant_id: int, position_id: int) -> dict:
+    """Single position by id, ownership-enforced.
+
+    Mirrors the IDOR pattern in db.positions.db_close_position: if the
+    row exists but doesn't belong to this tenant, return 'not_found' —
+    never reveals existence cross-tenant.
+    """
+    con = get_db()
+    try:
+        row = con.execute(
+            "SELECT * FROM positions WHERE id=? AND tenant_id=?",
+            (position_id, tenant_id),
+        ).fetchone()
+    finally:
+        con.close()
+    if row is None:
+        return {"error": "not_found"}
+    return _position_to_summary(_row_to_dict(row))
+
+
+def get_symbols_with_signals(*, tenant_id: int, limit: int = 10) -> dict:  # noqa: ARG001
+    """Curated symbols by current signal score. System-wide read; tenant_id
+    is accepted for signature uniformity but does not gate the result.
+    The scanner state is global (one snapshot per symbol regardless of
+    tenant) — the per-user notion enters at the signal-outcomes layer.
+    """
+    from db.signals import get_scans
+    rows = get_scans(limit=limit, only_signals=False)
+    # `get_scans` already orders newest-first; the model can reason about
+    # ordering itself, so we project to the fields it needs.
+    out = []
+    seen_symbols: set[str] = set()
+    for r in rows:
+        sym = r.get("symbol")
+        if not sym or sym in seen_symbols:
+            continue
+        seen_symbols.add(sym)
+        out.append({
+            "symbol":    sym,
+            "score":     r.get("score"),
+            "estado":    r.get("estado"),
+            "signal":    bool(r.get("señal") or 0),
+            "ts":        r.get("ts"),
+        })
+        if len(out) >= limit:
+            break
+    return {"symbols": out}
+
+
+def get_symbol_setup(*, tenant_id: int, symbol: str) -> dict:  # noqa: ARG001
+    """Latest scanner setup for one symbol. System-wide read (tenant_id
+    accepted but unused — same rationale as get_symbols_with_signals).
+    """
+    from db.signals import get_scans
+    norm = _normalize_symbol(symbol)
+    rows = get_scans(limit=1, symbol=norm)
+    if not rows:
+        return {"error": "not_found"}
+    r = rows[0]
+    return {
+        "symbol":   r.get("symbol"),
+        "estado":   r.get("estado"),
+        "score":    r.get("score"),
+        "signal":   bool(r.get("señal") or 0),
+        "direction": r.get("direction"),
+        "lrc_pct":  r.get("lrc_pct"),
+        "rsi_1h":   r.get("rsi_1h"),
+        "ts":       r.get("ts"),
+    }
+
+
+def get_kill_switch_state(*, tenant_id: int) -> dict:
+    """Portfolio tier + per-symbol kill-switch state. Tenant-aware DD
+    (PR #396) is what produces a portfolio_tier coherent with this user's
+    actual equity, not the legacy $1K simulator default.
+    """
+    from health import get_dashboard_state
+    from api.config import load_config
+    try:
+        dashboard = get_dashboard_state(load_config(), tenant_id=tenant_id)
+    except Exception:  # noqa: BLE001
+        log.warning("get_kill_switch_state: dashboard fetch failed", exc_info=True)
+        return {"error": "kill_switch_unavailable"}
+    return {
+        "portfolio_tier":     dashboard.get("portfolio", {}).get("tier"),
+        "portfolio_dd_pct":   dashboard.get("portfolio", {}).get("dd_pct"),
+        "concurrent_failures": dashboard.get("portfolio", {}).get("concurrent_failures"),
+        "symbols": [
+            {
+                "symbol":   s.get("symbol"),
+                "state":    s.get("state"),
+                "metrics":  s.get("metrics"),
+            }
+            for s in dashboard.get("symbols", [])
+        ],
+    }
+
+
+def get_recent_signals(*, tenant_id: int, limit: int = 10, since_hours: int = 24) -> dict:  # noqa: ARG001
+    """Most recent signals. System-wide read (the scanner emits the same
+    signal for every tenant; the per-user split lives in the dispatcher
+    layer added in B.4 #257)."""
+    from db.signals import get_scans
+    rows = get_scans(limit=limit, only_signals=True, since_hours=since_hours)
+    return {
+        "signals": [
+            {
+                "symbol":    r.get("symbol"),
+                "score":     r.get("score"),
+                "direction": r.get("direction"),
+                "ts":        r.get("ts"),
+                "estado":    r.get("estado"),
+            }
+            for r in rows
+        ]
+    }
+
+
+def get_closed_trades(*, tenant_id: int, window: str = "30d") -> dict:
+    """Closed positions for this tenant, windowed."""
+    from datetime import datetime, timedelta, timezone
+    from db.positions import db_get_positions
+
+    rows = db_get_positions(status="closed", tenant_id=tenant_id)
+    if window != "all":
+        days = {"7d": 7, "30d": 30, "90d": 90}.get(window, 30)
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        cutoff_iso = cutoff.isoformat()
+        rows = [r for r in rows if (r.get("exit_ts") or "") >= cutoff_iso]
+    return {"trades": [_position_to_summary(r) for r in rows]}
+
+
+def get_tune_proposal(*, tenant_id: int) -> dict:  # noqa: ARG001
+    """Latest pending auto-tune proposal. System-wide read (auto-tune
+    proposes parameters for the global symbol_overrides; tenant_id is
+    accepted for signature uniformity)."""
+    from api.tune import tune_latest
+    try:
+        latest = tune_latest()
+    except Exception:  # noqa: BLE001
+        log.warning("get_tune_proposal: tune_latest failed", exc_info=True)
+        return {"error": "tune_unavailable"}
+    if not latest:
+        return {"proposal": None}
+    # tune_latest returns a dict already; pick fields the model needs.
+    return {
+        "proposal": {
+            "id":           latest.get("id"),
+            "ts":           latest.get("ts"),
+            "status":       latest.get("status"),
+            "summary":      latest.get("summary"),
+            "applied":      latest.get("applied"),
+        }
+    }
+
+
+# ── Dispatch entry point ────────────────────────────────────────────────
+
+
+# Map of tool name → (input model class, handler function). The
+# conversation core in Phase 2 reads this to validate the model's input
+# and dispatch to the right handler with tenant_id bound.
+TOOL_HANDLERS: dict[str, Any] = {
+    "get_portfolio_overview":   get_portfolio_overview,
+    "get_positions":            get_positions,
+    "get_position_detail":      get_position_detail,
+    "get_symbols_with_signals": get_symbols_with_signals,
+    "get_symbol_setup":         get_symbol_setup,
+    "get_kill_switch_state":    get_kill_switch_state,
+    "get_recent_signals":       get_recent_signals,
+    "get_closed_trades":        get_closed_trades,
+    "get_tune_proposal":        get_tune_proposal,
+}
+
+
+def dispatch_tool(name: str, raw_input: dict, *, tenant_id: int) -> str:
+    """Validate the model's tool input against the schema, then run the
+    handler with `tenant_id` bound. Returns a JSON string suitable for
+    `tool_result.content`.
+
+    Errors (unknown tool, schema mismatch, handler exception) are
+    serialized as `{"error": "..."}` content with the calling convention
+    that the conversation core marks the `tool_result` block as
+    `is_error: true`. The model then self-corrects on the next turn.
+    """
+    from api.agent.tools.schemas import TOOL_INPUT_SCHEMAS
+    if name not in TOOL_HANDLERS:
+        return json.dumps({"error": "unknown_tool", "name": name})
+    schema = TOOL_INPUT_SCHEMAS.get(name)
+    try:
+        validated = schema(**(raw_input or {})) if schema else None
+    except Exception as e:  # noqa: BLE001
+        return json.dumps({"error": "invalid_input", "detail": str(e)})
+    try:
+        handler = TOOL_HANDLERS[name]
+        kwargs = validated.model_dump() if validated else {}
+        result = handler(tenant_id=tenant_id, **kwargs)
+    except Exception as e:  # noqa: BLE001
+        log.warning("dispatch_tool: %s raised %s", name, e, exc_info=True)
+        return json.dumps({"error": "handler_error", "detail": str(e)})
+    return json.dumps(result, default=str)

--- a/api/agent/tools/registry.py
+++ b/api/agent/tools/registry.py
@@ -1,0 +1,166 @@
+"""Tool catalog + per-surface subsets.
+
+Phase 1 deliverable. The conversation core (Phase 2) reads this module
+to build the `tools=[...]` array on every Messages API request — per
+surface, which keeps the model focused on the relevant tools and keeps
+the prompt cache hot (changing tool sets mid-session invalidates the
+prefix; per pre-reg §4.3 we never mix models within a conversation, and
+the per-surface tool subset is stable across a session because the
+surface is fixed at session-start).
+
+Each tool entry carries:
+  - name         — wire name used by the model when emitting tool_use
+  - description  — one-sentence guidance shown to the model in the
+                   system-prompt "tool docs" block (§7.2)
+  - schema       — Pydantic input model (from schemas.py)
+  - surfaces     — set of surface names this tool is exposed on
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Type
+
+from pydantic import BaseModel
+
+from api.agent.tools.schemas import (
+    TOOL_INPUT_SCHEMAS,
+    GetClosedTradesIn,
+    GetKillSwitchStateIn,
+    GetPortfolioOverviewIn,
+    GetPositionDetailIn,
+    GetPositionsIn,
+    GetRecentSignalsIn,
+    GetSymbolSetupIn,
+    GetSymbolsWithSignalsIn,
+    GetTuneProposalIn,
+)
+
+
+# Surface identifiers used by Phase 2's POST /agent/conversations/{id}/turn
+# body. Adding a new surface here means also adding a micro-prompt in
+# api/agent/prompts/surfaces.py (Phase 4) and a row to the matrix below.
+Surface = str  # 'dock' | 'symbol_detail' | 'kill_switch' | 'autotune' | 'historial'
+
+ALL_SURFACES: frozenset[Surface] = frozenset({
+    "dock", "symbol_detail", "kill_switch", "autotune", "historial",
+})
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    name: str
+    description: str
+    schema: Type[BaseModel]
+    surfaces: frozenset[Surface]
+
+
+# Catalog order matches pre-reg §5.1. Keep stable — the model sees these
+# in this order in the cached tool-docs block; reordering invalidates the
+# cache prefix.
+TOOL_CATALOG: tuple[ToolSpec, ...] = (
+    ToolSpec(
+        name="get_portfolio_overview",
+        description=(
+            "Aggregate snapshot of the user's portfolio: open position count, "
+            "total notional, current/peak equity, drawdown, portfolio tier. "
+            "Use this when the user asks a 'how am I doing overall' question."
+        ),
+        schema=GetPortfolioOverviewIn,
+        surfaces=frozenset({"dock", "kill_switch"}),
+    ),
+    ToolSpec(
+        name="get_positions",
+        description=(
+            "List the user's currently open positions with entry/SL/TP/size. "
+            "Use this when the user references 'mis posiciones' or asks for a list."
+        ),
+        schema=GetPositionsIn,
+        surfaces=frozenset({"dock", "symbol_detail"}),
+    ),
+    ToolSpec(
+        name="get_position_detail",
+        description=(
+            "Look up one position by its numeric id. Returns 'not_found' if the "
+            "id does not belong to the calling user — never reveals existence "
+            "across users. Use this when the user references a specific position id."
+        ),
+        schema=GetPositionDetailIn,
+        surfaces=frozenset({"dock", "symbol_detail"}),
+    ),
+    ToolSpec(
+        name="get_symbols_with_signals",
+        description=(
+            "List the curated 10 symbols (BTC, ETH, ADA, AVAX, DOGE, UNI, XLM, "
+            "PENDLE, JUP, RUNE) with their current scanner score and signal flag. "
+            "Use this when the user asks 'where is the best opportunity right now'."
+        ),
+        schema=GetSymbolsWithSignalsIn,
+        surfaces=frozenset({"dock"}),
+    ),
+    ToolSpec(
+        name="get_symbol_setup",
+        description=(
+            "Read the latest scanner setup for one symbol: LRC%, RSI, score, "
+            "direction, estado. Use this when the user asks about a specific "
+            "symbol's current state."
+        ),
+        schema=GetSymbolSetupIn,
+        surfaces=frozenset({"dock", "symbol_detail"}),
+    ),
+    ToolSpec(
+        name="get_kill_switch_state",
+        description=(
+            "Portfolio tier plus per-symbol kill-switch state "
+            "(NORMAL/ALERT/REDUCED/PAUSED/PROBATION). Use this when the user asks "
+            "about pausing, recovery, or the health of the system."
+        ),
+        schema=GetKillSwitchStateIn,
+        surfaces=frozenset({"dock", "kill_switch"}),
+    ),
+    ToolSpec(
+        name="get_recent_signals",
+        description=(
+            "List the most recent emitted signals (windowed). Use this when the "
+            "user asks what signals fired today, yesterday, etc."
+        ),
+        schema=GetRecentSignalsIn,
+        surfaces=frozenset({"dock", "symbol_detail"}),
+    ),
+    ToolSpec(
+        name="get_closed_trades",
+        description=(
+            "List closed trades for the user, windowed (7d/30d/90d/all). Use this "
+            "for performance review, win-rate questions, and historial analysis."
+        ),
+        schema=GetClosedTradesIn,
+        surfaces=frozenset({"dock", "historial", "autotune"}),
+    ),
+    ToolSpec(
+        name="get_tune_proposal",
+        description=(
+            "Return the latest pending auto-tune proposal, or null. Use this when "
+            "the user is on the AutoTune view or asks about parameter changes."
+        ),
+        schema=GetTuneProposalIn,
+        surfaces=frozenset({"dock", "autotune"}),
+    ),
+)
+
+
+# Sanity invariant: every entry in TOOL_CATALOG has a corresponding
+# schema in TOOL_INPUT_SCHEMAS, and vice versa. If you add a tool to one
+# and forget the other, this fires at import time — surfaces in CI as
+# a test_tool_registry_consistency failure.
+_CATALOG_NAMES = {t.name for t in TOOL_CATALOG}
+_SCHEMA_NAMES = set(TOOL_INPUT_SCHEMAS.keys())
+assert _CATALOG_NAMES == _SCHEMA_NAMES, (
+    f"Tool catalog/schema mismatch — catalog: {_CATALOG_NAMES}, "
+    f"schemas: {_SCHEMA_NAMES}"
+)
+
+
+def tools_for_surface(surface: Surface) -> tuple[ToolSpec, ...]:
+    """Subset of the catalog exposed on `surface`. Stable ordering — the
+    return preserves the catalog order so the prompt cache stays warm
+    across calls for the same surface."""
+    return tuple(t for t in TOOL_CATALOG if surface in t.surfaces)

--- a/api/agent/tools/schemas.py
+++ b/api/agent/tools/schemas.py
@@ -1,0 +1,81 @@
+"""Pydantic input schemas for every agent tool.
+
+These get serialized to JSON Schema and shipped in the `tools` array
+of every messages.create() call (Phase 2). Keep them small and well-
+described — the model uses the field descriptions to decide when to
+invoke the tool and what to pass.
+
+Pre-reg §5: tenant_id is NEVER an input field on any tool. It is
+resolved server-side from the JWT and bound into the handler before
+dispatch. Adding `tenant_id` to any schema below is a regression.
+"""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class GetPortfolioOverviewIn(BaseModel):
+    """No input — returns the user's portfolio snapshot."""
+    pass
+
+
+class GetPositionsIn(BaseModel):
+    """List currently open positions for the user."""
+    pass
+
+
+class GetPositionDetailIn(BaseModel):
+    """Look up one position by id. Returns 'not_found' if it doesn't
+    belong to the calling tenant — never reveals existence cross-tenant."""
+    position_id: int = Field(..., ge=1, description="Numeric position id from positions.id")
+
+
+class GetSymbolsWithSignalsIn(BaseModel):
+    """List curated symbols ordered by current signal score."""
+    limit: int = Field(default=10, ge=1, le=10,
+                       description="Max symbols to return (capped at 10, the curated set size)")
+
+
+class GetSymbolSetupIn(BaseModel):
+    """Read the latest scanner setup for one symbol."""
+    symbol: str = Field(..., min_length=2, max_length=20,
+                        description="Symbol ticker, e.g. 'BTCUSDT' or 'BTC'")
+
+
+class GetKillSwitchStateIn(BaseModel):
+    """No input — returns portfolio + per-symbol kill-switch state."""
+    pass
+
+
+class GetRecentSignalsIn(BaseModel):
+    """List the most recent signals the scanner emitted."""
+    limit: int = Field(default=10, ge=1, le=50)
+    since_hours: int = Field(default=24, ge=1, le=24 * 14,
+                             description="Hours of history to include (max 14 days)")
+
+
+class GetClosedTradesIn(BaseModel):
+    """List closed trades for the user, windowed."""
+    window: Literal["7d", "30d", "90d", "all"] = Field(default="30d")
+
+
+class GetTuneProposalIn(BaseModel):
+    """No input — returns the latest pending auto-tune proposal, or null."""
+    pass
+
+
+# Convenience map for the registry. Order here is the canonical tool
+# ordering used in the system prompt's tool documentation block.
+TOOL_INPUT_SCHEMAS: dict[str, type[BaseModel]] = {
+    "get_portfolio_overview":   GetPortfolioOverviewIn,
+    "get_positions":            GetPositionsIn,
+    "get_position_detail":      GetPositionDetailIn,
+    "get_symbols_with_signals": GetSymbolsWithSignalsIn,
+    "get_symbol_setup":         GetSymbolSetupIn,
+    "get_kill_switch_state":    GetKillSwitchStateIn,
+    "get_recent_signals":       GetRecentSignalsIn,
+    "get_closed_trades":        GetClosedTradesIn,
+    "get_tune_proposal":        GetTuneProposalIn,
+}

--- a/btc_api.py
+++ b/btc_api.py
@@ -421,15 +421,18 @@ def agent_chat(body: _AgentRequest):
     its input row when the feature flag is off — but in case it slips, we
     return a 503 with a clear reason so the UI can render a graceful note.
     """
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
-    if not api_key:
-        # Pre-reg §3.3 / §11.7: never leak env-var names, .env paths, or
-        # operator-only configuration detail through the wire. The frontend
-        # gates the dock on GET /agent/status (same closed-enum reason),
-        # so this 503 is the defense-in-depth case where someone bypasses
-        # the status check and calls /agent/chat directly.
+    # Delegate the availability check to the same resolver that backs
+    # GET /agent/status. This keeps the two surfaces in sync: an operator
+    # who disables the agent via cfg.agent.enabled=False (without touching
+    # the env var) now correctly gets a 503 here instead of the request
+    # silently sailing through. Closes the cfg-vs-env consistency gap
+    # flagged in PR #402 review.
+    from api.agent.config import get_agent_status  # noqa: PLC0415
+    _agent_status = get_agent_status()
+    if not _agent_status.enabled:
         from fastapi import HTTPException  # noqa: PLC0415
-        raise HTTPException(status_code=503, detail="agent_disabled")
+        raise HTTPException(status_code=503, detail=_agent_status.reason)
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
 
     payload = {
         "model":      "claude-haiku-4-5",

--- a/db/schema.py
+++ b/db/schema.py
@@ -293,6 +293,12 @@ def init_db() -> None:
     # Pre-reg: docs/superpowers/plans/2026-05-15-multi-tenant-b1-schema-pre-reg.md
     _migrate_multi_tenant_b1()
 
+    # Agent (copilot) audit + budget tables — epic #400 Phase 1.
+    # Pre-reg §9 / §10.1: every turn is audited, every side-effect carries
+    # an idempotency key, every tenant has a daily/monthly USD budget that
+    # resets computed-on-read (no cron).
+    _migrate_agent_audit()
+
 
 # Per-user tables that need a tenant_id column (Epic B B.1).
 # kill_switch_* tables intentionally NOT in this list — kept global for B.1
@@ -380,6 +386,98 @@ def _migrate_multi_tenant_b1() -> None:
         )
 
         con.commit()
+    finally:
+        con.close()
+
+
+def _migrate_agent_audit() -> None:
+    """Idempotent Phase 1 migration for the copilot audit + budget surface.
+
+    Creates three tables and their indexes. Safe to call repeatedly:
+    CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+
+    Schema source: docs/superpowers/specs/es/2026-05-19-trading-copilot-production-grade-pre-reg.md §9.1.
+    """
+    con = get_db()
+    try:
+        # agent_conversations: every turn (user / assistant / tool_result)
+        # written by the server-side loop. content_json is the redacted
+        # payload — full tool_use input/output is NOT persisted here; the
+        # tool side-effect surface lives in agent_side_effects below.
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_conversations (
+                id                          INTEGER PRIMARY KEY AUTOINCREMENT,
+                tenant_id                   INTEGER NOT NULL,
+                surface                     TEXT    NOT NULL,
+                conversation_id             TEXT    NOT NULL,
+                ts                          TEXT    NOT NULL,
+                role                        TEXT,
+                model                       TEXT,
+                input_tokens                INTEGER,
+                output_tokens               INTEGER,
+                cache_read_input_tokens     INTEGER,
+                cache_creation_input_tokens INTEGER,
+                latency_ms                  INTEGER,
+                cost_usd                    REAL,
+                content_json                TEXT,
+                refused                     INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_conv_tenant_ts "
+            "ON agent_conversations(tenant_id, ts DESC)"
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_conv_conversation "
+            "ON agent_conversations(conversation_id, ts ASC)"
+        )
+
+        # agent_side_effects: the propose/confirm ledger. idempotency_key
+        # is UNIQUE so a double-click confirm cannot execute twice. action
+        # is one of: close_position | reactivate_symbol | apply_tune.
+        # result: ok | error | conflict | expired.
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_side_effects (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                tenant_id       INTEGER NOT NULL,
+                conversation_id TEXT,
+                ts              TEXT    NOT NULL,
+                action          TEXT    NOT NULL,
+                args_json       TEXT,
+                idempotency_key TEXT    NOT NULL UNIQUE,
+                result          TEXT,
+                http_status     INTEGER
+            )
+            """
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_side_effects_tenant_ts "
+            "ON agent_side_effects(tenant_id, ts DESC)"
+        )
+
+        # agent_quotas: one row per tenant. daily_window_start and
+        # monthly_window_start drive the computed-on-read reset (pre-reg
+        # §9.1) — no cron needed. UNIQUE on tenant_id so upserts via
+        # ON CONFLICT(tenant_id) DO UPDATE work.
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_quotas (
+                tenant_id            INTEGER PRIMARY KEY,
+                daily_usd_used       REAL    NOT NULL DEFAULT 0,
+                daily_usd_cap        REAL    NOT NULL DEFAULT 1.0,
+                daily_window_start   TEXT    NOT NULL,
+                monthly_usd_used     REAL    NOT NULL DEFAULT 0,
+                monthly_window_start TEXT    NOT NULL
+            )
+            """
+        )
+        con.commit()
+        log.info("DB migration: agent_conversations + agent_side_effects + agent_quotas ready")
+    except Exception as e:  # noqa: BLE001
+        log.warning("DB migration agent audit: %s", e)
     finally:
         con.close()
 

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -80,14 +80,14 @@ def test_agent_status_disabled_when_api_key_whitespace(client, monkeypatch):
 
 
 def test_agent_status_disabled_when_cfg_disabled(client, monkeypatch):
-    """Operator-driven disable wins even if ANTHROPIC_API_KEY is set."""
-    import btc_api
+    """Operator-driven disable wins even if ANTHROPIC_API_KEY is set.
+
+    The router resolves load_config via the local reference imported in
+    api/agent/config.py (`from api.config import load_config`). That's the
+    only patch point that affects the flow; patching btc_api.load_config
+    would be a no-op for this code path.
+    """
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
-    monkeypatch.setattr(
-        btc_api, "load_config",
-        lambda: {"agent": {"enabled": False}},
-    )
-    # The router calls load_config via api.agent.config; patch that path too.
     import api.agent.config as agent_cfg
     monkeypatch.setattr(
         agent_cfg, "load_config",
@@ -133,6 +133,26 @@ def test_agent_chat_503_body_no_longer_leaks(client, monkeypatch):
             f"Body: {body_text!r}"
         )
     # And it carries the closed-enum reason instead of the prose leak.
+    assert resp.json() == {"detail": "agent_disabled"}
+
+
+def test_agent_chat_503_when_cfg_disabled_even_with_api_key(client, monkeypatch):
+    """Closes the cfg-vs-env consistency gap flagged in PR #402 review:
+    if the operator sets cfg.agent.enabled=False but leaves the env var
+    populated, /agent/chat must 503 (same way /agent/status does) instead
+    of silently letting the request through to Anthropic.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-but-real-looking")
+    import api.agent.config as agent_cfg
+    monkeypatch.setattr(
+        agent_cfg, "load_config",
+        lambda: {"agent": {"enabled": False}},
+    )
+    resp = client.post(
+        "/agent/chat",
+        json={"system": "test", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 503
     assert resp.json() == {"detail": "agent_disabled"}
 
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1,0 +1,389 @@
+"""Phase 1 of epic #400 — read-only tool layer.
+
+Covers:
+
+1. The audit schema is created by init_db (agent_conversations,
+   agent_side_effects, agent_quotas).
+
+2. Every per-user-table handler is strictly tenant-scoped. Two tenants
+   seeded with positions in the same symbol → tenant 1's tool never
+   surfaces tenant 2's rows, regardless of which read-only tool is
+   invoked.
+
+3. get_position_detail returns 'not_found' (not 'forbidden', not 500)
+   when the id belongs to another tenant — never reveals existence
+   cross-tenant. Same wire shape as 'truly absent', closing the IDOR
+   side channel.
+
+4. The dispatch surface validates inputs, dispatches by name, and
+   surfaces handler errors as JSON content (never raises).
+
+5. Catalog/schema parity (the import-time assert backstops this in
+   prod; the test makes the failure mode explicit in CI).
+
+6. Per-surface tool subsets match the matrix in api/agent/tools/registry.py.
+
+Multi-tenant policy: every read-only tool's handler signature has
+`tenant_id` as keyword-only required. This is checked statically (a
+positional call raises TypeError) — see
+test_handlers_signatures_require_tenant_id_keyword_only.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Same pattern as the other agent tests."""
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+# ── 1. Audit schema ────────────────────────────────────────────────────
+
+
+def test_init_db_creates_agent_audit_tables(tmp_db):
+    import btc_api
+    con = btc_api.get_db()
+    try:
+        rows = con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('agent_conversations', 'agent_side_effects', 'agent_quotas')"
+        ).fetchall()
+    finally:
+        con.close()
+    names = {r[0] for r in rows}
+    assert names == {"agent_conversations", "agent_side_effects", "agent_quotas"}, (
+        f"Missing agent audit table(s); found {names}"
+    )
+
+
+def test_agent_side_effects_idempotency_key_is_unique(tmp_db):
+    """A double-insert with the same idempotency_key must raise IntegrityError.
+    This is the property that makes the propose/confirm pattern safe against
+    double-click in Phase 3 — pre-reg §10.2."""
+    import sqlite3
+    import btc_api
+    con = btc_api.get_db()
+    try:
+        con.execute(
+            "INSERT INTO agent_side_effects "
+            "(tenant_id, conversation_id, ts, action, args_json, "
+            " idempotency_key, result, http_status) "
+            "VALUES (1, 'c1', '2026-05-19T10:00:00+00:00', 'close_position', "
+            "'{}', 'key-a', 'ok', 200)"
+        )
+        con.commit()
+        with pytest.raises(sqlite3.IntegrityError):
+            con.execute(
+                "INSERT INTO agent_side_effects "
+                "(tenant_id, conversation_id, ts, action, args_json, "
+                " idempotency_key, result, http_status) "
+                "VALUES (1, 'c1', '2026-05-19T10:00:01+00:00', 'close_position', "
+                "'{}', 'key-a', 'ok', 200)"
+            )
+            con.commit()
+    finally:
+        con.close()
+
+
+# ── 2. Tenant isolation per handler ─────────────────────────────────────
+
+
+def _seed_two_tenant_positions(con):
+    """Seed two open + two closed positions per tenant in the same symbol."""
+    for tid, base_price in ((1, 50_000.0), (2, 60_000.0)):
+        for direction, status, exit_price, exit_ts, pnl in (
+            ("LONG", "open",   None,            None,                       None),
+            ("LONG", "open",   None,            None,                       None),
+            ("LONG", "closed", base_price * 1.02, "2026-05-15T12:00:00+00:00",  base_price * 0.02),
+            ("LONG", "closed", base_price * 0.98, "2026-05-15T15:00:00+00:00", -base_price * 0.02),
+        ):
+            con.execute(
+                "INSERT INTO positions "
+                "(symbol, direction, status, entry_price, entry_ts, size_usd, "
+                " exit_price, exit_ts, pnl_usd, tenant_id) "
+                "VALUES ('BTCUSDT', ?, ?, ?, '2026-05-15T10:00:00+00:00', 1000, "
+                " ?, ?, ?, ?)",
+                (direction, status, base_price, exit_price, exit_ts, pnl, tid),
+            )
+    con.commit()
+
+
+def test_get_positions_filters_strictly_by_tenant(tmp_db):
+    from api.agent.tools.handlers import get_positions
+    import btc_api
+
+    con = btc_api.get_db()
+    try:
+        _seed_two_tenant_positions(con)
+    finally:
+        con.close()
+
+    out_a = get_positions(tenant_id=1)
+    out_b = get_positions(tenant_id=2)
+
+    assert len(out_a["positions"]) == 2
+    assert len(out_b["positions"]) == 2
+    assert all(p["entry_price"] == 50_000.0 for p in out_a["positions"])
+    assert all(p["entry_price"] == 60_000.0 for p in out_b["positions"])
+
+
+def test_get_closed_trades_filters_strictly_by_tenant(tmp_db):
+    from api.agent.tools.handlers import get_closed_trades
+    import btc_api
+
+    con = btc_api.get_db()
+    try:
+        _seed_two_tenant_positions(con)
+    finally:
+        con.close()
+
+    a = get_closed_trades(tenant_id=1, window="30d")
+    b = get_closed_trades(tenant_id=2, window="30d")
+
+    assert len(a["trades"]) == 2
+    assert len(b["trades"]) == 2
+    a_pnls = sorted(t["pnl_usd"] for t in a["trades"])
+    b_pnls = sorted(t["pnl_usd"] for t in b["trades"])
+    # Verify the cross-tenant leak vector is closed: tenant 1's PnLs are
+    # scaled to base 50k; tenant 2's to base 60k. Mixing would show up
+    # immediately as a leak across the assertion.
+    assert all(abs(p) == pytest.approx(1000.0) for p in a_pnls)
+    assert all(abs(p) == pytest.approx(1200.0) for p in b_pnls)
+
+
+# ── 3. get_position_detail IDOR contract ────────────────────────────────
+
+
+def test_get_position_detail_returns_not_found_for_other_tenant(tmp_db):
+    """Tenant 1 queries an id that exists but belongs to tenant 2. Result
+    must be the same shape as querying an id that does not exist at all —
+    never reveals existence."""
+    from api.agent.tools.handlers import get_position_detail
+    import btc_api
+
+    con = btc_api.get_db()
+    try:
+        cur = con.execute(
+            "INSERT INTO positions "
+            "(symbol, direction, status, entry_price, entry_ts, size_usd, tenant_id) "
+            "VALUES ('BTCUSDT', 'LONG', 'open', 50000, "
+            "'2026-05-15T10:00:00+00:00', 1000, 2)"
+        )
+        con.commit()
+        other_tenant_pos_id = cur.lastrowid
+    finally:
+        con.close()
+
+    # tenant 1 asks for tenant 2's position id
+    out_existing = get_position_detail(tenant_id=1, position_id=other_tenant_pos_id)
+    # tenant 1 asks for an id that doesn't exist at all
+    out_absent = get_position_detail(tenant_id=1, position_id=999_999)
+
+    assert out_existing == {"error": "not_found"}
+    assert out_absent == {"error": "not_found"}
+    # Same response shape → indistinguishable to a probing attacker.
+
+
+def test_get_position_detail_returns_row_for_own_tenant(tmp_db):
+    from api.agent.tools.handlers import get_position_detail
+    import btc_api
+
+    con = btc_api.get_db()
+    try:
+        cur = con.execute(
+            "INSERT INTO positions "
+            "(symbol, direction, status, entry_price, entry_ts, size_usd, tenant_id) "
+            "VALUES ('ETHUSDT', 'LONG', 'open', 3000, "
+            "'2026-05-15T10:00:00+00:00', 500, 7)"
+        )
+        con.commit()
+        own_pos_id = cur.lastrowid
+    finally:
+        con.close()
+
+    out = get_position_detail(tenant_id=7, position_id=own_pos_id)
+    assert out["id"] == own_pos_id
+    assert out["symbol"] == "ETHUSDT"
+    assert out["entry_price"] == 3000
+
+
+# ── 4. Dispatch surface ─────────────────────────────────────────────────
+
+
+def test_dispatch_unknown_tool_returns_error_json(tmp_db):
+    from api.agent.tools.handlers import dispatch_tool
+    out = dispatch_tool("nonexistent_tool", {}, tenant_id=1)
+    parsed = json.loads(out)
+    assert parsed == {"error": "unknown_tool", "name": "nonexistent_tool"}
+
+
+def test_dispatch_invalid_input_returns_error_json(tmp_db):
+    from api.agent.tools.handlers import dispatch_tool
+    # get_position_detail requires `position_id: int >= 1`; pass a string.
+    out = dispatch_tool("get_position_detail", {"position_id": "abc"}, tenant_id=1)
+    parsed = json.loads(out)
+    assert parsed["error"] == "invalid_input"
+    assert "position_id" in parsed["detail"].lower() or "type" in parsed["detail"].lower()
+
+
+def test_dispatch_handler_exception_returns_error_json(tmp_db, monkeypatch):
+    """If a handler raises (DB unavailable, scanner error, etc), the
+    dispatcher must serialize the failure — never propagate. The
+    conversation core marks the tool_result as is_error:true so the
+    model can self-correct."""
+    from api.agent.tools import handlers as h
+    from api.agent.tools.handlers import dispatch_tool
+
+    def _boom(**kwargs):
+        raise RuntimeError("simulated downstream failure")
+
+    monkeypatch.setitem(h.TOOL_HANDLERS, "get_positions", _boom)
+    out = dispatch_tool("get_positions", {}, tenant_id=1)
+    parsed = json.loads(out)
+    assert parsed["error"] == "handler_error"
+    assert "simulated downstream failure" in parsed["detail"]
+
+
+def test_dispatch_passes_validated_input_to_handler(tmp_db):
+    """Round-trip: dispatch_tool deserializes raw_input via Pydantic and
+    forwards the validated kwargs to the handler. Verify by inspecting
+    what a stub handler receives."""
+    from api.agent.tools import handlers as h
+    from api.agent.tools.handlers import dispatch_tool
+
+    received = {}
+
+    def _spy(*, tenant_id, **kwargs):
+        received["tenant_id"] = tenant_id
+        received["kwargs"] = kwargs
+        return {"ok": True}
+
+    spy_orig = h.TOOL_HANDLERS["get_recent_signals"]
+    try:
+        h.TOOL_HANDLERS["get_recent_signals"] = _spy
+        dispatch_tool(
+            "get_recent_signals",
+            {"limit": 5, "since_hours": 12},
+            tenant_id=42,
+        )
+    finally:
+        h.TOOL_HANDLERS["get_recent_signals"] = spy_orig
+
+    assert received["tenant_id"] == 42
+    assert received["kwargs"] == {"limit": 5, "since_hours": 12}
+
+
+# ── 5. Multi-tenant policy: handlers signature ──────────────────────────
+
+
+def test_handlers_signatures_require_tenant_id_keyword_only():
+    """Static check: every handler's `tenant_id` parameter must be
+    keyword-only AND have no default value. This makes positional misuse
+    fail loudly and makes "forgot to pass tenant_id" a TypeError instead
+    of a silent cross-tenant read.
+
+    Pre-reg §5.1 hard requirement.
+    """
+    from api.agent.tools.handlers import TOOL_HANDLERS
+
+    for name, fn in TOOL_HANDLERS.items():
+        sig = inspect.signature(fn)
+        tparam = sig.parameters.get("tenant_id")
+        assert tparam is not None, f"{name}: missing tenant_id parameter"
+        assert tparam.kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{name}: tenant_id must be KEYWORD_ONLY (got {tparam.kind})"
+        )
+        assert tparam.default is inspect.Parameter.empty, (
+            f"{name}: tenant_id must NOT have a default value "
+            f"(would allow silent omission)"
+        )
+
+
+def test_tenant_id_is_not_an_input_field_on_any_schema():
+    """Multi-tenant policy: tenant_id is server-bound, never model-supplied.
+    Any schema that exposes tenant_id is a regression."""
+    from api.agent.tools.schemas import TOOL_INPUT_SCHEMAS
+
+    for name, schema in TOOL_INPUT_SCHEMAS.items():
+        fields = schema.model_fields.keys()
+        assert "tenant_id" not in fields, (
+            f"{name}: schema must NOT expose tenant_id as an input field "
+            f"(it leaks the multi-tenant boundary to the model)"
+        )
+        assert "user_id" not in fields, (
+            f"{name}: schema must NOT expose user_id as an input field"
+        )
+
+
+# ── 6. Registry consistency + per-surface subsets ───────────────────────
+
+
+def test_tool_registry_matches_input_schemas():
+    from api.agent.tools.registry import TOOL_CATALOG
+    from api.agent.tools.schemas import TOOL_INPUT_SCHEMAS
+    catalog_names = {t.name for t in TOOL_CATALOG}
+    schema_names = set(TOOL_INPUT_SCHEMAS.keys())
+    assert catalog_names == schema_names
+
+
+def test_tool_registry_matches_handlers():
+    from api.agent.tools.registry import TOOL_CATALOG
+    from api.agent.tools.handlers import TOOL_HANDLERS
+    catalog_names = {t.name for t in TOOL_CATALOG}
+    handler_names = set(TOOL_HANDLERS.keys())
+    assert catalog_names == handler_names
+
+
+def test_tools_for_surface_dock_has_full_breadth():
+    from api.agent.tools.registry import tools_for_surface
+    tools = {t.name for t in tools_for_surface("dock")}
+    # The Dock is the main floating chat; it gets the broadest tool set.
+    # If you tighten the Dock subset in the future, update this assertion
+    # deliberately — don't just delete the test.
+    assert "get_portfolio_overview" in tools
+    assert "get_positions" in tools
+    assert "get_kill_switch_state" in tools
+    assert "get_symbols_with_signals" in tools
+
+
+def test_tools_for_surface_symbol_detail_excludes_kill_switch_and_tune():
+    from api.agent.tools.registry import tools_for_surface
+    tools = {t.name for t in tools_for_surface("symbol_detail")}
+    # SymbolDetail is scoped to one symbol; kill-switch + tune live in
+    # their dedicated views.
+    assert "get_kill_switch_state" not in tools
+    assert "get_tune_proposal" not in tools
+    assert "get_symbol_setup" in tools
+
+
+def test_tools_for_surface_autotune_excludes_position_writes():
+    """Sanity: the autotune surface gets get_tune_proposal +
+    get_closed_trades for context, but should never expose tools that
+    would let the model read raw position state. (Phase 3 will add
+    propose_apply_tune in a separate side-effects module — not a
+    read-only tool, so it doesn't live in this catalog.)"""
+    from api.agent.tools.registry import tools_for_surface
+    tools = {t.name for t in tools_for_surface("autotune")}
+    assert "get_tune_proposal" in tools
+    assert "get_closed_trades" in tools
+    assert "get_positions" not in tools
+    assert "get_position_detail" not in tools
+
+
+def test_tools_for_surface_unknown_surface_returns_empty():
+    from api.agent.tools.registry import tools_for_surface
+    assert tools_for_surface("nonexistent_surface") == tuple()


### PR DESCRIPTION
## Summary
Phase 1 del epic [#400](https://github.com/sssimon/trading-spacial/issues/400). Entrega el tool registry, los 9 read-only handlers tenant-scoped, y las 3 tablas de audit/budget. Phase 2 va a leer este catálogo para construir el \`tools[...]\` per-turn y persistir el ledger en las tablas nuevas.

Incluye **2 pickups del review de Phase 0** (PR #402) como primer commit del branch (issues 1 + 3 del reviewer):
- Borrar doble patch no-op en \`test_agent_status_disabled_when_cfg_disabled\`.
- Delegar el check del legacy \`/agent/chat\` 503 a \`get_agent_status()\` para cerrar la inconsistencia cfg-vs-env.

## Audit schema (\`db/schema.py\`)

| Tabla | Propósito |
|---|---|
| \`agent_conversations\` | Per-turn ledger (tenant, surface, conversation, role, model, tokens, latency, cost, content_json redacted, refused flag). Indexed \`(tenant_id, ts DESC)\` + \`(conversation_id, ts ASC)\`. |
| \`agent_side_effects\` | Propose/confirm ledger. \`idempotency_key UNIQUE\` — verified by test que doble-insert revienta. |
| \`agent_quotas\` | Per-tenant USD budget. \`daily_window_start\` + \`monthly_window_start\` para resets computed-on-read sin cron. |

Migración idempotente (\`CREATE TABLE IF NOT EXISTS\` + \`CREATE INDEX IF NOT EXISTS\`).

## Tool layer (\`api/agent/tools/\`)

### Schemas (\`schemas.py\`)
9 Pydantic input models. **\`tenant_id\` NUNCA aparece como field** — el modelo no ve la frontera multi-tenant. Verificado por test \`test_tenant_id_is_not_an_input_field_on_any_schema\`.

### Handlers (\`handlers.py\`)
| Handler | Per-user filter |
|---|---|
| \`get_portfolio_overview\` | sí — vía \`db_get_positions(tenant_id=)\` + \`get_dashboard_state(tenant_id=)\` (PR #396) |
| \`get_positions\` | sí |
| \`get_position_detail\` | sí, con IDOR closure (\`{\"error\": \"not_found\"}\` indistinguible de \"absent\") |
| \`get_closed_trades\` | sí |
| \`get_kill_switch_state\` | sí (via dashboard) |
| \`get_symbols_with_signals\` | system-wide (scanner state global) — tenant_id sigue keyword-required por consistencia |
| \`get_symbol_setup\` | system-wide — idem |
| \`get_recent_signals\` | system-wide — idem |
| \`get_tune_proposal\` | system-wide — idem |

**Multi-tenant policy hard-checked en CI:** \`test_handlers_signatures_require_tenant_id_keyword_only\` recorre todos los handlers via \`inspect\` y exige que \`tenant_id\` sea \`KEYWORD_ONLY\` con \`default=Parameter.empty\`. Cualquier handler nuevo que olvide esto rompe el test.

### Registry (\`registry.py\`)
\`TOOL_CATALOG\` ordenado per pre-reg §5.1. \`tools_for_surface(surface)\` devuelve subset estable por superficie. Assert at import time garantiza catalog ↔ schemas parity.

### Dispatch (\`dispatch_tool\`)
Valida input via Pydantic → ejecuta handler → serializa errores como JSON. **Nunca raise** — el conversation core marcará \`tool_result.is_error = true\` cuando vea \`error\` key, modelo se auto-corrige.

## Tests (\`tests/test_agent_tools.py\`, 18 cases)

| Categoría | # tests |
|---|---|
| Audit schema (init_db + UNIQUE idempotency_key) | 2 |
| Two-tenant isolation per handler | 2 |
| IDOR (get_position_detail cross-tenant → not_found) | 2 |
| Dispatch surface (unknown/invalid/exception) | 4 |
| Static handler signature check | 1 |
| Schema policy (no tenant_id/user_id field) | 1 |
| Registry consistency + per-surface subsets | 6 |

## Lo que NO hace este PR (Phase 2+)
- ❌ Cliente Anthropic SDK construction.
- ❌ POST /agent/conversations/{id}/turn SSE endpoint.
- ❌ Propose/confirm tools + HMAC con AGENT_PROPOSAL_SECRET.
- ❌ AgentDock rewire de \`chatAgent\` → \`useAgentStream\`.
- ❌ System prompts cacheables (Phase 2 los compone usando el registry).

## Test plan
- [x] \`pytest tests/test_agent_tools.py\` — 18/18 verde.
- [x] \`pytest tests/test_agent_status.py\` — 10/10 verde (incluye nuevo test del pickup #3).
- [x] Wide sweep \`pytest test_api test_multi_tenant_b* test_health_dashboard test_api_health_parity\` — 251/251 verde, sin regresiones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)