### PR TITLE
feat(agent): Phase 2A — backend conversation core (#400)

### DIFF
--- a/api/agent/audit.py
+++ b/api/agent/audit.py
@@ -1,0 +1,153 @@
+"""Per-turn audit writes to agent_conversations.
+
+Phase 2 of epic #400. Every completed model turn (MessageEnd) AND every
+errored turn (ErrorEvent) emits one row in `agent_conversations`. The
+write is best-effort and fail-tolerant: a DB hiccup must NOT kill the
+streaming response that's already on the wire to the user.
+
+Pre-reg §9. Shape of the row mirrors the schema in db/schema.py.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from db.connection import get_db
+
+log = logging.getLogger("api.agent.audit")
+
+
+def record_turn(
+    *,
+    tenant_id: int,
+    surface: str,
+    conversation_id: str,
+    role: str,                              # "assistant" | "error"
+    model: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+    cache_creation_input_tokens: int = 0,
+    latency_ms: Optional[int] = None,
+    cost_usd: Optional[float] = None,
+    content_summary: Optional[str] = None,  # redacted; never the raw text
+    refused: bool = False,
+) -> None:
+    """Persist one row to agent_conversations.
+
+    Failures here are logged but never raised — an audit miss is annoying;
+    a 500 to the user is worse. The streaming response is already on
+    the wire when this is called.
+    """
+    try:
+        con = get_db()
+        try:
+            con.execute(
+                """INSERT INTO agent_conversations
+                   (tenant_id, surface, conversation_id, ts, role, model,
+                    input_tokens, output_tokens,
+                    cache_read_input_tokens, cache_creation_input_tokens,
+                    latency_ms, cost_usd, content_json, refused)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    tenant_id, surface, conversation_id,
+                    datetime.now(timezone.utc).isoformat(),
+                    role, model,
+                    int(input_tokens or 0), int(output_tokens or 0),
+                    int(cache_read_input_tokens or 0),
+                    int(cache_creation_input_tokens or 0),
+                    latency_ms,
+                    cost_usd,
+                    json.dumps(content_summary) if content_summary else None,
+                    1 if refused else 0,
+                ),
+            )
+            con.commit()
+        finally:
+            con.close()
+    except Exception:  # noqa: BLE001
+        log.warning(
+            "record_turn failed for tenant=%s conv=%s — audit row dropped",
+            tenant_id, conversation_id, exc_info=True,
+        )
+
+
+class TurnAuditWrapper:
+    """Wrap a loop-events async iterator to persist a row on
+    MessageEnd / ErrorEvent. Yields events unchanged.
+
+    Usage in the endpoint:
+
+        wrapped = TurnAuditWrapper(
+            run_turn(client=..., ...),
+            tenant_id=tenant_id, surface=surface,
+            conversation_id=conversation_id, model=model,
+        )
+        return StreamingResponse(sse_serialize(wrapped), ...)
+    """
+
+    def __init__(
+        self,
+        events,
+        *,
+        tenant_id: int,
+        surface: str,
+        conversation_id: str,
+        model: str,
+    ):
+        self._events = events
+        self._tenant_id = tenant_id
+        self._surface = surface
+        self._conversation_id = conversation_id
+        self._model = model
+        self._t_start = time.monotonic()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        # Import here to avoid circular import: loop.py imports prompts,
+        # prompts depend on registry; this module is imported from
+        # router.py which sees them all.
+        from api.agent.loop import ErrorEvent, MessageEnd
+
+        try:
+            ev = await self._events.__anext__()
+        except StopAsyncIteration:
+            raise
+
+        if isinstance(ev, MessageEnd):
+            latency_ms = int((time.monotonic() - self._t_start) * 1000)
+            record_turn(
+                tenant_id=self._tenant_id,
+                surface=self._surface,
+                conversation_id=self._conversation_id,
+                role="assistant",
+                model=self._model,
+                input_tokens=ev.usage.get("input_tokens", 0),
+                output_tokens=ev.usage.get("output_tokens", 0),
+                cache_read_input_tokens=ev.usage.get("cache_read_input_tokens", 0),
+                cache_creation_input_tokens=ev.usage.get("cache_creation_input_tokens", 0),
+                latency_ms=latency_ms,
+                cost_usd=ev.cost_usd,
+                refused=False,
+            )
+        elif isinstance(ev, ErrorEvent):
+            latency_ms = int((time.monotonic() - self._t_start) * 1000)
+            record_turn(
+                tenant_id=self._tenant_id,
+                surface=self._surface,
+                conversation_id=self._conversation_id,
+                role="error",
+                model=self._model,
+                latency_ms=latency_ms,
+                # We don't store the user_message verbatim (it's a fixed
+                # friendly string, not signal worth indexing); the reason
+                # enum is the meaningful field.
+                content_summary=ev.reason,
+                refused=(ev.reason == "too_many_tool_hops"),
+            )
+        return ev

--- a/api/agent/clients.py
+++ b/api/agent/clients.py
@@ -32,13 +32,31 @@ def get_anthropic_client():
 
     In tests, override via `app.dependency_overrides[get_anthropic_client]`
     with a function that returns a FakeAnthropicClient instance.
+
+    Failure-mode correctness (PR #404 review issue #1, blocker): FastAPI
+    resolves ALL `Depends(...)` before executing the handler body. That
+    means this function runs BEFORE the in-handler `get_agent_status()`
+    check. If we read `os.environ["ANTHROPIC_API_KEY"]` blind here and
+    the key is missing, we KeyError → 500 with stack trace → leak the
+    env-var name on the wire. Exactly the bug Phase 0 closed for the
+    legacy /agent/chat.
+
+    Defense: gate on the same closed-enum status resolver before doing
+    any env read. When disabled, 503 with the closed-enum reason; only
+    proceed to construct the SDK client when status is enabled.
     """
+    # Local import to dodge the circular: api.agent.config doesn't import
+    # this module, but api.agent.router imports both.
+    from api.agent.config import get_agent_status  # noqa: PLC0415
+    status = get_agent_status()
+    if not status.enabled:
+        raise HTTPException(status_code=503, detail=status.reason)
+
     try:
         from anthropic import AsyncAnthropic  # noqa: PLC0415
     except ImportError as e:
         log.error("anthropic SDK not installed: %s", e)
-        # Same closed-enum reason as a missing key — the wire format
-        # never reveals whether it's a missing dependency vs a missing
-        # secret. Pre-reg §11.7.
+        # Same closed-enum reason — the wire format never reveals
+        # whether it's a missing dependency vs a missing secret.
         raise HTTPException(status_code=503, detail="agent_disabled")
     return AsyncAnthropic(api_key=os.environ["ANTHROPIC_API_KEY"].strip())

--- a/api/agent/clients.py
+++ b/api/agent/clients.py
@@ -1,0 +1,44 @@
+"""Lazy construction of the Anthropic SDK client.
+
+This module exists as a FastAPI dependency seam so tests can override
+the production AsyncAnthropic with FakeAnthropicClient via
+`app.dependency_overrides[get_anthropic_client] = lambda: fake`. Phase 2
+of epic #400.
+
+In production: returns a configured `anthropic.AsyncAnthropic`. The SDK
+is imported lazily — until ANTHROPIC_API_KEY is configured and the
+status endpoint reports enabled, the import is never triggered, so
+operators that never enable the copilot don't carry the dependency
+cost.
+
+Failure modes:
+  - SDK not installed → 503 agent_disabled (treated identically to "key
+    missing", same closed-enum reason).
+  - Key not in env → handled upstream by get_agent_status; this
+    function only runs after that check, so the env var is guaranteed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import HTTPException
+
+log = logging.getLogger("api.agent.clients")
+
+
+def get_anthropic_client():
+    """FastAPI dependency that returns a configured Anthropic async client.
+
+    In tests, override via `app.dependency_overrides[get_anthropic_client]`
+    with a function that returns a FakeAnthropicClient instance.
+    """
+    try:
+        from anthropic import AsyncAnthropic  # noqa: PLC0415
+    except ImportError as e:
+        log.error("anthropic SDK not installed: %s", e)
+        # Same closed-enum reason as a missing key — the wire format
+        # never reveals whether it's a missing dependency vs a missing
+        # secret. Pre-reg §11.7.
+        raise HTTPException(status_code=503, detail="agent_disabled")
+    return AsyncAnthropic(api_key=os.environ["ANTHROPIC_API_KEY"].strip())

--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -36,6 +36,7 @@ Failure modes (pre-reg §6.3):
 """
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Optional
@@ -265,7 +266,19 @@ async def run_turn(
             result_json = dispatch_tool(
                 tu.name or "", tu.input or {}, tenant_id=tenant_id,
             )
-            is_error = '"error"' in result_json
+            # is_error: structural detection (PR #404 review issue 2).
+            # The previous `'"error"' in result_json` substring match
+            # produced false positives on legitimate payloads carrying
+            # the string "error" inside a value (e.g. an enum like
+            # "no_error_state" or an exit_reason "liquidation_error").
+            # Parse the JSON and treat a top-level dict with an "error"
+            # key as an error response; parse failure is treated as
+            # error too (defensive).
+            try:
+                parsed = json.loads(result_json)
+                is_error = isinstance(parsed, dict) and "error" in parsed
+            except json.JSONDecodeError:
+                is_error = True
             yield ToolUseResult(
                 tool=tu.name or "",
                 status=("error" if is_error else "ok"),

--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -1,0 +1,301 @@
+"""Server-side agentic loop — Phase 2 of epic #400.
+
+The loop yields typed events; the streaming layer in `streaming.py`
+translates those into SSE frames for the wire.
+
+Contract (pre-reg §6.1, the corrected pseudocode after PR #401 review):
+
+  - Assistant message appended to `messages` exactly ONCE per model turn,
+    carrying ALL content blocks (text + tool_use). Splitting it per
+    tool_use is a wire-format error — Anthropic Messages API rejects.
+
+  - Tool results for all tool_use blocks in a turn collected into ONE
+    user message with the tool_result content blocks. The API rejects
+    a turn that splits tool_results across multiple user messages.
+
+  - MAX_TOOL_HOPS limits the agentic recursion within a single user
+    request. Beyond it, the loop yields `error(too_many_tool_hops)` and
+    stops; the model can be re-prompted in a new user turn.
+
+Tenant scoping (pre-reg §5, §8):
+
+  - The model never receives `tenant_id` as input on any tool.
+  - dispatch_tool() binds tenant_id keyword-only when invoking the
+    handler. The model can't override it because it doesn't appear in
+    the tool's input_schema.
+
+Failure modes (pre-reg §6.3):
+
+  - Upstream RateLimitError / 5xx → yield `error(reason="upstream")` and
+    stop. The HTTP layer retries with backoff; this layer doesn't.
+  - Tool handler raises → dispatch_tool serializes the failure as
+    `{"error": "..."}` JSON content; the next model turn sees the error
+    and self-corrects.
+  - Conversation > N turns (default 30, configurable) → yield
+    `conversation_cap_reached`; UI forces handoff to a new conversation.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Optional
+
+from api.agent.prompts import build_system_blocks
+from api.agent.tools.handlers import dispatch_tool
+from api.agent.tools.registry import tools_for_surface
+
+log = logging.getLogger("api.agent.loop")
+
+
+MAX_TOOL_HOPS = 4
+MAX_TURNS_PER_CONVERSATION = 30
+
+
+# ── Event types yielded by the loop ────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TextDelta:
+    text: str
+
+
+@dataclass(frozen=True)
+class ToolUseStart:
+    tool: str
+
+
+@dataclass(frozen=True)
+class ToolUseResult:
+    tool: str
+    status: str            # "ok" | "error"
+
+
+@dataclass(frozen=True)
+class MessageEnd:
+    usage: dict            # input_tokens / output_tokens / cache_read / cache_creation
+    stop_reason: str
+    cost_usd: float
+
+
+@dataclass(frozen=True)
+class ErrorEvent:
+    reason: str            # "upstream" | "too_many_tool_hops" | "conversation_cap_reached"
+    user_message: str
+
+
+LoopEvent = TextDelta | ToolUseStart | ToolUseResult | MessageEnd | ErrorEvent
+
+
+# ── Tool schema builder (registry → Anthropic tools array) ──────────────
+
+
+def _build_anthropic_tools(surface: str) -> list[dict]:
+    """Convert the per-surface tool subset into the JSON Schema shape the
+    Messages API expects."""
+    specs = tools_for_surface(surface)
+    out = []
+    for spec in specs:
+        # Pydantic schemas → JSON Schema. We strip `title` keys for cache
+        # determinism (Pydantic injects "title" inferred from field
+        # names; removing them keeps the bytes stable across pydantic
+        # versions). DETERMINISTIC SERIALIZATION is the spine of the
+        # prompt cache strategy — pre-reg §7.5 silent invalidators.
+        schema = spec.schema.model_json_schema()
+        _strip_titles(schema)
+        out.append({
+            "name": spec.name,
+            "description": spec.description,
+            "input_schema": schema,
+        })
+    return out
+
+
+def _strip_titles(node: Any) -> None:
+    """Recursively remove `title` keys from a JSON-schema dict tree."""
+    if isinstance(node, dict):
+        node.pop("title", None)
+        for v in node.values():
+            _strip_titles(v)
+    elif isinstance(node, list):
+        for v in node:
+            _strip_titles(v)
+
+
+# ── Cost model (token counts → USD) ─────────────────────────────────────
+#
+# Pricing in USD per 1M tokens, copied from the claude-api skill. Update
+# this map deliberately when bumping the anthropic SDK pin (pre-reg
+# §12.7 — Buffers internos).
+
+_MODEL_PRICING = {
+    "claude-opus-4-7":   {"in": 5.00, "out": 25.00},
+    "claude-sonnet-4-6": {"in": 3.00, "out": 15.00},
+    "claude-haiku-4-5":  {"in": 1.00, "out":  5.00},
+}
+
+
+def _estimate_cost_usd(model: str, usage: dict) -> float:
+    """Compute the USD cost of a turn from `response.usage`. Cache reads
+    are billed at ~0.1× input; cache writes (creation) at ~1.25×.
+    """
+    p = _MODEL_PRICING.get(model)
+    if not p:
+        return 0.0
+    in_per_m = p["in"]
+    out_per_m = p["out"]
+    in_uncached = (usage.get("input_tokens") or 0)
+    cache_read = (usage.get("cache_read_input_tokens") or 0)
+    cache_creation = (usage.get("cache_creation_input_tokens") or 0)
+    out_tokens = (usage.get("output_tokens") or 0)
+    cost = (
+        in_uncached * in_per_m
+        + cache_read * in_per_m * 0.1
+        + cache_creation * in_per_m * 1.25
+        + out_tokens * out_per_m
+    ) / 1_000_000.0
+    return round(cost, 6)
+
+
+# ── Loop ────────────────────────────────────────────────────────────────
+
+
+async def run_turn(
+    *,
+    client: Any,
+    model: str,
+    surface: str,
+    messages: list[dict],
+    tenant_id: int,
+    max_tokens: int = 4096,
+) -> AsyncIterator[LoopEvent]:
+    """Drive one user turn through the model + tool loop. Yields typed
+    events as the model streams and tools fire.
+
+    Mutates `messages` in place (appending the assistant message and any
+    tool_result user messages). The caller owns the conversation state
+    across turns; this function only handles one user-turn → final-text
+    cycle.
+
+    Pre-reg §6.1.
+    """
+    if len(messages) > MAX_TURNS_PER_CONVERSATION:
+        yield ErrorEvent(
+            reason="conversation_cap_reached",
+            user_message=(
+                "Esta conversación llegó al límite de turnos. "
+                "Abre una nueva conversación para seguir."
+            ),
+        )
+        return
+
+    system_blocks = build_system_blocks(surface)
+    tools = _build_anthropic_tools(surface)
+    hops = 0
+
+    while True:
+        # Open a fresh stream for each "model turn" in the agentic loop.
+        try:
+            async with client.messages.stream(
+                model=model,
+                max_tokens=max_tokens,
+                system=system_blocks,
+                tools=tools,
+                messages=messages,
+            ) as stream:
+                async for event in stream:
+                    if event.type == "content_block_start":
+                        cb = event.content_block
+                        if cb is not None and cb.type == "tool_use":
+                            yield ToolUseStart(tool=cb.name or "")
+                    elif event.type == "content_block_delta":
+                        d = event.delta
+                        if d is not None and d.type == "text_delta" and d.text:
+                            yield TextDelta(text=d.text)
+                final = await stream.get_final_message()
+        except Exception as e:  # noqa: BLE001
+            log.warning("agent loop upstream error: %s", e, exc_info=True)
+            yield ErrorEvent(
+                reason="upstream",
+                user_message=(
+                    "El copiloto está saturado, intenta de nuevo en unos segundos."
+                ),
+            )
+            return
+
+        usage_dict = {
+            "input_tokens":                getattr(final.usage, "input_tokens", 0) or 0,
+            "output_tokens":               getattr(final.usage, "output_tokens", 0) or 0,
+            "cache_read_input_tokens":     getattr(final.usage, "cache_read_input_tokens", 0) or 0,
+            "cache_creation_input_tokens": getattr(final.usage, "cache_creation_input_tokens", 0) or 0,
+        }
+
+        if final.stop_reason != "tool_use":
+            yield MessageEnd(
+                usage=usage_dict,
+                stop_reason=final.stop_reason,
+                cost_usd=_estimate_cost_usd(model, usage_dict),
+            )
+            return
+
+        # stop_reason == "tool_use" — we have one or more tool_use blocks
+        # to dispatch. Bump the hop counter; refuse if we've gone too deep.
+        hops += 1
+        if hops > MAX_TOOL_HOPS:
+            yield ErrorEvent(
+                reason="too_many_tool_hops",
+                user_message=(
+                    "No pude completar la consulta — intenta reformularla."
+                ),
+            )
+            return
+
+        # Append the assistant message ONCE (carries all tool_use blocks).
+        # See pre-reg §6.1 — splitting per tool_use is a wire-format error.
+        messages.append({
+            "role": "assistant",
+            "content": _blocks_to_api_shape(final.content),
+        })
+
+        # Collect tool_results for ALL tool_use blocks in this turn into
+        # ONE user message. The API rejects a turn that splits
+        # tool_results across multiple user messages.
+        tool_uses = [b for b in final.content if b.type == "tool_use"]
+        tool_results = []
+        for tu in tool_uses:
+            result_json = dispatch_tool(
+                tu.name or "", tu.input or {}, tenant_id=tenant_id,
+            )
+            is_error = '"error"' in result_json
+            yield ToolUseResult(
+                tool=tu.name or "",
+                status=("error" if is_error else "ok"),
+            )
+            tool_results.append({
+                "type":          "tool_result",
+                "tool_use_id":   tu.id,
+                "content":       result_json,
+                "is_error":      is_error,
+            })
+        messages.append({"role": "user", "content": tool_results})
+
+        # Loop back: send the tool_results to the model.
+
+
+def _blocks_to_api_shape(blocks: list) -> list[dict]:
+    """Convert the SDK's typed content blocks (or our fake's) into the
+    plain-dict shape the API accepts in the `messages` array.
+
+    The API doesn't accept the typed objects directly when echoed back —
+    it wants the raw dict form."""
+    out = []
+    for b in blocks:
+        if b.type == "text":
+            out.append({"type": "text", "text": b.text or ""})
+        elif b.type == "tool_use":
+            out.append({
+                "type":  "tool_use",
+                "id":    b.id,
+                "name":  b.name,
+                "input": b.input or {},
+            })
+    return out

--- a/api/agent/prompts/__init__.py
+++ b/api/agent/prompts/__init__.py
@@ -1,0 +1,31 @@
+"""Agent system-prompt blocks — Phase 2 of epic #400.
+
+The system prompt is built as a list of typed `text` blocks, every block
+marked `cache_control: {type: "ephemeral"}`. Anthropic's prompt-caching
+beta keys off the byte-exact prefix; arrangement order matters and is
+locked in pre-reg §7:
+
+  1. system.PERSONA_AND_SAFETY  — most stable, lives at the front
+  2. tool_docs(registry)         — stable per feature deploy
+  3. system.INVARIANTS           — stable per config edit
+  4. surfaces.for_surface(name)  — varies per surface
+
+Block 1 is hardcoded in `system.py`. Block 2 is generated from the
+tool registry at request time. Block 3 is hardcoded. Block 4 lives in
+`surfaces.py`, one micro-prompt per surface.
+
+Anything dynamic (timestamps, UUIDs, conversation-specific context)
+goes AFTER the last cache breakpoint, in the `messages` array — see
+pre-reg §7.5 silent invalidators.
+"""
+
+from api.agent.prompts.system import (  # noqa: F401
+    PERSONA_AND_SAFETY,
+    INVARIANTS,
+    build_tool_docs,
+    build_system_blocks,
+)
+from api.agent.prompts.surfaces import (  # noqa: F401
+    SURFACE_PROMPTS,
+    for_surface,
+)

--- a/api/agent/prompts/surfaces.py
+++ b/api/agent/prompts/surfaces.py
@@ -1,0 +1,81 @@
+"""Surface-specific micro-prompts (system-prompt block 4).
+
+Each surface gets a short instruction nudging the agent toward the
+right scope and tone for that view. These ARE NOT decision rules —
+the hard rules live in PERSONA_AND_SAFETY (block 1). These are
+"how to focus when the user is on this view".
+
+Pre-reg §4.3 / §7.4. Language: Venezuelan-neutral, "tú" forms.
+"""
+from __future__ import annotations
+
+
+# ── Per-surface micro-prompts ──────────────────────────────────────────
+
+
+_DOCK = """SUPERFICIE: Dock principal.
+Eres el copiloto general del dashboard. El usuario te puede preguntar lo
+que quiera sobre su portafolio, las señales del scanner, el kill-switch,
+o el tune.
+- Si la pregunta es ambigua, pide clarificación en UNA línea.
+- Si la pregunta toca múltiples temas, contesta lo principal y ofrece
+  abrir un tema secundario."""
+
+
+_SYMBOL_DETAIL = """SUPERFICIE: SymbolDetail drawer.
+Estás respondiendo dentro del drawer de un símbolo específico — el
+usuario está mirando ese símbolo. El context_hints del turno incluye el
+ticker activo.
+- Limita el alcance a ese símbolo. Si el usuario pregunta por otro,
+  sugiere abrir el drawer del otro y NO contestes con datos del actual
+  como si fueran del otro.
+- Los tools que tienes acceso son los de un solo símbolo: get_symbol_setup,
+  get_position_detail (para una posición específica), get_recent_signals.
+- NO emites propuestas de cierre desde aquí — esa interacción vive en el
+  Dock principal o en el botón "cerrar posición" de la card."""
+
+
+_KILL_SWITCH = """SUPERFICIE: KillSwitchView (panel de salud).
+El usuario está mirando el estado del kill-switch y quiere entender o
+negociar una transición.
+- Tu rol principal: ayudar a entender qué métricas dispararon el state
+  actual (WR20, P&L 30d, concurrent failures, portfolio DD).
+- Si el usuario pide liberar un símbolo PAUSED, evalúa las next_conditions
+  y emite propose_reactivate_symbol cuando tenga sentido. La UI muestra
+  el botón ámbar — el usuario confirma.
+- NO sugieras "liberar" si las condiciones no se cumplen. Explica qué
+  falta para cumplirlas."""
+
+
+_AUTOTUNE = """SUPERFICIE: AutoTuneView.
+El usuario está mirando una propuesta de re-calibración mensual. Tu rol
+es ayudar a entender el cambio y los datos de backtest detrás.
+- Usa get_tune_proposal para leer la propuesta actual y get_closed_trades
+  para razonar sobre el track-record reciente.
+- Si el usuario quiere aplicar el tune, emite propose_apply_tune. NO lo
+  apliques tú directamente — la UI confirma."""
+
+
+_HISTORIAL = """SUPERFICIE: HistorialView.
+El usuario está mirando el historial de trades cerrados. Tu rol es
+análisis pasivo: win-rate por símbolo, racha, P&L window, drawdown
+realizado.
+- NO sugieras cambios al sistema desde aquí (eso vive en AutoTune).
+- NO emites propuestas de cierre — los trades de esta vista ya están
+  cerrados."""
+
+
+SURFACE_PROMPTS: dict[str, str] = {
+    "dock":          _DOCK,
+    "symbol_detail": _SYMBOL_DETAIL,
+    "kill_switch":   _KILL_SWITCH,
+    "autotune":      _AUTOTUNE,
+    "historial":     _HISTORIAL,
+}
+
+
+def for_surface(surface: str) -> str:
+    """Return the micro-prompt for `surface`. Falls back to the Dock
+    prompt for an unknown surface — defensive; in practice the
+    surface enum is validated by the request schema."""
+    return SURFACE_PROMPTS.get(surface, SURFACE_PROMPTS["dock"])

--- a/api/agent/prompts/system.py
+++ b/api/agent/prompts/system.py
@@ -1,0 +1,157 @@
+"""Persona + safety + invariants + tool docs (system-prompt blocks 1-3).
+
+These three blocks are the most stable part of the system prompt. They
+change only when:
+
+  - Block 1 (PERSONA_AND_SAFETY): we deliberately retune the agent's
+    persona, refusal scope, or safety preamble. Each edit invalidates
+    the prompt cache for every conversation → coordinate with a deploy.
+  - Block 2 (build_tool_docs): the tool registry changes (a tool is
+    added, removed, or gets a different description). Adding a new
+    tool invalidates the cache prefix for every existing conversation
+    on the next turn — expected, fine.
+  - Block 3 (INVARIANTS): the curated 10-symbol list, tier semantics,
+    or regime detector change. Stable across most config edits.
+
+Anything dynamic (timestamps, conversation-specific context, the user
+turn) goes AFTER the last cache breakpoint in the `messages` array.
+See pre-reg §7.5 silent invalidators.
+
+Language: Venezuelan-neutral Spanish. The product is Venezuelan; the
+agent talks to traders in their language. NO voseo (no "trabajás",
+"ejecutás", "decís"); the system prompt uses "tú" forms ("trabajas",
+"ejecutas", "dices") consistently.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from api.agent.tools.registry import TOOL_CATALOG, ToolSpec, tools_for_surface
+
+
+# ── Block 1: Persona + safety preamble ─────────────────────────────────
+
+PERSONA_AND_SAFETY = """Eres el copiloto de crypto-scanner v6. Trabajas con dinero real en un mercado real.
+
+REGLAS DURAS:
+- NO das consejos direccionales ("compra", "vende", "shortea"). Explicas lo que el
+  sistema observa y le devuelves la decisión al usuario.
+- NO inventas datos. Para cualquier número, posición o señal: llamas una tool.
+- NO ejecutas acciones con efecto real. Para cerrar posición, liberar símbolo,
+  o aplicar tune: emites una propuesta. El usuario confirma en la UI.
+  Tu tool propone, la UI ejecuta.
+- Los IDs y símbolos que mencionas solo pueden venir de tool_results en ESTA
+  conversación. Nunca de tu memoria.
+- Operas con UNA cuenta (la del usuario autenticado). No revelas ni infieres
+  datos de otras cuentas.
+- Fuera de scope (precio de tokens no curados, noticias macro externas,
+  código, recetas): declinas brevemente y rediriges al sistema.
+
+TONO:
+- Conciso. Sin preámbulos ("Claro, te explico..."). Vas al punto.
+- Si la respuesta es un número, das el número y una línea de contexto. No tres
+  párrafos.
+- Si necesitas confirmación del usuario, lo dices explícitamente al final."""
+
+
+# ── Block 3: System invariants ─────────────────────────────────────────
+
+INVARIANTS = """INVARIANTES DEL SISTEMA
+
+SÍMBOLOS CURADOS (10):
+  BTC, ETH, ADA, AVAX, DOGE, UNI, XLM, PENDLE, JUP, RUNE.
+  El sistema NO opera fuera de esta lista. Si el usuario pregunta por SOL, XRP,
+  o cualquier otro, explicas que no está en la watch-list.
+
+TIERS DEL KILL-SWITCH (per-symbol):
+  NORMAL    — operando normal.
+  ALERT     — WR rolling 20 por debajo del umbral; alerta sin pausar.
+  REDUCED   — P&L 30d negativo + ALERT; size reducida al 50%.
+  PAUSED    — bloqueado para nuevas entradas; requiere PROBATION para reabrir.
+  PROBATION — re-evaluación con N trades antes de volver a NORMAL.
+
+TIERS DEL PORTAFOLIO:
+  NORMAL, WARNED, REDUCED, FROZEN.
+  Las thresholds viven en cfg.kill_switch.v2.thresholds.
+
+REGÍMENES DE MERCADO:
+  BULL    (score > 60) — LONG permitido, SHORT no.
+  NEUTRAL (40-60)      — LONG permitido, SHORT no.
+  BEAR    (score < 40) — LONG y SHORT permitidos.
+  El detector se actualiza diariamente.
+
+CONFIRMACIÓN DE ACCIONES:
+  Cuando emites una propose_* tool, el server firma la propuesta con un TTL
+  de 5 minutos y devuelve un proposal_id. La UI le muestra al usuario un
+  botón ámbar para confirmar. Si pasa el TTL, la propuesta expira; tienes
+  que volver a emitirla con el estado actualizado."""
+
+
+# ── Block 2: Tool documentation (generated from the registry) ───────────
+
+
+def _format_tool_doc(spec: ToolSpec) -> str:
+    """One tool's doc line. Stable wording so the cache prefix doesn't
+    shift unless the underlying tool changes."""
+    return f"- {spec.name}: {spec.description}"
+
+
+def build_tool_docs(specs: Iterable[ToolSpec] | None = None) -> str:
+    """Render the tool docs block in catalog order.
+
+    Pre-reg §7.5: this MUST be deterministic — same registry → same
+    bytes → cache hit. The catalog is a tuple (ordered); we never sort
+    here. Adding a new tool re-renders the block, which is the intended
+    cache invalidation.
+    """
+    specs = specs if specs is not None else TOOL_CATALOG
+    lines = ["TOOLS DISPONIBLES (todas son lecturas tenant-scoped):"]
+    lines.extend(_format_tool_doc(s) for s in specs)
+    lines.append(
+        "Si la pregunta del usuario requiere un dato concreto, llama la tool. "
+        "No respondas con números que no salieron de un tool_result."
+    )
+    return "\n".join(lines)
+
+
+# ── Block assembly ──────────────────────────────────────────────────────
+
+
+def build_system_blocks(surface: str) -> list[dict]:
+    """Return the system prompt as a list of cache_control'd text blocks,
+    in the canonical render order:
+
+      [persona, tool_docs, invariants, surface_micro_prompt]
+
+    Each block is marked `cache_control: {type: "ephemeral"}` so the
+    Anthropic API will serve it from cache on subsequent turns of the
+    same conversation (and across conversations on the same surface,
+    because surface 1-3 are surface-independent).
+
+    The Messages API accepts up to 4 cache_control breakpoints per
+    request; we use exactly that.
+    """
+    from api.agent.prompts.surfaces import for_surface
+    surface_specs = tools_for_surface(surface)
+    return [
+        {
+            "type": "text",
+            "text": PERSONA_AND_SAFETY,
+            "cache_control": {"type": "ephemeral"},
+        },
+        {
+            "type": "text",
+            "text": build_tool_docs(surface_specs),
+            "cache_control": {"type": "ephemeral"},
+        },
+        {
+            "type": "text",
+            "text": INVARIANTS,
+            "cache_control": {"type": "ephemeral"},
+        },
+        {
+            "type": "text",
+            "text": for_surface(surface),
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -1,14 +1,9 @@
-"""Agent API router. Phase 0 owns GET /agent/status only.
+"""Agent API router.
 
-The /agent/* surface lands incrementally per the pre-reg's 6-phase plan:
-
-  Phase 0 (this commit):
+  Phase 0:
     GET  /agent/status                              — public, no auth
 
-  Phase 1:
-    (no new endpoints — tool registry + audit schema land internally)
-
-  Phase 2:
+  Phase 2 (this commit):
     POST /agent/conversations/{conversation_id}/turn   — SSE streaming,
                                                          JWT-authenticated
 
@@ -27,14 +22,25 @@ configuration detail.
 from __future__ import annotations
 
 import logging
+from typing import Literal, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
 
+from api.agent.audit import TurnAuditWrapper
+from api.agent.clients import get_anthropic_client
 from api.agent.config import get_agent_status
+from api.agent.loop import run_turn
+from api.agent.streaming import sse_serialize
+from auth.dependencies import get_current_tenant_id
 
 log = logging.getLogger("api.agent.router")
 
 router = APIRouter(tags=["agent"])
+
+
+# ── /agent/status (Phase 0) ────────────────────────────────────────────
 
 
 @router.get("/agent/status", summary="Public agent feature status")
@@ -47,3 +53,107 @@ def get_status():
     """
     status = get_agent_status()
     return {"enabled": status.enabled, "reason": status.reason}
+
+
+# ── /agent/conversations/{id}/turn (Phase 2) ───────────────────────────
+
+
+_SURFACE_MODEL_DEFAULTS: dict[str, str] = {
+    "dock":          "claude-sonnet-4-6",
+    "symbol_detail": "claude-haiku-4-5",
+    "kill_switch":   "claude-sonnet-4-6",
+    "autotune":      "claude-sonnet-4-6",
+    "historial":     "claude-haiku-4-5",
+}
+
+
+class _AgentMessage(BaseModel):
+    role:    Literal["user", "assistant"]
+    content: str
+
+
+class _AgentContextHints(BaseModel):
+    symbol:      Optional[str] = None
+    position_id: Optional[int] = None
+    tune_id:     Optional[int] = None
+
+
+class _AgentTurnRequest(BaseModel):
+    surface:        Literal["dock", "symbol_detail", "kill_switch", "autotune", "historial"]
+    messages:       list[_AgentMessage] = Field(..., min_length=1)
+    context_hints:  Optional[_AgentContextHints] = None
+    # Optional model override (e.g. when the user clicks "análisis profundo"
+    # which flips the next turn to Opus). Server-side allowlist enforced.
+    model:          Optional[str] = None
+
+
+_ALLOWED_MODELS: frozenset[str] = frozenset({
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "claude-opus-4-7",
+})
+
+
+@router.post(
+    "/agent/conversations/{conversation_id}/turn",
+    summary="Stream one agent turn (SSE)",
+)
+async def post_agent_turn(
+    conversation_id: str,
+    body: _AgentTurnRequest,
+    tenant_id: int = Depends(get_current_tenant_id),
+    client = Depends(get_anthropic_client),  # noqa: B008
+):
+    """Stream a single user-turn through the model + tool loop.
+
+    Wire shape: `text/event-stream`. Frames are JSON objects with a
+    `type` field; see api/agent/streaming.py for the closed enum
+    (text_delta / tool_use_start / tool_use_result / message_end / error).
+
+    Pre-reg §4.4. Auth: cookie JWT → tenant_id. The model never sees
+    tenant_id; every tool call is bound server-side. The Anthropic
+    client is injected via Depends so tests override with a fake.
+    """
+    status = get_agent_status()
+    if not status.enabled:
+        raise HTTPException(status_code=503, detail=status.reason)
+
+    model = body.model or _SURFACE_MODEL_DEFAULTS[body.surface]
+    if model not in _ALLOWED_MODELS:
+        raise HTTPException(status_code=400, detail="model_not_allowed")
+
+    # Convert the request's messages into the API's `messages` array.
+    # The frontend owns the transcript and resends it every turn (same
+    # pattern as the legacy /agent/chat that this endpoint will replace).
+    messages: list[dict] = [
+        {"role": m.role, "content": m.content} for m in body.messages
+    ]
+
+    loop_events = run_turn(
+        client=client,
+        model=model,
+        surface=body.surface,
+        messages=messages,
+        tenant_id=tenant_id,
+    )
+    audited = TurnAuditWrapper(
+        loop_events,
+        tenant_id=tenant_id,
+        surface=body.surface,
+        conversation_id=conversation_id,
+        model=model,
+    )
+    sse_bytes = sse_serialize(audited)
+
+    # X-Accel-Buffering: no → nginx must not buffer the response. Without
+    # this header, every SSE frame piles up until nginx's 8KB buffer fills,
+    # killing the streaming UX. See pre-reg §6 (failure modes table).
+    return StreamingResponse(
+        sse_bytes,
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control":     "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection":        "keep-alive",
+        },
+    )

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 from typing import Literal, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Path
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -99,8 +99,14 @@ _ALLOWED_MODELS: frozenset[str] = frozenset({
     summary="Stream one agent turn (SSE)",
 )
 async def post_agent_turn(
-    conversation_id: str,
-    body: _AgentTurnRequest,
+    # Validated path param (PR #404 review issue 3): UUID / nanoid /
+    # other ascii-safe ids only, max 128 chars. Blocks pollution
+    # (whitespace, control chars, /, etc.) and minor DoS via huge ids
+    # being persisted to agent_conversations.
+    conversation_id: str = Path(
+        ..., min_length=1, max_length=128, pattern=r"^[A-Za-z0-9_\-]+$",
+    ),
+    body: _AgentTurnRequest = ...,  # noqa: B008
     tenant_id: int = Depends(get_current_tenant_id),
     client = Depends(get_anthropic_client),  # noqa: B008
 ):

--- a/api/agent/streaming.py
+++ b/api/agent/streaming.py
@@ -1,0 +1,64 @@
+"""SSE serialization of loop events — Phase 2 of epic #400.
+
+Translates the typed events yielded by `api.agent.loop.run_turn` into
+Server-Sent Events on the wire. Each frame is a `data: {json}\n\n` line
+with a `type` field that the frontend's `useAgentStream` hook switches on.
+
+Pre-reg §6.2. The event-type enum is closed:
+
+    text_delta | tool_use_start | tool_use_result | message_end | error
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict
+from typing import AsyncIterator
+
+from api.agent.loop import (
+    ErrorEvent,
+    LoopEvent,
+    MessageEnd,
+    TextDelta,
+    ToolUseResult,
+    ToolUseStart,
+)
+
+log = logging.getLogger("api.agent.streaming")
+
+
+def _sse_frame(event_type: str, payload: dict) -> bytes:
+    """Format one SSE frame. UTF-8 bytes ready to yield from FastAPI's
+    StreamingResponse. We use the `data:`-only form (no `event:` line)
+    because the frontend switches on the JSON's `type` field — simpler
+    than juggling SSE event types and giving the client a single parse
+    surface."""
+    payload_with_type = {"type": event_type, **payload}
+    return f"data: {json.dumps(payload_with_type)}\n\n".encode("utf-8")
+
+
+async def sse_serialize(events: AsyncIterator[LoopEvent]) -> AsyncIterator[bytes]:
+    """Consume loop events, yield SSE-framed bytes."""
+    async for ev in events:
+        if isinstance(ev, TextDelta):
+            yield _sse_frame("text_delta", {"text": ev.text})
+        elif isinstance(ev, ToolUseStart):
+            yield _sse_frame("tool_use_start", {"tool": ev.tool})
+        elif isinstance(ev, ToolUseResult):
+            yield _sse_frame("tool_use_result", {
+                "tool":   ev.tool,
+                "status": ev.status,
+            })
+        elif isinstance(ev, MessageEnd):
+            yield _sse_frame("message_end", {
+                "usage":       ev.usage,
+                "stop_reason": ev.stop_reason,
+                "cost_usd":    ev.cost_usd,
+            })
+        elif isinstance(ev, ErrorEvent):
+            yield _sse_frame("error", {
+                "reason":       ev.reason,
+                "user_message": ev.user_message,
+            })
+        else:
+            log.warning("sse_serialize: dropping unknown event type %s", type(ev))

--- a/api/agent/tools/handlers.py
+++ b/api/agent/tools/handlers.py
@@ -97,18 +97,23 @@ def get_portfolio_overview(*, tenant_id: int) -> dict:
 
     try:
         dashboard = get_dashboard_state(load_config(), tenant_id=tenant_id)
-        portfolio = dashboard.get("portfolio", {})
     except Exception:  # noqa: BLE001
         log.warning("get_portfolio_overview: dashboard fetch failed", exc_info=True)
-        portfolio = {}
+        # Consistent with get_kill_switch_state: when the dashboard is
+        # unavailable, surface the failure explicitly so the model knows
+        # the equity numbers are missing because of an outage, NOT
+        # because the user has zero equity. Returning nulls would be
+        # ambiguous (PR #403 review issue 1).
+        return {"error": "dashboard_unavailable"}
 
+    portfolio = dashboard.get("portfolio", {})
     return {
-        "open_positions_count":  open_count,
-        "open_positions_notional_usd": round(total_notional, 2),
-        "current_equity_usd":    portfolio.get("current_equity"),
-        "peak_equity_usd":       portfolio.get("peak_equity"),
-        "drawdown_pct":          portfolio.get("dd_pct"),
-        "portfolio_tier":        portfolio.get("tier"),
+        "open_positions_count":          open_count,
+        "open_positions_notional_usd":   round(total_notional, 2),
+        "current_equity_usd":            portfolio.get("current_equity"),
+        "peak_equity_usd":               portfolio.get("peak_equity"),
+        "drawdown_pct":                  portfolio.get("dd_pct"),
+        "portfolio_tier":                portfolio.get("tier"),
     }
 
 

--- a/api/agent/tools/handlers.py
+++ b/api/agent/tools/handlers.py
@@ -149,28 +149,25 @@ def get_symbols_with_signals(*, tenant_id: int, limit: int = 10) -> dict:  # noq
     is accepted for signature uniformity but does not gate the result.
     The scanner state is global (one snapshot per symbol regardless of
     tenant) — the per-user notion enters at the signal-outcomes layer.
+
+    De-dupe by symbol happens in SQL (one row per symbol = the latest
+    scan), so the caller gets up to `limit` *distinct* symbols rather
+    than `limit` raw scan rows that may all be the same symbol.
     """
-    from db.signals import get_scans
-    rows = get_scans(limit=limit, only_signals=False)
-    # `get_scans` already orders newest-first; the model can reason about
-    # ordering itself, so we project to the fields it needs.
-    out = []
-    seen_symbols: set[str] = set()
-    for r in rows:
-        sym = r.get("symbol")
-        if not sym or sym in seen_symbols:
-            continue
-        seen_symbols.add(sym)
-        out.append({
-            "symbol":    sym,
-            "score":     r.get("score"),
-            "estado":    r.get("estado"),
-            "signal":    bool(r.get("señal") or 0),
-            "ts":        r.get("ts"),
-        })
-        if len(out) >= limit:
-            break
-    return {"symbols": out}
+    from db.signals import get_latest_scan_per_symbol
+    rows = get_latest_scan_per_symbol(limit=limit, only_signals=False)
+    return {
+        "symbols": [
+            {
+                "symbol":    r.get("symbol"),
+                "score":     r.get("score"),
+                "estado":    r.get("estado"),
+                "signal":    bool(r.get("señal") or 0),
+                "ts":        r.get("ts"),
+            }
+            for r in rows if r.get("symbol")
+        ]
+    }
 
 
 def get_symbol_setup(*, tenant_id: int, symbol: str) -> dict:  # noqa: ARG001
@@ -243,16 +240,23 @@ def get_recent_signals(*, tenant_id: int, limit: int = 10, since_hours: int = 24
 
 
 def get_closed_trades(*, tenant_id: int, window: str = "30d") -> dict:
-    """Closed positions for this tenant, windowed."""
+    """Closed positions for this tenant, windowed.
+
+    The window is pushed into SQL via `db_get_positions(since=...)` so
+    we don't load the full history just to filter it down in Python
+    (PR #403 review issue 3).
+    """
     from datetime import datetime, timedelta, timezone
     from db.positions import db_get_positions
 
-    rows = db_get_positions(status="closed", tenant_id=tenant_id)
-    if window != "all":
+    if window == "all":
+        rows = db_get_positions(status="closed", tenant_id=tenant_id)
+    else:
         days = {"7d": 7, "30d": 30, "90d": 90}.get(window, 30)
-        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-        cutoff_iso = cutoff.isoformat()
-        rows = [r for r in rows if (r.get("exit_ts") or "") >= cutoff_iso]
+        cutoff_iso = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+        rows = db_get_positions(
+            status="closed", tenant_id=tenant_id, since=cutoff_iso,
+        )
     return {"trades": [_position_to_summary(r) for r in rows]}
 
 

--- a/api/agent/tools/registry.py
+++ b/api/agent/tools/registry.py
@@ -149,14 +149,19 @@ TOOL_CATALOG: tuple[ToolSpec, ...] = (
 
 # Sanity invariant: every entry in TOOL_CATALOG has a corresponding
 # schema in TOOL_INPUT_SCHEMAS, and vice versa. If you add a tool to one
-# and forget the other, this fires at import time — surfaces in CI as
-# a test_tool_registry_consistency failure.
+# and forget the other, this raises at import time so the process refuses
+# to start in production with an inconsistent registry. The test in
+# tests/test_agent_tools.py covers the same invariant in CI.
+#
+# `raise RuntimeError`, not `assert`: `python -O` strips assert
+# statements out of the bytecode entirely (PR #403 review issue 4).
 _CATALOG_NAMES = {t.name for t in TOOL_CATALOG}
 _SCHEMA_NAMES = set(TOOL_INPUT_SCHEMAS.keys())
-assert _CATALOG_NAMES == _SCHEMA_NAMES, (
-    f"Tool catalog/schema mismatch — catalog: {_CATALOG_NAMES}, "
-    f"schemas: {_SCHEMA_NAMES}"
-)
+if _CATALOG_NAMES != _SCHEMA_NAMES:
+    raise RuntimeError(
+        f"Tool catalog/schema mismatch — catalog: {_CATALOG_NAMES}, "
+        f"schemas: {_SCHEMA_NAMES}"
+    )
 
 
 def tools_for_surface(surface: Surface) -> tuple[ToolSpec, ...]:

--- a/btc_api.py
+++ b/btc_api.py
@@ -427,12 +427,16 @@ def agent_chat(body: _AgentRequest):
     # the env var) now correctly gets a 503 here instead of the request
     # silently sailing through. Closes the cfg-vs-env consistency gap
     # flagged in PR #402 review.
+    #
+    # get_agent_status() already guarantees ANTHROPIC_API_KEY is present
+    # and non-empty when status.enabled is True — no need for a redundant
+    # os.environ check below (PR #403 review issue 5).
     from api.agent.config import get_agent_status  # noqa: PLC0415
     _agent_status = get_agent_status()
     if not _agent_status.enabled:
         from fastapi import HTTPException  # noqa: PLC0415
         raise HTTPException(status_code=503, detail=_agent_status.reason)
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    api_key = os.environ["ANTHROPIC_API_KEY"].strip()
 
     payload = {
         "model":      "claude-haiku-4-5",

--- a/db/positions.py
+++ b/db/positions.py
@@ -115,11 +115,18 @@ def db_last_exit_ts(symbol: str, tenant_id: Optional[int] = None) -> Optional[da
 def db_get_positions(
     status: Optional[str] = None,
     tenant_id: Optional[int] = None,
+    since: Optional[str] = None,
 ) -> list:
-    """List positions, optionally filtered by status and tenant_id.
+    """List positions, optionally filtered by status, tenant_id, and since.
 
     Per B.5: when tenant_id is None (default), returns all rows (legacy).
     When tenant_id is int, filters strict to that tenant.
+
+    `since`: ISO 8601 string. When provided, filters to rows with
+    `exit_ts >= since` for status='closed' (the typical use — windowed
+    historial) or `entry_ts >= since` otherwise. Pushed into SQL so the
+    caller doesn't load the full history into Python just to discard it
+    (PR #403 review issue 3).
     """
     con = get_db()
     clauses: list[str] = []
@@ -130,6 +137,13 @@ def db_get_positions(
     if tenant_id is not None:
         clauses.append("tenant_id=?")
         params.append(tenant_id)
+    if since is not None:
+        # Use exit_ts when filtering closed trades (the historial case);
+        # otherwise entry_ts. Both columns are ISO 8601 strings so a
+        # lexicographic compare is correct.
+        ts_col = "exit_ts" if status == "closed" else "entry_ts"
+        clauses.append(f"{ts_col} >= ?")
+        params.append(since)
     where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
     rows = con.execute(
         f"SELECT * FROM positions{where} ORDER BY id DESC", params,

--- a/db/signals.py
+++ b/db/signals.py
@@ -82,6 +82,52 @@ def get_scans(limit=50, only_signals=False, only_setups=False,
     return [dict(r) for r in rows]
 
 
+def get_latest_scan_per_symbol(
+    limit: int = 10,
+    only_signals: bool = False,
+    since_hours: Optional[float] = None,
+) -> list:
+    """Return the latest scan per symbol, newest-first, capped at `limit`.
+
+    Why this exists (PR #403 review issue 2): the agent's
+    `get_symbols_with_signals` tool used to fetch `limit` raw rows from
+    `get_scans()` and de-dupe client-side. Because the scanner persists
+    many scans per symbol, a request for `limit=10` could surface only
+    4 unique symbols after the de-dupe, leaving the model uncertain
+    whether "4 results" meant "4 symbols matched" or "we silently cut
+    the result set". Doing the de-dupe in SQL guarantees the caller
+    gets up to `limit` distinct symbols.
+
+    Implementation: subquery picks `MAX(id)` per symbol (the scans table
+    is INSERT-only with monotonically increasing ids = newest), then
+    project rows by that id set and order by ts DESC. Identical
+    filtering semantics to `get_scans()`.
+    """
+    con = get_db()
+    conds: list[str] = []
+    params: list = []
+    if only_signals:
+        conds.append("señal = 1")
+    if since_hours is not None and since_hours > 0:
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=since_hours)).isoformat()
+        conds.append("ts >= ?")
+        params.append(cutoff)
+    where = ("WHERE " + " AND ".join(conds)) if conds else ""
+    params.append(limit)
+    rows = con.execute(
+        f"""SELECT * FROM scans
+            WHERE id IN (
+                SELECT MAX(id) FROM scans {where}
+                GROUP BY symbol
+            )
+            ORDER BY ts DESC
+            LIMIT ?""",
+        params,
+    ).fetchall()
+    con.close()
+    return [dict(r) for r in rows]
+
+
 def get_latest_signal(symbol: Optional[str] = None) -> Optional[dict]:
     con = get_db()
     if symbol:

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -52,3 +52,336 @@ def make_bar(symbol: str, timeframe: str, open_time: int, price: float = 100.0, 
     )
     defaults.update(overrides)
     return Bar(**defaults)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# FakeAnthropicClient — drop-in for `anthropic.AsyncAnthropic` in tests
+# ─────────────────────────────────────────────────────────────────────────
+#
+# Reproduces the streaming surface of the anthropic Python SDK (>=0.40)
+# that the Phase 2 agentic loop depends on. Built FIRST in PR 2A (pre-reg
+# §12.7 — Buffers internos) so the SSE event contract is frozen before
+# the loop starts depending on it.
+#
+# Why a hand-rolled fake instead of unittest.mock:
+#
+#   - SDK's messages.stream() is an async context manager that yields a
+#     typed iterator of events; mocking that surface with AsyncMock makes
+#     test bodies unreadable and silently drifts on minor SDK bumps.
+#   - A focused fake forces us to think about which event types the loop
+#     actually reacts to — that's the correctness surface.
+#
+# Pin: anthropic >= 0.40 (see requirements.txt). When the pin bumps, run
+# the suite against the live model under @pytest.mark.live to catch
+# silent drift before merging the bump (pre-reg §12.7).
+
+import json as _json
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class FakeContentBlock:
+    """A content block in the final assistant message."""
+    type: str                           # "text" | "tool_use"
+    text: Optional[str] = None
+    id: Optional[str] = None
+    name: Optional[str] = None
+    input: Optional[dict] = None
+
+
+@dataclass
+class FakeUsage:
+    """Mirror of `response.usage` — fields the cache verification test reads."""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+
+
+@dataclass
+class FakeFinalMessage:
+    """What stream.get_final_message() returns."""
+    content: list = field(default_factory=list)
+    stop_reason: str = "end_turn"
+    usage: FakeUsage = field(default_factory=FakeUsage)
+    model: str = "claude-sonnet-4-6"
+
+
+@dataclass
+class FakeDelta:
+    type: str                           # "text_delta" | "input_json_delta"
+    text: Optional[str] = None
+    partial_json: Optional[str] = None
+
+
+@dataclass
+class FakeContentBlockMeta:
+    type: str                           # "text" | "tool_use"
+    name: Optional[str] = None
+    id: Optional[str] = None
+
+
+@dataclass
+class FakeEvent:
+    """Event yielded by the stream iterator — mirrors `event.type`,
+    `event.delta`, `event.content_block`."""
+    type: str
+    delta: Optional[FakeDelta] = None
+    content_block: Optional[FakeContentBlockMeta] = None
+    index: int = 0
+
+
+class FakeTurnBuilder:
+    """Fluent builder for one turn's events + final message.
+
+    Usage:
+        events, final = (
+            FakeTurnBuilder()
+            .text("Hola ").text("mundo")
+            .end_turn()
+            .usage(input_tokens=100, cache_read=80)
+            .build()
+        )
+    """
+
+    def __init__(self):
+        self._events: list[FakeEvent] = []
+        self._content: list[FakeContentBlock] = []
+        self._index = 0
+        self._stop_reason: Optional[str] = None
+        self._usage = FakeUsage()
+        self._block_open = False
+
+    def text(self, chunk: str) -> "FakeTurnBuilder":
+        """Append a text chunk. Multiple chunks accumulate into one text block."""
+        if not self._content or self._content[-1].type != "text":
+            self._close_open_block()
+            self._events.append(FakeEvent(
+                type="content_block_start",
+                index=self._index,
+                content_block=FakeContentBlockMeta(type="text"),
+            ))
+            self._content.append(FakeContentBlock(type="text", text=""))
+            self._block_open = True
+        self._events.append(FakeEvent(
+            type="content_block_delta",
+            index=self._index,
+            delta=FakeDelta(type="text_delta", text=chunk),
+        ))
+        self._content[-1].text = (self._content[-1].text or "") + chunk
+        return self
+
+    def tool_use(
+        self,
+        name: str,
+        input: dict,
+        tool_use_id: str = "toolu_fake_001",
+    ) -> "FakeTurnBuilder":
+        """Emit a tool_use block. Closes any open text block first."""
+        self._close_open_block()
+        self._events.append(FakeEvent(
+            type="content_block_start",
+            index=self._index,
+            content_block=FakeContentBlockMeta(
+                type="tool_use", name=name, id=tool_use_id,
+            ),
+        ))
+        # SDK streams tool inputs as input_json_delta chunks; we send the
+        # whole JSON as one chunk. The loop accumulates either way.
+        self._events.append(FakeEvent(
+            type="content_block_delta",
+            index=self._index,
+            delta=FakeDelta(type="input_json_delta", partial_json=_json.dumps(input)),
+        ))
+        self._events.append(FakeEvent(type="content_block_stop", index=self._index))
+        self._index += 1
+        self._content.append(FakeContentBlock(
+            type="tool_use", name=name, id=tool_use_id, input=input,
+        ))
+        return self
+
+    def end_turn(self) -> "FakeTurnBuilder":
+        self._close_open_block()
+        self._stop_reason = "end_turn"
+        self._events.append(FakeEvent(type="message_delta"))
+        self._events.append(FakeEvent(type="message_stop"))
+        return self
+
+    def stop_tool_use(self) -> "FakeTurnBuilder":
+        """Close with stop_reason='tool_use' so the loop dispatches the tool."""
+        self._close_open_block()
+        self._stop_reason = "tool_use"
+        self._events.append(FakeEvent(type="message_delta"))
+        self._events.append(FakeEvent(type="message_stop"))
+        return self
+
+    def max_tokens(self) -> "FakeTurnBuilder":
+        self._close_open_block()
+        self._stop_reason = "max_tokens"
+        self._events.append(FakeEvent(type="message_delta"))
+        self._events.append(FakeEvent(type="message_stop"))
+        return self
+
+    def usage(
+        self,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read: int = 0,
+        cache_creation: int = 0,
+    ) -> "FakeTurnBuilder":
+        self._usage = FakeUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        )
+        return self
+
+    def _close_open_block(self) -> None:
+        if self._block_open:
+            self._events.append(FakeEvent(type="content_block_stop", index=self._index))
+            self._index += 1
+            self._block_open = False
+
+    def build(self) -> tuple[list, "FakeFinalMessage"]:
+        if self._stop_reason is None:
+            raise RuntimeError(
+                "FakeTurnBuilder: call end_turn() / stop_tool_use() / max_tokens() before build()"
+            )
+        return self._events, FakeFinalMessage(
+            content=self._content,
+            stop_reason=self._stop_reason,
+            usage=self._usage,
+        )
+
+
+class FakeStream:
+    """Async context manager + iterator that mirrors the SDK's
+    MessageStreamManager. Works with both `async with` and `async for`,
+    plus `await stream.get_final_message()`."""
+
+    def __init__(
+        self,
+        events: list,
+        final: "FakeFinalMessage",
+        raise_on_enter: Optional[Exception] = None,
+        raise_mid_stream: Optional[Exception] = None,
+    ):
+        self._events = events
+        self._final = final
+        self._raise_on_enter = raise_on_enter
+        self._raise_mid_stream = raise_mid_stream
+        self._pos = 0
+
+    async def __aenter__(self):
+        if self._raise_on_enter is not None:
+            raise self._raise_on_enter
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        # Fire mid-stream errors halfway through the event list.
+        if self._raise_mid_stream is not None and self._pos == max(1, len(self._events) // 2):
+            raise self._raise_mid_stream
+        if self._pos >= len(self._events):
+            raise StopAsyncIteration
+        ev = self._events[self._pos]
+        self._pos += 1
+        return ev
+
+    async def get_final_message(self):
+        return self._final
+
+
+class FakeMessages:
+    """Mirror of `client.messages.*`. Phase 2 only uses `stream(**kwargs)`."""
+
+    def __init__(self, client: "FakeAnthropicClient"):
+        self._client = client
+
+    def stream(self, **kwargs):
+        # Record the kwargs so tests can assert what the loop sent
+        # (model, system layout, tools, messages, etc).
+        self._client.calls.append(kwargs)
+        return self._client._next_stream()
+
+
+class FakeAnthropicClient:
+    """Drop-in replacement for `anthropic.AsyncAnthropic` in tests.
+
+    Each test queues one FakeStream per expected turn. If the loop opens
+    more streams than queued, the fake raises a loud error — silent
+    fall-through to "default response" is the kind of bug we won't catch.
+    """
+
+    def __init__(self):
+        self.messages = FakeMessages(self)
+        self.calls: list[dict] = []
+        self._queued: list[FakeStream] = []
+
+    def queue_turn(self, built: tuple[list, "FakeFinalMessage"]) -> None:
+        events, final = built
+        self._queued.append(FakeStream(events=events, final=final))
+
+    def queue_error(self, exc: Exception, *, mid_stream: bool = False) -> None:
+        """Queue an error. By default the error fires when the stream is
+        opened (mimics a 429 at request time). Pass mid_stream=True to
+        fire halfway through event iteration (mimics a dropped connection)."""
+        if mid_stream:
+            events, final = (
+                FakeTurnBuilder()
+                .text("partial chunk").text(" before drop")
+                .end_turn()
+                .build()
+            )
+            self._queued.append(FakeStream(
+                events=events, final=final, raise_mid_stream=exc,
+            ))
+        else:
+            self._queued.append(FakeStream(
+                events=[],
+                final=FakeFinalMessage(),
+                raise_on_enter=exc,
+            ))
+
+    def _next_stream(self) -> FakeStream:
+        if not self._queued:
+            raise RuntimeError(
+                "FakeAnthropicClient: no queued turns. The loop opened "
+                "more streams than the test queued — likely a runaway "
+                "tool-use cycle. Inspect self.calls to see what was sent."
+            )
+        return self._queued.pop(0)
+
+
+# Cheap self-test at import — failures here surface as ImportError at
+# test collection, not as confusing failures inside a test body.
+def _self_test_fake_anthropic_client() -> None:
+    events, final = (
+        FakeTurnBuilder()
+        .text("Hola ").text("mundo")
+        .tool_use("get_positions", {}, tool_use_id="toolu_1")
+        .stop_tool_use()
+        .usage(input_tokens=10, output_tokens=5, cache_read=8)
+        .build()
+    )
+    # Stream order: text_start, 2x text_delta, text_stop, tool_use_start,
+    # input_json_delta, tool_use_stop, message_delta, message_stop.
+    type_seq = [e.type for e in events]
+    assert type_seq[0] == "content_block_start"
+    assert type_seq.count("content_block_delta") == 3  # 2 text + 1 tool input
+    assert type_seq[-1] == "message_stop"
+    assert final.stop_reason == "tool_use"
+    assert final.usage.cache_read_input_tokens == 8
+    assert len(final.content) == 2
+    assert final.content[0].type == "text"
+    assert final.content[1].type == "tool_use"
+
+
+_self_test_fake_anthropic_client()

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -209,6 +209,43 @@ async def test_run_turn_dispatches_multiple_tools_in_one_user_message(tmp_db, mo
 
 
 @pytest.mark.anyio
+async def test_run_turn_does_not_misdetect_error_on_legitimate_payload(tmp_db, monkeypatch):
+    """PR #404 review issue 2: a tool can legitimately return a payload
+    that mentions the substring "error" (e.g. an exit_reason value of
+    "liquidation_error" or a state name of "no_error_state"). The
+    previous `'"error"' in result_json` substring check produced a
+    false positive here, telling the model the call failed when it
+    didn't. Switched to JSON-parse + top-level "error" key check.
+    """
+    from api.agent.loop import run_turn, ToolUseResult
+    from api.agent.tools import handlers as h
+
+    monkeypatch.setitem(
+        h.TOOL_HANDLERS, "get_recent_signals",
+        lambda **kw: {"signals": [{"symbol": "BTC", "estado": "no_error_state"}]},
+    )
+
+    c = FakeAnthropicClient()
+    c.queue_turn(
+        FakeTurnBuilder()
+        .tool_use("get_recent_signals", {})
+        .stop_tool_use()
+        .build()
+    )
+    c.queue_turn(FakeTurnBuilder().text("ok").end_turn().build())
+
+    msgs = [{"role": "user", "content": "señales recientes"}]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+    results = [e for e in events if isinstance(e, ToolUseResult)]
+    # Substring match would have flagged this as an error; the JSON-parse
+    # check correctly recognizes it as a normal payload.
+    assert results == [ToolUseResult(tool="get_recent_signals", status="ok")]
+
+
+@pytest.mark.anyio
 async def test_run_turn_handles_hallucinated_position_id(tmp_db):
     """The model invents a position_id; the real handler returns
     not_found; the loop surfaces is_error:true on the tool_result so
@@ -617,6 +654,64 @@ def test_endpoint_audits_error_turns(authed_client):
     # content_json carries the reason enum value, JSON-encoded.
     assert json.loads(row["content_json"]) == "upstream"
     assert row["refused"] == 0  # upstream is not a refusal
+
+
+def test_endpoint_503_when_api_key_missing_via_direct_curl(authed_client, monkeypatch):
+    """PR #404 review issue 1 (BLOCKER): FastAPI resolves Depends() BEFORE
+    the handler body. Without the status guard inside get_anthropic_client,
+    a direct POST with ANTHROPIC_API_KEY missing would 500 with a
+    KeyError stack trace — re-leaking the env-var name that #381 closed.
+
+    This test reverts the dependency_overrides on get_anthropic_client so
+    the real resolver runs, then unsets the env var. Must 503 with the
+    closed-enum reason, NOT 500.
+    """
+    import btc_api
+    from api.agent.clients import get_anthropic_client
+    client, _fake = authed_client
+    # Revert the test fake so the real resolver runs.
+    btc_api.app.dependency_overrides.pop(get_anthropic_client, None)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    resp = client.post(
+        "/agent/conversations/bypass-test/turn",
+        json={"surface": "dock", "messages": [{"role": "user", "content": "x"}]},
+    )
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "agent_disabled"}
+    # And the body must not leak the env-var name on this path either.
+    for forbidden in ("ANTHROPIC_API_KEY", ".env", "restart"):
+        assert forbidden not in resp.text, (
+            f"/agent/conversations bypass-test leaked {forbidden!r}: {resp.text!r}"
+        )
+
+
+def test_endpoint_400_when_conversation_id_invalid(authed_client):
+    """PR #404 review issue 3: conversation_id must be alphanumeric +
+    _-, max 128 chars. Blocks pollution and minor DoS."""
+    client, fake = authed_client
+    # No queue — request should 422 on path validation before hitting the loop.
+    # Note: control characters (\n, \r, \0) are rejected by httpx URL
+    # validation before they reach the server, so we don't test them
+    # at the endpoint level — that's a separate layer of defense.
+    cases = [
+        "a" * 200,           # too long
+        "with/slash",        # path separator
+        "with space",        # whitespace (httpx encodes; FastAPI Path() rejects)
+        "",                  # empty
+    ]
+    for bad in cases:
+        resp = client.post(
+            f"/agent/conversations/{bad}/turn",
+            json={"surface": "dock", "messages": [{"role": "user", "content": "x"}]},
+        )
+        # FastAPI returns 422 on path validation failures; 404 if the path
+        # itself doesn't match the route (empty string case). Either is
+        # acceptable — what matters is we never reach the loop.
+        assert resp.status_code in (404, 422), (
+            f"conversation_id={bad!r} should be rejected, got {resp.status_code}"
+        )
+    assert fake.calls == []  # zero turns opened across all attempts
 
 
 def test_endpoint_audits_isolated_per_tenant(authed_client, monkeypatch):

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,0 +1,672 @@
+"""Phase 2 conversation core — agentic loop tests.
+
+Covers:
+
+  - Simple text response → run_turn yields TextDelta + MessageEnd.
+  - Tool use: the model emits a tool_use, the loop dispatches it,
+    appends the assistant message ONCE and the tool_result in ONE
+    user message (the wire-format invariant from pre-reg §6.1).
+  - Multi-tool: two tool_use blocks in one turn → both dispatched,
+    both results collected into ONE user message.
+  - Hallucination guard at the dispatch layer: position_ids and
+    symbols the model "invents" return not_found via the handler;
+    we verify the loop surfaces that as is_error:true on the
+    tool_result block.
+  - Cache verification: usage.cache_read_input_tokens is propagated
+    from the response into the MessageEnd.usage payload (the prompt
+    cache hit-rate target in spec §14 reads from this field).
+  - max_tool_hops: a model that loops indefinitely with tool_use
+    gets stopped after MAX_TOOL_HOPS and emits an error event.
+  - Conversation cap: messages longer than the cap → conversation_cap_reached.
+  - Graceful failures: upstream exception → error event with friendly
+    user_message, no 500 propagated.
+  - Cost computation: matches the published per-1M pricing.
+
+All tests use `FakeAnthropicClient` from tests/_fakes.py.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests._fakes import FakeAnthropicClient, FakeTurnBuilder
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+async def _collect(events_iter):
+    """Drain the async iterator into a list."""
+    out = []
+    async for ev in events_iter:
+        out.append(ev)
+    return out
+
+
+# ── Simple text turn ───────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_run_turn_simple_text(tmp_db):
+    from api.agent.loop import run_turn, TextDelta, MessageEnd
+    c = FakeAnthropicClient()
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("Tu portafolio está ")
+        .text("en NORMAL.")
+        .end_turn()
+        .usage(input_tokens=120, output_tokens=10)
+        .build()
+    )
+    msgs = [{"role": "user", "content": "¿cómo va el portafolio?"}]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+    text_chunks = [e.text for e in events if isinstance(e, TextDelta)]
+    ends = [e for e in events if isinstance(e, MessageEnd)]
+    assert "".join(text_chunks) == "Tu portafolio está en NORMAL."
+    assert len(ends) == 1
+    assert ends[0].stop_reason == "end_turn"
+    assert ends[0].usage["input_tokens"] == 120
+
+
+# ── Tool dispatch (single tool) — wire-format invariant ────────────────
+
+
+@pytest.mark.anyio
+async def test_run_turn_dispatches_single_tool(tmp_db, monkeypatch):
+    """The model emits propose tool_use → loop dispatches → appends
+    assistant message ONCE → appends tool_result in ONE user message
+    → second model turn returns text → MessageEnd."""
+    from api.agent.loop import run_turn, TextDelta, ToolUseStart, ToolUseResult, MessageEnd
+    from api.agent.tools import handlers as h
+
+    captured: dict = {}
+
+    def _stub_get_positions(*, tenant_id):
+        captured["tenant_id"] = tenant_id
+        return {"positions": [{"id": 1, "symbol": "BTC"}]}
+
+    monkeypatch.setitem(h.TOOL_HANDLERS, "get_positions", _stub_get_positions)
+
+    c = FakeAnthropicClient()
+    # Turn 1: text + tool_use(get_positions) + stop_reason=tool_use
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("Déjame consultar... ")
+        .tool_use("get_positions", {}, tool_use_id="toolu_abc")
+        .stop_tool_use()
+        .build()
+    )
+    # Turn 2 (after tool dispatch): final text + end_turn
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("Tienes 1 posición abierta de BTC.")
+        .end_turn()
+        .build()
+    )
+
+    msgs = [{"role": "user", "content": "qué posiciones tengo"}]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=42,
+    ))
+
+    # The handler was called with the JWT tenant_id, not whatever the
+    # model might have sent (it can't — tenant_id isn't a tool input).
+    assert captured["tenant_id"] == 42
+
+    # Loop emitted: tool_use_start + tool_use_result + final text + end.
+    starts = [e for e in events if isinstance(e, ToolUseStart)]
+    results = [e for e in events if isinstance(e, ToolUseResult)]
+    ends = [e for e in events if isinstance(e, MessageEnd)]
+    assert [s.tool for s in starts] == ["get_positions"]
+    assert [r.status for r in results] == ["ok"]
+    assert len(ends) == 1
+
+    # Wire-format invariant (pre-reg §6.1):
+    #   - exactly ONE assistant message appended,
+    #   - exactly ONE user message with tool_results follows.
+    # The third entry onwards depends on the loop's second turn output;
+    # we check the first three slots.
+    assert msgs[0]["role"] == "user"
+    assert msgs[1]["role"] == "assistant"
+    assistant_content = msgs[1]["content"]
+    assert isinstance(assistant_content, list)
+    assert any(b["type"] == "tool_use" for b in assistant_content)
+    assert msgs[2]["role"] == "user"
+    user_content = msgs[2]["content"]
+    assert isinstance(user_content, list)
+    assert all(b["type"] == "tool_result" for b in user_content)
+    assert len(user_content) == 1
+
+
+# ── Multi-tool dispatch ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_run_turn_dispatches_multiple_tools_in_one_user_message(tmp_db, monkeypatch):
+    """Two tool_use blocks in one model turn → both dispatched → BOTH
+    tool_results in ONE user message (NOT split — the API rejects split
+    tool_results)."""
+    from api.agent.loop import run_turn
+    from api.agent.tools import handlers as h
+
+    def _stub_portfolio(*, tenant_id):
+        return {"open_positions_count": 2}
+
+    def _stub_positions(*, tenant_id):
+        return {"positions": []}
+
+    monkeypatch.setitem(h.TOOL_HANDLERS, "get_portfolio_overview", _stub_portfolio)
+    monkeypatch.setitem(h.TOOL_HANDLERS, "get_positions", _stub_positions)
+
+    c = FakeAnthropicClient()
+    c.queue_turn(
+        FakeTurnBuilder()
+        .tool_use("get_portfolio_overview", {}, tool_use_id="toolu_1")
+        .tool_use("get_positions", {}, tool_use_id="toolu_2")
+        .stop_tool_use()
+        .build()
+    )
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("Tienes 2 posiciones, 0 abiertas.")
+        .end_turn()
+        .build()
+    )
+
+    msgs = [{"role": "user", "content": "estado completo"}]
+    await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+
+    # After the loop runs: msgs[0]=user, msgs[1]=assistant (with TWO
+    # tool_use blocks), msgs[2]=user (with TWO tool_result blocks
+    # bundled together), msgs[3]=assistant (final text).
+    assistant_content = msgs[1]["content"]
+    tool_uses = [b for b in assistant_content if b["type"] == "tool_use"]
+    assert len(tool_uses) == 2
+
+    user_content = msgs[2]["content"]
+    tool_results = [b for b in user_content if b["type"] == "tool_result"]
+    assert len(tool_results) == 2
+    assert {tr["tool_use_id"] for tr in tool_results} == {"toolu_1", "toolu_2"}
+
+
+# ── Hallucinated position_id (defense-in-depth at dispatch) ────────────
+
+
+@pytest.mark.anyio
+async def test_run_turn_handles_hallucinated_position_id(tmp_db):
+    """The model invents a position_id; the real handler returns
+    not_found; the loop surfaces is_error:true on the tool_result so
+    the model self-corrects on the next turn."""
+    from api.agent.loop import run_turn, ToolUseResult
+
+    c = FakeAnthropicClient()
+    c.queue_turn(
+        FakeTurnBuilder()
+        .tool_use("get_position_detail", {"position_id": 9999})
+        .stop_tool_use()
+        .build()
+    )
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("Esa posición no existe.")
+        .end_turn()
+        .build()
+    )
+
+    msgs = [{"role": "user", "content": "detalles posición 9999"}]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+
+    results = [e for e in events if isinstance(e, ToolUseResult)]
+    assert results[0].status == "error"  # not_found → status=error
+
+    # And the tool_result block carries is_error:true so the model knows.
+    user_content = msgs[2]["content"]
+    assert user_content[0]["is_error"] is True
+    parsed = json.loads(user_content[0]["content"])
+    assert parsed == {"error": "not_found"}
+
+
+# ── Cache verification ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_run_turn_propagates_cache_read_tokens(tmp_db):
+    """The MessageEnd event carries cache_read_input_tokens from the
+    SDK's usage — this is the field the spec §14 cache-hit-rate target
+    reads from."""
+    from api.agent.loop import run_turn, MessageEnd
+
+    c = FakeAnthropicClient()
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("hola")
+        .end_turn()
+        .usage(input_tokens=10, output_tokens=2, cache_read=850, cache_creation=0)
+        .build()
+    )
+    msgs = [{"role": "user", "content": "hi"}]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+    end = next(e for e in events if isinstance(e, MessageEnd))
+    assert end.usage["cache_read_input_tokens"] == 850
+    assert end.usage["cache_creation_input_tokens"] == 0
+    # Cost: 10 in × $3/1M + 850 cache_read × $3/1M × 0.1 + 2 out × $15/1M
+    #     = 30e-6 + 255e-6 + 30e-6 = 315e-6
+    assert end.cost_usd == pytest.approx(0.000315, abs=1e-7)
+
+
+# ── Max tool hops ──────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_run_turn_max_tool_hops_emits_error(tmp_db, monkeypatch):
+    """If the model keeps emitting tool_use indefinitely, the loop stops
+    after MAX_TOOL_HOPS and yields an error event."""
+    from api.agent.loop import run_turn, ErrorEvent, MAX_TOOL_HOPS
+    from api.agent.tools import handlers as h
+
+    monkeypatch.setitem(h.TOOL_HANDLERS, "get_positions", lambda **kw: {"positions": []})
+
+    c = FakeAnthropicClient()
+    # Queue MAX_TOOL_HOPS + 1 turns all emitting tool_use.
+    for _ in range(MAX_TOOL_HOPS + 1):
+        c.queue_turn(
+            FakeTurnBuilder()
+            .tool_use("get_positions", {}, tool_use_id=f"toolu_{_}")
+            .stop_tool_use()
+            .build()
+        )
+
+    msgs = [{"role": "user", "content": "loop forever"}]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+
+    errors = [e for e in events if isinstance(e, ErrorEvent)]
+    assert errors and errors[-1].reason == "too_many_tool_hops"
+
+
+# ── Conversation cap ───────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_run_turn_conversation_cap_short_circuits(tmp_db):
+    """messages > MAX_TURNS_PER_CONVERSATION → conversation_cap_reached
+    error event immediately, without opening a stream."""
+    from api.agent.loop import run_turn, ErrorEvent, MAX_TURNS_PER_CONVERSATION
+
+    c = FakeAnthropicClient()  # no turns queued — proves we don't open one
+
+    msgs = [
+        {"role": "user", "content": f"msg {i}"}
+        for i in range(MAX_TURNS_PER_CONVERSATION + 1)
+    ]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+
+    errors = [e for e in events if isinstance(e, ErrorEvent)]
+    assert len(errors) == 1
+    assert errors[0].reason == "conversation_cap_reached"
+    # No stream was opened — proven by the fake having zero calls.
+    assert c.calls == []
+
+
+# ── Graceful upstream failures ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_run_turn_upstream_429_emits_error_no_raise(tmp_db):
+    """A 429 from Anthropic → error event with friendly user_message.
+    NO uncaught exception propagated to the HTTP layer."""
+    from api.agent.loop import run_turn, ErrorEvent
+
+    c = FakeAnthropicClient()
+    c.queue_error(RuntimeError("rate-limited 429"))
+
+    msgs = [{"role": "user", "content": "hola"}]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+
+    errors = [e for e in events if isinstance(e, ErrorEvent)]
+    assert errors and errors[0].reason == "upstream"
+    # And the user-facing text is the friendly one (no env-var leak,
+    # no stack trace).
+    assert "saturado" in errors[0].user_message.lower() or \
+           "intenta" in errors[0].user_message.lower()
+
+
+# ── Cost model ─────────────────────────────────────────────────────────
+
+
+def test_cost_estimation_matches_published_pricing():
+    """The cost formula uses the published per-1M USD pricing for
+    Sonnet 4.6 / Haiku 4.5 / Opus 4.7. If the cached pricing in
+    api/agent/loop.py drifts vs Anthropic's published rates, this
+    test catches it."""
+    from api.agent.loop import _estimate_cost_usd
+    # Sonnet 4.6: $3/1M input, $15/1M output. 1M input + 1M output = $18.
+    cost = _estimate_cost_usd(
+        "claude-sonnet-4-6",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    assert cost == pytest.approx(18.0)
+    # Haiku 4.5: $1/1M input, $5/1M output.
+    cost = _estimate_cost_usd(
+        "claude-haiku-4-5",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    assert cost == pytest.approx(6.0)
+    # Opus 4.7: $5/1M input, $25/1M output.
+    cost = _estimate_cost_usd(
+        "claude-opus-4-7",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    assert cost == pytest.approx(30.0)
+
+
+# ── System prompt blocks are cache-control'd ───────────────────────────
+
+
+def test_system_blocks_carry_cache_control():
+    """All four blocks must have cache_control: {type: ephemeral} so the
+    Anthropic API serves them from cache. Pre-reg §7.5 silent invariant."""
+    from api.agent.prompts import build_system_blocks
+    blocks = build_system_blocks("dock")
+    assert len(blocks) == 4
+    for b in blocks:
+        assert b["type"] == "text"
+        assert b["cache_control"] == {"type": "ephemeral"}
+
+
+def test_system_blocks_are_deterministic_across_calls():
+    """Same surface → byte-identical output across calls. If this fails,
+    the cache prefix shifts on every turn and the spec §14 cache-hit-rate
+    target ≥70% is unreachable."""
+    from api.agent.prompts import build_system_blocks
+    a = build_system_blocks("dock")
+    b = build_system_blocks("dock")
+    assert a == b
+    # And: dock vs symbol_detail differ only on block 4.
+    c = build_system_blocks("symbol_detail")
+    assert a[0] == c[0]  # persona
+    assert a[2] == c[2]  # invariants
+    assert a[3] != c[3]  # surface micro-prompt differs
+
+
+# ── anyio fixture (project does not have a project-wide config) ────────
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── E2E: POST /agent/conversations/{id}/turn via TestClient ────────────
+
+
+@pytest.fixture
+def authed_client(tmp_path, monkeypatch):
+    """TestClient with the agent dependencies overridden: tenant_id=1,
+    api-key-check bypassed, and the Anthropic client swapped for a
+    FakeAnthropicClient that the test mutates."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from auth.dependencies import get_current_tenant_id
+    from api.agent.clients import get_anthropic_client
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
+
+    fake_client = FakeAnthropicClient()
+    btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 1
+    btc_api.app.dependency_overrides[get_anthropic_client] = lambda: fake_client
+    try:
+        yield TestClient(btc_api.app), fake_client
+    finally:
+        btc_api.app.dependency_overrides.pop(get_current_tenant_id, None)
+        btc_api.app.dependency_overrides.pop(get_anthropic_client, None)
+
+
+def test_endpoint_streams_text_deltas_as_sse_frames(authed_client):
+    client, fake = authed_client
+    fake.queue_turn(
+        FakeTurnBuilder()
+        .text("Hola ").text("mundo")
+        .end_turn()
+        .usage(input_tokens=10, output_tokens=2)
+        .build()
+    )
+    resp = client.post(
+        "/agent/conversations/test-conv-1/turn",
+        json={
+            "surface":  "dock",
+            "messages": [{"role": "user", "content": "saluda"}],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert resp.headers.get("x-accel-buffering") == "no"
+
+    body = resp.text
+    # Parse the SSE frames — each starts with `data: ` and ends with `\n\n`.
+    frames = [
+        line[len("data: "):]
+        for line in body.split("\n\n")
+        if line.startswith("data: ")
+    ]
+    parsed = [json.loads(f) for f in frames]
+    types = [p["type"] for p in parsed]
+
+    assert "text_delta" in types
+    assert types[-1] == "message_end"
+    text_deltas = [p["text"] for p in parsed if p["type"] == "text_delta"]
+    assert "".join(text_deltas) == "Hola mundo"
+    end = next(p for p in parsed if p["type"] == "message_end")
+    assert end["stop_reason"] == "end_turn"
+    assert end["usage"]["input_tokens"] == 10
+
+
+def test_endpoint_503_when_status_disabled(authed_client, monkeypatch):
+    """If get_agent_status reports disabled (operator flipped the flag),
+    the endpoint must 503 without invoking the model — even though the
+    fake client is wired up."""
+    client, fake = authed_client
+    import api.agent.config as agent_cfg
+    monkeypatch.setattr(
+        agent_cfg, "load_config",
+        lambda: {"agent": {"enabled": False}},
+    )
+    resp = client.post(
+        "/agent/conversations/test-conv-2/turn",
+        json={
+            "surface":  "dock",
+            "messages": [{"role": "user", "content": "hola"}],
+        },
+    )
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "agent_disabled"}
+    # And the fake was never invoked — proves we short-circuited cleanly.
+    assert fake.calls == []
+
+
+def test_endpoint_400_when_model_not_allowed(authed_client):
+    client, _fake = authed_client
+    resp = client.post(
+        "/agent/conversations/test-conv-3/turn",
+        json={
+            "surface":  "dock",
+            "messages": [{"role": "user", "content": "hola"}],
+            "model":    "gpt-4",   # not in the allowlist
+        },
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "model_not_allowed"}
+
+
+# ── Audit writes — per-turn row in agent_conversations ─────────────────
+
+
+def test_endpoint_audits_each_completed_turn(authed_client):
+    """Every MessageEnd produces a row in agent_conversations with the
+    turn's usage + cost + tenant_id + surface + conversation_id."""
+    import btc_api
+    client, fake = authed_client
+
+    fake.queue_turn(
+        FakeTurnBuilder()
+        .text("Tu portafolio está en NORMAL.")
+        .end_turn()
+        .usage(input_tokens=150, output_tokens=12, cache_read=120)
+        .build()
+    )
+    resp = client.post(
+        "/agent/conversations/test-conv-audit-1/turn",
+        json={
+            "surface":  "kill_switch",
+            "messages": [{"role": "user", "content": "estado"}],
+        },
+    )
+    assert resp.status_code == 200
+    # Consume the body so the StreamingResponse closes and the audit
+    # wrapper runs the persistence step.
+    _ = resp.text
+
+    con = btc_api.get_db()
+    try:
+        rows = con.execute(
+            "SELECT tenant_id, surface, conversation_id, role, model, "
+            "input_tokens, output_tokens, cache_read_input_tokens, "
+            "cost_usd, refused "
+            "FROM agent_conversations WHERE conversation_id = ?",
+            ("test-conv-audit-1",),
+        ).fetchall()
+    finally:
+        con.close()
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["tenant_id"] == 1
+    assert row["surface"] == "kill_switch"
+    assert row["role"] == "assistant"
+    assert row["model"] == "claude-sonnet-4-6"
+    assert row["input_tokens"] == 150
+    assert row["output_tokens"] == 12
+    assert row["cache_read_input_tokens"] == 120
+    assert row["cost_usd"] is not None and row["cost_usd"] > 0
+    assert row["refused"] == 0
+
+
+def test_endpoint_audits_error_turns(authed_client):
+    """Error events also produce an audit row (role='error', the reason
+    is the content_summary). Lets us track error rate post-rollout."""
+    import btc_api
+    client, fake = authed_client
+
+    fake.queue_error(RuntimeError("simulated 429"))
+    resp = client.post(
+        "/agent/conversations/test-conv-audit-err/turn",
+        json={
+            "surface":  "dock",
+            "messages": [{"role": "user", "content": "hola"}],
+        },
+    )
+    assert resp.status_code == 200
+    _ = resp.text
+
+    con = btc_api.get_db()
+    try:
+        rows = con.execute(
+            "SELECT role, content_json, refused FROM agent_conversations "
+            "WHERE conversation_id = ?",
+            ("test-conv-audit-err",),
+        ).fetchall()
+    finally:
+        con.close()
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["role"] == "error"
+    # content_json carries the reason enum value, JSON-encoded.
+    assert json.loads(row["content_json"]) == "upstream"
+    assert row["refused"] == 0  # upstream is not a refusal
+
+
+def test_endpoint_audits_isolated_per_tenant(authed_client, monkeypatch):
+    """Two turns from two tenants → two rows, each scoped to its tenant.
+    Multi-tenant invariant for the audit row itself (pre-reg §8)."""
+    import btc_api
+    from auth.dependencies import get_current_tenant_id
+
+    # First turn as tenant=1
+    client, fake = authed_client
+    fake.queue_turn(
+        FakeTurnBuilder().text("turn-1").end_turn().usage(input_tokens=10).build()
+    )
+    resp = client.post(
+        "/agent/conversations/iso-conv/turn",
+        json={
+            "surface":  "dock",
+            "messages": [{"role": "user", "content": "msg-1"}],
+        },
+    )
+    assert resp.status_code == 200
+    _ = resp.text
+
+    # Swap the override to tenant=2 for the second turn.
+    btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 2
+    fake.queue_turn(
+        FakeTurnBuilder().text("turn-2").end_turn().usage(input_tokens=20).build()
+    )
+    resp = client.post(
+        "/agent/conversations/iso-conv-tenant2/turn",
+        json={
+            "surface":  "dock",
+            "messages": [{"role": "user", "content": "msg-2"}],
+        },
+    )
+    assert resp.status_code == 200
+    _ = resp.text
+
+    con = btc_api.get_db()
+    try:
+        rows = con.execute(
+            "SELECT tenant_id, conversation_id, input_tokens "
+            "FROM agent_conversations ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        con.close()
+    assert len(rows) == 2
+    assert dict(rows[0])["tenant_id"] == 1
+    assert dict(rows[0])["conversation_id"] == "iso-conv"
+    assert dict(rows[0])["input_tokens"] == 10
+    assert dict(rows[1])["tenant_id"] == 2
+    assert dict(rows[1])["conversation_id"] == "iso-conv-tenant2"
+    assert dict(rows[1])["input_tokens"] == 20

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -329,6 +329,27 @@ def test_tenant_id_is_not_an_input_field_on_any_schema():
         )
 
 
+# ── 5b. Error-shape consistency across handlers (PR #403 review issue 1)
+
+
+def test_get_portfolio_overview_surfaces_error_when_dashboard_fails(tmp_db, monkeypatch):
+    """When get_dashboard_state raises, the handler must return a
+    closed-shape error (consistent with get_kill_switch_state), NOT a
+    partial result with null equity. Returning nulls would be ambiguous
+    to the model — could read as "user has zero equity" vs. "we couldn't
+    read it"."""
+    from api.agent.tools import handlers as h
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated dashboard failure")
+
+    # Patch the local reference inside the handler module.
+    import health
+    monkeypatch.setattr(health, "get_dashboard_state", _boom)
+    out = h.get_portfolio_overview(tenant_id=1)
+    assert out == {"error": "dashboard_unavailable"}
+
+
 # ── 6. Registry consistency + per-surface subsets ───────────────────────
 
 


### PR DESCRIPTION
## Summary
Phase 2A del epic [#400](https://github.com/sssimon/trading-spacial/issues/400). Backend del SSE streaming + server-side agentic loop + 4 bloques cacheables del system prompt + audit per-turn. **Frontend sigue consumiendo \`/agent/chat\` viejo**; Phase 2B rewirea el AgentDock una vez este backend bake. Per recomendación del reviewer (PR #403), **FakeAnthropicClient se construyó PRIMERO** para congelar el contrato del SSE antes de que el loop lo dependa.

Incluye los 2 pickups del review de Phase 1 (issues 2 + 3): dedup de \`get_symbols_with_signals\` en SQL via \`MAX(id) GROUP BY symbol\`, y \`db_get_positions(since=)\` para empujar el window de historial a SQL.

## Estructura del PR

| Commit | Qué hace |
|---|---|
| \`4b23bcd\` | Pickups 1+3 de Phase 0 review (heredado de Phase 1 branch). |
| \`3c41355\` | Pickups 1+4+5 de Phase 1 review (consistency fixes pre-Phase 2). |
| \`(este commit)\` | Trabajo principal de Phase 2A. |

## Lo que entrega

### Backend nuevo

- **\`api/agent/clients.py\`** — Depends seam para inyectar el cliente Anthropic. Tests overridan con \`FakeAnthropicClient\`.
- **\`api/agent/prompts/{system,surfaces}.py\`** — System prompt en 4 bloques cacheables (persona+safety, tool docs, invariantes, micro-prompt por surface). Cada uno con \`cache_control: {type: \"ephemeral\"}\`. **Venezolano neutro, NO voseo**.
- **\`api/agent/loop.py\`** — Agentic loop while-based per pre-reg §6.1 corregido. \`MAX_TOOL_HOPS=4\`, \`MAX_TURNS_PER_CONVERSATION=30\` (compaction beta descartada per pre-reg §6.3). Cost model con per-1M pricing de Sonnet 4.6 / Haiku 4.5 / Opus 4.7.
- **\`api/agent/streaming.py\`** — SSE serializer con closed-enum frame types.
- **\`api/agent/audit.py\`** — \`TurnAuditWrapper\` persiste cada MessageEnd / ErrorEvent en \`agent_conversations\`. Fail-tolerant: audit miss nunca tumba el StreamingResponse.
- **\`POST /agent/conversations/{conversation_id}/turn\`** — endpoint nuevo. JWT auth via \`Depends(get_current_tenant_id)\`. Per-surface model defaults con allowlist. \`X-Accel-Buffering: no\` header.

### Pickups del review de Phase 1

- **\`db/signals.py + get_latest_scan_per_symbol\`** — SQL-side dedup. Agent tool ahora retorna \`limit\` distintos símbolos, no \`limit\` raw scans.
- **\`db/positions.py + since=\`** — window pushed to SQL en lieu de filter en Python.

### Tests (17 cases nuevos en \`tests/test_agent_loop.py\`)

- Simple text turn → text_deltas + MessageEnd.
- Single tool dispatch con wire-format invariant verificado (1 assistant msg, 1 user msg bundling tool_results).
- Multi-tool dispatch: 2 tool_use → 2 tool_results en UN solo user message.
- Hallucinated \`position_id\` → \`is_error:true\` on tool_result.
- Cache verification: \`cache_read_input_tokens\` propaga desde response.usage.
- \`MAX_TOOL_HOPS\` boundary → error event.
- Conversation cap > 30 → \`conversation_cap_reached\` sin abrir stream.
- Upstream 429 → ErrorEvent friendly, no raise.
- Cost model matches published pricing para los 3 modelos.
- System prompt: 4 blocks, todos cache_control'd, byte-identical across calls.
- E2E endpoint: SSE frames, X-Accel-Buffering header, 503 cuando disabled, 400 cuando model not allowed.
- Audit writes per turn (assistant + error rows). Multi-tenant isolation del audit row mismo.

**Sweep total:** 236/236 verde (test_agent_*, test_api, test_health_dashboard, test_multi_tenant_*).

## Lo que NO hace este PR (lands después)

| Fuera de scope | Lands en |
|---|---|
| Frontend rewire: \`agent/client.ts\`, \`useAgentStream\`, \`AgentDock\` sin \`<<<TOOL:...>>>\` markers | **Phase 2B** |
| Propose/confirm con AGENT_PROPOSAL_SECRET HMAC | **Phase 3** |
| Quota enforcement (writer + computed-on-read reset) | **Phase 5** |
| GET /agent/metrics admin endpoint | **Phase 5** |

## Test plan
- [x] \`pytest tests/test_agent_*.py\` — 46/46 verde.
- [x] Wide sweep \`pytest test_api test_health_dashboard test_multi_tenant_*\` — 236/236 verde.
- [ ] Smoke en \`trading.sdar.dev\` con curl (cuando se deploy):
      \`curl -N -X POST https://trading.sdar.dev/api/agent/conversations/smoke-1/turn -H \"Cookie: ...\" -H \"Content-Type: application/json\" -d '{\"surface\": \"dock\", \"messages\": [{\"role\": \"user\", \"content\": \"hola\"}]}'\`
      → ver text/event-stream frames.
- [ ] Validar cache_read_input_tokens > 0 en el segundo turn de la misma conversación (target ≥70% post-warmup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)