### PR TITLE
feat(agent): Phase 2B — frontend SSE rewire + AgentDock to useAgentStream (#400)

### DIFF
--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -101,8 +101,13 @@ def _build_anthropic_tools(surface: str) -> tuple[dict, ...]:
     requires a process restart). maxsize=8 comfortably covers the 5
     declared surfaces + headroom (PR #404 review pickup).
 
-    Returns a tuple (not a list) so the cache value is immutable — a
-    caller that mutates the returned schema would corrupt the cache.
+    Returns a tuple wrapper so callers can't reassign list elements.
+    NOTE: the inner dicts remain mutable; callers MUST treat the return
+    value as read-only — mutating any nested schema (e.g.
+    `tools[0]["input_schema"]["properties"]["foo"] = ...`) corrupts the
+    cache for every subsequent request. We don't deepcopy on every call
+    because that would defeat the cache; the discipline lives at the
+    call sites (PR #405 review issue 3).
     """
     specs = tools_for_surface(surface)
     out = []

--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, AsyncIterator, Optional
 
 from api.agent.prompts import build_system_blocks
@@ -90,9 +91,19 @@ LoopEvent = TextDelta | ToolUseStart | ToolUseResult | MessageEnd | ErrorEvent
 # ── Tool schema builder (registry → Anthropic tools array) ──────────────
 
 
-def _build_anthropic_tools(surface: str) -> list[dict]:
+@lru_cache(maxsize=8)
+def _build_anthropic_tools(surface: str) -> tuple[dict, ...]:
     """Convert the per-surface tool subset into the JSON Schema shape the
-    Messages API expects."""
+    Messages API expects.
+
+    Cached on `surface` because Pydantic's model_json_schema() is not
+    free and the tool catalog is immutable at runtime (any catalog edit
+    requires a process restart). maxsize=8 comfortably covers the 5
+    declared surfaces + headroom (PR #404 review pickup).
+
+    Returns a tuple (not a list) so the cache value is immutable — a
+    caller that mutates the returned schema would corrupt the cache.
+    """
     specs = tools_for_surface(surface)
     out = []
     for spec in specs:
@@ -108,7 +119,7 @@ def _build_anthropic_tools(surface: str) -> list[dict]:
             "description": spec.description,
             "input_schema": schema,
         })
-    return out
+    return tuple(out)
 
 
 def _strip_titles(node: Any) -> None:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -52,4 +52,28 @@ server {
         proxy_read_timeout 30s;
         proxy_connect_timeout 5s;
     }
+
+    # SSE streaming surface for the copilot turn endpoint (#400 Phase 2).
+    # Distinct location with proxy buffering disabled so SSE frames reach
+    # the browser as the backend emits them, not in nginx-sized chunks.
+    # The backend also sets X-Accel-Buffering: no defensively, but pinning
+    # it here too means a misconfigured upstream can't break SSE silently.
+    #
+    # proxy_read_timeout bumped to 300s — a long agent turn (multi-tool
+    # dispatch + deep thinking) can legitimately keep the stream open
+    # several minutes; the 30s default would 504 mid-turn.
+    location /api/agent/conversations/ {
+        proxy_pass         http://host.docker.internal:8000/agent/conversations/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_buffering    off;
+        proxy_cache        off;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_connect_timeout 5s;
+        chunked_transfer_encoding off;
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,14 +29,12 @@ import {
   getSignals,
   forceScan,
   getTuneLatest,
-  applyTune,
   rejectTune,
   getPositions,
   getCapital,
   closePosition,
   updatePosition,
   getHealthDashboard,
-  releaseKillSwitch,
 } from './api';
 import type {
   SymbolStatus,
@@ -480,16 +478,11 @@ const App: React.FC = () => {
     setDockOpen(true);
   }, []);
 
-  // Confirm path — only fired by the dock when the agent emitted the
-  // confirm_release tool marker AND the user clicked the amber button.
-  const handleConfirmRelease = useCallback(async (symbol: string) => {
-    try {
-      await releaseKillSwitch(symbol, 'manual_override_via_copilot');
-      await fetchAll();
-    } catch (err) {
-      window.alert(`No se pudo liberar ${symbol}: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }, [fetchAll]);
+  // handleConfirmRelease / handleConfirmApplyTune used to live here as
+  // post-marker callbacks fired by the legacy AgentDock <<<TOOL:...>>>
+  // parsing. Phase 2B kills the marker protocol; Phase 3 reintroduces
+  // these flows as signed proposal events through
+  // POST /agent/proposals/{id}/confirm.
 
   const handleAskAgent = useCallback((p: Position, insight: PositionInsight) => {
     const liveSym = symbols.find((s) => s.symbol === p.symbol);
@@ -534,28 +527,20 @@ const App: React.FC = () => {
     catch (err) { window.alert(`No se pudo rechazar el tune: ${err instanceof Error ? err.message : String(err)}`); }
   }, [fetchAll]);
 
-  // Apply is the friction-by-design path. Opens the dock with a
-  // confrontational prompt instead of calling the backend directly —
-  // the backend call happens later, only after the agent emits
-  // <<<TOOL:confirm_apply_tune:N>>> and the user clicks the amber button.
+  // Negotiate is the friction-by-design path. Opens the dock with a
+  // confrontational prompt — the model now drives the conversation
+  // toward articulation via the system prompt (api/agent/prompts/system.py)
+  // instead of waiting for a hardcoded marker.
   const handleTuneNegotiate = useCallback((tune: TuneRun) => {
     const changeCount = tune.results.filter((r) => r.recommendation === 'CHANGE').length;
     setDockInitialPrompt(
       `Estoy por aplicar el auto-tune #${tune.id} (corrido hace ${tune.hoursAgo}h). ` +
       `Propone ${changeCount} cambios sobre los multiplicadores ATR (SL/TP/BE) de la estrategia en vivo. ` +
       `Antes de confirmar, ayúdame a articular: ¿qué riesgos ves? ¿Hay algún símbolo donde la ` +
-      `mejora se vea frágil? Hazme preguntas concretas, no me dejes aplicar sin justificación. ` +
-      `Cuando estés convencido, emití <<<TOOL:confirm_apply_tune:${tune.id}>>>.`,
+      `mejora se vea frágil? Hazme preguntas concretas, no me dejes aplicar sin justificación.`,
     );
     setDockOpen(true);
   }, []);
-
-  // Final confirm — triggered by the inline button the dock renders when
-  // the agent emits the confirm_apply_tune marker.
-  const handleConfirmApplyTune = useCallback(async (_tuneId: number) => {
-    try { await applyTune(); await fetchAll(); }
-    catch (err) { window.alert(`No se pudo aplicar el tune: ${err instanceof Error ? err.message : String(err)}`); }
-  }, [fetchAll]);
 
   const handleLogout = async () => {
     try { await logout(); } catch (err) { console.warn('[app] logout error:', err); }
@@ -782,8 +767,10 @@ const App: React.FC = () => {
           macro={macroState}
           initialPrompt={dockInitialPrompt}
           onOpenSymbol={openSymbolByPair}
-          onConfirmRelease={handleConfirmRelease}
-          onConfirmApplyTune={handleConfirmApplyTune}
+          // onConfirmRelease / onConfirmApplyTune handlers stay alive on
+          // the App.tsx side (KillSwitchView + AutoTuneView still call
+          // them directly). The Dock no longer parses <<<TOOL:...>>>
+          // markers — Phase 3 re-wires those into signed proposal events.
         />
       )}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -461,19 +461,24 @@ const App: React.FC = () => {
   }, []);
 
   // Override negotiation — opens the dock with a confrontational prompt
-  // INSTEAD of releasing directly. The release only fires once the agent
-  // emits <<<TOOL:confirm_release:SYM>>> and the user clicks the amber
-  // button.
+  // so the user has to articulate WHY before releasing. Phase 2B note:
+  // this chat is articulation-only — there is no confirm-release button
+  // available from the Dock right now. Phase 3 of #400 will reintroduce
+  // it as a signed proposal event. Until then, use `scripts/release_pause.py`
+  // from a terminal once the conversation has clarified intent.
   const handleNegotiateRelease = useCallback((sym: DashboardSymbolState, verdict: CardVerdict | null) => {
     const base   = sym.symbol.replace('USDT', '');
     const sinceMs = sym.state_since ? Date.now() - new Date(sym.state_since).getTime() : 0;
     const sinceH  = Math.max(0, Math.round(sinceMs / 3600000));
     setDockInitialPrompt(
-      `Estoy por liberar ${base} (${sym.symbol}) manualmente antes del ciclo automático. ` +
+      `Estoy considerando liberar ${base} (${sym.symbol}) manualmente antes del ciclo automático. ` +
       `El sistema lo tiene en ${sym.state} desde hace ~${sinceH}h. ` +
       `Tu lectura inicial fue: "${verdict?.text ?? 'sin lectura previa'}". ` +
-      `Antes de confirmar, ayúdame a articular: ¿qué cambió en mi tesis del par para querer adelantarme al sistema? ` +
-      `Hazme preguntas concretas; no me dejes liberar sin justificación.`,
+      `Ayúdame a articular: ¿qué cambió en mi tesis del par para querer adelantarme al sistema? ` +
+      `Hazme preguntas concretas. ` +
+      `Nota: este chat es solo para pensar en voz alta. El botón de confirmar se ` +
+      `reintroduce en Phase 3 del rewire del copiloto; por ahora la acción la sigo ` +
+      `disparando yo desde un terminal.`,
     );
     setDockOpen(true);
   }, []);
@@ -527,17 +532,20 @@ const App: React.FC = () => {
     catch (err) { window.alert(`No se pudo rechazar el tune: ${err instanceof Error ? err.message : String(err)}`); }
   }, [fetchAll]);
 
-  // Negotiate is the friction-by-design path. Opens the dock with a
-  // confrontational prompt — the model now drives the conversation
-  // toward articulation via the system prompt (api/agent/prompts/system.py)
-  // instead of waiting for a hardcoded marker.
+  // Tune negotiation — same friction-by-design pattern. Phase 2B note:
+  // articulation-only until Phase 3 wires the confirm step as a signed
+  // proposal event. Operator runs `scripts/apply_tune.py` from a
+  // terminal after the chat has clarified intent.
   const handleTuneNegotiate = useCallback((tune: TuneRun) => {
     const changeCount = tune.results.filter((r) => r.recommendation === 'CHANGE').length;
     setDockInitialPrompt(
-      `Estoy por aplicar el auto-tune #${tune.id} (corrido hace ${tune.hoursAgo}h). ` +
+      `Estoy considerando aplicar el auto-tune #${tune.id} (corrido hace ${tune.hoursAgo}h). ` +
       `Propone ${changeCount} cambios sobre los multiplicadores ATR (SL/TP/BE) de la estrategia en vivo. ` +
-      `Antes de confirmar, ayúdame a articular: ¿qué riesgos ves? ¿Hay algún símbolo donde la ` +
-      `mejora se vea frágil? Hazme preguntas concretas, no me dejes aplicar sin justificación.`,
+      `Ayúdame a articular: ¿qué riesgos ves? ¿Hay algún símbolo donde la ` +
+      `mejora se vea frágil? Hazme preguntas concretas. ` +
+      `Nota: este chat es solo para pensar en voz alta. El botón de confirmar se ` +
+      `reintroduce en Phase 3 del rewire del copiloto; por ahora la acción la sigo ` +
+      `disparando yo desde un terminal.`,
     );
     setDockOpen(true);
   }, []);
@@ -767,10 +775,11 @@ const App: React.FC = () => {
           macro={macroState}
           initialPrompt={dockInitialPrompt}
           onOpenSymbol={openSymbolByPair}
-          // onConfirmRelease / onConfirmApplyTune handlers stay alive on
-          // the App.tsx side (KillSwitchView + AutoTuneView still call
-          // them directly). The Dock no longer parses <<<TOOL:...>>>
-          // markers — Phase 3 re-wires those into signed proposal events.
+          // onConfirmRelease / onConfirmApplyTune props removed in
+          // Phase 2B together with the <<<TOOL:...>>> marker protocol
+          // they used to fire. Phase 3 re-wires confirm actions as
+          // signed proposal events from the backend
+          // (POST /agent/proposals/{id}/confirm), not props.
         />
       )}
 

--- a/frontend/src/agent/client.ts
+++ b/frontend/src/agent/client.ts
@@ -1,0 +1,136 @@
+// ============================================================
+// agent/client.ts — SSE client for /agent/conversations/{id}/turn.
+//
+// The browser's built-in EventSource only supports GET requests with
+// no custom headers — it cannot send our POST body or honor the JWT
+// cookie auth on cross-route navigation. We use fetch() + a
+// ReadableStream reader to parse the `text/event-stream` body
+// manually. Same wire format the server emits.
+//
+// Pre-reg §6.2. Phase 2B of epic #400.
+// ============================================================
+
+import type {
+  AgentStreamEvent,
+  AgentTurnRequest,
+} from './types';
+
+const BASE_URL = '/api';
+
+function readCsrfCookie(): string {
+  const m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]+)/);
+  return m ? decodeURIComponent(m[1]) : '';
+}
+
+export interface StreamTurnOptions extends AgentTurnRequest {
+  conversation_id: string;
+  signal?:         AbortSignal;
+}
+
+export class AgentStreamError extends Error {
+  status: number;
+  reason: string;
+  constructor(status: number, reason: string, message?: string) {
+    super(message ?? `agent stream failed: ${status} ${reason}`);
+    this.status = status;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Stream a single agent turn. Returns an async iterable of typed
+ * events; the caller consumes with `for await (const ev of ...)`.
+ *
+ * The wire is `data: {json}\n\n` frames. We buffer partial chunks and
+ * emit one event per frame; the final partial chunk after the stream
+ * closes is dropped (it's always empty when the server flushes properly).
+ *
+ * Throws AgentStreamError on non-2xx HTTP responses. Network errors
+ * propagate as fetch's TypeError; the hook catches both and renders a
+ * friendly fallback message.
+ */
+export async function* streamAgentTurn(
+  opts: StreamTurnOptions,
+): AsyncIterable<AgentStreamEvent> {
+  const { conversation_id, signal, ...body } = opts;
+  const path = `${BASE_URL}/agent/conversations/${encodeURIComponent(conversation_id)}/turn`;
+
+  const headers: Record<string, string> = {
+    'Content-Type':     'application/json',
+    'Accept':           'text/event-stream',
+    // Mirrors the request<>() wrapper in api.ts — CSRF cookie required
+    // on non-safe methods for the AuthMiddleware.
+    'X-CSRF-Token':     readCsrfCookie(),
+  };
+
+  const resp = await fetch(path, {
+    method:      'POST',
+    credentials: 'include',
+    headers,
+    body:        JSON.stringify(body),
+    signal,
+  });
+
+  if (!resp.ok || !resp.body) {
+    // Try to parse the JSON error body for the closed-enum reason.
+    let reason = `http_${resp.status}`;
+    try {
+      const errBody = await resp.json();
+      if (typeof errBody?.detail === 'string') reason = errBody.detail;
+    } catch {
+      // ignore parse failure — keep generic reason
+    }
+    throw new AgentStreamError(resp.status, reason);
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buf = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      // SSE frame separator is \n\n. Each frame has lines like
+      // "data: {json}". We only emit one event per frame; the server
+      // never multi-lines a single event today.
+      let sep = buf.indexOf('\n\n');
+      while (sep !== -1) {
+        const frame = buf.slice(0, sep);
+        buf = buf.slice(sep + 2);
+        sep = buf.indexOf('\n\n');
+        if (!frame.startsWith('data: ')) continue;
+        const json = frame.slice('data: '.length).trim();
+        if (!json) continue;
+        try {
+          yield JSON.parse(json) as AgentStreamEvent;
+        } catch (e) {
+          // A malformed frame is a server bug — log it but don't kill
+          // the iteration. The next frame may be parseable.
+          if (typeof console !== 'undefined') {
+            console.warn('agent stream: malformed frame', json, e);
+          }
+        }
+      }
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // releaseLock fails on cancelled streams; ignore.
+    }
+  }
+}
+
+/**
+ * Generate a short, URL-safe conversation id. The backend validates the
+ * shape (alphanumeric + _-, max 128 chars) so we keep this conservative.
+ */
+export function newConversationId(): string {
+  // 8 bytes of crypto-random → 16 hex chars. Good enough for an id
+  // that scopes a chat session. The backend persists it verbatim.
+  const buf = new Uint8Array(8);
+  crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/frontend/src/agent/types.ts
+++ b/frontend/src/agent/types.ts
@@ -1,0 +1,78 @@
+// ============================================================
+// agent/types.ts — typed events on the wire from
+// POST /agent/conversations/{id}/turn.
+//
+// Mirrors the closed-enum frame types serialized in
+// api/agent/streaming.py. The hook (useAgentStream) switches on
+// `type` to update local state.
+//
+// Pre-reg §6.2. Phase 2B of epic #400.
+// ============================================================
+
+export interface AgentTextDelta {
+  type: 'text_delta';
+  text: string;
+}
+
+export interface AgentToolUseStart {
+  type:  'tool_use_start';
+  tool:  string;
+}
+
+export interface AgentToolUseResult {
+  type:    'tool_use_result';
+  tool:    string;
+  status:  'ok' | 'error';
+}
+
+export interface AgentMessageEnd {
+  type:        'message_end';
+  usage:       {
+    input_tokens:                number;
+    output_tokens:               number;
+    cache_read_input_tokens:     number;
+    cache_creation_input_tokens: number;
+  };
+  stop_reason: string;
+  cost_usd:    number;
+}
+
+export interface AgentErrorEvent {
+  type:          'error';
+  reason:        string;   // closed enum from backend; UI shows user_message verbatim
+  user_message:  string;
+}
+
+export type AgentStreamEvent =
+  | AgentTextDelta
+  | AgentToolUseStart
+  | AgentToolUseResult
+  | AgentMessageEnd
+  | AgentErrorEvent;
+
+// Wire shape of the messages we send in the body. Mirrors
+// _AgentMessage in api/agent/router.py.
+export interface AgentApiMessage {
+  role:    'user' | 'assistant';
+  content: string;
+}
+
+export type AgentSurface =
+  | 'dock'
+  | 'symbol_detail'
+  | 'kill_switch'
+  | 'autotune'
+  | 'historial';
+
+export interface AgentContextHints {
+  symbol?:      string;
+  position_id?: number;
+  tune_id?:     number;
+}
+
+export interface AgentTurnRequest {
+  surface:        AgentSurface;
+  messages:       AgentApiMessage[];
+  context_hints?: AgentContextHints;
+  model?:         string;
+}

--- a/frontend/src/agent/useAgentStream.test.tsx
+++ b/frontend/src/agent/useAgentStream.test.tsx
@@ -1,0 +1,243 @@
+// ============================================================
+// useAgentStream.test.tsx — covers the streaming reducer.
+//
+// We don't need a full DOM render — we test the hook in isolation by
+// stubbing the fetch + ReadableStream pair that streamAgentTurn reads.
+// The reducer's job is: accumulate text_deltas into the last assistant
+// bubble, attach tool_use chips, surface error events as the assistant
+// text, and clear loading on completion.
+// ============================================================
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAgentStream } from './useAgentStream';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+
+function encode(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+/** Builds a ReadableStream that emits the supplied SSE frames in order.
+ *  Each entry is a single frame's `data: {json}` — we add the terminator. */
+function sseReadable(frames: object[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const f of frames) {
+        controller.enqueue(encode(`data: ${JSON.stringify(f)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function stubFetchOnce(stream: ReadableStream<Uint8Array>, status = 200) {
+  const resp = new Response(stream, {
+    status,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+  // @ts-expect-error — overriding global for the test
+  global.fetch = vi.fn().mockResolvedValueOnce(resp);
+}
+
+function stubFetchError(status: number, detail: string) {
+  // @ts-expect-error — overriding global for the test
+  global.fetch = vi.fn().mockResolvedValueOnce(
+    new Response(JSON.stringify({ detail }), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+
+// ── Test environment setup ─────────────────────────────────────────────
+
+
+beforeEach(() => {
+  // jsdom's document.cookie default is empty — CSRF wrapper reads it.
+  document.cookie = 'csrf_token=t';
+  // Vitest's jsdom env doesn't ship crypto.getRandomValues by default
+  // in older versions; ensure it's there for newConversationId().
+  if (!globalThis.crypto?.getRandomValues) {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: {
+        getRandomValues: (buf: Uint8Array) => {
+          for (let i = 0; i < buf.length; i++) buf[i] = i;
+          return buf;
+        },
+      },
+    });
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+
+describe('useAgentStream', () => {
+  it('accumulates text_delta chunks into the assistant bubble', async () => {
+    stubFetchOnce(sseReadable([
+      { type: 'text_delta', text: 'Hola ' },
+      { type: 'text_delta', text: 'mundo' },
+      {
+        type: 'message_end',
+        usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        stop_reason: 'end_turn',
+        cost_usd: 0.0001,
+      },
+    ]));
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    await act(async () => {
+      await result.current.sendTurn('saluda');
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.msgs).toHaveLength(2);
+    expect(result.current.msgs[0]).toEqual({ role: 'user', text: 'saluda' });
+    expect(result.current.msgs[1].role).toBe('assistant');
+    expect(result.current.msgs[1].text).toBe('Hola mundo');
+  });
+
+  it('tracks tool_use_start / tool_use_result chips on the bubble', async () => {
+    stubFetchOnce(sseReadable([
+      { type: 'tool_use_start', tool: 'get_positions' },
+      { type: 'tool_use_result', tool: 'get_positions', status: 'ok' },
+      { type: 'text_delta', text: 'Tienes 1 posición.' },
+      { type: 'message_end', usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, stop_reason: 'end_turn', cost_usd: 0 },
+    ]));
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    await act(async () => {
+      await result.current.sendTurn('qué tengo');
+    });
+
+    const asst = result.current.msgs[1];
+    expect(asst.tool_chips).toEqual([{ tool: 'get_positions', status: 'ok' }]);
+    expect(asst.text).toBe('Tienes 1 posición.');
+  });
+
+  it('replaces the placeholder with user_message on an error event', async () => {
+    stubFetchOnce(sseReadable([
+      { type: 'error', reason: 'upstream', user_message: 'El copiloto está saturado, intenta en unos segundos.' },
+    ]));
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    await act(async () => {
+      await result.current.sendTurn('hola');
+    });
+
+    const asst = result.current.msgs[1];
+    expect(asst.text).toBe('El copiloto está saturado, intenta en unos segundos.');
+    expect(asst.tool_chips).toEqual([]);
+  });
+
+  it('shows a friendly fallback on a non-2xx response without leaking the closed-enum reason verbatim', async () => {
+    stubFetchError(503, 'agent_disabled');
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    await act(async () => {
+      await result.current.sendTurn('hola');
+    });
+
+    const asst = result.current.msgs[1];
+    // The hook renders a user-facing translation of the closed-enum
+    // reason — the raw reason string never reaches the bubble.
+    expect(asst.text).toBe('El copiloto no está disponible en este momento.');
+  });
+
+  it('rolls a new conversation id on conversation_cap_reached', async () => {
+    // First call returns the cap-reached error.
+    const stream1 = sseReadable([
+      { type: 'error', reason: 'conversation_cap_reached', user_message: 'cap' },
+    ]);
+    // Second call should succeed because resetConversation rolled a new id.
+    const stream2 = sseReadable([
+      { type: 'text_delta', text: 'fresh' },
+      { type: 'message_end', usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, stop_reason: 'end_turn', cost_usd: 0 },
+    ]);
+
+    let callCount = 0;
+    const idsSent: string[] = [];
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      // url shape: /api/agent/conversations/{id}/turn
+      const match = url.match(/conversations\/([^/]+)\/turn/);
+      if (match) idsSent.push(match[1]);
+      callCount += 1;
+      if (callCount === 1) {
+        return Promise.resolve(new Response(stream1, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+      }
+      return Promise.resolve(new Response(stream2, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    await act(async () => {
+      await result.current.sendTurn('msg1');
+    });
+    await act(async () => {
+      await result.current.sendTurn('msg2');
+    });
+
+    expect(idsSent).toHaveLength(2);
+    // The cap rolled a fresh id, so the second call's id is different.
+    expect(idsSent[0]).not.toBe(idsSent[1]);
+  });
+
+  it('refuses to send while a previous turn is in flight', async () => {
+    // Create a stream that we control — the second sendTurn fires before
+    // the first resolves.
+    let releaseFirst: () => void = () => {};
+    const firstStreamPromise = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const stream1 = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        await firstStreamPromise;
+        controller.enqueue(encode(`data: ${JSON.stringify({
+          type: 'message_end',
+          usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+          stop_reason: 'end_turn',
+          cost_usd: 0,
+        })}\n\n`));
+        controller.close();
+      },
+    });
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(stream1, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+    );
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    // Don't await — we want sendTurn1 in flight when sendTurn2 fires.
+    let firstPromise: Promise<void>;
+    act(() => {
+      firstPromise = result.current.sendTurn('msg1');
+    });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // sendTurn2 should no-op (returns immediately) because loading=true.
+    await act(async () => {
+      await result.current.sendTurn('msg2');
+    });
+
+    // Only one user message in the transcript — the second was rejected.
+    const userMsgs = result.current.msgs.filter((m) => m.role === 'user');
+    expect(userMsgs.map((m) => m.text)).toEqual(['msg1']);
+
+    // Release the first stream and let it complete cleanly.
+    releaseFirst();
+    await act(async () => {
+      await firstPromise!;
+    });
+  });
+});

--- a/frontend/src/agent/useAgentStream.ts
+++ b/frontend/src/agent/useAgentStream.ts
@@ -1,0 +1,201 @@
+// ============================================================
+// useAgentStream.ts — React hook over streamAgentTurn.
+//
+// Manages: rolling local transcript (assistant text accumulates from
+// text_delta events), in-flight indicator, error surfacing as a final
+// assistant message (so the user sees the friendly fallback inline,
+// not as a toast), and tool-use status chips.
+//
+// Phase 2B of epic #400.
+// ============================================================
+
+import { useCallback, useRef, useState } from 'react';
+
+import {
+  AgentStreamError,
+  newConversationId,
+  streamAgentTurn,
+} from './client';
+import type {
+  AgentApiMessage,
+  AgentContextHints,
+  AgentStreamEvent,
+  AgentSurface,
+} from './types';
+
+export interface ChatMsg {
+  role:    'user' | 'assistant';
+  text:    string;
+  // Inline tool-use chips that render below the bubble while the turn
+  // is in flight. The hook clears this on the next user turn.
+  tool_chips?: Array<{ tool: string; status: 'pending' | 'ok' | 'error' }>;
+}
+
+export interface UseAgentStreamOptions {
+  surface: AgentSurface;
+}
+
+export interface UseAgentStreamReturn {
+  msgs:           ChatMsg[];
+  loading:        boolean;
+  sendTurn:       (text: string, hints?: AgentContextHints) => Promise<void>;
+  resetConversation: () => void;
+}
+
+/**
+ * Send one user turn, stream the assistant response into the local
+ * transcript. The hook keeps the conversation id stable across turns
+ * until `resetConversation()` is called (e.g. when the user clicks
+ * "nueva conversación" after a `conversation_cap_reached` event).
+ */
+export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamReturn {
+  const [msgs, setMsgs] = useState<ChatMsg[]>([]);
+  const [loading, setLoading] = useState(false);
+  const conversationIdRef = useRef<string>(newConversationId());
+
+  const resetConversation = useCallback(() => {
+    conversationIdRef.current = newConversationId();
+    setMsgs([]);
+  }, []);
+
+  const sendTurn = useCallback(
+    async (text: string, hints?: AgentContextHints) => {
+      if (!text.trim() || loading) return;
+      // Snapshot the transcript-up-to-now and append the user turn +
+      // an empty assistant placeholder atomically. The placeholder is
+      // what the streaming text appends to.
+      let prevMsgs: ChatMsg[] = [];
+      setMsgs((cur) => {
+        prevMsgs = cur;
+        return [
+          ...cur,
+          { role: 'user', text },
+          { role: 'assistant', text: '', tool_chips: [] },
+        ];
+      });
+      setLoading(true);
+
+      // Build the API request from the snapshot we just took. The
+      // backend rebuilds the system prompt server-side; we only ship
+      // the user/assistant transcript.
+      const apiMessages: AgentApiMessage[] = [
+        ...prevMsgs.map((m) => ({ role: m.role, content: m.text })),
+        { role: 'user' as const, content: text },
+      ];
+
+      try {
+        for await (const ev of streamAgentTurn({
+          conversation_id: conversationIdRef.current,
+          surface:         opts.surface,
+          messages:        apiMessages,
+          context_hints:   hints,
+        })) {
+          applyEvent(ev, setMsgs, resetConversation);
+        }
+      } catch (err) {
+        const userMsg =
+          err instanceof AgentStreamError && err.reason === 'agent_disabled'
+            ? 'El copiloto no está disponible en este momento.'
+            : 'El copiloto está saturado, intenta en unos segundos.';
+        setMsgs((cur) => {
+          const updated = [...cur];
+          const last = updated[updated.length - 1];
+          if (last && last.role === 'assistant') {
+            updated[updated.length - 1] = { ...last, text: userMsg, tool_chips: [] };
+          } else {
+            updated.push({ role: 'assistant', text: userMsg });
+          }
+          return updated;
+        });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loading, opts.surface, resetConversation],
+  );
+
+  return { msgs, loading, sendTurn, resetConversation };
+}
+
+// ── pure-ish reducer for one event ─────────────────────────────────────
+
+function applyEvent(
+  ev: AgentStreamEvent,
+  setMsgs: React.Dispatch<React.SetStateAction<ChatMsg[]>>,
+  resetConversation: () => void,
+) {
+  switch (ev.type) {
+    case 'text_delta':
+      setMsgs((cur) => {
+        const updated = [...cur];
+        const last = updated[updated.length - 1];
+        if (last && last.role === 'assistant') {
+          updated[updated.length - 1] = { ...last, text: last.text + ev.text };
+        }
+        return updated;
+      });
+      break;
+
+    case 'tool_use_start':
+      setMsgs((cur) => {
+        const updated = [...cur];
+        const last = updated[updated.length - 1];
+        if (last && last.role === 'assistant') {
+          updated[updated.length - 1] = {
+            ...last,
+            tool_chips: [
+              ...(last.tool_chips ?? []),
+              { tool: ev.tool, status: 'pending' },
+            ],
+          };
+        }
+        return updated;
+      });
+      break;
+
+    case 'tool_use_result':
+      setMsgs((cur) => {
+        const updated = [...cur];
+        const last = updated[updated.length - 1];
+        if (last && last.role === 'assistant') {
+          const chips = (last.tool_chips ?? []).map((c) =>
+            c.tool === ev.tool && c.status === 'pending'
+              ? { ...c, status: ev.status }
+              : c,
+          );
+          updated[updated.length - 1] = { ...last, tool_chips: chips };
+        }
+        return updated;
+      });
+      break;
+
+    case 'message_end':
+      // No-op for the transcript — the streamed text is already in place.
+      // Future Phase 5: surface cost_usd / cache hit info to a debug
+      // panel for the operator. For now we just let the backend audit
+      // the row and move on.
+      break;
+
+    case 'error':
+      // Replace the placeholder (which is "" so far on a fast-error
+      // path) with the friendly user_message. The closed-enum reason
+      // is ignored by the user-facing UI; it lives in the audit row.
+      setMsgs((cur) => {
+        const updated = [...cur];
+        const last = updated[updated.length - 1];
+        if (last && last.role === 'assistant') {
+          updated[updated.length - 1] = { ...last, text: ev.user_message, tool_chips: [] };
+        } else {
+          updated.push({ role: 'assistant', text: ev.user_message });
+        }
+        return updated;
+      });
+      if (ev.reason === 'conversation_cap_reached') {
+        // Auto-spin a fresh conversation id so the next user turn
+        // doesn't immediately hit the cap again. The user still has
+        // to click "send" to use it.
+        resetConversation();
+      }
+      break;
+  }
+}

--- a/frontend/src/components/AgentDock.module.css
+++ b/frontend/src/components/AgentDock.module.css
@@ -232,6 +232,45 @@
   color: var(--nbc-primary-fg);
 }
 
+/* Tool-use status chips — inline under the assistant bubble while the
+ * turn is in flight. Mirrors the typed tool_use_start / tool_use_result
+ * SSE events: pending → spinner-style dim chip; ok → bull; error → bear.
+ * Phase 2B of epic #400. */
+.toolChipsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+.toolChip {
+  font-family: var(--nbc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  padding: 3px 8px;
+  border: 1px solid;
+  background: transparent;
+  user-select: none;
+}
+.toolChipPending {
+  color: var(--nbc-fg-muted);
+  border-color: var(--nbc-border-dim);
+  opacity: 0.85;
+  animation: dockToolChipPulse 1.2s ease-in-out infinite;
+}
+.toolChipOk {
+  color: var(--bull);
+  border-color: var(--bull);
+}
+.toolChipError {
+  color: var(--bear);
+  border-color: var(--bear);
+}
+@keyframes dockToolChipPulse {
+  0%, 100% { opacity: 0.55; }
+  50%      { opacity: 1; }
+}
+
 /* confirm_release marker — destructive override, amber to signal weight */
 .toolConfirm {
   font-family: var(--nbc-font-mono);

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -4,17 +4,18 @@
 // Mounted at App level so the conversation persists across tab
 // changes (Mercado → Posiciones → Kill-switch → back to Mercado).
 //
-// Each turn rebuilds the system prompt with the current portfolio
-// snapshot so the agent always sees fresh data.
-// Tool-marker protocol: `<<<TOOL:open_symbol:BTCUSDT>>>` becomes a
-// "▸ abrir BTCUSDT" link button under the message.
+// Phase 2B of epic #400 — rewired from the legacy /agent/chat (one
+// shot, frontend-built system prompt, marker-parsed pseudo-tools)
+// to the proper SSE streaming endpoint POST /agent/conversations/{id}/turn
+// with a server-side system prompt and typed tool_use events. The
+// `<<<TOOL:...>>>` marker protocol is dead — its UX (inline action
+// buttons) returns in Phase 3 via signed proposal events.
 // ============================================================
 
 import React, { useEffect, useRef, useState } from 'react';
 import styles from './AgentDock.module.css';
 import type { SymbolStatus, Position, MacroState } from '../types';
-import { chatAgent, type AgentMessage } from '../api';
-import { formatPrice } from '../utils';
+import { useAgentStream } from '../agent/useAgentStream';
 
 interface AgentDockProps {
   open:           boolean;
@@ -24,27 +25,10 @@ interface AgentDockProps {
   positions:      Position[];
   macro:          MacroState;
   initialPrompt?: string | null;
+  /** Kept for future use — Phase 3's proposal events will dispatch
+   *  open_symbol via a structured action, not a text marker. */
   onOpenSymbol?:  (pair: string) => void;
-  /** Confirm a manual kill-switch release once the agent emits
-   *  <<<TOOL:confirm_release:SYM>>>. Renders an amber "▸ confirmar
-   *  release de SYM" button inline under the agent message. */
-  onConfirmRelease?: (symbol: string) => Promise<void> | void;
-  /** Confirm applying an auto-tune run once the agent emits
-   *  <<<TOOL:confirm_apply_tune:N>>>. Renders an amber "▸ confirmar
-   *  apply del tune #N" button inline under the agent message. */
-  onConfirmApplyTune?: (tuneId: number) => Promise<void> | void;
   unreadHint?:    boolean;
-}
-
-interface ToolCall {
-  name: string;
-  arg?: string;
-}
-interface DockMsg {
-  role:   'user' | 'assistant';
-  text:   string;
-  tools?: ToolCall[];
-  error?: boolean;
 }
 
 const DOCK_SUGGESTIONS = [
@@ -56,13 +40,18 @@ const DOCK_SUGGESTIONS = [
 
 const AgentDock: React.FC<AgentDockProps> = ({
   open, onOpen, onClose,
-  symbols, positions, macro,
-  initialPrompt, onOpenSymbol, onConfirmRelease, onConfirmApplyTune, unreadHint,
+  symbols, positions,
+  initialPrompt, unreadHint,
 }) => {
-  const [msgs,    setMsgs]    = useState<DockMsg[]>([]);
-  const [input,   setInput]   = useState('');
-  const [loading, setLoading] = useState(false);
+  const [input, setInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
+  const greetedRef = useRef(false);
+
+  const { msgs, loading, sendTurn } = useAgentStream({ surface: 'dock' });
+  // We render a synthetic welcome bubble before the first real turn so
+  // the dock isn't an empty void on open. It lives outside the stream
+  // hook because it never goes on the wire — purely UI.
+  const [welcome, setWelcome] = useState<string | null>(null);
 
   // Close on Escape
   useEffect(() => {
@@ -72,94 +61,37 @@ const AgentDock: React.FC<AgentDockProps> = ({
     return () => window.removeEventListener('keydown', onKey);
   }, [open, onClose]);
 
-  // Welcome message on first open
+  // Welcome message on first open. Only shown until the first real
+  // exchange — once msgs.length > 0 we hide it to avoid duplicate
+  // bubbles.
   useEffect(() => {
-    if (open && msgs.length === 0 && !initialPrompt) {
-      setMsgs([{
-        role: 'assistant',
-        text: `Hola. Estoy mirando tus ${symbols.length} pares y ${positions.length} posiciones. Pregúntame lo que quieras.`,
-      }]);
+    if (open && !greetedRef.current && !initialPrompt) {
+      setWelcome(
+        `Hola. Estoy mirando tus ${symbols.length} pares y ${positions.length} posiciones. ` +
+        `Pregúntame lo que quieras.`,
+      );
+      greetedRef.current = true;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, initialPrompt, symbols.length, positions.length]);
 
-  // Auto-send the initial prompt when one is passed in
+  // Auto-send the initial prompt when one is passed in.
   useEffect(() => {
     if (open && initialPrompt && msgs.length === 0) {
-      void send(initialPrompt);
+      void sendTurn(initialPrompt);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, initialPrompt]);
 
-  // Autoscroll
+  // Autoscroll on new messages or loading state changes.
   useEffect(() => {
     if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [msgs, loading]);
 
-  const send = async (text: string) => {
+  const submit = async (text: string) => {
     const t = text.trim();
     if (!t || loading) return;
-    setMsgs((p) => [...p, { role: 'user', text: t }]);
     setInput('');
-    setLoading(true);
-
-    try {
-      const openPositions = positions.filter((p) => p.status === 'open');
-      const positionsLine = openPositions.length === 0
-        ? ''
-        : ' (' + openPositions.map((p) => `${p.symbol.replace('USDT','')} ${(p.pnl_pct ?? 0) > 0 ? '+' : ''}${(p.pnl_pct ?? 0).toFixed(2)}%`).join(', ') + ')';
-
-      const signalSyms = symbols
-        .filter((s) => (s.score ?? 0) >= 5 && s.señal === true)
-        .map((s) => `- ${s.symbol.replace('USDT','')}: score ${s.score ?? 0}/9, LRC ${(s.lrc_pct ?? 0).toFixed(1)}%, side ${s.direction ?? 'LONG'}, precio $${formatPrice(s.live_price ?? s.price)}`)
-        .join('\n');
-
-      const fundingStr = macro.funding != null ? `${(macro.funding * 100).toFixed(4)}%/8h` : '—';
-      const fngStr     = macro.fng != null ? String(macro.fng) : '—';
-
-      const sysPrompt = `Eres un copiloto de trading de la app crypto-scanner v6. El usuario está en la vista Mercado.
-
-PORTAFOLIO ACTUAL:
-- Pares en watchlist: ${symbols.length}
-- Posiciones abiertas: ${openPositions.length}${positionsLine}
-- Régimen: ${macro.regime ?? '—'}
-- F&G: ${fngStr}
-- Funding BTC: ${fundingStr}
-- Errores del escáner: ${macro.errors}
-- Kill-switch pausados: ${macro.killSwitchActive}
-
-PARES CON SEÑAL (score ≥ 5 + gatillo):
-${signalSyms || '- ninguno'}
-
-INSTRUCCIONES:
-- Responde en español, breve (2-4 oraciones máx).
-- No inventes datos que no están arriba.
-- Si el usuario pregunta sobre un par específico, sugiere abrirlo terminando con <<<TOOL:open_symbol:NOMBRE>>> donde NOMBRE es el símbolo completo incluyendo USDT (ej: <<<TOOL:open_symbol:BTCUSDT>>>).
-- Si el usuario quiere liberar manualmente un par del kill-switch y justifica con UN argumento concreto (cambio de régimen macro, evento puntual identificable, par específico con causa clara, etc), termina la respuesta con <<<TOOL:confirm_release:NOMBRE>>> con el símbolo completo incluyendo USDT. Si la justificación es vaga ("siento que ya está bien", "creo que ya pasó"), pide MÁS detalles concretos SIN emitir el marker — tu trabajo es hacer que el usuario articule su tesis antes del override.
-- Si el usuario quiere aplicar un auto-tune (modificar SL/TP/BE de la estrategia en vivo) y articula argumentos concretos por símbolo (razón económica, contexto reciente del par, tesis sobre por qué el backtest es representativo del régimen actual), termina la respuesta con <<<TOOL:confirm_apply_tune:N>>> donde N es el ID numérico del tune. Si la justificación es vaga o solo cita las métricas del propio backtest sin razonar sobre el mercado, pedí más detalles SIN emitir el marker.
-- Si pregunta por todas sus posiciones, lista las que están arriba.
-- Si pide un resumen "en simple" o "para papá", usa lenguaje muy directo, sin jerga.
-- No uses negrita más de una vez por respuesta.`;
-
-      const history: AgentMessage[] = msgs.slice(-6).map((m) => ({
-        role:    m.role,
-        content: m.text,
-      }));
-      const resp = await chatAgent({
-        system:   sysPrompt,
-        messages: [...history, { role: 'user', content: t }],
-      });
-      const { tools, cleaned } = extractTools(resp.text || '');
-      setMsgs((p) => [...p, { role: 'assistant', text: cleaned, tools }]);
-    } catch (err) {
-      setMsgs((p) => [...p, {
-        role:  'assistant',
-        text:  err instanceof Error ? `No pude analizar: ${err.message}` : 'No pude analizar. Inténtalo de nuevo.',
-        error: true,
-      }]);
-    } finally {
-      setLoading(false);
-    }
+    await sendTurn(t);
   };
 
   return (
@@ -193,16 +125,20 @@ INSTRUCCIONES:
           </header>
 
           <div className={styles.scroll} ref={scrollRef}>
+            {welcome && msgs.length === 0 && (
+              <DockMessage role="assistant" text={welcome} />
+            )}
             {msgs.map((m, i) => (
               <DockMessage
                 key={i}
-                m={m}
-                onOpenSymbol={onOpenSymbol}
-                onConfirmRelease={onConfirmRelease}
-                onConfirmApplyTune={onConfirmApplyTune}
+                role={m.role}
+                text={m.text}
+                toolChips={m.tool_chips}
+                showTyping={
+                  m.role === 'assistant' && loading && i === msgs.length - 1 && m.text === ''
+                }
               />
             ))}
-            {loading && <DockTyping />}
           </div>
 
           <div className={styles.sugg}>
@@ -210,13 +146,13 @@ INSTRUCCIONES:
               <button
                 key={i}
                 className={styles.suggChip}
-                onClick={() => send(s)}
+                onClick={() => void submit(s)}
                 disabled={loading}
               >{s}</button>
             ))}
           </div>
 
-          <form className={styles.inputRow} onSubmit={(e) => { e.preventDefault(); void send(input); }}>
+          <form className={styles.inputRow} onSubmit={(e) => { e.preventDefault(); void submit(input); }}>
             <span className={styles.prompt}>&gt;</span>
             <input
               className={styles.input}
@@ -234,29 +170,20 @@ INSTRUCCIONES:
   );
 };
 
-// ── Helpers / sub-components ─────────────────────────────────
+// ── Sub-components ──────────────────────────────────────────────────
 
-// Extract `<<<TOOL:name:ARG>>>` markers; the agent can append them to
-// trigger downstream UI affordances (currently only `open_symbol`).
-function extractTools(text: string): { tools: ToolCall[]; cleaned: string } {
-  const tools: ToolCall[] = [];
-  const cleaned = text.replace(/<<<TOOL:([a-z_]+)(?::([A-Z0-9_]+))?>>>/g, (_, name: string, arg?: string) => {
-    tools.push({ name, arg });
-    return '';
-  }).trim();
-  return { tools, cleaned };
+interface DockMessageProps {
+  role:       'user' | 'assistant';
+  text:       string;
+  toolChips?: Array<{ tool: string; status: 'pending' | 'ok' | 'error' }>;
+  showTyping?: boolean;
 }
 
-const DockMessage: React.FC<{
-  m: DockMsg;
-  onOpenSymbol?:     (pair: string) => void;
-  onConfirmRelease?: (symbol: string) => Promise<void> | void;
-  onConfirmApplyTune?: (tuneId: number) => Promise<void> | void;
-}> = ({ m, onOpenSymbol, onConfirmRelease, onConfirmApplyTune }) => {
-  if (m.role === 'user') {
+const DockMessage: React.FC<DockMessageProps> = ({ role, text, toolChips, showTyping }) => {
+  if (role === 'user') {
     return (
       <div className={`${styles.msg} ${styles.msgUser}`}>
-        <div className={`${styles.bubble} ${styles.bubbleUser}`}>{m.text}</div>
+        <div className={`${styles.bubble} ${styles.bubbleUser}`}>{text}</div>
       </div>
     );
   }
@@ -264,45 +191,36 @@ const DockMessage: React.FC<{
     <div className={`${styles.msg} ${styles.msgAsst}`}>
       <div className={styles.msgAvatar}>◈</div>
       <div className={styles.msgBody}>
-        {m.text && (
-          <div className={[styles.bubble, styles.bubbleAsst, m.error ? styles.bubbleError : ''].filter(Boolean).join(' ')}>
-            <DockText text={m.text} />
+        {showTyping && (
+          <div className={`${styles.bubble} ${styles.bubbleAsst} ${styles.bubbleTyping}`}>
+            <span className={styles.typingDot} />
+            <span className={styles.typingDot} />
+            <span className={styles.typingDot} />
           </div>
         )}
-        {m.tools?.map((t, i) => {
-          if (t.name === 'open_symbol' && t.arg && onOpenSymbol) {
-            const display = t.arg.replace('USDT', '');
-            return (
-              <button
+        {!showTyping && text && (
+          <div className={`${styles.bubble} ${styles.bubbleAsst}`}>
+            <DockText text={text} />
+          </div>
+        )}
+        {toolChips && toolChips.length > 0 && (
+          <div className={styles.toolChipsRow}>
+            {toolChips.map((c, i) => (
+              <span
                 key={i}
-                className={styles.toolLink}
-                onClick={() => onOpenSymbol(t.arg!)}
-              >▸ abrir {display}</button>
-            );
-          }
-          if (t.name === 'confirm_release' && t.arg && onConfirmRelease) {
-            const display = t.arg.replace('USDT', '');
-            return (
-              <button
-                key={i}
-                className={styles.toolConfirm}
-                onClick={() => void onConfirmRelease(t.arg!)}
-              >▸ confirmar release de {display}</button>
-            );
-          }
-          if (t.name === 'confirm_apply_tune' && t.arg && onConfirmApplyTune) {
-            const id = parseInt(t.arg, 10);
-            if (!Number.isFinite(id)) return null;
-            return (
-              <button
-                key={i}
-                className={styles.toolConfirm}
-                onClick={() => void onConfirmApplyTune(id)}
-              >▸ confirmar apply del tune #{id}</button>
-            );
-          }
-          return null;
-        })}
+                className={[
+                  styles.toolChip,
+                  c.status === 'pending' ? styles.toolChipPending :
+                  c.status === 'ok'      ? styles.toolChipOk :
+                                            styles.toolChipError,
+                ].join(' ')}
+                title={`tool ${c.tool} — ${c.status}`}
+              >
+                {c.status === 'pending' ? '⋯' : c.status === 'ok' ? '✓' : '✗'} {c.tool}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -327,18 +245,5 @@ const DockText: React.FC<{ text: string }> = ({ text }) => {
     </>
   );
 };
-
-const DockTyping: React.FC = () => (
-  <div className={`${styles.msg} ${styles.msgAsst}`}>
-    <div className={styles.msgAvatar}>◈</div>
-    <div className={styles.msgBody}>
-      <div className={`${styles.bubble} ${styles.bubbleAsst} ${styles.bubbleTyping}`}>
-        <span className={styles.typingDot} />
-        <span className={styles.typingDot} />
-        <span className={styles.typingDot} />
-      </div>
-    </div>
-  </div>
-);
 
 export default AgentDock;


### PR DESCRIPTION
## Summary

Phase 2B del epic [#400](https://github.com/sssimon/trading-spacial/issues/400). El AgentDock ahora consume el SSE streaming endpoint (\`POST /agent/conversations/{id}/turn\`) que entregó Phase 2A en lugar del legacy \`/agent/chat\` one-shot. El system prompt se arma server-side; el frontend deja de construirlo. El protocolo de marcadores \`<<<TOOL:...>>>\` está muerto — su UX (botones inline de release/apply_tune) regresa en Phase 3 como signed proposal events.

Incluye el pickup \`lru_cache\` que el reviewer recomendó en el round 1 del PR #404.

**Cierra el resto de #381** además de lo que Phase 0 ya capó.

## Backend pickup
- \`api/agent/loop.py\`: \`_build_anthropic_tools\` envuelto en \`@lru_cache(maxsize=8)\`, retorna tuple. Ahorra el \`model_json_schema()\` por turno (catálogo immutable at runtime).

## Frontend nuevo

| Archivo | Qué hace |
|---|---|
| \`agent/types.ts\` | Closed-enum event types mirror de \`api/agent/streaming.py\`. |
| \`agent/client.ts\` | \`streamAgentTurn()\` con fetch + ReadableStream (EventSource es GET-only, no soporta POST + cookies + body). \`AgentStreamError\` con closed-enum reason. \`newConversationId()\` con crypto.getRandomValues. |
| \`agent/useAgentStream.ts\` | React hook: rolling transcript, text_delta accumulation, tool_use chips (pending → ok/error), error events as inline assistant text, auto-reset on \`conversation_cap_reached\`, no race (sendTurn no-op while loading). |
| \`agent/useAgentStream.test.tsx\` | 6 tests con vitest + ReadableStream mock. |

## Frontend AgentDock rewire

**Eliminado:**
- \`chatAgent\` + \`AgentMessage\` imports.
- \`onConfirmRelease\` + \`onConfirmApplyTune\` props.
- \`extractTools()\` + \`<<<TOOL:...>>>\` regex.
- Toda la construcción client-side del system prompt (200+ chars de snapshot del portafolio + tool instructions). Ahora vive en \`api/agent/prompts/system.py\`.

**Agregado:**
- \`DockMessage\` renderiza tool_chips inline bajo el bubble con 3 estados (pending pulsing, ok bull, error bear).
- Pulse animation en el chip pending.

## Infra
- \`nginx.conf\` — nuevo \`location /api/agent/conversations/\` con \`proxy_buffering off\`, \`proxy_cache off\`, \`proxy_read_timeout 300s\`, \`chunked_transfer_encoding off\`. Pinning explícito para que SSE no se rompa por config upstream.

## Tests
- Frontend: 86 passed / 7 skipped.
- Backend: 199 passed (sin regresiones del \`lru_cache\` pickup).
- \`cd frontend && npm run build\` → ok.

## Lo que NO hace este PR (Phase 3)
- \`propose_close_position\` / \`propose_reactivate_symbol\` / \`propose_apply_tune\` con \`AGENT_PROPOSAL_SECRET\` HMAC.
- Signed proposal events en SSE.
- Amber confirm buttons como structured action chips.
- **SymbolDetail copilot rewire** — el sub-componente sigue en legacy \`/agent/chat\`; se rewirea junto con el propose/confirm pattern porque comparten la UX de side-effect.

## Test plan
- [x] \`pytest tests/test_agent_*.py tests/test_api.py tests/test_health_dashboard.py\` — 199/199.
- [x] \`cd frontend && npm run test -- --run\` — 86/86 (+ 7 skipped que ya estaban).
- [x] \`cd frontend && npm run build\` — ok.
- [ ] Smoke en \`trading.sdar.dev\` con \`cfg.agent.enabled=true\`:
      1. Abrir Dock → mensaje de bienvenida.
      2. \"hola\" → text_delta stream visible (caracteres llegando incremental).
      3. \"qué posiciones tengo\" → tool chip aparece (pending → ok) y después el texto.
      4. Segundo turno → cache_read_input_tokens > 0 en \`agent_conversations\` (target ≥70% post-warmup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)