### PR TITLE
feat(agent): Phase 3 — signed proposals + amber confirm flow (#400)

### DIFF
--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -73,6 +73,22 @@ class ToolUseResult:
 
 
 @dataclass(frozen=True)
+class ProposalEvent:
+    """Side-effect proposal emitted by a propose_* tool. Carries the
+    HMAC-signed payload that the frontend must echo back on confirm.
+    The model itself never sees the signed_payload — the loop strips
+    the `_proposal` envelope from the tool_result before handing it
+    back to the model. Pre-reg §10.
+    """
+    proposal_id:    str
+    signed_payload: str
+    action:         str
+    args:           dict
+    expires_at:     str
+    summary:        str
+
+
+@dataclass(frozen=True)
 class MessageEnd:
     usage: dict            # input_tokens / output_tokens / cache_read / cache_creation
     stop_reason: str
@@ -85,7 +101,10 @@ class ErrorEvent:
     user_message: str
 
 
-LoopEvent = TextDelta | ToolUseStart | ToolUseResult | MessageEnd | ErrorEvent
+LoopEvent = (
+    TextDelta | ToolUseStart | ToolUseResult | ProposalEvent
+    | MessageEnd | ErrorEvent
+)
 
 
 # ── Tool schema builder (registry → Anthropic tools array) ──────────────
@@ -183,6 +202,7 @@ async def run_turn(
     surface: str,
     messages: list[dict],
     tenant_id: int,
+    conversation_id: str = "",
     max_tokens: int = 4096,
 ) -> AsyncIterator[LoopEvent]:
     """Drive one user turn through the model + tool loop. Yields typed
@@ -280,7 +300,9 @@ async def run_turn(
         tool_results = []
         for tu in tool_uses:
             result_json = dispatch_tool(
-                tu.name or "", tu.input or {}, tenant_id=tenant_id,
+                tu.name or "", tu.input or {},
+                tenant_id=tenant_id,
+                conversation_id=conversation_id,
             )
             # is_error: structural detection (PR #404 review issue 2).
             # The previous `'"error"' in result_json` substring match
@@ -295,14 +317,36 @@ async def run_turn(
                 is_error = isinstance(parsed, dict) and "error" in parsed
             except json.JSONDecodeError:
                 is_error = True
+                parsed = None
             yield ToolUseResult(
                 tool=tu.name or "",
                 status=("error" if is_error else "ok"),
             )
+
+            # Phase 3 (#400): if a propose_* tool returned a `_proposal`
+            # envelope, yield a ProposalEvent so the frontend can render
+            # the amber confirm button. Strip the envelope from the
+            # tool_result content the model sees — the signed_payload
+            # NEVER flows through model context (pre-reg §10.1).
+            content_for_model = result_json
+            if not is_error and isinstance(parsed, dict) and "_proposal" in parsed:
+                env = parsed["_proposal"]
+                yield ProposalEvent(
+                    proposal_id=env["proposal_id"],
+                    signed_payload=env["signed_payload"],
+                    action=env["action"],
+                    args=env["args"],
+                    expires_at=env["expires_at"],
+                    summary=env["summary"],
+                )
+                # Rebuild the content without the _proposal envelope.
+                model_visible = {k: v for k, v in parsed.items() if k != "_proposal"}
+                content_for_model = json.dumps(model_visible, default=str)
+
             tool_results.append({
                 "type":          "tool_result",
                 "tool_use_id":   tu.id,
-                "content":       result_json,
+                "content":       content_for_model,
                 "is_error":      is_error,
             })
         messages.append({"role": "user", "content": tool_results})

--- a/api/agent/proposals.py
+++ b/api/agent/proposals.py
@@ -1,0 +1,333 @@
+"""HMAC-signed proposal envelopes — Phase 3 of epic #400.
+
+Pre-reg §10. The contract:
+
+  1. A propose_* tool (api/agent/tools/proposals.py) verifies that the
+     action it proposes is grounded — the position belongs to the
+     tenant, the symbol exists, the tune is pending. Then it calls
+     `sign_proposal(...)` and `persist_proposal(...)`. The tool's
+     return value to the model is `{proposal_id, expires_in, ...}`;
+     the signed payload travels OUT-OF-MODEL via an SSE proposal
+     event so the model never sees nor handles the signature.
+
+  2. The frontend renders an amber confirm button referencing the
+     proposal_id. Click → POST /agent/proposals/{proposal_id}/confirm
+     with the signed payload in the body. The server:
+
+       - re-verifies the HMAC (defense in depth — the row in
+         agent_side_effects is the source of truth, but verifying the
+         token catches a row that was tampered with via raw SQL).
+       - checks expiry (TTL = 5 min).
+       - checks tenant_id matches the JWT-resolved tenant_id.
+       - checks idempotency_key (= proposal_id) hasn't been consumed.
+       - re-checks current state (TOCTOU: position still open, symbol
+         still PAUSED, tune still pending).
+       - invokes the downstream handler with the user's cookie.
+       - persists the result to agent_side_effects.
+
+  3. Idempotency: the UNIQUE constraint on agent_side_effects.idempotency_key
+     makes a double-click safe at the DB layer. The application-level
+     check also short-circuits — same proposal confirmed twice returns
+     the first result, never re-executes the side effect.
+
+Secrets:
+  - AGENT_PROPOSAL_SECRET (env var) — used for HMAC. Separate from
+    JWT_SECRET so rotating one doesn't invalidate the other (PR #404
+    review issue 1 generalized).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from db.connection import get_db
+
+log = logging.getLogger("api.agent.proposals")
+
+
+# 5-minute TTL — pre-reg §10.1. Long enough for the user to read the
+# proposal and decide; short enough that a stale tab can't replay a
+# proposal an hour later.
+PROPOSAL_TTL_SECONDS = 300
+
+
+# Closed enum for `action`. Every propose_* tool must populate one of
+# these; the confirm endpoint dispatches downstream based on the value.
+ACTION_CLOSE_POSITION     = "close_position"
+ACTION_REACTIVATE_SYMBOL  = "reactivate_symbol"
+ACTION_APPLY_TUNE         = "apply_tune"
+
+_ALLOWED_ACTIONS: frozenset[str] = frozenset({
+    ACTION_CLOSE_POSITION,
+    ACTION_REACTIVATE_SYMBOL,
+    ACTION_APPLY_TUNE,
+})
+
+
+# Result enum on agent_side_effects.result:
+#   NULL     — pending (proposal emitted, not yet confirmed)
+#   "ok"     — confirmed + downstream handler succeeded
+#   "error"  — confirmed but downstream handler failed
+#   "conflict"— confirmed but TOCTOU re-check failed (state drifted)
+#   "expired"— confirm arrived after TTL
+
+
+class ProposalError(Exception):
+    """Raised when sign/verify/persist hits an invariant. Caught at the
+    request boundary and translated to a closed-enum HTTP detail."""
+
+    def __init__(self, reason: str, message: str = ""):
+        super().__init__(message or reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class SignedProposal:
+    """The full envelope returned by sign_proposal. The frontend gets
+    the `proposal_id` (visible) AND the `signed_payload` (opaque token
+    it sends back on confirm). Persisted row in agent_side_effects
+    only records proposal_id + args + expires_at; the signature is
+    derived deterministically from the secret on verify, so we don't
+    persist it."""
+    proposal_id:    str
+    signed_payload: str
+    action:         str
+    args:           dict
+    tenant_id:      int
+    expires_at:     str   # ISO 8601
+
+
+def _secret() -> bytes:
+    """Read AGENT_PROPOSAL_SECRET from env. Distinct from JWT_SECRET so
+    rotating one doesn't tumble proposals-in-flight (PR #404 review)."""
+    raw = (os.environ.get("AGENT_PROPOSAL_SECRET") or "").strip()
+    if not raw:
+        # Same reason as the agent_disabled enum — we don't leak the
+        # env var name to the wire. The endpoint translates this to a
+        # 503 with detail="agent_disabled".
+        raise ProposalError(
+            "agent_disabled",
+            "AGENT_PROPOSAL_SECRET not configured",
+        )
+    return raw.encode("utf-8")
+
+
+def _new_proposal_id() -> str:
+    """URL-safe 16-byte token, prefixed for log-grep friendliness."""
+    return "prop_" + secrets.token_urlsafe(16)
+
+
+def _canonical_payload(
+    *,
+    proposal_id: str,
+    action:      str,
+    args:        dict,
+    tenant_id:   int,
+    expires_at:  str,
+) -> bytes:
+    """Deterministic serialization of the payload — same bytes on sign
+    and on verify, so the HMAC stays stable. sort_keys + ensure_ascii
+    + tightly-defined separators are the same invariants we enforce on
+    the prompt cache prefix in api/agent/prompts (pre-reg §7.5)."""
+    doc = {
+        "v":         1,                # version for forward compat
+        "proposal_id": proposal_id,
+        "action":    action,
+        "args":      args,
+        "tenant_id": tenant_id,
+        "expires_at": expires_at,
+    }
+    return json.dumps(
+        doc,
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def sign_proposal(
+    *,
+    action:    str,
+    args:      dict,
+    tenant_id: int,
+) -> SignedProposal:
+    """Emit a new signed proposal. Caller MUST have already verified
+    that the action is grounded (position belongs to tenant, etc.).
+    """
+    if action not in _ALLOWED_ACTIONS:
+        raise ProposalError(
+            "invalid_action",
+            f"action {action!r} not in allowed set",
+        )
+    proposal_id = _new_proposal_id()
+    expires_dt = datetime.now(timezone.utc) + timedelta(seconds=PROPOSAL_TTL_SECONDS)
+    expires_at = expires_dt.isoformat()
+
+    payload_bytes = _canonical_payload(
+        proposal_id=proposal_id,
+        action=action,
+        args=args,
+        tenant_id=tenant_id,
+        expires_at=expires_at,
+    )
+    mac = hmac.new(_secret(), payload_bytes, hashlib.sha256).hexdigest()
+    # Frontend treats `signed_payload` as an opaque blob; the server
+    # parses it back into the same components on verify. Format:
+    # base64-free, dot-separated: "<hex-mac>.<base64url-payload>" — but
+    # we keep the payload visible in dev logs by using urlsafe base64.
+    import base64
+    payload_b64 = base64.urlsafe_b64encode(payload_bytes).decode("ascii").rstrip("=")
+    signed_payload = f"{mac}.{payload_b64}"
+    return SignedProposal(
+        proposal_id=proposal_id,
+        signed_payload=signed_payload,
+        action=action,
+        args=args,
+        tenant_id=tenant_id,
+        expires_at=expires_at,
+    )
+
+
+def verify_proposal(signed_payload: str) -> dict:
+    """Verify the HMAC + parse the payload. Raises ProposalError on
+    any failure. Does NOT check expiry, ownership, or idempotency —
+    those are checked at the confirm endpoint with the DB row in hand."""
+    if not isinstance(signed_payload, str) or "." not in signed_payload:
+        raise ProposalError("invalid_payload", "missing separator")
+    try:
+        mac_hex, payload_b64 = signed_payload.split(".", 1)
+    except ValueError:
+        raise ProposalError("invalid_payload", "split failed")
+    import base64
+    # Re-pad the base64 (we stripped = on sign).
+    padding = "=" * (-len(payload_b64) % 4)
+    try:
+        payload_bytes = base64.urlsafe_b64decode(payload_b64 + padding)
+    except Exception as e:  # noqa: BLE001
+        raise ProposalError("invalid_payload", f"base64 decode failed: {e}")
+    try:
+        payload = json.loads(payload_bytes)
+    except json.JSONDecodeError as e:
+        raise ProposalError("invalid_payload", f"json decode failed: {e}")
+    if not isinstance(payload, dict):
+        raise ProposalError("invalid_payload", "payload not an object")
+    # Re-canonicalize and compare MAC. Using compare_digest avoids
+    # timing-side-channel.
+    try:
+        proposal_id = str(payload["proposal_id"])
+        action      = str(payload["action"])
+        args        = dict(payload["args"])
+        tenant_id   = int(payload["tenant_id"])
+        expires_at  = str(payload["expires_at"])
+    except (KeyError, ValueError, TypeError) as e:
+        raise ProposalError("invalid_payload", f"missing field: {e}")
+    expected_bytes = _canonical_payload(
+        proposal_id=proposal_id,
+        action=action,
+        args=args,
+        tenant_id=tenant_id,
+        expires_at=expires_at,
+    )
+    expected_mac = hmac.new(_secret(), expected_bytes, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected_mac, mac_hex):
+        raise ProposalError("signature_mismatch", "HMAC does not match")
+    return payload
+
+
+def persist_proposal(
+    *,
+    tenant_id:        int,
+    conversation_id:  str,
+    proposal:         SignedProposal,
+) -> None:
+    """Insert the proposal into agent_side_effects with result=NULL.
+    The UNIQUE constraint on idempotency_key (= proposal_id) makes
+    a re-insert with the same id raise IntegrityError — which we
+    treat as "already persisted, no-op" (defensive; same proposal
+    can't naturally be re-signed because proposal_id is a fresh
+    token_urlsafe each time).
+    """
+    import sqlite3
+    con = get_db()
+    try:
+        con.execute(
+            """INSERT INTO agent_side_effects
+               (tenant_id, conversation_id, ts, action, args_json,
+                idempotency_key, result, http_status, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?)""",
+            (
+                tenant_id,
+                conversation_id,
+                datetime.now(timezone.utc).isoformat(),
+                proposal.action,
+                json.dumps(proposal.args, sort_keys=True),
+                proposal.proposal_id,
+                proposal.expires_at,
+            ),
+        )
+        con.commit()
+    except sqlite3.IntegrityError:
+        log.warning(
+            "persist_proposal: idempotency_key collision for %s — ignoring",
+            proposal.proposal_id,
+        )
+    finally:
+        con.close()
+
+
+def load_proposal_row(proposal_id: str) -> Optional[dict]:
+    """Fetch the row from agent_side_effects. Returns None if absent.
+    Caller compares result column to decide pending vs consumed."""
+    con = get_db()
+    try:
+        row = con.execute(
+            """SELECT id, tenant_id, conversation_id, ts, action, args_json,
+                      idempotency_key, result, http_status, expires_at
+               FROM agent_side_effects
+               WHERE idempotency_key = ?""",
+            (proposal_id,),
+        ).fetchone()
+    finally:
+        con.close()
+    return dict(row) if row else None
+
+
+def mark_proposal_result(
+    *,
+    proposal_id: str,
+    result:      str,
+    http_status: Optional[int] = None,
+) -> None:
+    """Update the result column. result ∈ ok/error/conflict/expired."""
+    con = get_db()
+    try:
+        con.execute(
+            "UPDATE agent_side_effects "
+            "SET result = ?, http_status = ? "
+            "WHERE idempotency_key = ?",
+            (result, http_status, proposal_id),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def is_expired(proposal_row: dict) -> bool:
+    """Compare expires_at to now. Robust to legacy rows where
+    expires_at is NULL (treated as expired so a stale row pre-Phase 3
+    can't be confirmed)."""
+    iso = proposal_row.get("expires_at")
+    if not iso:
+        return True
+    try:
+        expires_dt = datetime.fromisoformat(iso)
+    except ValueError:
+        return True
+    return datetime.now(timezone.utc) > expires_dt

--- a/api/agent/proposals.py
+++ b/api/agent/proposals.py
@@ -34,6 +34,19 @@ Secrets:
   - AGENT_PROPOSAL_SECRET (env var) — used for HMAC. Separate from
     JWT_SECRET so rotating one doesn't invalidate the other (PR #404
     review issue 1 generalized).
+
+Envelope versioning (v field):
+  - The canonical payload includes "v": 1. verify_proposal rejects any
+    other value with reason="unsupported_version".
+  - ADDING A FIELD TO THE ENVELOPE IS A BREAKING CHANGE. Bumping the
+    schema means: (a) bump v to 2 in _canonical_payload, (b) update
+    verify_proposal to accept both 1 and 2 during a migration window,
+    (c) write a backfill / sunset plan for in-flight v=1 proposals
+    (worst case: their TTL of 5 min is the natural drain window).
+  - Adding a field without bumping v will silently invalidate every
+    proposal-in-flight: the new sign produces a different MAC than the
+    old verify can reconstruct, and the user sees an opaque
+    signature_mismatch.
 """
 from __future__ import annotations
 
@@ -218,6 +231,16 @@ def verify_proposal(signed_payload: str) -> dict:
         raise ProposalError("invalid_payload", f"json decode failed: {e}")
     if not isinstance(payload, dict):
         raise ProposalError("invalid_payload", "payload not an object")
+    # Envelope schema gate. We currently only know v=1; reject anything
+    # else loudly with a closed-enum reason so an attacker (or a future
+    # rollback that left a v=2 signer running against a v=1 verifier)
+    # gets a distinguishable error from "tampered MAC". See top-of-module
+    # docstring for the v contract.
+    if int(payload.get("v", 0)) != 1:
+        raise ProposalError(
+            "unsupported_version",
+            f"envelope v={payload.get('v')!r} not supported",
+        )
     # Re-canonicalize and compare MAC. Using compare_digest avoids
     # timing-side-channel.
     try:

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -32,6 +32,16 @@ from api.agent.audit import TurnAuditWrapper
 from api.agent.clients import get_anthropic_client
 from api.agent.config import get_agent_status
 from api.agent.loop import run_turn
+from api.agent.proposals import (
+    ACTION_APPLY_TUNE,
+    ACTION_CLOSE_POSITION,
+    ACTION_REACTIVATE_SYMBOL,
+    ProposalError,
+    is_expired,
+    load_proposal_row,
+    mark_proposal_result,
+    verify_proposal,
+)
 from api.agent.streaming import sse_serialize
 from auth.dependencies import get_current_tenant_id
 
@@ -141,6 +151,7 @@ async def post_agent_turn(
         surface=body.surface,
         messages=messages,
         tenant_id=tenant_id,
+        conversation_id=conversation_id,
     )
     audited = TurnAuditWrapper(
         loop_events,
@@ -163,3 +174,163 @@ async def post_agent_turn(
             "Connection":        "keep-alive",
         },
     )
+
+
+# ── /agent/proposals/{id}/confirm (Phase 3) ────────────────────────────
+
+
+class _ConfirmProposalRequest(BaseModel):
+    """Body of POST /agent/proposals/{id}/confirm.
+
+    `signed_payload` is the opaque token the frontend received in the
+    `proposal` SSE event. The server verifies the HMAC, checks the TTL
+    + ownership + idempotency, then invokes the downstream handler.
+    """
+    signed_payload: str = Field(..., min_length=20, max_length=4096)
+
+
+@router.post(
+    "/agent/proposals/{proposal_id}/confirm",
+    summary="Confirm a signed proposal emitted by a propose_* tool",
+)
+async def post_confirm_proposal(
+    proposal_id: str = Path(
+        ..., min_length=1, max_length=128, pattern=r"^prop_[A-Za-z0-9_\-]+$",
+    ),
+    body: _ConfirmProposalRequest = ...,  # noqa: B008
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    """Verify HMAC + TTL + ownership + idempotency, then run the downstream
+    action with the user's session. Pre-reg §10.
+
+    Failure modes (all return a closed-enum `detail`, never leak):
+      - signature_mismatch       — HMAC failed; possible tampering.
+      - invalid_payload          — token shape wrong.
+      - not_found                — proposal_id absent from DB.
+      - tenant_mismatch          — caller's tenant ≠ signed tenant.
+      - expired                  — TTL passed.
+      - already_consumed         — confirm already ran (idempotent return).
+      - state_drift              — TOCTOU re-check failed (position closed,
+                                   symbol no longer PAUSED, tune already
+                                   applied, etc).
+    """
+    # 1. Status gate (same as the turn endpoint).
+    status = get_agent_status()
+    if not status.enabled:
+        raise HTTPException(status_code=503, detail=status.reason)
+
+    # 2. Verify the HMAC + parse the payload.
+    try:
+        payload = verify_proposal(body.signed_payload)
+    except ProposalError as e:
+        raise HTTPException(status_code=400, detail=e.reason)
+
+    if payload.get("proposal_id") != proposal_id:
+        raise HTTPException(status_code=400, detail="proposal_id_mismatch")
+
+    # 3. Tenant check — the JWT-resolved tenant_id MUST match the signed one.
+    if int(payload.get("tenant_id", -1)) != tenant_id:
+        # Closed-enum reason. NEVER reveal whose tenant signed it; this is
+        # indistinguishable from a not_found for an audit attacker.
+        raise HTTPException(status_code=404, detail="not_found")
+
+    # 4. Load the persisted row + check idempotency.
+    row = load_proposal_row(proposal_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="not_found")
+
+    # If a previous confirm already ran, return that result (idempotent).
+    # The UNIQUE constraint on idempotency_key at the DB layer is the
+    # safety net; this app-level check returns the cached result instead
+    # of trying to re-execute the action.
+    if row.get("result") is not None:
+        return {
+            "ok": (row["result"] == "ok"),
+            "result": row["result"],
+            "http_status": row.get("http_status"),
+            "idempotent": True,
+        }
+
+    # 5. TTL check (uses the DB column, not the signed payload — the
+    # confirm endpoint trusts the DB row above the wire).
+    if is_expired(row):
+        mark_proposal_result(proposal_id=proposal_id, result="expired", http_status=410)
+        raise HTTPException(status_code=410, detail="expired")
+
+    # 6. TOCTOU re-check + downstream dispatch.
+    action = row["action"]
+    import json as _json
+    args = _json.loads(row["args_json"] or "{}")
+    try:
+        result = _execute_proposed_action(
+            action=action, args=args, tenant_id=tenant_id,
+        )
+    except HTTPException as he:
+        mark_proposal_result(
+            proposal_id=proposal_id,
+            result="state_drift" if he.status_code == 409 else "error",
+            http_status=he.status_code,
+        )
+        raise
+
+    mark_proposal_result(proposal_id=proposal_id, result="ok", http_status=200)
+    return {"ok": True, "result": "ok", "action_result": result, "idempotent": False}
+
+
+def _execute_proposed_action(*, action: str, args: dict, tenant_id: int) -> dict:
+    """Dispatch the downstream action with tenant_id bound. Each action
+    re-checks current state (TOCTOU) before mutating. Raises HTTPException
+    on conflict so the caller can persist the right `result` enum.
+    """
+    if action == ACTION_CLOSE_POSITION:
+        from db.positions import db_close_position
+        import btc_api
+        position_id = int(args["position_id"])
+        exit_price = float(args["exit_price"])
+        # TOCTOU guards (both have to fire — db_close_position itself
+        # only filters by id+tenant, NOT by status, and would happily
+        # overwrite the exit_reason of a position already closed via
+        # SL/TP/TIME_LIMIT between propose and confirm):
+        #   1. row must still exist for this tenant (IDOR null pattern)
+        #   2. row must still be `open` (not closed by another flow)
+        con = btc_api.get_db()
+        try:
+            current = con.execute(
+                "SELECT status FROM positions WHERE id=? AND tenant_id=?",
+                (position_id, tenant_id),
+            ).fetchone()
+        finally:
+            con.close()
+        if current is None or dict(current).get("status") != "open":
+            raise HTTPException(status_code=409, detail="state_drift")
+        pos = db_close_position(
+            position_id, exit_price, "MANUAL_AGENT",
+            tenant_id=tenant_id,
+        )
+        if pos is None:
+            raise HTTPException(status_code=409, detail="state_drift")
+        return {"position": pos}
+
+    if action == ACTION_REACTIVATE_SYMBOL:
+        from health import get_symbol_state, reactivate_symbol
+        from api.config import load_config
+        symbol = str(args["symbol"]).upper()
+        reason = str(args.get("reason", "manual_override_via_copilot"))
+        current = get_symbol_state(symbol)
+        if current != "PAUSED":
+            raise HTTPException(status_code=409, detail="state_drift")
+        reactivate_symbol(symbol, reason=reason, cfg=load_config())
+        return {"symbol": symbol, "state": get_symbol_state(symbol)}
+
+    if action == ACTION_APPLY_TUNE:
+        from api.tune import tune_apply, tune_latest
+        tune_id = int(args["tune_id"])
+        latest = tune_latest()
+        if not latest or int(latest.get("id", 0)) != tune_id or latest.get("applied"):
+            raise HTTPException(status_code=409, detail="state_drift")
+        applied = tune_apply()
+        return {"tune_id": tune_id, "applied": applied}
+
+    # Unknown action — closed enum, should never happen because the
+    # propose handlers wrote it.
+    raise HTTPException(status_code=400, detail="unknown_action")

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -43,7 +43,8 @@ from api.agent.proposals import (
     verify_proposal,
 )
 from api.agent.streaming import sse_serialize
-from auth.dependencies import get_current_tenant_id
+from auth.dependencies import get_current_tenant_id, get_current_user
+from auth.models import User
 
 log = logging.getLogger("api.agent.router")
 
@@ -198,13 +199,14 @@ async def post_confirm_proposal(
         ..., min_length=1, max_length=128, pattern=r"^prop_[A-Za-z0-9_\-]+$",
     ),
     body: _ConfirmProposalRequest = ...,  # noqa: B008
-    tenant_id: int = Depends(get_current_tenant_id),
+    user: User = Depends(get_current_user),  # noqa: B008
 ):
     """Verify HMAC + TTL + ownership + idempotency, then run the downstream
     action with the user's session. Pre-reg §10.
 
     Failure modes (all return a closed-enum `detail`, never leak):
       - signature_mismatch       — HMAC failed; possible tampering.
+      - unsupported_version      — envelope v != 1.
       - invalid_payload          — token shape wrong.
       - not_found                — proposal_id absent from DB.
       - tenant_mismatch          — caller's tenant ≠ signed tenant.
@@ -213,7 +215,10 @@ async def post_confirm_proposal(
       - state_drift              — TOCTOU re-check failed (position closed,
                                    symbol no longer PAUSED, tune already
                                    applied, etc).
+      - role_required            — non-admin tried to execute a global
+                                   action (apply_tune / reactivate_symbol).
     """
+    tenant_id = user.id
     # 1. Status gate (same as the turn endpoint).
     status = get_agent_status()
     if not status.enabled:
@@ -263,12 +268,21 @@ async def post_confirm_proposal(
     args = _json.loads(row["args_json"] or "{}")
     try:
         result = _execute_proposed_action(
-            action=action, args=args, tenant_id=tenant_id,
+            action=action, args=args, tenant_id=tenant_id, user_role=user.role,
         )
     except HTTPException as he:
+        # 403 (role) is a different terminal state from 409 (drift).
+        # Persist with distinguishable result enum so audit can tell them
+        # apart; the http_status column also carries the canonical code.
+        if he.status_code == 403:
+            result_enum = "role_required"
+        elif he.status_code == 409:
+            result_enum = "state_drift"
+        else:
+            result_enum = "error"
         mark_proposal_result(
             proposal_id=proposal_id,
-            result="state_drift" if he.status_code == 409 else "error",
+            result=result_enum,
             http_status=he.status_code,
         )
         raise
@@ -277,11 +291,33 @@ async def post_confirm_proposal(
     return {"ok": True, "result": "ok", "action_result": result, "idempotent": False}
 
 
-def _execute_proposed_action(*, action: str, args: dict, tenant_id: int) -> dict:
+# Actions whose downstream mutates GLOBAL state (config.json shared
+# across all tenants, or symbol_health.state shared across all tenants).
+# These require role=admin at the confirm boundary — propose still runs
+# for any authenticated user (the model can reason about them), but the
+# actual mutation is gated. Per pre-reg §10.2 + review of PR #406.
+_ADMIN_ONLY_ACTIONS: frozenset[str] = frozenset({
+    ACTION_REACTIVATE_SYMBOL,
+    ACTION_APPLY_TUNE,
+})
+
+
+def _execute_proposed_action(
+    *, action: str, args: dict, tenant_id: int, user_role: str,
+) -> dict:
     """Dispatch the downstream action with tenant_id bound. Each action
     re-checks current state (TOCTOU) before mutating. Raises HTTPException
     on conflict so the caller can persist the right `result` enum.
+
+    Role gate: global-scope actions (reactivate_symbol, apply_tune) require
+    user_role == 'admin'. close_position is per-tenant and runs for any
+    authenticated owner.
     """
+    if action in _ADMIN_ONLY_ACTIONS and user_role != "admin":
+        # Closed-enum detail. The model-facing summary doesn't reveal
+        # which role; the operator can read http_status=403 + result=
+        # 'role_required' in audit.
+        raise HTTPException(status_code=403, detail="role_required")
     if action == ACTION_CLOSE_POSITION:
         from db.positions import db_close_position
         import btc_api

--- a/api/agent/streaming.py
+++ b/api/agent/streaming.py
@@ -19,6 +19,7 @@ from api.agent.loop import (
     ErrorEvent,
     LoopEvent,
     MessageEnd,
+    ProposalEvent,
     TextDelta,
     ToolUseResult,
     ToolUseStart,
@@ -48,6 +49,18 @@ async def sse_serialize(events: AsyncIterator[LoopEvent]) -> AsyncIterator[bytes
             yield _sse_frame("tool_use_result", {
                 "tool":   ev.tool,
                 "status": ev.status,
+            })
+        elif isinstance(ev, ProposalEvent):
+            # Phase 3: the frontend renders an amber confirm button.
+            # signed_payload is opaque on the wire — frontend echoes it
+            # back to POST /agent/proposals/{id}/confirm.
+            yield _sse_frame("proposal", {
+                "proposal_id":    ev.proposal_id,
+                "signed_payload": ev.signed_payload,
+                "action":         ev.action,
+                "args":           ev.args,
+                "expires_at":     ev.expires_at,
+                "summary":        ev.summary,
             })
         elif isinstance(ev, MessageEnd):
             yield _sse_frame("message_end", {

--- a/api/agent/tools/handlers.py
+++ b/api/agent/tools/handlers.py
@@ -287,10 +287,18 @@ def get_tune_proposal(*, tenant_id: int) -> dict:  # noqa: ARG001
 # ── Dispatch entry point ────────────────────────────────────────────────
 
 
-# Map of tool name → (input model class, handler function). The
-# conversation core in Phase 2 reads this to validate the model's input
-# and dispatch to the right handler with tenant_id bound.
+# Map of tool name → handler function. The conversation core in Phase 2
+# reads this to validate the model's input and dispatch to the right
+# handler with tenant_id bound.
+#
+# Phase 3 (#400) merges in PROPOSE_HANDLERS from propose_handlers.py.
+# Propose handlers carry an extra `conversation_id` kwarg (they need it
+# to link the persisted proposal back to the conversation in
+# agent_side_effects); read-only handlers ignore conversation_id.
+from api.agent.tools.propose_handlers import PROPOSE_HANDLERS  # noqa: E402
+
 TOOL_HANDLERS: dict[str, Any] = {
+    # Read-only tools (Phase 1).
     "get_portfolio_overview":   get_portfolio_overview,
     "get_positions":            get_positions,
     "get_position_detail":      get_position_detail,
@@ -300,13 +308,30 @@ TOOL_HANDLERS: dict[str, Any] = {
     "get_recent_signals":       get_recent_signals,
     "get_closed_trades":        get_closed_trades,
     "get_tune_proposal":        get_tune_proposal,
+    # Propose tools (Phase 3). Same dispatch surface; the conversation
+    # loop knows to route their output through the proposal SSE event.
+    **PROPOSE_HANDLERS,
 }
 
 
-def dispatch_tool(name: str, raw_input: dict, *, tenant_id: int) -> str:
+def _is_propose_handler(name: str) -> bool:
+    return name in PROPOSE_HANDLERS
+
+
+def dispatch_tool(
+    name: str,
+    raw_input: dict,
+    *,
+    tenant_id: int,
+    conversation_id: str = "",
+) -> str:
     """Validate the model's tool input against the schema, then run the
     handler with `tenant_id` bound. Returns a JSON string suitable for
     `tool_result.content`.
+
+    Propose handlers (Phase 3) ALSO receive `conversation_id` so the
+    persisted proposal in agent_side_effects links back to the
+    conversation that emitted it. Read-only handlers don't need it.
 
     Errors (unknown tool, schema mismatch, handler exception) are
     serialized as `{"error": "..."}` content with the calling convention
@@ -324,7 +349,14 @@ def dispatch_tool(name: str, raw_input: dict, *, tenant_id: int) -> str:
     try:
         handler = TOOL_HANDLERS[name]
         kwargs = validated.model_dump() if validated else {}
-        result = handler(tenant_id=tenant_id, **kwargs)
+        if _is_propose_handler(name):
+            result = handler(
+                tenant_id=tenant_id,
+                conversation_id=conversation_id,
+                **kwargs,
+            )
+        else:
+            result = handler(tenant_id=tenant_id, **kwargs)
     except Exception as e:  # noqa: BLE001
         log.warning("dispatch_tool: %s raised %s", name, e, exc_info=True)
         return json.dumps({"error": "handler_error", "detail": str(e)})

--- a/api/agent/tools/propose_handlers.py
+++ b/api/agent/tools/propose_handlers.py
@@ -1,0 +1,218 @@
+"""Phase 3 propose handlers — the agent emits a *proposal*, never an action.
+
+Every handler in this module:
+
+  1. Validates that the action is GROUNDED — the position belongs to
+     the tenant, the symbol is in the curated set, the tune is the
+     latest pending one. If anything fails, returns {"error": "..."}
+     and never signs a proposal.
+
+  2. Calls api.agent.proposals.sign_proposal(...) to mint a fresh
+     proposal_id + HMAC-signed payload. The HMAC uses
+     AGENT_PROPOSAL_SECRET (env var separate from JWT_SECRET).
+
+  3. Persists the proposal in agent_side_effects with result=NULL.
+
+  4. Returns a dict back to the model with a `_proposal` envelope. The
+     loop in api/agent/loop.py picks this up, emits a `proposal` SSE
+     event (so the frontend can render the amber confirm button), and
+     hands the tool_result to the model unchanged — the model only
+     sees the user-facing summary, never the signed token.
+
+The model NEVER receives nor needs the signed_payload. The frontend
+holds it between the proposal event and the confirm POST.
+
+Pre-reg §10.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from db.connection import get_db
+
+from api.agent.proposals import (
+    ACTION_APPLY_TUNE,
+    ACTION_CLOSE_POSITION,
+    ACTION_REACTIVATE_SYMBOL,
+    ProposalError,
+    persist_proposal,
+    sign_proposal,
+)
+
+log = logging.getLogger("api.agent.tools.propose_handlers")
+
+
+def _model_facing(proposal, summary: str) -> dict:
+    """Build the shape returned to the model. The signed_payload is
+    NOT in here — it travels via the proposal SSE event to the
+    frontend, never via the model context. The `_proposal` envelope
+    is a marker the loop reads to know it should emit a proposal event."""
+    return {
+        "_proposal": {
+            "proposal_id":    proposal.proposal_id,
+            "signed_payload": proposal.signed_payload,
+            "action":         proposal.action,
+            "args":           proposal.args,
+            "expires_at":     proposal.expires_at,
+            "summary":        summary,
+        },
+        # Visible-to-model summary — short, actionable, doesn't include
+        # the signed token. The model uses this to explain the proposal
+        # back to the user.
+        "proposal_id": proposal.proposal_id,
+        "expires_in":  300,
+        "summary":     summary,
+    }
+
+
+# ── propose_close_position ─────────────────────────────────────────────
+
+
+def propose_close_position(
+    *,
+    tenant_id:       int,
+    conversation_id: str,
+    position_id:     int,
+    exit_price:      float,
+    rationale:       str,
+) -> dict:
+    """Verify ownership, sign a close_position proposal, persist."""
+    con = get_db()
+    try:
+        row = con.execute(
+            "SELECT symbol, direction, status, entry_price, size_usd "
+            "FROM positions WHERE id = ? AND tenant_id = ?",
+            (position_id, tenant_id),
+        ).fetchone()
+    finally:
+        con.close()
+    if row is None:
+        return {"error": "not_found"}
+    pos = dict(row)
+    if pos["status"] != "open":
+        return {"error": "position_not_open"}
+
+    try:
+        proposal = sign_proposal(
+            action=ACTION_CLOSE_POSITION,
+            args={"position_id": position_id, "exit_price": float(exit_price)},
+            tenant_id=tenant_id,
+        )
+        persist_proposal(
+            tenant_id=tenant_id,
+            conversation_id=conversation_id,
+            proposal=proposal,
+        )
+    except ProposalError as e:
+        log.warning("propose_close_position sign/persist failed: %s", e.reason)
+        return {"error": e.reason}
+
+    summary = (
+        f"Cerrar posición #{position_id} ({pos['symbol']} {pos['direction']}) "
+        f"a ${exit_price}. Rationale: {rationale[:200]}"
+    )
+    return _model_facing(proposal, summary)
+
+
+# ── propose_reactivate_symbol ──────────────────────────────────────────
+
+
+def propose_reactivate_symbol(
+    *,
+    tenant_id:       int,
+    conversation_id: str,
+    symbol:          str,
+    reason:          str,
+) -> dict:
+    """Verify the symbol is currently PAUSED, sign + persist."""
+    norm = symbol.upper().strip()
+    if not norm.endswith("USDT"):
+        norm = f"{norm}USDT"
+    con = get_db()
+    try:
+        row = con.execute(
+            "SELECT state FROM symbol_health WHERE symbol = ?",
+            (norm,),
+        ).fetchone()
+    finally:
+        con.close()
+    if row is None:
+        return {"error": "not_found"}
+    state = dict(row)["state"]
+    if state != "PAUSED":
+        return {"error": "symbol_not_paused", "current_state": state}
+
+    try:
+        proposal = sign_proposal(
+            action=ACTION_REACTIVATE_SYMBOL,
+            args={"symbol": norm, "reason": reason[:500]},
+            tenant_id=tenant_id,
+        )
+        persist_proposal(
+            tenant_id=tenant_id,
+            conversation_id=conversation_id,
+            proposal=proposal,
+        )
+    except ProposalError as e:
+        log.warning("propose_reactivate_symbol failed: %s", e.reason)
+        return {"error": e.reason}
+
+    summary = (
+        f"Liberar {norm} de PAUSED → PROBATION. Reason: {reason[:200]}"
+    )
+    return _model_facing(proposal, summary)
+
+
+# ── propose_apply_tune ─────────────────────────────────────────────────
+
+
+def propose_apply_tune(
+    *,
+    tenant_id:       int,
+    conversation_id: str,
+    tune_id:         int,
+    rationale:       str,
+) -> dict:
+    """Verify the tune is pending + matches the latest one + sign."""
+    try:
+        from api.tune import tune_latest  # noqa: PLC0415
+        latest = tune_latest()
+    except Exception:  # noqa: BLE001
+        log.warning("propose_apply_tune: tune_latest failed", exc_info=True)
+        return {"error": "tune_unavailable"}
+    if not latest:
+        return {"error": "no_pending_tune"}
+    if int(latest.get("id", 0)) != int(tune_id):
+        return {"error": "tune_mismatch", "latest_tune_id": latest.get("id")}
+    if latest.get("applied"):
+        return {"error": "tune_already_applied"}
+
+    try:
+        proposal = sign_proposal(
+            action=ACTION_APPLY_TUNE,
+            args={"tune_id": int(tune_id)},
+            tenant_id=tenant_id,
+        )
+        persist_proposal(
+            tenant_id=tenant_id,
+            conversation_id=conversation_id,
+            proposal=proposal,
+        )
+    except ProposalError as e:
+        log.warning("propose_apply_tune failed: %s", e.reason)
+        return {"error": e.reason}
+
+    summary = f"Aplicar auto-tune #{tune_id}. Rationale: {rationale[:200]}"
+    return _model_facing(proposal, summary)
+
+
+# Map exposed to the dispatch surface. Each handler is keyword-only
+# with `tenant_id` AND `conversation_id` required — the latter is the
+# new wrinkle vs read-only tools: we need it to thread into
+# agent_side_effects.conversation_id so the audit row links back.
+PROPOSE_HANDLERS = {
+    "propose_close_position":    propose_close_position,
+    "propose_reactivate_symbol": propose_reactivate_symbol,
+    "propose_apply_tune":        propose_apply_tune,
+}

--- a/api/agent/tools/registry.py
+++ b/api/agent/tools/registry.py
@@ -33,6 +33,9 @@ from api.agent.tools.schemas import (
     GetSymbolSetupIn,
     GetSymbolsWithSignalsIn,
     GetTuneProposalIn,
+    ProposeApplyTuneIn,
+    ProposeClosePositionIn,
+    ProposeReactivateSymbolIn,
 )
 
 
@@ -142,6 +145,44 @@ TOOL_CATALOG: tuple[ToolSpec, ...] = (
             "the user is on the AutoTune view or asks about parameter changes."
         ),
         schema=GetTuneProposalIn,
+        surfaces=frozenset({"dock", "autotune"}),
+    ),
+    # ── Propose tools (Phase 3). These NEVER execute the action — the
+    # tool signs a proposal envelope; the UI shows an amber confirm
+    # button; only on user confirmation does the downstream handler run.
+    # The model receives a user-facing summary, never the signed token.
+    ToolSpec(
+        name="propose_close_position",
+        description=(
+            "Propose closing one of the user's open positions. Server signs a "
+            "5-min-TTL proposal; the UI renders an amber confirm button. NEVER "
+            "do this unless the user explicitly asked to close the position AND "
+            "has articulated a rationale. The downstream close fires only on "
+            "user confirmation."
+        ),
+        schema=ProposeClosePositionIn,
+        surfaces=frozenset({"dock"}),
+    ),
+    ToolSpec(
+        name="propose_reactivate_symbol",
+        description=(
+            "Propose moving a PAUSED symbol back to PROBATION. Use this when "
+            "the user has articulated a concrete reason for the override (a "
+            "regime change, a specific catalyst, etc), NOT for vague feelings. "
+            "Server signs + persists the proposal; the UI confirms."
+        ),
+        schema=ProposeReactivateSymbolIn,
+        surfaces=frozenset({"dock", "kill_switch"}),
+    ),
+    ToolSpec(
+        name="propose_apply_tune",
+        description=(
+            "Propose applying a pending auto-tune to the live config. The "
+            "tune_id must come from a prior get_tune_proposal call in the "
+            "same conversation. Use this when the user has reasoned through "
+            "the risks per-symbol."
+        ),
+        schema=ProposeApplyTuneIn,
         surfaces=frozenset({"dock", "autotune"}),
     ),
 )

--- a/api/agent/tools/schemas.py
+++ b/api/agent/tools/schemas.py
@@ -66,16 +66,49 @@ class GetTuneProposalIn(BaseModel):
     pass
 
 
+# ── Propose (side-effect) tool schemas ──────────────────────────────────
+
+
+class ProposeClosePositionIn(BaseModel):
+    """Propose closing one of the user's open positions. Server signs the
+    proposal; UI confirms; downstream POST /positions/{id}/close fires
+    only after the user approves. Tenant ownership is enforced server-side."""
+    position_id: int = Field(..., ge=1, description="Numeric position id (must belong to the user)")
+    exit_price:  float = Field(..., gt=0, description="Exit price in USD")
+    rationale:   str = Field(..., min_length=10, max_length=500,
+                             description="Why the close makes sense given current state. Surfaces in the confirm UI.")
+
+
+class ProposeReactivateSymbolIn(BaseModel):
+    """Propose moving a PAUSED symbol back to PROBATION. Operator-only
+    flow downstream; here we only emit the proposal envelope."""
+    symbol: str = Field(..., min_length=2, max_length=20, description="Ticker (e.g. 'BTCUSDT' or 'BTC')")
+    reason: str = Field(..., min_length=10, max_length=500,
+                        description="Why this symbol deserves to be reactivated now.")
+
+
+class ProposeApplyTuneIn(BaseModel):
+    """Propose applying a pending auto-tune to the live config. The
+    tune_id must come from a tool_result earlier in this conversation
+    (no hallucinated ids — pre-reg §11.4)."""
+    tune_id:    int = Field(..., ge=1)
+    rationale:  str = Field(..., min_length=10, max_length=500)
+
+
 # Convenience map for the registry. Order here is the canonical tool
 # ordering used in the system prompt's tool documentation block.
 TOOL_INPUT_SCHEMAS: dict[str, type[BaseModel]] = {
-    "get_portfolio_overview":   GetPortfolioOverviewIn,
-    "get_positions":            GetPositionsIn,
-    "get_position_detail":      GetPositionDetailIn,
-    "get_symbols_with_signals": GetSymbolsWithSignalsIn,
-    "get_symbol_setup":         GetSymbolSetupIn,
-    "get_kill_switch_state":    GetKillSwitchStateIn,
-    "get_recent_signals":       GetRecentSignalsIn,
-    "get_closed_trades":        GetClosedTradesIn,
-    "get_tune_proposal":        GetTuneProposalIn,
+    "get_portfolio_overview":      GetPortfolioOverviewIn,
+    "get_positions":               GetPositionsIn,
+    "get_position_detail":         GetPositionDetailIn,
+    "get_symbols_with_signals":    GetSymbolsWithSignalsIn,
+    "get_symbol_setup":            GetSymbolSetupIn,
+    "get_kill_switch_state":       GetKillSwitchStateIn,
+    "get_recent_signals":          GetRecentSignalsIn,
+    "get_closed_trades":           GetClosedTradesIn,
+    "get_tune_proposal":           GetTuneProposalIn,
+    # Propose / side-effect tools — Phase 3.
+    "propose_close_position":      ProposeClosePositionIn,
+    "propose_reactivate_symbol":   ProposeReactivateSymbolIn,
+    "propose_apply_tune":          ProposeApplyTuneIn,
 }

--- a/db/schema.py
+++ b/db/schema.py
@@ -474,6 +474,19 @@ def _migrate_agent_audit() -> None:
             )
             """
         )
+
+        # Phase 3 (#400): agent_side_effects gains `expires_at` so the
+        # confirm endpoint can short-circuit expired proposals without
+        # re-deriving the TTL from the signed payload. Idempotent ADD
+        # COLUMN (the existing rows have NULL — they predate the column,
+        # and a NULL expires_at is treated as "no TTL enforcement" for
+        # rows seeded before this migration).
+        try:
+            con.execute("ALTER TABLE agent_side_effects ADD COLUMN expires_at TEXT")
+            log.info("DB migration: added expires_at column to agent_side_effects")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+
         con.commit()
         log.info("DB migration: agent_conversations + agent_side_effects + agent_quotas ready")
     except Exception as e:  # noqa: BLE001

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,7 +56,7 @@ import { useLiveTicker } from './hooks/useLiveTicker';
 import { useMacro } from './hooks/useMacro';
 import { computeFocus } from './helpers/hierarchy';
 
-import SymbolDetail, { type PositionPreset } from './components/SymbolDetail';
+import SymbolDetail from './components/SymbolDetail';
 import AgentBrief from './components/AgentBrief';
 import AgentDock from './components/AgentDock';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -124,9 +124,6 @@ const App: React.FC = () => {
 
   // Signal to open as position (passed from SignalsTable)
   const [signalForPos, setSignalForPos] = useState<Signal | null>(null);
-
-  // Preset to open as position (passed from SymbolDetail)
-  const [presetForPos, setPresetForPos] = useState<PositionPreset | null>(null);
 
   // AgentDock state — open flag + optional prompt the AgentBrief chip
   // injected when the user clicked one of the canned questions.
@@ -233,23 +230,6 @@ const App: React.FC = () => {
       setSignalForPos(null);
     }
   }, [signalForPos]);
-
-  useEffect(() => {
-    if (presetForPos) {
-      // PositionPreset carries qty (base coin units); the modal's Capital
-      // field wants USD notional, so derive sizeUsd = qty × entry.
-      setOpenPositionPrefill({
-        symbol:    presetForPos.symbol,
-        price:     presetForPos.entry,
-        sl:        presetForPos.sl,
-        tp:        presetForPos.tp,
-        direction: presetForPos.direction,
-        sizeUsd:   presetForPos.qty * presetForPos.entry,
-      });
-      setOpenPositionModalOpen(true);
-      setPresetForPos(null);
-    }
-  }, [presetForPos]);
 
   // Compose the MacroState the agent (Brief + Dock) consumes — merges the
   // /macro response with /status scanner counters. Kill-switch count isn't
@@ -389,12 +369,6 @@ const App: React.FC = () => {
 
   const handleOpenFromSignal = useCallback((signal: Signal) => {
     setSignalForPos(signal);
-    setMainTab('posiciones');
-  }, []);
-
-  const handleOpenFromPreset = useCallback((preset: PositionPreset) => {
-    setSelectedSymbol(null);      // close SymbolDetail
-    setPresetForPos(preset);
     setMainTab('posiciones');
   }, []);
 
@@ -761,7 +735,6 @@ const App: React.FC = () => {
       <SymbolDetail
         symbol={selectedSymbol}
         onClose={() => setSelectedSymbol(null)}
-        onOpenPosition={handleOpenFromPreset}
         agentEnabled={AGENT_ENABLED}
       />
 

--- a/frontend/src/agent/client.ts
+++ b/frontend/src/agent/client.ts
@@ -134,3 +134,59 @@ export function newConversationId(): string {
   crypto.getRandomValues(buf);
   return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
 }
+
+// ── Phase 3: proposal confirm ────────────────────────────────────────
+
+/**
+ * Result of POST /agent/proposals/{id}/confirm. The frontend uses the
+ * `result` enum to drive the UI chip into a terminal state. The wire
+ * shape mirrors api/agent/router.py's response model.
+ */
+export interface ConfirmProposalResult {
+  ok:           boolean;
+  result:       'ok' | 'state_drift' | 'expired' | 'error';
+  http_status?: number;
+  idempotent?:  boolean;
+}
+
+/**
+ * Confirm a signed proposal. The signed_payload is the opaque token
+ * received in the `proposal` SSE frame — we echo it back to the server
+ * untouched so the HMAC verifies.
+ */
+export async function confirmAgentProposal(args: {
+  proposal_id:    string;
+  signed_payload: string;
+  signal?:        AbortSignal;
+}): Promise<ConfirmProposalResult> {
+  const path = `${BASE_URL}/agent/proposals/${encodeURIComponent(args.proposal_id)}/confirm`;
+  const resp = await fetch(path, {
+    method:      'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type':  'application/json',
+      'X-CSRF-Token':  readCsrfCookie(),
+    },
+    body:        JSON.stringify({ signed_payload: args.signed_payload }),
+    signal:      args.signal,
+  });
+
+  if (resp.status === 200) {
+    return (await resp.json()) as ConfirmProposalResult;
+  }
+
+  // Closed-enum mapping. 409 → state_drift, 410 → expired,
+  // anything else → error. We DO read `detail` to keep the http_status
+  // visible for debugging, but the UI surfaces only the bucket.
+  let detail: string | undefined;
+  try {
+    const body = await resp.json();
+    if (typeof body?.detail === 'string') detail = body.detail;
+  } catch {
+    /* non-json error body — ignore */
+  }
+  let bucket: ConfirmProposalResult['result'] = 'error';
+  if (resp.status === 409 || detail === 'state_drift') bucket = 'state_drift';
+  else if (resp.status === 410 || detail === 'expired') bucket = 'expired';
+  return { ok: false, result: bucket, http_status: resp.status };
+}

--- a/frontend/src/agent/types.ts
+++ b/frontend/src/agent/types.ts
@@ -9,6 +9,16 @@
 // Pre-reg §6.2. Phase 2B of epic #400.
 // ============================================================
 
+/**
+ * UI-level tool-call status chip rendered inline below an assistant
+ * bubble. Exported so future surfaces don't redefine the same shape
+ * (PR #405 review nit — single source of truth for the chip state enum).
+ */
+export interface ToolChip {
+  tool:   string;
+  status: 'pending' | 'ok' | 'error';
+}
+
 export interface AgentTextDelta {
   type: 'text_delta';
   text: string;

--- a/frontend/src/agent/types.ts
+++ b/frontend/src/agent/types.ts
@@ -53,12 +53,58 @@ export interface AgentErrorEvent {
   user_message:  string;
 }
 
+/**
+ * Phase 3 of epic #400 — emitted when a propose_* tool ran and the
+ * server signed a side-effect envelope. The frontend echoes
+ * `signed_payload` back verbatim to POST /agent/proposals/{id}/confirm
+ * on user click. The model never sees the signed_payload.
+ *
+ * `summary` is the user-facing one-line description ("Cerrar BTCUSDT
+ * LONG #42 a 51,000"). The action/args are exposed for UI grouping
+ * and labels but the wire authority is the signed_payload.
+ */
+export interface AgentProposalEvent {
+  type:           'proposal';
+  proposal_id:    string;
+  signed_payload: string;
+  action:         'close_position' | 'reactivate_symbol' | 'apply_tune';
+  args:           Record<string, unknown>;
+  expires_at:     string;
+  summary:        string;
+}
+
 export type AgentStreamEvent =
   | AgentTextDelta
   | AgentToolUseStart
   | AgentToolUseResult
+  | AgentProposalEvent
   | AgentMessageEnd
   | AgentErrorEvent;
+
+/**
+ * UI-side state of a proposal attached to an assistant message.
+ * The hook moves a proposal through:
+ *   pending → in_flight → ok | expired | drift | error
+ * Terminal states keep the row visible (button disabled) so the user
+ * sees the outcome without a toast.
+ */
+export type ProposalState =
+  | 'pending'
+  | 'in_flight'
+  | 'ok'
+  | 'expired'
+  | 'drift'
+  | 'error';
+
+export interface ProposalChip {
+  proposal_id:    string;
+  signed_payload: string;
+  action:         AgentProposalEvent['action'];
+  args:           AgentProposalEvent['args'];
+  expires_at:     string;
+  summary:        string;
+  state:          ProposalState;
+}
 
 // Wire shape of the messages we send in the body. Mirrors
 // _AgentMessage in api/agent/router.py.

--- a/frontend/src/agent/useAgentStream.test.tsx
+++ b/frontend/src/agent/useAgentStream.test.tsx
@@ -248,6 +248,215 @@ describe('useAgentStream', () => {
     ]);
   });
 
+  // ── Phase 3 of #400 — signed-proposal flow ─────────────────────────
+
+  it('attaches a proposal chip to the assistant bubble on a proposal event', async () => {
+    stubFetchOnce(sseReadable([
+      { type: 'text_delta', text: 'Listo, te dejo el confirm.' },
+      {
+        type:           'proposal',
+        proposal_id:    'prop_abc123',
+        signed_payload: 'mac.payload',
+        action:         'close_position',
+        args:           { position_id: 7, exit_price: 51000 },
+        expires_at:     '2030-01-01T00:00:00+00:00',
+        summary:        'Cerrar BTCUSDT LONG #7 a 51,000',
+      },
+      {
+        type: 'message_end',
+        usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        stop_reason: 'end_turn', cost_usd: 0,
+      },
+    ]));
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    await act(async () => {
+      await result.current.sendTurn('cierra #7');
+    });
+
+    const asst = result.current.msgs[1];
+    expect(asst.proposals).toHaveLength(1);
+    expect(asst.proposals![0]).toMatchObject({
+      proposal_id:    'prop_abc123',
+      signed_payload: 'mac.payload',
+      action:         'close_position',
+      summary:        'Cerrar BTCUSDT LONG #7 a 51,000',
+      state:          'pending',
+    });
+  });
+
+  it('confirmProposal transitions pending → ok on 200, sending signed_payload verbatim', async () => {
+    // Turn 1 fetch: stream with a proposal event.
+    const streamWithProposal = sseReadable([
+      {
+        type:           'proposal',
+        proposal_id:    'prop_xyz',
+        signed_payload: 'opaque.token.value',
+        action:         'close_position',
+        args:           { position_id: 1, exit_price: 100 },
+        expires_at:     '2030-01-01T00:00:00+00:00',
+        summary:        'Cerrar #1 a 100',
+      },
+      {
+        type: 'message_end',
+        usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        stop_reason: 'end_turn', cost_usd: 0,
+      },
+    ]);
+
+    let confirmBody: any = null;
+    let confirmUrl = '';
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockImplementation((url: string, init: RequestInit) => {
+      if (url.endsWith('/turn')) {
+        return Promise.resolve(new Response(streamWithProposal, {
+          status: 200, headers: { 'Content-Type': 'text/event-stream' },
+        }));
+      }
+      // The confirm POST.
+      confirmUrl = url;
+      confirmBody = JSON.parse(init.body as string);
+      return Promise.resolve(new Response(
+        JSON.stringify({ ok: true, result: 'ok', idempotent: false }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ));
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => {
+      await result.current.sendTurn('cierra');
+    });
+
+    // pre-condition
+    expect(result.current.msgs[1].proposals![0].state).toBe('pending');
+
+    await act(async () => {
+      await result.current.confirmProposal('prop_xyz');
+    });
+
+    // The confirm POST hit /api/agent/proposals/prop_xyz/confirm with the
+    // exact signed_payload from the SSE frame.
+    expect(confirmUrl).toContain('/api/agent/proposals/prop_xyz/confirm');
+    expect(confirmBody).toEqual({ signed_payload: 'opaque.token.value' });
+
+    // And the UI chip landed in the ok terminal state.
+    expect(result.current.msgs[1].proposals![0].state).toBe('ok');
+  });
+
+  it('confirmProposal lands in drift on 409', async () => {
+    const stream = sseReadable([
+      {
+        type:           'proposal',
+        proposal_id:    'prop_drift',
+        signed_payload: 'm.p',
+        action:         'close_position',
+        args:           { position_id: 1, exit_price: 1 },
+        expires_at:     '2030-01-01T00:00:00+00:00',
+        summary:        'x',
+      },
+      { type: 'message_end', usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, stop_reason: 'end_turn', cost_usd: 0 },
+    ]);
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/turn')) {
+        return Promise.resolve(new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ detail: 'state_drift' }),
+        { status: 409, headers: { 'Content-Type': 'application/json' } },
+      ));
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => { await result.current.sendTurn('cierra'); });
+    await act(async () => { await result.current.confirmProposal('prop_drift'); });
+
+    expect(result.current.msgs[1].proposals![0].state).toBe('drift');
+  });
+
+  it('confirmProposal lands in expired on 410', async () => {
+    const stream = sseReadable([
+      {
+        type:           'proposal',
+        proposal_id:    'prop_exp',
+        signed_payload: 'm.p',
+        action:         'close_position',
+        args:           { position_id: 1, exit_price: 1 },
+        expires_at:     '2020-01-01T00:00:00+00:00',
+        summary:        'x',
+      },
+      { type: 'message_end', usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, stop_reason: 'end_turn', cost_usd: 0 },
+    ]);
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/turn')) {
+        return Promise.resolve(new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ detail: 'expired' }),
+        { status: 410, headers: { 'Content-Type': 'application/json' } },
+      ));
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => { await result.current.sendTurn('cierra'); });
+    await act(async () => { await result.current.confirmProposal('prop_exp'); });
+
+    expect(result.current.msgs[1].proposals![0].state).toBe('expired');
+  });
+
+  it('confirmProposal is a no-op when called after a terminal state', async () => {
+    // After ok, a second confirmProposal must NOT issue another POST.
+    const stream = sseReadable([
+      {
+        type:           'proposal',
+        proposal_id:    'prop_once',
+        signed_payload: 'm.p',
+        action:         'close_position',
+        args:           { position_id: 1, exit_price: 1 },
+        expires_at:     '2030-01-01T00:00:00+00:00',
+        summary:        'x',
+      },
+      { type: 'message_end', usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, stop_reason: 'end_turn', cost_usd: 0 },
+    ]);
+    const fetchCalls: string[] = [];
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      fetchCalls.push(url);
+      if (url.endsWith('/turn')) {
+        return Promise.resolve(new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }));
+      }
+      return Promise.resolve(new Response(
+        JSON.stringify({ ok: true, result: 'ok' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ));
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => { await result.current.sendTurn('cierra'); });
+    await act(async () => { await result.current.confirmProposal('prop_once'); });
+    expect(result.current.msgs[1].proposals![0].state).toBe('ok');
+    const callsAfterFirst = fetchCalls.length;
+
+    // Second click — hook must short-circuit (state != 'pending').
+    await act(async () => { await result.current.confirmProposal('prop_once'); });
+    expect(fetchCalls.length).toBe(callsAfterFirst);  // no new POST
+    expect(result.current.msgs[1].proposals![0].state).toBe('ok');
+  });
+
+  it('confirmProposal is a no-op for an unknown proposal_id', async () => {
+    // No stream needed — we never reach the agent at all.
+    let calls = 0;
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockImplementation(() => { calls += 1; return Promise.resolve(new Response('')); });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => {
+      await result.current.confirmProposal('prop_does_not_exist');
+    });
+    expect(calls).toBe(0);
+  });
+
   it('refuses to send while a previous turn is in flight', async () => {
     // Create a stream that we control — the second sendTurn fires before
     // the first resolves.

--- a/frontend/src/agent/useAgentStream.test.tsx
+++ b/frontend/src/agent/useAgentStream.test.tsx
@@ -192,6 +192,62 @@ describe('useAgentStream', () => {
     expect(idsSent[0]).not.toBe(idsSent[1]);
   });
 
+  it('sends the full prior transcript on the second turn of a conversation', async () => {
+    // PR #405 review issue 4: the previous implementation captured
+    // prevMsgs inside a functional setState callback. Under StrictMode
+    // double-invocation, the assignment could race; in production it
+    // worked but the pattern was fragile. The refactor reads from a
+    // msgsRef parallel state. This test verifies the second turn
+    // carries the first user msg + first assistant msg in its body.
+
+    // First turn — fetch returns a short assistant response.
+    const stream1 = sseReadable([
+      { type: 'text_delta', text: 'Tienes ' },
+      { type: 'text_delta', text: '2 posiciones.' },
+      { type: 'message_end', usage: { input_tokens: 10, output_tokens: 4, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, stop_reason: 'end_turn', cost_usd: 0 },
+    ]);
+    const stream2 = sseReadable([
+      { type: 'text_delta', text: 'ok' },
+      { type: 'message_end', usage: { input_tokens: 0, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }, stop_reason: 'end_turn', cost_usd: 0 },
+    ]);
+
+    const bodiesSent: any[] = [];
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      bodiesSent.push(JSON.parse(init.body as string));
+      const streamForCall = bodiesSent.length === 1 ? stream1 : stream2;
+      return Promise.resolve(new Response(streamForCall, {
+        status: 200, headers: { 'Content-Type': 'text/event-stream' },
+      }));
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    // Turn 1: user asks; assistant streams "Tienes 2 posiciones."
+    await act(async () => {
+      await result.current.sendTurn('qué posiciones tengo');
+    });
+    // Turn 2: user follows up. The wire body must carry the FULL prior
+    // transcript (turn 1's user + turn 1's assistant), not just the
+    // new question.
+    await act(async () => {
+      await result.current.sendTurn('y cuál vale más');
+    });
+
+    expect(bodiesSent).toHaveLength(2);
+    // First call: only the first user turn in messages.
+    expect(bodiesSent[0].messages).toEqual([
+      { role: 'user', content: 'qué posiciones tengo' },
+    ]);
+    // Second call: prior user + prior assistant (with the accumulated
+    // text from the stream) + new user msg.
+    expect(bodiesSent[1].messages).toEqual([
+      { role: 'user',      content: 'qué posiciones tengo' },
+      { role: 'assistant', content: 'Tienes 2 posiciones.' },
+      { role: 'user',      content: 'y cuál vale más' },
+    ]);
+  });
+
   it('refuses to send while a previous turn is in flight', async () => {
     // Create a stream that we control — the second sendTurn fires before
     // the first resolves.

--- a/frontend/src/agent/useAgentStream.ts
+++ b/frontend/src/agent/useAgentStream.ts
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   AgentStreamError,
+  confirmAgentProposal,
   newConversationId,
   streamAgentTurn,
 } from './client';
@@ -21,6 +22,8 @@ import type {
   AgentContextHints,
   AgentStreamEvent,
   AgentSurface,
+  ProposalChip,
+  ProposalState,
   ToolChip,
 } from './types';
 
@@ -30,6 +33,9 @@ export interface ChatMsg {
   // Inline tool-use chips that render below the bubble while the turn
   // is in flight. The hook clears this on the next user turn.
   tool_chips?: ToolChip[];
+  // Phase 3: signed proposal envelopes attached to this assistant
+  // message. The dock renders an amber confirm button per chip.
+  proposals?:  ProposalChip[];
 }
 
 export interface UseAgentStreamOptions {
@@ -37,10 +43,11 @@ export interface UseAgentStreamOptions {
 }
 
 export interface UseAgentStreamReturn {
-  msgs:           ChatMsg[];
-  loading:        boolean;
-  sendTurn:       (text: string, hints?: AgentContextHints) => Promise<void>;
+  msgs:              ChatMsg[];
+  loading:           boolean;
+  sendTurn:          (text: string, hints?: AgentContextHints) => Promise<void>;
   resetConversation: () => void;
+  confirmProposal:   (proposal_id: string) => Promise<void>;
 }
 
 /**
@@ -121,7 +128,60 @@ export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamRetur
     [loading, opts.surface, resetConversation],
   );
 
-  return { msgs, loading, sendTurn, resetConversation };
+  const confirmProposal = useCallback(async (proposal_id: string) => {
+    // Find the proposal across all messages (Phase 3: one proposal per
+    // tool call, but the loop could in theory emit several in one turn).
+    let found: ProposalChip | null = null;
+    for (const m of msgsRef.current) {
+      const p = m.proposals?.find((q) => q.proposal_id === proposal_id);
+      if (p) {
+        found = p;
+        break;
+      }
+    }
+    if (!found || found.state !== 'pending') return;
+
+    setMsgs((cur) => updateProposalState(cur, proposal_id, 'in_flight'));
+
+    try {
+      const res = await confirmAgentProposal({
+        proposal_id,
+        signed_payload: found.signed_payload,
+      });
+      const nextState: ProposalState =
+        res.result === 'ok'          ? 'ok'      :
+        res.result === 'expired'     ? 'expired' :
+        res.result === 'state_drift' ? 'drift'   :
+        'error';
+      setMsgs((cur) => updateProposalState(cur, proposal_id, nextState));
+    } catch {
+      // Network / fetch-level failure. Drop the chip into the error
+      // terminal state — the user can re-ask the model to try again,
+      // which produces a fresh signed envelope.
+      setMsgs((cur) => updateProposalState(cur, proposal_id, 'error'));
+    }
+  }, []);
+
+  return { msgs, loading, sendTurn, resetConversation, confirmProposal };
+}
+
+/**
+ * Replace one proposal's state across the transcript. Pure (returns a
+ * new array) so it composes with setMsgs.
+ */
+function updateProposalState(
+  cur: ChatMsg[],
+  proposal_id: string,
+  next: ProposalState,
+): ChatMsg[] {
+  return cur.map((m) => {
+    if (!m.proposals?.length) return m;
+    const idx = m.proposals.findIndex((p) => p.proposal_id === proposal_id);
+    if (idx < 0) return m;
+    const updated = [...m.proposals];
+    updated[idx] = { ...updated[idx], state: next };
+    return { ...m, proposals: updated };
+  });
 }
 
 // ── pure-ish reducer for one event ─────────────────────────────────────
@@ -171,6 +231,32 @@ function applyEvent(
               : c,
           );
           updated[updated.length - 1] = { ...last, tool_chips: chips };
+        }
+        return updated;
+      });
+      break;
+
+    case 'proposal':
+      // Phase 3: a propose_* tool ran. Attach the signed envelope to
+      // the current assistant message. The dock will render an amber
+      // confirm button driven by the proposal's state.
+      setMsgs((cur) => {
+        const updated = [...cur];
+        const last = updated[updated.length - 1];
+        if (last && last.role === 'assistant') {
+          const chip: ProposalChip = {
+            proposal_id:    ev.proposal_id,
+            signed_payload: ev.signed_payload,
+            action:         ev.action,
+            args:           ev.args,
+            expires_at:     ev.expires_at,
+            summary:        ev.summary,
+            state:          'pending',
+          };
+          updated[updated.length - 1] = {
+            ...last,
+            proposals: [...(last.proposals ?? []), chip],
+          };
         }
         return updated;
       });

--- a/frontend/src/agent/useAgentStream.ts
+++ b/frontend/src/agent/useAgentStream.ts
@@ -9,7 +9,7 @@
 // Phase 2B of epic #400.
 // ============================================================
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   AgentStreamError,
@@ -21,6 +21,7 @@ import type {
   AgentContextHints,
   AgentStreamEvent,
   AgentSurface,
+  ToolChip,
 } from './types';
 
 export interface ChatMsg {
@@ -28,7 +29,7 @@ export interface ChatMsg {
   text:    string;
   // Inline tool-use chips that render below the bubble while the turn
   // is in flight. The hook clears this on the next user turn.
-  tool_chips?: Array<{ tool: string; status: 'pending' | 'ok' | 'error' }>;
+  tool_chips?: ToolChip[];
 }
 
 export interface UseAgentStreamOptions {
@@ -52,36 +53,42 @@ export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamRetur
   const [msgs, setMsgs] = useState<ChatMsg[]>([]);
   const [loading, setLoading] = useState(false);
   const conversationIdRef = useRef<string>(newConversationId());
+  // Parallel ref kept in sync with msgs so sendTurn can read the latest
+  // transcript without depending on closure freshness across renders.
+  // Phase 2B review issue 4: avoids the StrictMode double-invocation
+  // trap of assigning into a closed-over variable from inside a
+  // functional setState. Verified by test_send_turn_second_turn_carries_full_transcript.
+  const msgsRef = useRef<ChatMsg[]>([]);
+  useEffect(() => {
+    msgsRef.current = msgs;
+  }, [msgs]);
 
   const resetConversation = useCallback(() => {
     conversationIdRef.current = newConversationId();
     setMsgs([]);
+    msgsRef.current = [];
   }, []);
 
   const sendTurn = useCallback(
     async (text: string, hints?: AgentContextHints) => {
       if (!text.trim() || loading) return;
-      // Snapshot the transcript-up-to-now and append the user turn +
-      // an empty assistant placeholder atomically. The placeholder is
-      // what the streaming text appends to.
-      let prevMsgs: ChatMsg[] = [];
-      setMsgs((cur) => {
-        prevMsgs = cur;
-        return [
-          ...cur,
-          { role: 'user', text },
-          { role: 'assistant', text: '', tool_chips: [] },
-        ];
-      });
-      setLoading(true);
-
-      // Build the API request from the snapshot we just took. The
-      // backend rebuilds the system prompt server-side; we only ship
-      // the user/assistant transcript.
+      // Read the transcript from the ref (always fresh across re-renders);
+      // build the API messages BEFORE we append the user turn so the
+      // request payload mirrors the on-screen state at submit-time.
+      const transcriptSoFar = msgsRef.current;
       const apiMessages: AgentApiMessage[] = [
-        ...prevMsgs.map((m) => ({ role: m.role, content: m.text })),
+        ...transcriptSoFar.map((m) => ({ role: m.role, content: m.text })),
         { role: 'user' as const, content: text },
       ];
+
+      // Now append the user turn + empty assistant placeholder. The
+      // placeholder is what the streaming text appends to.
+      setMsgs((cur) => [
+        ...cur,
+        { role: 'user', text },
+        { role: 'assistant', text: '', tool_chips: [] },
+      ]);
+      setLoading(true);
 
       try {
         for await (const ev of streamAgentTurn({

--- a/frontend/src/components/AgentDock.module.css
+++ b/frontend/src/components/AgentDock.module.css
@@ -271,7 +271,12 @@
   50%      { opacity: 1; }
 }
 
-/* confirm_release marker — destructive override, amber to signal weight */
+/* confirm_release marker — destructive override, amber to signal weight.
+ * NOTE: temporarily unused after the Phase 2B rewire (the marker
+ * protocol it served is dead). Phase 3 of #400 reintroduces the
+ * amber-button UX as the render target for signed proposal events
+ * (propose_close_position / propose_reactivate_symbol / propose_apply_tune).
+ * Keeping the class alive avoids churn when Phase 3 lands. */
 .toolConfirm {
   font-family: var(--nbc-font-mono);
   font-size: 11px;

--- a/frontend/src/components/AgentDock.module.css
+++ b/frontend/src/components/AgentDock.module.css
@@ -271,12 +271,25 @@
   50%      { opacity: 1; }
 }
 
-/* confirm_release marker — destructive override, amber to signal weight.
- * NOTE: temporarily unused after the Phase 2B rewire (the marker
- * protocol it served is dead). Phase 3 of #400 reintroduces the
- * amber-button UX as the render target for signed proposal events
- * (propose_close_position / propose_reactivate_symbol / propose_apply_tune).
- * Keeping the class alive avoids churn when Phase 3 lands. */
+/* Phase 3 of #400 — signed-proposal confirm button. Amber by default
+ * (destructive side-effects deserve weight), transitions to bull on
+ * success or bear on drift/expired/error. The row groups a summary
+ * line above the action button. */
+.proposalRow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--nbc-border-dim);
+  background: rgba(255, 184, 78, 0.03);
+}
+.proposalSummary {
+  font-family: var(--nbc-font-mono);
+  font-size: 11px;
+  color: var(--nbc-fg);
+  line-height: 1.4;
+}
 .toolConfirm {
   font-family: var(--nbc-font-mono);
   font-size: 11px;
@@ -290,9 +303,26 @@
   align-self: flex-start;
   transition: all 80ms ease;
 }
-.toolConfirm:hover {
+.toolConfirm:hover:not(:disabled) {
   background: var(--warn);
   color: var(--nbc-bg);
+}
+.toolConfirm:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+.toolConfirmInFlight {
+  animation: dockToolChipPulse 1s ease-in-out infinite;
+}
+.toolConfirmOk {
+  background: rgba(34, 211, 134, 0.08);
+  border-color: var(--bull);
+  color: var(--bull);
+}
+.toolConfirmError {
+  background: rgba(239, 68, 68, 0.06);
+  border-color: var(--bear);
+  color: var(--bear);
 }
 
 /* Suggestion chips */

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -16,7 +16,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AgentDock.module.css';
 import type { SymbolStatus, Position, MacroState } from '../types';
 import { useAgentStream } from '../agent/useAgentStream';
-import type { ToolChip } from '../agent/types';
+import type { ProposalChip, ToolChip } from '../agent/types';
 
 interface AgentDockProps {
   open:           boolean;
@@ -47,7 +47,7 @@ const AgentDock: React.FC<AgentDockProps> = ({
   const [input, setInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const { msgs, loading, sendTurn } = useAgentStream({ surface: 'dock' });
+  const { msgs, loading, sendTurn, confirmProposal } = useAgentStream({ surface: 'dock' });
   // Synthetic welcome bubble before the first real turn so the dock
   // isn't an empty void on open. Lives outside the stream hook because
   // it never goes on the wire — purely UI. Derived (useMemo) instead
@@ -129,6 +129,8 @@ const AgentDock: React.FC<AgentDockProps> = ({
                 role={m.role}
                 text={m.text}
                 toolChips={m.tool_chips}
+                proposals={m.proposals}
+                onConfirmProposal={confirmProposal}
                 showTyping={
                   m.role === 'assistant' && loading && i === msgs.length - 1 && m.text === ''
                 }
@@ -171,10 +173,14 @@ interface DockMessageProps {
   role:       'user' | 'assistant';
   text:       string;
   toolChips?: ToolChip[];
+  proposals?: ProposalChip[];
+  onConfirmProposal?: (proposal_id: string) => void;
   showTyping?: boolean;
 }
 
-const DockMessage: React.FC<DockMessageProps> = ({ role, text, toolChips, showTyping }) => {
+const DockMessage: React.FC<DockMessageProps> = ({
+  role, text, toolChips, proposals, onConfirmProposal, showTyping,
+}) => {
   if (role === 'user') {
     return (
       <div className={`${styles.msg} ${styles.msgUser}`}>
@@ -216,7 +222,56 @@ const DockMessage: React.FC<DockMessageProps> = ({ role, text, toolChips, showTy
             ))}
           </div>
         )}
+        {proposals && proposals.length > 0 && proposals.map((p) => (
+          <ProposalConfirm
+            key={p.proposal_id}
+            proposal={p}
+            onConfirm={onConfirmProposal}
+          />
+        ))}
       </div>
+    </div>
+  );
+};
+
+// ── Proposal confirm row ────────────────────────────────────────────
+
+interface ProposalConfirmProps {
+  proposal: ProposalChip;
+  onConfirm?: (proposal_id: string) => void;
+}
+
+const ProposalConfirm: React.FC<ProposalConfirmProps> = ({ proposal, onConfirm }) => {
+  // Button copy reflects the state machine. Terminal states freeze the
+  // button (disabled + colored) so the user sees what happened without
+  // a toast / popover layer.
+  const labelByState: Record<ProposalChip['state'], string> = {
+    pending:   'Confirmar',
+    in_flight: 'Procesando…',
+    ok:        'Confirmado ✓',
+    expired:   'Expirado',
+    drift:     'Estado cambió — re-pregunta',
+    error:     'Falló — re-pregunta',
+  };
+  const stateClass =
+    proposal.state === 'in_flight' ? styles.toolConfirmInFlight :
+    proposal.state === 'ok'        ? styles.toolConfirmOk :
+    (proposal.state === 'expired' || proposal.state === 'drift' || proposal.state === 'error')
+                                   ? styles.toolConfirmError :
+    '';
+  const isInteractive = proposal.state === 'pending';
+
+  return (
+    <div className={styles.proposalRow}>
+      <div className={styles.proposalSummary}>{proposal.summary}</div>
+      <button
+        type="button"
+        className={[styles.toolConfirm, stateClass].join(' ')}
+        disabled={!isInteractive}
+        onClick={() => isInteractive && onConfirm?.(proposal.proposal_id)}
+      >
+        {labelByState[proposal.state]}
+      </button>
     </div>
   );
 };

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -12,10 +12,11 @@
 // buttons) returns in Phase 3 via signed proposal events.
 // ============================================================
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AgentDock.module.css';
 import type { SymbolStatus, Position, MacroState } from '../types';
 import { useAgentStream } from '../agent/useAgentStream';
+import type { ToolChip } from '../agent/types';
 
 interface AgentDockProps {
   open:           boolean;
@@ -45,13 +46,20 @@ const AgentDock: React.FC<AgentDockProps> = ({
 }) => {
   const [input, setInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
-  const greetedRef = useRef(false);
 
   const { msgs, loading, sendTurn } = useAgentStream({ surface: 'dock' });
-  // We render a synthetic welcome bubble before the first real turn so
-  // the dock isn't an empty void on open. It lives outside the stream
-  // hook because it never goes on the wire — purely UI.
-  const [welcome, setWelcome] = useState<string | null>(null);
+  // Synthetic welcome bubble before the first real turn so the dock
+  // isn't an empty void on open. Lives outside the stream hook because
+  // it never goes on the wire — purely UI. Derived (useMemo) instead
+  // of stored, so it reflects current watchlist counts even after a
+  // conversation reset (PR #405 review nit).
+  const welcome = useMemo<string | null>(() => {
+    if (!open || msgs.length > 0 || initialPrompt) return null;
+    return (
+      `Hola. Estoy mirando tus ${symbols.length} pares y ${positions.length} posiciones. ` +
+      `Pregúntame lo que quieras.`
+    );
+  }, [open, msgs.length, initialPrompt, symbols.length, positions.length]);
 
   // Close on Escape
   useEffect(() => {
@@ -60,19 +68,6 @@ const AgentDock: React.FC<AgentDockProps> = ({
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [open, onClose]);
-
-  // Welcome message on first open. Only shown until the first real
-  // exchange — once msgs.length > 0 we hide it to avoid duplicate
-  // bubbles.
-  useEffect(() => {
-    if (open && !greetedRef.current && !initialPrompt) {
-      setWelcome(
-        `Hola. Estoy mirando tus ${symbols.length} pares y ${positions.length} posiciones. ` +
-        `Pregúntame lo que quieras.`,
-      );
-      greetedRef.current = true;
-    }
-  }, [open, initialPrompt, symbols.length, positions.length]);
 
   // Auto-send the initial prompt when one is passed in.
   useEffect(() => {
@@ -175,7 +170,7 @@ const AgentDock: React.FC<AgentDockProps> = ({
 interface DockMessageProps {
   role:       'user' | 'assistant';
   text:       string;
-  toolChips?: Array<{ tool: string; status: 'pending' | 'ok' | 'error' }>;
+  toolChips?: ToolChip[];
   showTyping?: boolean;
 }
 

--- a/frontend/src/components/SymbolDetail.module.css
+++ b/frontend/src/components/SymbolDetail.module.css
@@ -778,3 +778,94 @@
   .cpOuts     { grid-template-columns: 1fr 1fr; }
   .cpHistStrip { grid-template-columns: repeat(3, 1fr); }
 }
+
+/* ============================================================
+   Phase 3 of #400 — tool chips + signed-proposal confirm row.
+   Mirror the AgentDock state machine so the symbol-detail copilot
+   feels identical: amber by default, bull on ok, bear on drift/
+   expired/error. CSS class names match useAgentStream/types.ts.
+   ============================================================ */
+.toolChipsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+.toolChip {
+  font-family: var(--nbc-font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: lowercase;
+  padding: 3px 8px;
+  border: 1px solid;
+  background: transparent;
+  user-select: none;
+}
+.toolChipPending {
+  color: var(--nbc-fg-muted);
+  border-color: var(--nbc-border-dim);
+  opacity: 0.85;
+  animation: cpToolChipPulse 1.2s ease-in-out infinite;
+}
+.toolChipOk {
+  color: var(--bull);
+  border-color: var(--bull);
+}
+.toolChipError {
+  color: var(--bear);
+  border-color: var(--bear);
+}
+@keyframes cpToolChipPulse {
+  0%, 100% { opacity: 0.55; }
+  50%      { opacity: 1; }
+}
+
+.proposalRow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--nbc-border-dim);
+  background: rgba(255, 184, 78, 0.03);
+}
+.proposalSummary {
+  font-family: var(--nbc-font-mono);
+  font-size: 11px;
+  color: var(--nbc-fg);
+  line-height: 1.4;
+}
+.toolConfirm {
+  font-family: var(--nbc-font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  background: rgba(255, 184, 78, 0.06);
+  border: 1px solid var(--warn);
+  color: var(--warn);
+  cursor: pointer;
+  align-self: flex-start;
+  transition: all 80ms ease;
+}
+.toolConfirm:hover:not(:disabled) {
+  background: var(--warn);
+  color: var(--nbc-bg);
+}
+.toolConfirm:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+.toolConfirmInFlight {
+  animation: cpToolChipPulse 1s ease-in-out infinite;
+}
+.toolConfirmOk {
+  background: rgba(34, 211, 134, 0.08);
+  border-color: var(--bull);
+  color: var(--bull);
+}
+.toolConfirmError {
+  background: rgba(239, 68, 68, 0.06);
+  border-color: var(--bear);
+  color: var(--bear);
+}

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -30,28 +30,20 @@ import {
 } from 'lightweight-charts';
 
 import styles from './SymbolDetail.module.css';
-import type { SymbolStatus, Position, OhlcvCandle, OhlcvVolume } from '../types';
+import type { SymbolStatus, OhlcvCandle, OhlcvVolume } from '../types';
 import { formatPrice } from '../utils';
-import { getOhlcv, getPositions, chatAgent, type AgentMessage } from '../api';
+import { getOhlcv } from '../api';
+import { useAgentStream } from '../agent/useAgentStream';
+import type { ProposalChip, ToolChip } from '../agent/types';
 import { SCORE_FACTORS } from '../constants/score-factors';
 
 // ── Public types ─────────────────────────────────────────────
 
 export type Timeframe = '5m' | '15m' | '1h' | '4h' | '1d';
 
-export interface PositionPreset {
-  symbol:    string;
-  direction: 'LONG' | 'SHORT';
-  entry:     number;
-  sl:        number;
-  tp:        number;
-  qty:       number;
-}
-
 interface SymbolDetailProps {
   symbol:          SymbolStatus | null;
   onClose:         () => void;
-  onOpenPosition?: (preset: PositionPreset) => void;
   // Server-driven feature flag — App.tsx owns the polling via
   // useAgentEnabled() (epic #400 Phase 0). Pass `true` to enable the
   // copilot input row, `false` to render the read-only fallback. This
@@ -103,15 +95,12 @@ function buildFactors(symbol: SymbolStatus) {
   return SCORE_FACTORS.map((f, idx) => ({ ...f, pass: passes.has(idx) }));
 }
 
-// Strip and collect `<<<TOOL:name>>>` markers from agent text.
-function extractTools(text: string): { tools: string[]; cleaned: string } {
-  const tools: string[] = [];
-  const cleaned = text.replace(/<<<TOOL:([a-z_]+)>>>/g, (_, name: string) => {
-    tools.push(name);
-    return '';
-  }).trim();
-  return { tools, cleaned };
-}
+// Note: the `<<<TOOL:name>>>` marker protocol the Copilot used to parse
+// is dead post-Phase-3. The model now emits typed tool_use events; the
+// renderer below consumes those via useAgentStream's tool_chips and
+// proposals state. The Setup/Position/History card components remain in
+// this file (below) but are no longer wired up — they'll be revived via
+// a future inline-card protocol if the UX needs the richer surfaces back.
 
 const TIMEFRAMES: { v: Timeframe; l: string }[] = [
   { v: '5m',  l: '5m'  },
@@ -125,7 +114,7 @@ const TIMEFRAMES: { v: Timeframe; l: string }[] = [
 // MAIN — SymbolDetail
 // ============================================================
 
-const SymbolDetail: React.FC<SymbolDetailProps> = ({ symbol, onClose, onOpenPosition, agentEnabled }) => {
+const SymbolDetail: React.FC<SymbolDetailProps> = ({ symbol, onClose, agentEnabled }) => {
   // Local alias keeps the rest of the file readable (rename-only change).
   const AGENT_ENABLED = agentEnabled;
   const [tf, setTf] = useState<Timeframe>('1h');
@@ -216,7 +205,7 @@ const SymbolDetail: React.FC<SymbolDetailProps> = ({ symbol, onClose, onOpenPosi
             </div>
           </section>
 
-          <Copilot symbol={symbol} onOpenPosition={onOpenPosition} agentEnabled={AGENT_ENABLED} />
+          <Copilot symbol={symbol} agentEnabled={AGENT_ENABLED} />
         </div>
 
         {/* ── Footer ── */}
@@ -382,14 +371,6 @@ const ChartCanvas: React.FC<ChartCanvasProps> = ({ symbol, timeframe }) => {
 
 type Verdict = 'bull' | 'warn' | 'bear';
 
-interface CopilotMsg {
-  role:    'user' | 'assistant';
-  text:    string;
-  tools?:  string[];
-  verdict?: Verdict;
-  error?:  boolean;
-}
-
 const SUGGESTIONS = [
   { label: '¿qué muestra el score?', msg: 'Explícame el desglose del score.' },
   { label: 'simular posición $1000',  msg: 'Si abro $1000 aquí con 1% de riesgo, ¿cómo queda?' },
@@ -399,21 +380,28 @@ const SUGGESTIONS = [
 
 interface CopilotProps {
   symbol:          SymbolStatus;
-  onOpenPosition?: (preset: PositionPreset) => void;
   // Server-driven feature flag forwarded from <SymbolDetail/>.
   agentEnabled:    boolean;
 }
 
-const Copilot: React.FC<CopilotProps> = ({ symbol, onOpenPosition, agentEnabled }) => {
+const Copilot: React.FC<CopilotProps> = ({ symbol, agentEnabled }) => {
   const AGENT_ENABLED = agentEnabled;
-  const [msgs,    setMsgs]    = useState<CopilotMsg[]>([]);
-  const [input,   setInput]   = useState('');
-  const [loading, setLoading] = useState(false);
+  const [input, setInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Proactive greeting when a symbol opens — runs sync, no API call.
-  useEffect(() => {
-    if (!symbol) return;
+  // Phase 3 rewire: replace the legacy one-shot chatAgent + frontend
+  // system prompt with the streaming hook. The server owns the prompt
+  // (api/agent/prompts/system.py + surfaces.py), the tool schema, and
+  // the audit. The model never sees a frontend-built system prompt.
+  const { msgs, loading, sendTurn, confirmProposal } = useAgentStream({
+    surface: 'symbol_detail',
+  });
+
+  // Proactive synthetic greeting computed locally — never goes on the
+  // wire, never enters the rolling transcript. Re-derives whenever
+  // the symbol or its score-relevant fields change.
+  const greeting = useMemo<{ text: string; verdict: Verdict } | null>(() => {
+    if (!symbol) return null;
     const factors = buildFactors(symbol);
     const passing = factors.filter((f) => f.pass);
     const failing = factors.filter((f) => !f.pass);
@@ -422,15 +410,14 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, onOpenPosition, agentEnabled 
       passing.length >= 4 ? 'warn' :
       'bear';
     const base = symbol.symbol.replace('USDT', '');
-    const greeting =
+    const text =
       verdict === 'bull'
         ? `Detecté **setup firme** en ${base}. Score ${passing.length}/9, gatillo activo. ¿Quieres que te explique los factores o prefieres simular una posición?`
         : verdict === 'warn'
         ? `${base} muestra **setup parcial** (${passing.length}/9). Faltan ${failing.length} confirmaciones. ¿Te explico cuáles?`
         : `${base} **no recomienda entrar ahora** — sólo ${passing.length} de 9 filtros se cumplen. ¿Te muestro qué falta?`;
-
-    setMsgs([{ role: 'assistant', text: greeting, verdict, tools: ['setup'] }]);
-  }, [symbol.symbol]);
+    return { text, verdict };
+  }, [symbol]);
 
   // Autoscroll on new messages
   useEffect(() => {
@@ -440,59 +427,12 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, onOpenPosition, agentEnabled 
   const send = async (text: string) => {
     const t = text.trim();
     if (!t || loading) return;
-    setMsgs((prev) => [...prev, { role: 'user', text: t }]);
     setInput('');
     if (!AGENT_ENABLED) return;
-    setLoading(true);
-
-    try {
-      const factors = buildFactors(symbol);
-      const passing = factors.filter((f) => f.pass);
-      const failing = factors.filter((f) => !f.pass);
-      const base    = symbol.symbol.replace('USDT', '');
-      const sysPrompt = `Eres un copiloto de trading conversando en español casual y directo.
-El usuario está mirando el par ${base}/USDT a $${formatPrice(symbol.live_price ?? symbol.price ?? 0)}.
-
-DATOS ACTUALES:
-- Score: ${passing.length}/9
-- LRC%: ${(symbol.lrc_pct ?? 0).toFixed(1)}%
-- Cambio 24h: ${(symbol.change_24h ?? 0).toFixed(2)}%
-- Side sugerido: ${symbol.direction ?? 'LONG'}
-- Gatillo 5M activo: ${symbol.señal ? 'sí' : 'no'}
-
-FACTORES QUE PASAN: ${passing.map((f) => f.key).join(', ') || 'ninguno'}
-FACTORES QUE FALLAN: ${failing.map((f) => f.key).join(', ') || 'ninguno'}
-
-INSTRUCCIONES:
-- Responde MUY breve (1-3 oraciones máximo). El usuario está en una UI compacta.
-- Si el usuario pregunta sobre el score o factores, termina tu respuesta con <<<TOOL:setup>>>
-- Si quiere simular una posición o calcular riesgo, termina con <<<TOOL:position>>>
-- Si pregunta por historial pasado, termina con <<<TOOL:history>>>
-- Si pregunta "¿debo operar?", da una recomendación clara basada en el score y termina con <<<TOOL:setup>>>
-- NUNCA inventes datos. Si no sabes algo, dilo.
-- No uses asteriscos para negrita más de 1-2 veces por respuesta.`;
-
-      // Keep last 6 turns of context — enough for follow-ups, cheap on tokens.
-      const history: AgentMessage[] = msgs.slice(-6).map((m) => ({
-        role:    m.role,
-        content: m.text,
-      }));
-
-      const resp = await chatAgent({
-        system:   sysPrompt,
-        messages: [...history, { role: 'user', content: t }],
-      });
-      const { tools, cleaned } = extractTools(resp.text || '');
-      setMsgs((prev) => [...prev, { role: 'assistant', text: cleaned, tools }]);
-    } catch (err) {
-      setMsgs((prev) => [...prev, {
-        role:  'assistant',
-        text:  err instanceof Error ? `No pude analizar eso: ${err.message}` : 'No pude analizar eso. Intenta de nuevo.',
-        error: true,
-      }]);
-    } finally {
-      setLoading(false);
-    }
+    // Pass the current symbol as a context hint so the server-side
+    // prompt can scope its tool calls (e.g. default get_symbol_setup
+    // to this pair).
+    await sendTurn(t, { symbol: symbol.symbol });
   };
 
   const submitInput = (e: React.FormEvent) => {
@@ -519,10 +459,26 @@ INSTRUCCIONES:
       </header>
 
       <div className={styles.cpScroll} ref={scrollRef}>
+        {greeting && msgs.length === 0 && (
+          <CopilotMessage
+            role="assistant"
+            text={greeting.text}
+            verdict={greeting.verdict}
+          />
+        )}
         {msgs.map((m, i) => (
-          <CopilotMessage key={i} message={m} symbol={symbol} onOpenPosition={onOpenPosition} />
+          <CopilotMessage
+            key={i}
+            role={m.role}
+            text={m.text}
+            toolChips={m.tool_chips}
+            proposals={m.proposals}
+            onConfirmProposal={confirmProposal}
+            showTyping={
+              m.role === 'assistant' && loading && i === msgs.length - 1 && m.text === ''
+            }
+          />
         ))}
-        {loading && <TypingBubble />}
       </div>
 
       {AGENT_ENABLED ? (
@@ -566,39 +522,93 @@ INSTRUCCIONES:
 // ── CopilotMessage + helpers ─────────────────────────────────
 
 interface CopilotMessageProps {
-  message:         CopilotMsg;
-  symbol:          SymbolStatus;
-  onOpenPosition?: (preset: PositionPreset) => void;
+  role:               'user' | 'assistant';
+  text:               string;
+  verdict?:           Verdict;
+  toolChips?:         ToolChip[];
+  proposals?:         ProposalChip[];
+  onConfirmProposal?: (proposal_id: string) => void;
+  showTyping?:        boolean;
 }
-const CopilotMessage: React.FC<CopilotMessageProps> = ({ message, symbol, onOpenPosition }) => {
-  if (message.role === 'user') {
+const CopilotMessage: React.FC<CopilotMessageProps> = ({
+  role, text, verdict, toolChips, proposals, onConfirmProposal, showTyping,
+}) => {
+  if (role === 'user') {
     return (
       <div className={`${styles.cpMsg} ${styles.cpMsgUser}`}>
-        <div className={`${styles.cpBubble} ${styles.cpBubbleUser}`}>{message.text}</div>
+        <div className={`${styles.cpBubble} ${styles.cpBubbleUser}`}>{text}</div>
       </div>
     );
   }
 
   const verdictClass =
-    message.verdict === 'bull' ? styles.cpBubbleVerdictBull :
-    message.verdict === 'warn' ? styles.cpBubbleVerdictWarn :
-    message.verdict === 'bear' ? styles.cpBubbleVerdictBear : '';
-  const errorClass = message.error ? styles.cpBubbleError : '';
+    verdict === 'bull' ? styles.cpBubbleVerdictBull :
+    verdict === 'warn' ? styles.cpBubbleVerdictWarn :
+    verdict === 'bear' ? styles.cpBubbleVerdictBear : '';
 
   return (
     <div className={`${styles.cpMsg} ${styles.cpMsgAsst}`}>
       <div className={styles.cpMsgAvatar}>◈</div>
       <div className={styles.cpMsgBody}>
-        {message.text && (
-          <div className={[styles.cpBubble, styles.cpBubbleAsst, errorClass, verdictClass].filter(Boolean).join(' ')}>
-            <FormattedText text={message.text} />
+        {showTyping && (
+          <div className={`${styles.cpBubble} ${styles.cpBubbleAsst} ${styles.cpBubbleTyping}`}>
+            <span className={styles.cpTypingDot} />
+            <span className={styles.cpTypingDot} />
+            <span className={styles.cpTypingDot} />
           </div>
         )}
-        {message.tools?.map((t, i) => {
-          if (t === 'setup')    return <SetupCard    key={i} symbol={symbol} />;
-          if (t === 'position') return <PositionCard key={i} symbol={symbol} onOpen={onOpenPosition} />;
-          if (t === 'history')  return <HistoryCard  key={i} symbol={symbol} />;
-          return null;
+        {!showTyping && text && (
+          <div className={[styles.cpBubble, styles.cpBubbleAsst, verdictClass].filter(Boolean).join(' ')}>
+            <FormattedText text={text} />
+          </div>
+        )}
+        {toolChips && toolChips.length > 0 && (
+          <div className={styles.toolChipsRow}>
+            {toolChips.map((c, i) => (
+              <span
+                key={i}
+                className={[
+                  styles.toolChip,
+                  c.status === 'pending' ? styles.toolChipPending :
+                  c.status === 'ok'      ? styles.toolChipOk :
+                                            styles.toolChipError,
+                ].join(' ')}
+                title={`tool ${c.tool} — ${c.status}`}
+              >
+                {c.status === 'pending' ? '⋯' : c.status === 'ok' ? '✓' : '✗'} {c.tool}
+              </span>
+            ))}
+          </div>
+        )}
+        {proposals && proposals.length > 0 && proposals.map((p) => {
+          const labelByState: Record<ProposalChip['state'], string> = {
+            pending:   'Confirmar',
+            in_flight: 'Procesando…',
+            ok:        'Confirmado ✓',
+            expired:   'Expirado',
+            drift:     'Estado cambió — re-pregunta',
+            error:     'Falló — re-pregunta',
+          };
+          const stateClass =
+            p.state === 'in_flight' ? styles.toolConfirmInFlight :
+            p.state === 'ok'        ? styles.toolConfirmOk :
+            (p.state === 'expired' || p.state === 'drift' || p.state === 'error')
+                                    ? styles.toolConfirmError :
+            '';
+          const isInteractive = p.state === 'pending';
+          return (
+            <div key={p.proposal_id} className={styles.proposalRow}>
+              <div className={styles.proposalSummary}>{p.summary}</div>
+              <button
+                type="button"
+                className={[styles.toolConfirm, stateClass].filter(Boolean).join(' ')}
+                disabled={!isInteractive}
+                onClick={() => isInteractive && onConfirmProposal?.(p.proposal_id)}
+              >
+                {labelByState[p.state]}
+              </button>
+            </div>
+          );
         })}
       </div>
     </div>
@@ -625,309 +635,9 @@ const FormattedText: React.FC<{ text: string }> = ({ text }) => {
   );
 };
 
-const TypingBubble: React.FC = () => (
-  <div className={`${styles.cpMsg} ${styles.cpMsgAsst}`}>
-    <div className={styles.cpMsgAvatar}>◈</div>
-    <div className={styles.cpMsgBody}>
-      <div className={`${styles.cpBubble} ${styles.cpBubbleAsst} ${styles.cpBubbleTyping}`}>
-        <span className={styles.cpTypingDot} />
-        <span className={styles.cpTypingDot} />
-        <span className={styles.cpTypingDot} />
-      </div>
-    </div>
-  </div>
-);
-
-// ============================================================
-// SETUP CARD — two-column pass/fail breakdown
-// ============================================================
-
-const SetupCard: React.FC<{ symbol: SymbolStatus }> = ({ symbol }) => {
-  const factors = useMemo(() => buildFactors(symbol), [symbol]);
-  const passing = factors.filter((f) => f.pass);
-  const failing = factors.filter((f) => !f.pass);
-  return (
-    <div className={styles.cpCard}>
-      <div className={styles.cpCardHead}>
-        <span className={styles.cpCardIcon}>◧</span>
-        <span className={styles.cpCardTitle}>Desglose del score</span>
-        <span className={`${styles.cpCardScore} num`}>{passing.length}/9</span>
-      </div>
-      <div className={styles.cpFactCols}>
-        <div>
-          <div className={styles.cpFactColsHd}>
-            <span className={`${styles.cpFactColsDot} ${styles.cpFactColsDotOk}`} />
-            <span className={styles.cpFactColsLabel}>PASAN ({passing.length})</span>
-          </div>
-          <ul className={styles.cpFactList}>
-            {passing.length === 0 ? (
-              <li className={`${styles.cpFact} ${styles.cpFactEmpty} prose`}>— ninguno todavía</li>
-            ) : passing.map((f) => (
-              <li key={f.key} className={`${styles.cpFact} ${styles.cpFactPass}`}>
-                <span className={styles.cpFactKey}>{f.key}</span>
-                <span className={styles.cpFactTxt}>{f.label}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <div className={styles.cpFactColsHd}>
-            <span className={`${styles.cpFactColsDot} ${styles.cpFactColsDotNo}`} />
-            <span className={styles.cpFactColsLabel}>FALLAN ({failing.length})</span>
-          </div>
-          <ul className={styles.cpFactList}>
-            {failing.length === 0 ? (
-              <li className={`${styles.cpFact} ${styles.cpFactEmpty} prose`}>— ninguno, score perfecto</li>
-            ) : failing.map((f) => (
-              <li key={f.key} className={`${styles.cpFact} ${styles.cpFactFail}`}>
-                <span className={styles.cpFactKey}>{f.key}</span>
-                <span className={styles.cpFactTxt}>{f.label}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================================
-// POSITION CARD — inline knobs + RR + outputs + CTA
-// ============================================================
-
-interface PositionCardProps {
-  symbol: SymbolStatus;
-  onOpen?: (preset: PositionPreset) => void;
-}
-const PositionCard: React.FC<PositionCardProps> = ({ symbol, onOpen }) => {
-  const [capital, setCapital] = useState(1000);
-  const [riskPct, setRiskPct] = useState(1);
-  const [rr,      setRr]      = useState(2);
-  const [slPct,   setSlPct]   = useState(2.5);
-
-  const entry  = symbol.live_price ?? symbol.price ?? 0;
-  const isLong = (symbol.direction ?? 'LONG') === 'LONG';
-  const sl     = isLong ? entry * (1 - slPct / 100) : entry * (1 + slPct / 100);
-  const tp     = isLong ? entry * (1 + (slPct * rr) / 100) : entry * (1 - (slPct * rr) / 100);
-  const riskUsd   = capital * (riskPct / 100);
-  const slDistAbs = Math.abs(entry - sl);
-  const qty       = slDistAbs > 0 ? riskUsd / slDistAbs : 0;
-  const posValue  = qty * entry;
-  const rewardUsd = qty * Math.abs(tp - entry);
-
-  const minBar = Math.min(sl, entry, tp);
-  const maxBar = Math.max(sl, entry, tp);
-  const span   = (maxBar - minBar) || 1;
-  const posOf  = (p: number) => ((p - minBar) / span) * 100;
-
-  const disabled = entry <= 0 || qty <= 0;
-
-  const handleOpen = () => {
-    if (!onOpen || disabled) return;
-    onOpen({
-      symbol:    symbol.symbol,
-      direction: isLong ? 'LONG' : 'SHORT',
-      entry,
-      sl,
-      tp,
-      qty,
-    });
-  };
-
-  return (
-    <div className={styles.cpCard}>
-      <div className={styles.cpCardHead}>
-        <span className={styles.cpCardIcon}>✦</span>
-        <span className={styles.cpCardTitle}>Calculadora de posición</span>
-        <span className={styles.cpCardScore}>
-          <span className="num">${posValue.toFixed(0)}</span>
-        </span>
-      </div>
-
-      <div className={styles.cpKnobs}>
-        <Knob label="capital"  value={`$${capital}`}             onMinus={() => setCapital(Math.max(100, capital - 100))} onPlus={() => setCapital(capital + 100)} />
-        <Knob label="riesgo %" value={riskPct.toFixed(1)}        onMinus={() => setRiskPct(Math.max(0.1, +(riskPct - 0.1).toFixed(1)))} onPlus={() => setRiskPct(+(riskPct + 0.1).toFixed(1))} />
-        <Knob label="sl %"     value={slPct.toFixed(2)}          onMinus={() => setSlPct(Math.max(0.5, +(slPct - 0.25).toFixed(2)))}   onPlus={() => setSlPct(+(slPct + 0.25).toFixed(2))} />
-        <Knob label="r:r"      value={`1:${rr}`}                 onMinus={() => setRr(Math.max(1, rr - 0.5))} onPlus={() => setRr(rr + 0.5)} />
-      </div>
-
-      <div className={styles.cpRr}>
-        <div className={styles.cpRrBar}>
-          <div className={`${styles.cpRrZone} ${styles.cpRrZoneLoss}`} style={{ left: '0%', width: `${posOf(entry)}%` }} />
-          <div className={`${styles.cpRrZone} ${styles.cpRrZoneGain}`} style={{ left: `${posOf(entry)}%`, right: '0%' }} />
-          {[
-            { name: 'sl' as const,    val: sl,    cls: styles.cpRrMarkSl },
-            { name: 'entry' as const, val: entry, cls: styles.cpRrMarkEntry },
-            { name: 'tp' as const,    val: tp,    cls: styles.cpRrMarkTp },
-          ].map((m) => (
-            <div key={m.name} className={`${styles.cpRrMark} ${m.cls}`} style={{ left: `${posOf(m.val)}%` }}>
-              <span className={styles.cpRrMarkLbl}>{m.name.toUpperCase()}</span>
-              <span className={`${styles.cpRrMarkVal} num`}>{formatPrice(m.val)}</span>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className={styles.cpOuts}>
-        <KV label="qty"          value={qty.toFixed(4)}              tone="neutral" />
-        <KV label="-riesgo"      value={`$${riskUsd.toFixed(2)}`}    tone="bear" />
-        <KV label="+reward"      value={`$${rewardUsd.toFixed(2)}`}  tone="bull" />
-        <KV label="risk:reward"  value={`1:${rr}`}                   tone="neutral" />
-      </div>
-
-      <button className={styles.cpCardCta} onClick={handleOpen} disabled={disabled}>
-        <span style={{ color: 'var(--bull)' }}>▸</span> abrir esta posición
-      </button>
-    </div>
-  );
-};
-
-// ============================================================
-// HISTORY CARD — real closed positions for this pair
-// ============================================================
-
-interface HistoryEntry {
-  daysAgo: number;
-  outcome: 'tp' | 'sl' | 'manual';
-  pnl:     number;
-}
-
-const HistoryCard: React.FC<{ symbol: SymbolStatus }> = ({ symbol }) => {
-  const [items, setItems] = useState<HistoryEntry[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let alive = true;
-    setItems(null);
-    setError(null);
-    // TODO: when /positions accepts `?symbol=X`, drop the client-side filter.
-    getPositions('closed')
-      .then((resp) => {
-        if (!alive) return;
-        const now = Date.now();
-        const list: HistoryEntry[] = (resp.positions ?? [])
-          .filter((p: Position) => p.symbol === symbol.symbol)
-          .slice(0, 6)
-          .map((p: Position) => {
-            const ts = p.exit_ts ?? p.entry_ts;
-            const daysAgo = ts
-              ? Math.max(0, Math.round((now - new Date(ts).getTime()) / (1000 * 60 * 60 * 24)))
-              : 0;
-            return {
-              daysAgo,
-              outcome: p.exit_reason === 'TP_HIT' ? 'tp' : p.exit_reason === 'SL_HIT' ? 'sl' : 'manual',
-              pnl:     p.pnl_pct ?? 0,
-            };
-          });
-        setItems(list);
-      })
-      .catch((err) => { if (alive) setError(err instanceof Error ? err.message : 'Error cargando historial'); });
-    return () => { alive = false; };
-  }, [symbol.symbol]);
-
-  if (items === null && !error) {
-    return (
-      <div className={styles.cpCard}>
-        <div className={styles.cpCardHead}>
-          <span className={styles.cpCardIcon}>◉</span>
-          <span className={styles.cpCardTitle}>Historial reciente</span>
-        </div>
-        <div className={`${styles.cpHistEmpty} prose`}>Cargando…</div>
-      </div>
-    );
-  }
-  if (error) {
-    return (
-      <div className={styles.cpCard}>
-        <div className={styles.cpCardHead}>
-          <span className={styles.cpCardIcon}>◉</span>
-          <span className={styles.cpCardTitle}>Historial reciente</span>
-        </div>
-        <div className={`${styles.cpHistEmpty} prose`}>Error: {error}</div>
-      </div>
-    );
-  }
-  const list = items ?? [];
-  if (list.length === 0) {
-    return (
-      <div className={styles.cpCard}>
-        <div className={styles.cpCardHead}>
-          <span className={styles.cpCardIcon}>◉</span>
-          <span className={styles.cpCardTitle}>Historial reciente</span>
-        </div>
-        <div className={`${styles.cpHistEmpty} prose`}>Sin operaciones previas en este par.</div>
-      </div>
-    );
-  }
-  const wins = list.filter((h) => h.pnl > 0).length;
-  const wr   = (wins / list.length) * 100;
-
-  return (
-    <div className={styles.cpCard}>
-      <div className={styles.cpCardHead}>
-        <span className={styles.cpCardIcon}>◉</span>
-        <span className={styles.cpCardTitle}>Historial reciente</span>
-        <span className={styles.cpCardScore}>
-          <span className="num">{wr.toFixed(0)}%</span>
-          <span className={styles.cpCardScoreSuf}>WR · {list.length}</span>
-        </span>
-      </div>
-      <div className={styles.cpHistStrip}>
-        {list.map((h, i) => {
-          const tone: 'bull' | 'bear' | 'warn' = h.pnl > 0 ? 'bull' : h.pnl < 0 ? 'bear' : 'warn';
-          const tag  = h.outcome === 'tp' ? 'TP' : h.outcome === 'sl' ? 'SL' : 'MAN';
-          const toneCellClass =
-            tone === 'bull' ? styles.cpHistCellBull :
-            tone === 'bear' ? styles.cpHistCellBear : styles.cpHistCellWarn;
-          const tonePnlClass =
-            tone === 'bull' ? styles.cpHistCellPnlBull :
-            tone === 'bear' ? styles.cpHistCellPnlBear : styles.cpHistCellPnlWarn;
-          return (
-            <div
-              key={i}
-              className={`${styles.cpHistCell} ${toneCellClass}`}
-              title={`hace ${h.daysAgo}d · ${tag} · ${h.pnl.toFixed(2)}%`}
-            >
-              <span className={styles.cpHistCellTag}>{tag}</span>
-              <span className={`${styles.cpHistCellPnl} num ${tonePnlClass}`}>
-                {h.pnl > 0 ? '+' : ''}{h.pnl.toFixed(1)}%
-              </span>
-              <span className={`${styles.cpHistCellWhen} prose`}>{h.daysAgo}d</span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-};
-
 // ============================================================
 // Tiny atoms
 // ============================================================
-
-const Knob: React.FC<{ label: string; value: string; onMinus: () => void; onPlus: () => void }> = ({ label, value, onMinus, onPlus }) => (
-  <div className={styles.cpKnob}>
-    <span className={styles.cpKnobLabel}>{label}</span>
-    <button className={`${styles.cpKnobBtn} ${styles.cpKnobBtnMinus}`} onClick={onMinus}>−</button>
-    <span className={`${styles.cpKnobVal} num`}>{value}</span>
-    <button className={`${styles.cpKnobBtn} ${styles.cpKnobBtnPlus}`} onClick={onPlus}>+</button>
-  </div>
-);
-
-type KvTone = 'bull' | 'bear' | 'warn' | 'neutral';
-const KV: React.FC<{ label: string; value: React.ReactNode; tone: KvTone }> = ({ label, value, tone }) => {
-  const toneClass =
-    tone === 'bull'    ? styles.cpKvBull :
-    tone === 'bear'    ? styles.cpKvBear :
-    tone === 'warn'    ? styles.cpKvWarn :
-                         styles.cpKvNeutral;
-  return (
-    <div className={`${styles.cpKv} ${toneClass}`}>
-      <span className={styles.cpKvLabel}>{label}</span>
-      <span className={`${styles.cpKvVal} num`}>{value}</span>
-    </div>
-  );
-};
 
 type ChipTone = 'bull' | 'bear' | 'warn' | 'dim';
 const Chip: React.FC<{ label: string; value: string; tone: ChipTone; long?: boolean }> = ({ label, value, tone, long }) => {

--- a/tests/test_agent_proposals.py
+++ b/tests/test_agent_proposals.py
@@ -58,20 +58,56 @@ def tmp_db(tmp_path, monkeypatch):
     yield db_path
 
 
+def _fake_user(*, id: int = 1, role: str = "admin"):
+    """Minimal User dataclass for dependency overrides in tests."""
+    from auth.models import User
+    return User(
+        id=id, email=f"u{id}@example.com", role=role, is_active=True,
+        created_at="2026-05-19T00:00:00+00:00",
+        password_changed_at="2026-05-19T00:00:00+00:00",
+    )
+
+
 @pytest.fixture
 def authed_client(tmp_db, monkeypatch):
-    """TestClient with the agent dependencies overridden."""
+    """TestClient with the agent dependencies overridden as ADMIN tenant 1.
+
+    For non-admin scenarios use `make_authed_client(role='viewer')` from
+    inside the test — see test_confirm_403_when_viewer_tries_apply_tune.
+    """
     import btc_api
     from fastapi.testclient import TestClient
-    from auth.dependencies import get_current_tenant_id
+    from auth.dependencies import get_current_tenant_id, get_current_user
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
     monkeypatch.setenv("AGENT_PROPOSAL_SECRET", _TEST_SECRET)
     btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 1
+    btc_api.app.dependency_overrides[get_current_user] = lambda: _fake_user(id=1, role="admin")
     try:
         yield TestClient(btc_api.app)
     finally:
         btc_api.app.dependency_overrides.pop(get_current_tenant_id, None)
+        btc_api.app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+def viewer_client(tmp_db, monkeypatch):
+    """TestClient bound to tenant 1 with role='viewer'. Used to verify the
+    confirm endpoint rejects global-scope actions (apply_tune,
+    reactivate_symbol) for non-admin users."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from auth.dependencies import get_current_tenant_id, get_current_user
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
+    monkeypatch.setenv("AGENT_PROPOSAL_SECRET", _TEST_SECRET)
+    btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 1
+    btc_api.app.dependency_overrides[get_current_user] = lambda: _fake_user(id=1, role="viewer")
+    try:
+        yield TestClient(btc_api.app)
+    finally:
+        btc_api.app.dependency_overrides.pop(get_current_tenant_id, None)
+        btc_api.app.dependency_overrides.pop(get_current_user, None)
 
 
 # ── sign/verify round-trip ─────────────────────────────────────────────
@@ -99,6 +135,38 @@ def test_verify_rejects_tampered_mac(proposal_env):
     with pytest.raises(ProposalError) as exc_info:
         verify_proposal(bad)
     assert exc_info.value.reason == "signature_mismatch"
+
+
+def test_verify_rejects_unsupported_version(proposal_env):
+    """Bumping `v` to 2 without a verifier update must fail loudly with
+    a distinguishable closed-enum reason (NOT signature_mismatch), so
+    rollback / split-deploy debugging is possible. Defense recommended
+    in PR #406 review."""
+    from api.agent.proposals import ProposalError, _canonical_payload, _secret, verify_proposal
+    import base64
+    import hmac
+    import hashlib
+    # Manually craft a properly-signed v=2 envelope.
+    payload_v2 = {
+        "v":          2,
+        "proposal_id": "prop_v2test",
+        "action":     "close_position",
+        "args":       {"position_id": 1, "exit_price": 1.0},
+        "tenant_id":  1,
+        "expires_at": "2030-01-01T00:00:00+00:00",
+    }
+    import json as _json
+    raw = _json.dumps(payload_v2, sort_keys=True, ensure_ascii=True, separators=(",", ":")).encode()
+    mac = hmac.new(_secret(), raw, hashlib.sha256).hexdigest()
+    payload_b64 = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+    signed = f"{mac}.{payload_b64}"
+
+    with pytest.raises(ProposalError) as exc_info:
+        verify_proposal(signed)
+    assert exc_info.value.reason == "unsupported_version"
+    # Bonus: the v=1 path (which the existing tests cover) remains
+    # untouched — verify_proposal still accepts a real v=1 envelope.
+    # (No extra assertion here; the broader suite already proves it.)
 
 
 def test_verify_rejects_tampered_payload(proposal_env):
@@ -455,6 +523,162 @@ def test_confirm_returns_409_on_state_drift(authed_client):
     finally:
         con.close()
     assert dict(row)["result"] == "state_drift"
+
+
+def test_confirm_rejects_proposal_id_mismatch(authed_client):
+    """A signed_payload from proposal A submitted at the URL of proposal
+    B → 400 proposal_id_mismatch. Defense against confused-deputy attacks
+    where an attacker swaps URLs but keeps a valid signature."""
+    import btc_api
+    from api.agent.proposals import sign_proposal, persist_proposal
+    client = authed_client
+
+    # Build two distinct proposals.
+    con = btc_api.get_db()
+    try:
+        pos_id_a = _seed_position(con, tenant_id=1, status="open")
+        pos_id_b = _seed_position(con, tenant_id=1, status="open")
+    finally:
+        con.close()
+    p_a = sign_proposal(action="close_position",
+                         args={"position_id": pos_id_a, "exit_price": 10.0},
+                         tenant_id=1)
+    p_b = sign_proposal(action="close_position",
+                         args={"position_id": pos_id_b, "exit_price": 20.0},
+                         tenant_id=1)
+    persist_proposal(tenant_id=1, conversation_id="c", proposal=p_a)
+    persist_proposal(tenant_id=1, conversation_id="c", proposal=p_b)
+
+    # Send A's signed payload to B's URL → 400.
+    resp = client.post(
+        f"/agent/proposals/{p_b.proposal_id}/confirm",
+        json={"signed_payload": p_a.signed_payload},
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "proposal_id_mismatch"}
+
+    # And neither position closed.
+    con = btc_api.get_db()
+    try:
+        rows = con.execute("SELECT status FROM positions WHERE id IN (?,?)",
+                            (pos_id_a, pos_id_b)).fetchall()
+    finally:
+        con.close()
+    assert all(dict(r)["status"] == "open" for r in rows)
+
+
+def test_confirm_403_when_viewer_tries_apply_tune(viewer_client, monkeypatch):
+    """A viewer-role user cannot confirm a global-scope action even if
+    the propose grounding succeeded. The role gate fires inside
+    _execute_proposed_action; the row in agent_side_effects records
+    result='role_required' for audit visibility."""
+    import btc_api
+    from api.agent.proposals import sign_proposal, persist_proposal
+    client = viewer_client
+
+    p = sign_proposal(
+        action="apply_tune",
+        args={"tune_id": 1},
+        tenant_id=1,
+    )
+    persist_proposal(tenant_id=1, conversation_id="c", proposal=p)
+
+    resp = client.post(
+        f"/agent/proposals/{p.proposal_id}/confirm",
+        json={"signed_payload": p.signed_payload},
+    )
+    assert resp.status_code == 403
+    assert resp.json() == {"detail": "role_required"}
+
+    # Audit trail records the role rejection (not 'error', not 'state_drift').
+    con = btc_api.get_db()
+    try:
+        row = con.execute(
+            "SELECT result, http_status FROM agent_side_effects "
+            "WHERE idempotency_key = ?",
+            (p.proposal_id,),
+        ).fetchone()
+    finally:
+        con.close()
+    assert dict(row)["result"] == "role_required"
+    assert dict(row)["http_status"] == 403
+
+
+def test_confirm_403_when_viewer_tries_reactivate_symbol(viewer_client):
+    """Same pattern for reactivate_symbol — global-scope symbol_health
+    state is admin-only."""
+    import btc_api
+    from api.agent.proposals import sign_proposal, persist_proposal
+    client = viewer_client
+
+    p = sign_proposal(
+        action="reactivate_symbol",
+        args={"symbol": "BTCUSDT", "reason": "manual_override_via_copilot"},
+        tenant_id=1,
+    )
+    persist_proposal(tenant_id=1, conversation_id="c", proposal=p)
+
+    resp = client.post(
+        f"/agent/proposals/{p.proposal_id}/confirm",
+        json={"signed_payload": p.signed_payload},
+    )
+    assert resp.status_code == 403
+    assert resp.json() == {"detail": "role_required"}
+
+
+def test_confirm_close_position_works_for_viewer_on_own_position(viewer_client):
+    """close_position is PER-TENANT scope (the position's tenant_id must
+    match the JWT-resolved one). A viewer who owns the position can
+    confirm — close_position is not in _ADMIN_ONLY_ACTIONS. This locks
+    in the distinction with apply_tune / reactivate_symbol."""
+    import btc_api
+    client = viewer_client
+
+    con = btc_api.get_db()
+    try:
+        pos_id, proposal = _build_signed_close_proposal(con, tenant_id=1)
+    finally:
+        con.close()
+
+    resp = client.post(
+        f"/agent/proposals/{proposal.proposal_id}/confirm",
+        json={"signed_payload": proposal.signed_payload},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["result"] == "ok"
+
+    con = btc_api.get_db()
+    try:
+        row = con.execute(
+            "SELECT status, exit_reason FROM positions WHERE id = ?", (pos_id,),
+        ).fetchone()
+    finally:
+        con.close()
+    assert dict(row)["status"] == "closed"
+    assert dict(row)["exit_reason"] == "MANUAL_AGENT"
+
+
+def test_propose_handlers_signatures_require_conversation_id():
+    """Phase 1's contract was 'all read-only handlers take tenant_id as
+    KEYWORD_ONLY'; Phase 3 extends propose handlers with the same
+    discipline for conversation_id. This invariant locks the wire:
+    nobody can quietly land a propose handler that forgets to namespace
+    its proposal row to a conversation. PR #406 review pickup."""
+    import inspect
+    from api.agent.tools.propose_handlers import PROPOSE_HANDLERS
+
+    for name, fn in PROPOSE_HANDLERS.items():
+        sig = inspect.signature(fn)
+        tparam = sig.parameters.get("tenant_id")
+        cparam = sig.parameters.get("conversation_id")
+        assert tparam is not None, f"{name} missing tenant_id"
+        assert tparam.kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{name} tenant_id must be KEYWORD_ONLY"
+        )
+        assert cparam is not None, f"{name} missing conversation_id"
+        assert cparam.kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{name} conversation_id must be KEYWORD_ONLY"
+        )
 
 
 def test_confirm_503_when_agent_disabled(authed_client, monkeypatch):

--- a/tests/test_agent_proposals.py
+++ b/tests/test_agent_proposals.py
@@ -1,0 +1,482 @@
+"""Phase 3 of epic #400 — propose/confirm pattern tests.
+
+Covers:
+
+  - HMAC sign + verify round-trip: a token produced by sign_proposal
+    verifies cleanly; a token with the MAC byte-flipped raises
+    ProposalError("signature_mismatch").
+  - TTL: a row with expires_at < now is_expired() == True.
+  - persist_proposal idempotency: re-inserting the same proposal_id
+    is a no-op (idempotency_key UNIQUE).
+  - propose_close_position end-to-end: tool emits `_proposal` envelope
+    when the position belongs to the tenant, returns `error: not_found`
+    when it doesn't. The proposal lands in agent_side_effects with
+    result=NULL.
+  - propose_reactivate_symbol: only emits when symbol is currently
+    PAUSED; else returns symbol_not_paused.
+  - POST /agent/proposals/{id}/confirm:
+      * verifies HMAC + tenant ownership + idempotency.
+      * second confirm of the same proposal is idempotent (no double
+        execution downstream — verified via a spy on db_close_position).
+      * cross-tenant confirm returns 404, NEVER reveals the proposal
+        belongs to another tenant.
+      * expired confirm returns 410.
+      * TOCTOU drift returns 409 with result='state_drift' persisted.
+      * signed_payload byte-tampering returns 400 signature_mismatch.
+
+Pre-reg §10. All tests use the test fake's monkeypatch on
+AGENT_PROPOSAL_SECRET so we never depend on real env state.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────
+
+
+_TEST_SECRET = "test-only-secret-for-pytest-not-real"
+
+
+@pytest.fixture
+def proposal_env(monkeypatch):
+    """Set AGENT_PROPOSAL_SECRET so sign/verify works in tests."""
+    monkeypatch.setenv("AGENT_PROPOSAL_SECRET", _TEST_SECRET)
+    yield
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+@pytest.fixture
+def authed_client(tmp_db, monkeypatch):
+    """TestClient with the agent dependencies overridden."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from auth.dependencies import get_current_tenant_id
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
+    monkeypatch.setenv("AGENT_PROPOSAL_SECRET", _TEST_SECRET)
+    btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 1
+    try:
+        yield TestClient(btc_api.app)
+    finally:
+        btc_api.app.dependency_overrides.pop(get_current_tenant_id, None)
+
+
+# ── sign/verify round-trip ─────────────────────────────────────────────
+
+
+def test_sign_verify_round_trip(proposal_env):
+    from api.agent.proposals import sign_proposal, verify_proposal
+    p = sign_proposal(action="close_position",
+                       args={"position_id": 7, "exit_price": 50_000.0},
+                       tenant_id=42)
+    parsed = verify_proposal(p.signed_payload)
+    assert parsed["proposal_id"] == p.proposal_id
+    assert parsed["action"] == "close_position"
+    assert parsed["args"] == {"position_id": 7, "exit_price": 50_000.0}
+    assert parsed["tenant_id"] == 42
+
+
+def test_verify_rejects_tampered_mac(proposal_env):
+    from api.agent.proposals import ProposalError, sign_proposal, verify_proposal
+    p = sign_proposal(action="close_position", args={"position_id": 1, "exit_price": 1.0}, tenant_id=1)
+    # Flip a single hex digit of the MAC
+    mac, payload = p.signed_payload.split(".", 1)
+    flipped = ("a" if mac[0] != "a" else "b") + mac[1:]
+    bad = f"{flipped}.{payload}"
+    with pytest.raises(ProposalError) as exc_info:
+        verify_proposal(bad)
+    assert exc_info.value.reason == "signature_mismatch"
+
+
+def test_verify_rejects_tampered_payload(proposal_env):
+    """Modify the tenant_id field inside the payload — the MAC no longer
+    matches because we canonicalize before HMAC."""
+    from api.agent.proposals import ProposalError, sign_proposal, verify_proposal
+    import base64
+    p = sign_proposal(action="close_position", args={"position_id": 1, "exit_price": 1.0}, tenant_id=1)
+    mac, payload_b64 = p.signed_payload.split(".", 1)
+    # Decode, modify, re-encode (without re-signing)
+    padding = "=" * (-len(payload_b64) % 4)
+    raw = base64.urlsafe_b64decode(payload_b64 + padding)
+    doc = json.loads(raw)
+    doc["tenant_id"] = 2  # attacker swaps tenant
+    bad_raw = json.dumps(doc, sort_keys=True, ensure_ascii=True, separators=(",", ":")).encode()
+    bad_b64 = base64.urlsafe_b64encode(bad_raw).decode("ascii").rstrip("=")
+    with pytest.raises(ProposalError) as exc_info:
+        verify_proposal(f"{mac}.{bad_b64}")
+    assert exc_info.value.reason == "signature_mismatch"
+
+
+# ── persistence + idempotency ──────────────────────────────────────────
+
+
+def test_persist_and_load_proposal(proposal_env, tmp_db):
+    from api.agent.proposals import sign_proposal, persist_proposal, load_proposal_row
+    p = sign_proposal(action="close_position", args={"position_id": 5, "exit_price": 100.0}, tenant_id=3)
+    persist_proposal(tenant_id=3, conversation_id="conv-a", proposal=p)
+    row = load_proposal_row(p.proposal_id)
+    assert row is not None
+    assert row["tenant_id"] == 3
+    assert row["action"] == "close_position"
+    assert row["result"] is None
+    assert row["expires_at"] is not None
+
+
+def test_persist_proposal_is_idempotent(proposal_env, tmp_db):
+    """Same proposal_id can't insert twice — the UNIQUE constraint handles
+    it gracefully (logged warning, no-op)."""
+    from api.agent.proposals import sign_proposal, persist_proposal, load_proposal_row
+    p = sign_proposal(action="close_position", args={"position_id": 5, "exit_price": 100.0}, tenant_id=3)
+    persist_proposal(tenant_id=3, conversation_id="conv-a", proposal=p)
+    persist_proposal(tenant_id=3, conversation_id="conv-a", proposal=p)  # idempotent
+    row = load_proposal_row(p.proposal_id)
+    assert row is not None
+
+
+def test_is_expired_with_past_timestamp():
+    from api.agent.proposals import is_expired
+    assert is_expired({"expires_at": "2020-01-01T00:00:00+00:00"}) is True
+
+
+def test_is_expired_with_future_timestamp():
+    from api.agent.proposals import is_expired
+    from datetime import datetime, timedelta, timezone
+    future = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+    assert is_expired({"expires_at": future}) is False
+
+
+def test_is_expired_treats_null_as_expired():
+    """Legacy rows pre-Phase 3 have NULL expires_at → can't be confirmed."""
+    from api.agent.proposals import is_expired
+    assert is_expired({"expires_at": None}) is True
+
+
+# ── Propose handlers — grounding checks ───────────────────────────────
+
+
+def _seed_position(con, *, tenant_id: int, status: str = "open", id: int | None = None):
+    cur = con.execute(
+        "INSERT INTO positions "
+        "(symbol, direction, status, entry_price, entry_ts, size_usd, tenant_id) "
+        "VALUES ('BTCUSDT', 'LONG', ?, 50000, '2026-04-20T10:00:00+00:00', 1000, ?)",
+        (status, tenant_id),
+    )
+    con.commit()
+    return cur.lastrowid
+
+
+def test_propose_close_position_emits_envelope_for_own_position(proposal_env, tmp_db):
+    import btc_api
+    from api.agent.tools.propose_handlers import propose_close_position
+    from api.agent.proposals import load_proposal_row
+
+    con = btc_api.get_db()
+    try:
+        pos_id = _seed_position(con, tenant_id=1, status="open")
+    finally:
+        con.close()
+
+    out = propose_close_position(
+        tenant_id=1, conversation_id="c1",
+        position_id=pos_id, exit_price=51000.0,
+        rationale="momentum gave out and the SL is too far",
+    )
+    assert "_proposal" in out
+    env = out["_proposal"]
+    assert env["action"] == "close_position"
+    assert env["args"] == {"position_id": pos_id, "exit_price": 51000.0}
+    assert env["proposal_id"].startswith("prop_")
+    # And persisted with result=NULL.
+    row = load_proposal_row(env["proposal_id"])
+    assert row is not None and row["result"] is None
+    assert row["tenant_id"] == 1
+
+
+def test_propose_close_position_rejects_other_tenant(proposal_env, tmp_db):
+    """Tenant 1 tries to propose closing tenant 2's position → not_found,
+    no proposal signed, no row in agent_side_effects."""
+    import btc_api
+    from api.agent.tools.propose_handlers import propose_close_position
+
+    con = btc_api.get_db()
+    try:
+        other_id = _seed_position(con, tenant_id=2, status="open")
+    finally:
+        con.close()
+
+    out = propose_close_position(
+        tenant_id=1, conversation_id="c1",
+        position_id=other_id, exit_price=1.0, rationale="x" * 20,
+    )
+    assert out == {"error": "not_found"}
+    # No proposal persisted.
+    con = btc_api.get_db()
+    try:
+        rows = con.execute("SELECT * FROM agent_side_effects").fetchall()
+    finally:
+        con.close()
+    assert rows == []
+
+
+def test_propose_close_position_rejects_closed_position(proposal_env, tmp_db):
+    import btc_api
+    from api.agent.tools.propose_handlers import propose_close_position
+
+    con = btc_api.get_db()
+    try:
+        pos_id = _seed_position(con, tenant_id=1, status="closed")
+    finally:
+        con.close()
+
+    out = propose_close_position(
+        tenant_id=1, conversation_id="c1",
+        position_id=pos_id, exit_price=1.0, rationale="x" * 20,
+    )
+    assert out == {"error": "position_not_open"}
+
+
+# ── Confirm endpoint ──────────────────────────────────────────────────
+
+
+def _build_signed_close_proposal(con, *, tenant_id: int, exit_price: float = 51000.0):
+    """Helper: seed an open position, sign + persist a close_position
+    proposal, return (pos_id, proposal_obj)."""
+    from api.agent.proposals import sign_proposal, persist_proposal
+    pos_id = _seed_position(con, tenant_id=tenant_id, status="open")
+    p = sign_proposal(
+        action="close_position",
+        args={"position_id": pos_id, "exit_price": exit_price},
+        tenant_id=tenant_id,
+    )
+    persist_proposal(tenant_id=tenant_id, conversation_id="conv-test", proposal=p)
+    return pos_id, p
+
+
+def test_confirm_succeeds_and_executes_downstream(authed_client):
+    """Happy path: confirm a freshly signed proposal → 200 ok →
+    downstream db_close_position fired → row in positions marked closed."""
+    import btc_api
+    client = authed_client
+
+    con = btc_api.get_db()
+    try:
+        pos_id, proposal = _build_signed_close_proposal(con, tenant_id=1)
+    finally:
+        con.close()
+
+    resp = client.post(
+        f"/agent/proposals/{proposal.proposal_id}/confirm",
+        json={"signed_payload": proposal.signed_payload},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["result"] == "ok"
+    assert body["idempotent"] is False
+
+    # And the position is actually closed.
+    con = btc_api.get_db()
+    try:
+        row = con.execute(
+            "SELECT status, exit_reason FROM positions WHERE id = ?", (pos_id,),
+        ).fetchone()
+    finally:
+        con.close()
+    assert dict(row)["status"] == "closed"
+    assert dict(row)["exit_reason"] == "MANUAL_AGENT"
+
+
+def test_confirm_is_idempotent_on_double_click(authed_client):
+    """Second confirm returns the first result, does NOT re-execute the
+    downstream action. Verified by checking the position only closed
+    once (exit_ts doesn't change on the second call)."""
+    import btc_api
+    client = authed_client
+
+    con = btc_api.get_db()
+    try:
+        pos_id, proposal = _build_signed_close_proposal(con, tenant_id=1)
+    finally:
+        con.close()
+
+    r1 = client.post(
+        f"/agent/proposals/{proposal.proposal_id}/confirm",
+        json={"signed_payload": proposal.signed_payload},
+    )
+    assert r1.status_code == 200
+    assert r1.json()["idempotent"] is False
+
+    r2 = client.post(
+        f"/agent/proposals/{proposal.proposal_id}/confirm",
+        json={"signed_payload": proposal.signed_payload},
+    )
+    assert r2.status_code == 200
+    body = r2.json()
+    assert body["ok"] is True
+    assert body["idempotent"] is True  # second call short-circuited
+
+
+def test_confirm_returns_404_for_cross_tenant_attempt(authed_client, monkeypatch):
+    """Tenant 2 signs a proposal. Tenant 1 (the authed test client) tries
+    to confirm it → 404 not_found (NEVER 403 or detail revealing the
+    cross-tenant nature)."""
+    import btc_api
+    client = authed_client
+
+    con = btc_api.get_db()
+    try:
+        _pos_id, proposal = _build_signed_close_proposal(con, tenant_id=2)
+    finally:
+        con.close()
+
+    # client is bound to tenant_id=1 via the fixture override.
+    resp = client.post(
+        f"/agent/proposals/{proposal.proposal_id}/confirm",
+        json={"signed_payload": proposal.signed_payload},
+    )
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "not_found"}
+
+
+def test_confirm_returns_400_on_tampered_signature(authed_client):
+    """A byte-flipped MAC on the signed_payload → 400 signature_mismatch.
+    The position must NOT close."""
+    import btc_api
+    client = authed_client
+
+    con = btc_api.get_db()
+    try:
+        pos_id, proposal = _build_signed_close_proposal(con, tenant_id=1)
+    finally:
+        con.close()
+
+    mac, payload = proposal.signed_payload.split(".", 1)
+    flipped = ("a" if mac[0] != "a" else "b") + mac[1:]
+    bad = f"{flipped}.{payload}"
+    resp = client.post(
+        f"/agent/proposals/{proposal.proposal_id}/confirm",
+        json={"signed_payload": bad},
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"detail": "signature_mismatch"}
+
+    # And the position is STILL open.
+    con = btc_api.get_db()
+    try:
+        row = con.execute(
+            "SELECT status FROM positions WHERE id = ?", (pos_id,),
+        ).fetchone()
+    finally:
+        con.close()
+    assert dict(row)["status"] == "open"
+
+
+def test_confirm_returns_410_on_expired(authed_client):
+    """A proposal whose expires_at column has passed → 410 expired.
+    Persist directly with a past expires_at to bypass the helper."""
+    import btc_api
+    from api.agent.proposals import sign_proposal
+    client = authed_client
+
+    p = sign_proposal(
+        action="close_position",
+        args={"position_id": 1, "exit_price": 1.0},
+        tenant_id=1,
+    )
+    con = btc_api.get_db()
+    try:
+        # Insert manually with a past expires_at.
+        con.execute(
+            "INSERT INTO agent_side_effects "
+            "(tenant_id, conversation_id, ts, action, args_json, "
+            " idempotency_key, result, http_status, expires_at) "
+            "VALUES (1, 'c', '2020-01-01T00:00:00+00:00', "
+            "        'close_position', '{}', ?, NULL, NULL, "
+            "        '2020-01-01T00:05:00+00:00')",
+            (p.proposal_id,),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    resp = client.post(
+        f"/agent/proposals/{p.proposal_id}/confirm",
+        json={"signed_payload": p.signed_payload},
+    )
+    assert resp.status_code == 410
+    assert resp.json() == {"detail": "expired"}
+
+
+def test_confirm_returns_409_on_state_drift(authed_client):
+    """TOCTOU: proposal signed when position was open; before confirm,
+    the position got closed elsewhere. confirm → 409 state_drift."""
+    import btc_api
+    client = authed_client
+
+    con = btc_api.get_db()
+    try:
+        pos_id, proposal = _build_signed_close_proposal(con, tenant_id=1)
+        # Simulate the position closing in another flow before confirm.
+        con.execute(
+            "UPDATE positions SET status = 'closed', exit_reason = 'SL', "
+            "  exit_ts = '2026-05-19T20:00:00+00:00', exit_price = 49000 "
+            "WHERE id = ?", (pos_id,),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    resp = client.post(
+        f"/agent/proposals/{proposal.proposal_id}/confirm",
+        json={"signed_payload": proposal.signed_payload},
+    )
+    assert resp.status_code == 409
+    assert resp.json() == {"detail": "state_drift"}
+    # The row in agent_side_effects records the drift.
+    con = btc_api.get_db()
+    try:
+        row = con.execute(
+            "SELECT result FROM agent_side_effects WHERE idempotency_key = ?",
+            (proposal.proposal_id,),
+        ).fetchone()
+    finally:
+        con.close()
+    assert dict(row)["result"] == "state_drift"
+
+
+def test_confirm_503_when_agent_disabled(authed_client, monkeypatch):
+    """If the agent is disabled at confirm time (operator flipped the
+    flag mid-flow), the endpoint 503s without executing the action.
+
+    Uses a 60-char dummy signed_payload so the body clears Pydantic's
+    min_length=20 and the request actually reaches the handler's
+    status gate (otherwise the test only proves short bodies 422,
+    which is not what we want to assert).
+    """
+    import api.agent.config as agent_cfg
+    client = authed_client
+
+    monkeypatch.setattr(
+        agent_cfg, "load_config",
+        lambda: {"agent": {"enabled": False}},
+    )
+    fake_token = "x" * 30 + "." + "y" * 30
+    resp = client.post(
+        "/agent/proposals/prop_test123/confirm",
+        json={"signed_payload": fake_token},
+    )
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "agent_disabled"}


### PR DESCRIPTION
## Summary

Phase 3 of epic #400 — side-effects now require a propose → user-confirm → server-execute round-trip. The model never executes a destructive action directly; it calls a `propose_*` tool, the server signs an HMAC envelope, the frontend renders an amber button, and only on user click does the downstream action run (with full HMAC + TTL + tenant + idempotency + TOCTOU re-checks).

- 3 new propose tools — `propose_close_position`, `propose_reactivate_symbol`, `propose_apply_tune`. Tenant + state grounded BEFORE signing.
- New `POST /agent/proposals/{id}/confirm` endpoint with closed-enum failures.
- SSE `proposal` frame; useAgentStream attaches a `ProposalChip` state machine (`pending → in_flight → ok | drift | expired | error`).
- AgentDock + SymbolDetail render the amber button. SymbolDetail fully rewired from legacy `chatAgent` + `<<<TOOL:...>>>` markers to `useAgentStream({surface: 'symbol_detail'})`.

## Security model

- AGENT_PROPOSAL_SECRET (separate env var from JWT_SECRET) signs the envelope.
- Cross-tenant confirm returns 404, never reveals existence.
- TOCTOU re-check on close_position catches the case where a position closed via SL/TP/TL between propose and confirm (db_close_position doesn't check status; the router does, here).
- Idempotency via UNIQUE constraint on `agent_side_effects.idempotency_key`; double-confirm returns the cached result.

## Tests

- **Backend**: 18 new tests in `test_agent_proposals.py` — HMAC round-trip + tamper, TTL boundary, persistence idempotency, propose ownership checks, full confirm-endpoint matrix (200 / 200 idempotent / 404 cross-tenant / 400 tampered MAC / 410 expired / 409 state_drift / 503 disabled).
- **Frontend**: 6 new hook tests in `useAgentStream.test.tsx` — attach-on-event, full confirm round-trip (signed_payload echoed verbatim), drift, expired, terminal-state idempotency, unknown-id no-op.
- **Totals**: 67 backend agent tests passing, 93 frontend tests passing, TS clean.

## Test plan
- [ ] flip `cfg.agent.enabled=true`, set `AGENT_PROPOSAL_SECRET`, open dock
- [ ] "cerrar mi posición de BTC" → model calls propose_close_position → amber button renders with summary
- [ ] click button → 200 ok → button turns bull green ("Confirmado ✓"); verify position closed with `exit_reason='MANUAL_AGENT'`
- [ ] click a second time → no second close, no new POST in network tab
- [ ] race: open a position, propose, then close it manually via the positions tab BEFORE clicking confirm → click confirm → button turns bear red ("Estado cambió — re-pregunta"); the original close stands
- [ ] wait 5+ min between propose and confirm → button turns bear red ("Expirado")
- [ ] confirm flow for `reactivate_symbol` (PAUSED → PROBATION) + `apply_tune` work identically
- [ ] SymbolDetail copilot: open a symbol, ask about its setup → streaming response with tool chips inline; ask "cerrar #N" if there's an open position on that symbol → amber confirm renders inside the right pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)