### PR TITLE
feat(agent): Phase 4 — per-surface model + tool snapshot tests (#400)

### DIFF
--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -162,7 +162,19 @@ def _strip_titles(node: Any) -> None:
 # Pricing in USD per 1M tokens, copied from the claude-api skill. Update
 # this map deliberately when bumping the anthropic SDK pin (pre-reg
 # §12.7 — Buffers internos).
-
+#
+# This dict is the canonical pricing source for the cost calculator.
+# Context-window capacities (1M / 1M / 200K) and the human-readable
+# "Opus is bigger, Haiku is cheaper" framing live in the api/agent/models.py
+# docstring — model selection logic + the cost-model dict are different
+# concerns, but pricing $$/$$/per-1M numbers must NOT be duplicated to
+# both files (PR #407 review issue 2). If Anthropic ships a price change,
+# the only number to update is here.
+#
+# Cached snapshot 2026-04-29:
+#   - claude-opus-4-7   — $5.00 in / $25.00 out, 1M ctx
+#   - claude-sonnet-4-6 — $3.00 in / $15.00 out, 1M ctx
+#   - claude-haiku-4-5  — $1.00 in / $5.00  out, 200K ctx
 _MODEL_PRICING = {
     "claude-opus-4-7":   {"in": 5.00, "out": 25.00},
     "claude-sonnet-4-6": {"in": 3.00, "out": 15.00},

--- a/api/agent/models.py
+++ b/api/agent/models.py
@@ -17,19 +17,19 @@ inline; centralizing them lets us:
     a broken deploy at process start);
   - keep `api/agent/router.py` focused on HTTP plumbing.
 
-Pricing context (cached 2026-04-29):
+Pricing source: the canonical $/1M-token map lives in
+`api/agent/loop.py:_MODEL_PRICING` (it's the dict the cost calculator
+actually reads). DO NOT duplicate numeric prices here — when Anthropic
+ships a price change, there is exactly one number to update, in one
+file (PR #407 review issue 2).
 
-  - claude-opus-4-7   — $5.00 / $25.00 per 1M tok in/out, 1M ctx
-  - claude-sonnet-4-6 — $3.00 / $15.00 per 1M tok in/out, 1M ctx
-  - claude-haiku-4-5  — $1.00 / $5.00  per 1M tok in/out, 200K ctx
-
-Surface defaults are calibrated to the kind of reasoning each view
-needs: Dock + KillSwitch + AutoTune get Sonnet because portfolio-level
-synthesis benefits from the deeper model. SymbolDetail + Historial get
-Haiku — narrower context, more about reading single-symbol setups or
-windowed history, faster and cheaper. The user can still flip to Opus
-on demand via the `model` override on the turn request (the router
-enforces the allowlist).
+Context-window capacities (informational, used to pick the right
+surface model — not for billing): Opus 4.7 + Sonnet 4.6 are 1M; Haiku
+4.5 is 200K. Surfaces that need broad portfolio synthesis use Sonnet
+(or Opus on override); surfaces scoped to a single symbol or windowed
+history use Haiku — narrower context, faster, cheaper. The user can
+flip to Opus on demand via the `model` override on the turn request
+(the router enforces the allowlist).
 """
 from __future__ import annotations
 

--- a/api/agent/models.py
+++ b/api/agent/models.py
@@ -1,0 +1,82 @@
+"""Per-surface model selection — Phase 4 of epic #400.
+
+Pre-reg §4.3 ("ningún surface mezcla modelos dentro de la misma sesión"):
+the surface is fixed at session-start, the model is bound to that surface
+deterministically, and the prompt-cache prefix stays warm because tools +
+system prompt are stable for the surface.
+
+This module is the canonical source for both the per-surface default and
+the allowlist of legitimate model IDs. The router used to declare these
+inline; centralizing them lets us:
+
+  - re-use the same defaults from a future telemetry endpoint that
+    reports "what model are dock turns actually running on";
+  - add a single test surface for the invariant "every declared surface
+    maps to a model in the allowlist", which fires at import time and at
+    test time (defense in depth, since the import-time check rolls back
+    a broken deploy at process start);
+  - keep `api/agent/router.py` focused on HTTP plumbing.
+
+Pricing context (cached 2026-04-29):
+
+  - claude-opus-4-7   — $5.00 / $25.00 per 1M tok in/out, 1M ctx
+  - claude-sonnet-4-6 — $3.00 / $15.00 per 1M tok in/out, 1M ctx
+  - claude-haiku-4-5  — $1.00 / $5.00  per 1M tok in/out, 200K ctx
+
+Surface defaults are calibrated to the kind of reasoning each view
+needs: Dock + KillSwitch + AutoTune get Sonnet because portfolio-level
+synthesis benefits from the deeper model. SymbolDetail + Historial get
+Haiku — narrower context, more about reading single-symbol setups or
+windowed history, faster and cheaper. The user can still flip to Opus
+on demand via the `model` override on the turn request (the router
+enforces the allowlist).
+"""
+from __future__ import annotations
+
+
+# Canonical mapping. Adding a new surface here REQUIRES adding it to:
+#   - api/agent/prompts/surfaces.py  (micro-prompt)
+#   - api/agent/tools/registry.py    (tool subset via the `surfaces` field)
+#   - frontend/src/agent/surfaces.ts (UI metadata)
+#   - the Literal[...] in api/agent/router.py's _AgentTurnRequest
+# The invariant check below + test_models_invariants in
+# tests/test_agent_models.py catches the first two; a snapshot test on
+# the tool subset catches drift in the third.
+SURFACE_MODEL_DEFAULTS: dict[str, str] = {
+    "dock":          "claude-sonnet-4-6",
+    "symbol_detail": "claude-haiku-4-5",
+    "kill_switch":   "claude-sonnet-4-6",
+    "autotune":      "claude-sonnet-4-6",
+    "historial":     "claude-haiku-4-5",
+}
+
+
+# Closed allowlist of model IDs accepted by the turn endpoint. A user-
+# supplied `model` override on the turn request is rejected unless it
+# appears here. New models go through deliberate code review — pricing
+# + capability gates live in this set, not in env vars.
+ALLOWED_MODELS: frozenset[str] = frozenset({
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "claude-opus-4-7",
+})
+
+
+def default_model_for_surface(surface: str) -> str:
+    """Return the default model id for a surface. Raises KeyError if the
+    surface is unknown — that's the right behavior at the call site,
+    since the router has already validated the surface via the Literal
+    on the request schema before we get here."""
+    return SURFACE_MODEL_DEFAULTS[surface]
+
+
+# Import-time invariant: every default must be in the allowlist. If a
+# typo lands in SURFACE_MODEL_DEFAULTS the process refuses to start. We
+# use RuntimeError (not assert) because `python -O` strips asserts and
+# we want this check to fire in production too (mirror of the same
+# pattern in api/agent/tools/registry.py).
+_bad = {s: m for s, m in SURFACE_MODEL_DEFAULTS.items() if m not in ALLOWED_MODELS}
+if _bad:
+    raise RuntimeError(
+        f"SURFACE_MODEL_DEFAULTS contains models not in ALLOWED_MODELS: {_bad}"
+    )

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -32,6 +32,7 @@ from api.agent.audit import TurnAuditWrapper
 from api.agent.clients import get_anthropic_client
 from api.agent.config import get_agent_status
 from api.agent.loop import run_turn
+from api.agent.models import ALLOWED_MODELS, default_model_for_surface
 from api.agent.proposals import (
     ACTION_APPLY_TUNE,
     ACTION_CLOSE_POSITION,
@@ -67,15 +68,11 @@ def get_status():
 
 
 # ── /agent/conversations/{id}/turn (Phase 2) ───────────────────────────
-
-
-_SURFACE_MODEL_DEFAULTS: dict[str, str] = {
-    "dock":          "claude-sonnet-4-6",
-    "symbol_detail": "claude-haiku-4-5",
-    "kill_switch":   "claude-sonnet-4-6",
-    "autotune":      "claude-sonnet-4-6",
-    "historial":     "claude-haiku-4-5",
-}
+#
+# Per-surface model defaults + the allowlist live in api/agent/models.py
+# (Phase 4 of #400). The router consumes them but never declares them
+# inline — keeping the data structure in one place makes the matrix easy
+# to inspect from telemetry / tests / a future admin endpoint.
 
 
 class _AgentMessage(BaseModel):
@@ -96,13 +93,6 @@ class _AgentTurnRequest(BaseModel):
     # Optional model override (e.g. when the user clicks "análisis profundo"
     # which flips the next turn to Opus). Server-side allowlist enforced.
     model:          Optional[str] = None
-
-
-_ALLOWED_MODELS: frozenset[str] = frozenset({
-    "claude-sonnet-4-6",
-    "claude-haiku-4-5",
-    "claude-opus-4-7",
-})
 
 
 @router.post(
@@ -135,8 +125,8 @@ async def post_agent_turn(
     if not status.enabled:
         raise HTTPException(status_code=503, detail=status.reason)
 
-    model = body.model or _SURFACE_MODEL_DEFAULTS[body.surface]
-    if model not in _ALLOWED_MODELS:
+    model = body.model or default_model_for_surface(body.surface)
+    if model not in ALLOWED_MODELS:
         raise HTTPException(status_code=400, detail="model_not_allowed")
 
     # Convert the request's messages into the API's `messages` array.

--- a/frontend/src/agent/surfaces.ts
+++ b/frontend/src/agent/surfaces.ts
@@ -1,0 +1,77 @@
+// ============================================================
+// agent/surfaces.ts — single source of truth for the 5 copilot
+// surface identifiers. Phase 4 of epic #400.
+//
+// Each mount of <useAgentStream/> picks one surface; the backend
+// (api/agent/router.py + api/agent/models.py) uses that string to
+// pick the right model + per-surface system-prompt block + tool
+// subset. Adding a new surface here REQUIRES corresponding entries
+// in:
+//   - api/agent/models.py           (SURFACE_MODEL_DEFAULTS)
+//   - api/agent/prompts/surfaces.py (SURFACE_PROMPTS)
+//   - api/agent/tools/registry.py   (TOOL_CATALOG[*].surfaces)
+//
+// Keeping the surface strings as named constants (not stringly-
+// typed literals scattered across the codebase) means grep finds
+// every mount in one shot, and a typo in one mount fails at
+// compile time instead of at runtime when the backend rejects
+// the unknown surface.
+// ============================================================
+
+import type { AgentSurface } from './types';
+
+// ── Named constants ────────────────────────────────────────────────
+
+export const SURFACE_DOCK:          AgentSurface = 'dock';
+export const SURFACE_SYMBOL_DETAIL: AgentSurface = 'symbol_detail';
+export const SURFACE_KILL_SWITCH:   AgentSurface = 'kill_switch';
+export const SURFACE_AUTOTUNE:      AgentSurface = 'autotune';
+export const SURFACE_HISTORIAL:     AgentSurface = 'historial';
+
+/**
+ * Frozen enumeration of every surface. Use this when you need to iterate
+ * (e.g. preloading per-surface assets, telemetry coverage report). The
+ * order matters for snapshot stability — keep it the same as
+ * api/agent/router.py's _AgentTurnRequest Literal.
+ */
+export const ALL_SURFACES: readonly AgentSurface[] = Object.freeze([
+  SURFACE_DOCK,
+  SURFACE_SYMBOL_DETAIL,
+  SURFACE_KILL_SWITCH,
+  SURFACE_AUTOTUNE,
+  SURFACE_HISTORIAL,
+]);
+
+// ── Per-surface UI metadata ────────────────────────────────────────
+
+/**
+ * Human-facing label per surface, shown in debug panels and (eventually)
+ * the conversation header so the user can see which copilot mode they're
+ * talking to. Venezuelan-neutral Spanish.
+ */
+export const SURFACE_LABELS: Readonly<Record<AgentSurface, string>> = Object.freeze({
+  dock:          'Copiloto general',
+  symbol_detail: 'Copiloto del par',
+  kill_switch:   'Copiloto del kill-switch',
+  autotune:      'Copiloto del auto-tune',
+  historial:     'Copiloto del historial',
+});
+
+/**
+ * Which UI mount uses each surface. Informational only — keeps a single
+ * place to consult when adding a new surface (or when removing one,
+ * to know which mount to clean up).
+ *
+ * NOTE: as of Phase 4, only `dock` (AgentDock) and `symbol_detail`
+ * (SymbolDetail) have live mounts. The other three are declared on the
+ * backend (model + prompt + tools) but unmounted on the frontend — a
+ * future epic will add KillSwitchView / AutoTuneView / HistorialView
+ * copilot panels.
+ */
+export const SURFACE_MOUNTS: Readonly<Record<AgentSurface, string | null>> = Object.freeze({
+  dock:          'components/AgentDock',
+  symbol_detail: 'components/SymbolDetail',
+  kill_switch:   null,
+  autotune:      null,
+  historial:     null,
+});

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AgentDock.module.css';
 import type { SymbolStatus, Position, MacroState } from '../types';
 import { useAgentStream } from '../agent/useAgentStream';
+import { SURFACE_DOCK } from '../agent/surfaces';
 import type { ProposalChip, ToolChip } from '../agent/types';
 
 interface AgentDockProps {
@@ -47,7 +48,7 @@ const AgentDock: React.FC<AgentDockProps> = ({
   const [input, setInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const { msgs, loading, sendTurn, confirmProposal } = useAgentStream({ surface: 'dock' });
+  const { msgs, loading, sendTurn, confirmProposal } = useAgentStream({ surface: SURFACE_DOCK });
   // Synthetic welcome bubble before the first real turn so the dock
   // isn't an empty void on open. Lives outside the stream hook because
   // it never goes on the wire — purely UI. Derived (useMemo) instead

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -34,6 +34,7 @@ import type { SymbolStatus, OhlcvCandle, OhlcvVolume } from '../types';
 import { formatPrice } from '../utils';
 import { getOhlcv } from '../api';
 import { useAgentStream } from '../agent/useAgentStream';
+import { SURFACE_SYMBOL_DETAIL } from '../agent/surfaces';
 import type { ProposalChip, ToolChip } from '../agent/types';
 import { SCORE_FACTORS } from '../constants/score-factors';
 
@@ -394,7 +395,7 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, agentEnabled }) => {
   // (api/agent/prompts/system.py + surfaces.py), the tool schema, and
   // the audit. The model never sees a frontend-built system prompt.
   const { msgs, loading, sendTurn, confirmProposal } = useAgentStream({
-    surface: 'symbol_detail',
+    surface: SURFACE_SYMBOL_DETAIL,
   });
 
   // Proactive synthetic greeting computed locally — never goes on the

--- a/tests/test_agent_models.py
+++ b/tests/test_agent_models.py
@@ -1,0 +1,217 @@
+"""Phase 4 of epic #400 — per-surface model + tool snapshot tests.
+
+Locks two matrices that drift quietly otherwise:
+
+  1. SURFACE → model:    api/agent/models.py    SURFACE_MODEL_DEFAULTS
+  2. SURFACE → tool set: api/agent/tools/registry.py  tools_for_surface()
+
+Both matrices are "stable contracts" that the prompt cache, telemetry,
+and per-surface UX all depend on. Quiet drift (somebody flips Dock from
+Sonnet to Haiku without telemetry headers-up, or adds a tool to a
+surface that doesn't need it and blows the cache prefix) is exactly the
+class of bug snapshot tests catch.
+
+If a snapshot fails, the fix is:
+  - Confirm the change is deliberate (not a copy-paste mistake).
+  - Update the EXPECTED constant in this file.
+  - Note WHY in the commit message (the test failure log will quote
+    the diff for review).
+"""
+from __future__ import annotations
+
+from typing import FrozenSet
+
+
+# ── 1. Per-surface MODEL snapshot ────────────────────────────────────
+
+
+# Canonical mapping locked. If this matrix needs to change, do it
+# deliberately — DO NOT silently update both sides without a
+# corresponding commit message explaining why and what it costs.
+EXPECTED_SURFACE_MODELS: dict[str, str] = {
+    "dock":          "claude-sonnet-4-6",
+    "symbol_detail": "claude-haiku-4-5",
+    "kill_switch":   "claude-sonnet-4-6",
+    "autotune":      "claude-sonnet-4-6",
+    "historial":     "claude-haiku-4-5",
+}
+
+
+def test_surface_model_defaults_snapshot():
+    """Lock the full SURFACE_MODEL_DEFAULTS map. If this fails, somebody
+    changed model selection for at least one surface — update
+    EXPECTED_SURFACE_MODELS in this file deliberately."""
+    from api.agent.models import SURFACE_MODEL_DEFAULTS
+
+    assert dict(SURFACE_MODEL_DEFAULTS) == EXPECTED_SURFACE_MODELS
+
+
+def test_allowed_models_snapshot():
+    """Closed allowlist of accepted model IDs. Adding a new model is
+    deliberate. Removing one is even more so — it can break in-flight
+    overrides."""
+    from api.agent.models import ALLOWED_MODELS
+
+    assert ALLOWED_MODELS == frozenset({
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5",
+        "claude-opus-4-7",
+    })
+
+
+def test_default_model_for_surface_returns_canonical_value():
+    """Helper API — used by the router on every turn."""
+    from api.agent.models import default_model_for_surface
+
+    for surface, expected in EXPECTED_SURFACE_MODELS.items():
+        assert default_model_for_surface(surface) == expected
+
+
+def test_default_model_for_surface_unknown_surface_raises_keyerror():
+    """Defensive — the router validates the surface via the Literal[...]
+    on the request schema, but if a caller bypasses that, the helper
+    should fail loudly, not silently fall back to a default that
+    obscures the bug."""
+    from api.agent.models import default_model_for_surface
+    import pytest as _pytest
+
+    with _pytest.raises(KeyError):
+        default_model_for_surface("nonexistent_surface")
+
+
+def test_every_default_is_in_allowlist():
+    """The module's import-time check enforces this too, but having it
+    in CI as a named test gives an unambiguous failure message ("you
+    typo'd a model id in defaults") instead of an ImportError stack
+    trace at process start."""
+    from api.agent.models import ALLOWED_MODELS, SURFACE_MODEL_DEFAULTS
+
+    for surface, model in SURFACE_MODEL_DEFAULTS.items():
+        assert model in ALLOWED_MODELS, (
+            f"{surface} maps to {model!r} which is not in ALLOWED_MODELS"
+        )
+
+
+# ── 2. Per-surface TOOL snapshot ──────────────────────────────────────
+
+
+# Exact tool name set per surface, locked. Order does not matter (the
+# registry preserves catalog order for cache stability — that's an
+# implementation detail covered by a separate test). What this guards is
+# the SET membership: which tools the model sees on each surface.
+#
+# If the diff on this constant is non-trivial, the reviewer should ask:
+#
+#   - Does the new tool break the prompt-cache prefix (it'll change
+#     the cached tools-block bytes on the surfaces that get it)?
+#   - Does the removed tool leave the model without a way to answer
+#     a class of question the surface advertises in its micro-prompt?
+#   - Does adding a tool to a propose-only surface (kill_switch,
+#     autotune) expose a new action path that needs role-checks
+#     (see api/agent/router.py _ADMIN_ONLY_ACTIONS)?
+EXPECTED_SURFACE_TOOLS: dict[str, FrozenSet[str]] = {
+    "dock": frozenset({
+        "get_portfolio_overview",
+        "get_positions",
+        "get_position_detail",
+        "get_symbols_with_signals",
+        "get_symbol_setup",
+        "get_kill_switch_state",
+        "get_recent_signals",
+        "get_closed_trades",
+        "get_tune_proposal",
+        "propose_close_position",
+        "propose_reactivate_symbol",
+        "propose_apply_tune",
+    }),
+    "symbol_detail": frozenset({
+        "get_positions",
+        "get_position_detail",
+        "get_symbol_setup",
+        "get_recent_signals",
+    }),
+    "kill_switch": frozenset({
+        "get_portfolio_overview",
+        "get_kill_switch_state",
+        "propose_reactivate_symbol",
+    }),
+    "autotune": frozenset({
+        "get_closed_trades",
+        "get_tune_proposal",
+        "propose_apply_tune",
+    }),
+    "historial": frozenset({
+        "get_closed_trades",
+    }),
+}
+
+
+def test_tool_subset_per_surface_snapshot():
+    """Lock the full tool subset per surface. Failures are real signal —
+    the matrix above is the contract between the model's reasoning
+    capabilities and the UI surface it's reasoning on."""
+    from api.agent.tools.registry import tools_for_surface
+
+    for surface, expected in EXPECTED_SURFACE_TOOLS.items():
+        actual = frozenset(t.name for t in tools_for_surface(surface))
+        assert actual == expected, (
+            f"surface {surface!r}: expected {sorted(expected)}, "
+            f"got {sorted(actual)}"
+        )
+
+
+def test_no_surface_lost_tools_silently():
+    """Defense: the union of per-surface tool sets must cover every
+    tool in the catalog. A tool that's declared in the catalog but
+    exposed on zero surfaces is dead weight at best and a wire-shape
+    surprise at worst."""
+    from api.agent.tools.registry import TOOL_CATALOG, tools_for_surface
+
+    all_catalog_names = {t.name for t in TOOL_CATALOG}
+    exposed_anywhere: set[str] = set()
+    for surface in EXPECTED_SURFACE_TOOLS:
+        exposed_anywhere.update(t.name for t in tools_for_surface(surface))
+    assert all_catalog_names == exposed_anywhere, (
+        "Some tools in TOOL_CATALOG are not exposed on any surface: "
+        f"{all_catalog_names - exposed_anywhere}"
+    )
+
+
+# ── 3. Cross-surface invariants ──────────────────────────────────────
+
+
+def test_surfaces_match_prompts_module():
+    """Every surface in SURFACE_MODEL_DEFAULTS must have a matching
+    micro-prompt in api/agent/prompts/surfaces.py. The runtime falls
+    back to dock for an unknown surface (defensive); this test makes
+    the matrix authoritative instead — adding a surface requires the
+    same set in both places."""
+    from api.agent.models import SURFACE_MODEL_DEFAULTS
+    from api.agent.prompts.surfaces import SURFACE_PROMPTS
+
+    assert set(SURFACE_MODEL_DEFAULTS.keys()) == set(SURFACE_PROMPTS.keys())
+
+
+def test_surfaces_match_router_literal():
+    """Every surface in SURFACE_MODEL_DEFAULTS must also appear in the
+    Literal[...] on api/agent/router.py's _AgentTurnRequest.surface, or
+    the router will 422 a request for a surface the rest of the system
+    knows about. We can't inspect Literal directly without pulling
+    pydantic internals; we parse the source instead — narrow but
+    pragmatic, and the failure mode is unambiguous."""
+    import inspect
+    from api.agent import router as _router
+    from api.agent.models import SURFACE_MODEL_DEFAULTS
+
+    source = inspect.getsource(_router)
+    # The Literal lives on a single line per request schema; we look
+    # for the exact substring on each surface name. This is brittle to
+    # a refactor — but a brittle test with a clear message beats silent
+    # drift between the router schema and the models map.
+    for surface in SURFACE_MODEL_DEFAULTS:
+        token = f'"{surface}"'
+        assert token in source, (
+            f"surface {surface!r} declared in SURFACE_MODEL_DEFAULTS but "
+            f"not present as a literal in api/agent/router.py — "
+            f"requests for it will 422"
+        )

--- a/tests/test_agent_models.py
+++ b/tests/test_agent_models.py
@@ -196,22 +196,56 @@ def test_surfaces_match_router_literal():
     """Every surface in SURFACE_MODEL_DEFAULTS must also appear in the
     Literal[...] on api/agent/router.py's _AgentTurnRequest.surface, or
     the router will 422 a request for a surface the rest of the system
-    knows about. We can't inspect Literal directly without pulling
-    pydantic internals; we parse the source instead — narrow but
-    pragmatic, and the failure mode is unambiguous."""
+    knows about.
+
+    Implementation note: we walk the AST of router.py and collect string
+    literals from every `Literal[...]` subscript we find, then compare
+    the union against SURFACE_MODEL_DEFAULTS.keys(). PR #407 review
+    issue 1: an earlier version of this test used a substring `surface in
+    source` check, which produces false negatives when somebody removes
+    the Literal annotation but the surface name still appears elsewhere
+    in the module (a log line, an example, etc). The AST walk catches
+    that drift; the substring version did not.
+    """
+    import ast
     import inspect
     from api.agent import router as _router
     from api.agent.models import SURFACE_MODEL_DEFAULTS
 
     source = inspect.getsource(_router)
-    # The Literal lives on a single line per request schema; we look
-    # for the exact substring on each surface name. This is brittle to
-    # a refactor — but a brittle test with a clear message beats silent
-    # drift between the router schema and the models map.
-    for surface in SURFACE_MODEL_DEFAULTS:
-        token = f'"{surface}"'
-        assert token in source, (
-            f"surface {surface!r} declared in SURFACE_MODEL_DEFAULTS but "
-            f"not present as a literal in api/agent/router.py — "
-            f"requests for it will 422"
+    tree = ast.parse(source)
+
+    literal_strings: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Subscript):
+            continue
+        # Pydantic v2 schemas use `typing.Literal[...]`. We accept either
+        # `Literal` or `typing.Literal` as the subscript target — anything
+        # named Literal at the end of an attribute chain.
+        target = node.value
+        name = (
+            target.id if isinstance(target, ast.Name)
+            else target.attr if isinstance(target, ast.Attribute)
+            else None
         )
+        if name != "Literal":
+            continue
+        # The slice can be a single ast.Constant (one-arg Literal) or an
+        # ast.Tuple (multi-arg Literal). Older 3.x versions wrapped slice
+        # in ast.Index; 3.9+ collapsed it. We support both shapes
+        # defensively even though current CI runs on 3.12+.
+        slc = node.slice
+        if hasattr(ast, "Index") and isinstance(slc, ast.Index):  # py <= 3.8
+            slc = slc.value  # type: ignore[attr-defined]
+        elts = slc.elts if isinstance(slc, ast.Tuple) else [slc]
+        for elt in elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                literal_strings.add(elt.value)
+
+    declared = set(SURFACE_MODEL_DEFAULTS.keys())
+    missing_from_router = declared - literal_strings
+    assert not missing_from_router, (
+        f"surfaces in SURFACE_MODEL_DEFAULTS missing from any Literal[...] "
+        f"in api/agent/router.py: {sorted(missing_from_router)} — "
+        f"requests for these will 422"
+    )


### PR DESCRIPTION
## Summary

Phase 4 of epic #400. Centralizes two matrices that were either inlined or scattered across the codebase, and locks both with snapshot tests:

- **surface → model**: extracted from `api/agent/router.py` to `api/agent/models.py`
- **surface → tool subset**: already in `api/agent/tools/registry.py` as data, now snapshot-locked

Plus a frontend single source of truth at `frontend/src/agent/surfaces.ts` so AgentDock + SymbolDetail import named constants instead of typing string literals.

## What changes

**Backend**
- `api/agent/models.py` — new module. `SURFACE_MODEL_DEFAULTS`, `ALLOWED_MODELS`, `default_model_for_surface()`. Pricing rationale + import-time invariant (model in defaults must be in allowlist).
- `api/agent/router.py` — consumes from `models.py` instead of declaring inline. Behavior identical; the request schema's `Literal[...]` is unchanged.

**Frontend**
- `frontend/src/agent/surfaces.ts` — named constants for the 5 surfaces + UI metadata (labels, mount points). `SURFACE_MOUNTS` shows that only `dock` and `symbol_detail` have live mounts today; the other three (`kill_switch`, `autotune`, `historial`) are backend-ready but unmounted.
- `AgentDock` + `SymbolDetail` rewired to use the constants.

**Tests** (`tests/test_agent_models.py` — 9 new)
- Snapshot per-surface model
- Snapshot `ALLOWED_MODELS` frozenset
- Snapshot per-surface tool name set (5 frozensets locked)
- Coverage invariant: no orphan tools (every catalog entry exposed on >= 1 surface)
- Cross-module: surfaces in `models.py` match `prompts/surfaces.py` and the router's `Literal[...]`. Drift between any of these triggers a named failure instead of a runtime 422.

## Totals
- 82 backend agent tests (9 new)
- 93 frontend tests (no new)
- TS clean

## Out of scope (anchored for future)
- Actual UI mounts for `kill_switch` / `autotune` / `historial` surfaces. The backend (model + prompt + tools) is ready; the React components don't exist yet. A future epic will add `KillSwitchView` / `AutoTuneView` / `HistorialView` copilot panels and, per PR #406 review, the shared `<ProposalConfirm/>` extraction before wiring those panels.

## Test plan
- [ ] CI green
- [ ] Manual: open Dock + SymbolDetail, confirm copilot still streams normally (constants don't change behavior, just sourcing)
- [ ] `git grep \"surface: '\(dock\|symbol_detail\)'\"` returns only test files (constants used everywhere else)

🤖 Generated with [Claude Code](https://claude.com/claude-code)