### PR TITLE
feat(agent): Phase 5A — quotas + breaker + metrics + SSE keepalive (#400)

### DIFF
--- a/api/agent/audit.py
+++ b/api/agent/audit.py
@@ -104,6 +104,11 @@ class TurnAuditWrapper:
         self._conversation_id = conversation_id
         self._model = model
         self._t_start = time.monotonic()
+        # PR #405 + Phase 5 pickup: track terminal-event observation so a
+        # client disconnect / asyncio cancellation can still record an
+        # audit row. Without this, mid-stream client aborts go silent
+        # in the audit table — bad for operator debugging.
+        self._terminal_recorded = False
 
     def __aiter__(self):
         return self
@@ -117,6 +122,13 @@ class TurnAuditWrapper:
         try:
             ev = await self._events.__anext__()
         except StopAsyncIteration:
+            # Iterator ended without a MessageEnd / ErrorEvent. This is
+            # the cancellation / disconnect path: the loop yielded
+            # nothing terminal but the consumer is done. Record a
+            # synthetic 'cancelled' error so the audit table reflects
+            # the failure mode.
+            if not self._terminal_recorded:
+                self._record_cancelled()
             raise
 
         if isinstance(ev, MessageEnd):
@@ -135,6 +147,12 @@ class TurnAuditWrapper:
                 cost_usd=ev.cost_usd,
                 refused=False,
             )
+            # Charge the tenant's daily/monthly quota AFTER the turn
+            # completed successfully — best-effort, swallows exceptions
+            # (see api/agent/quotas.py:record_spend docstring).
+            from api.agent.quotas import record_spend
+            record_spend(self._tenant_id, ev.cost_usd or 0.0)
+            self._terminal_recorded = True
         elif isinstance(ev, ErrorEvent):
             latency_ms = int((time.monotonic() - self._t_start) * 1000)
             record_turn(
@@ -150,4 +168,42 @@ class TurnAuditWrapper:
                 content_summary=ev.reason,
                 refused=(ev.reason == "too_many_tool_hops"),
             )
+            self._terminal_recorded = True
         return ev
+
+    def _record_cancelled(self) -> None:
+        """Best-effort audit row for the iterator-ended-early path. Same
+        fail-quiet discipline as record_turn — a missed cancellation row
+        is annoying, raising here would surface as a 500 on a request
+        that's already torn down."""
+        try:
+            latency_ms = int((time.monotonic() - self._t_start) * 1000)
+            record_turn(
+                tenant_id=self._tenant_id,
+                surface=self._surface,
+                conversation_id=self._conversation_id,
+                role="error",
+                model=self._model,
+                latency_ms=latency_ms,
+                content_summary="cancelled",
+                refused=False,
+            )
+            self._terminal_recorded = True
+        except Exception:  # noqa: BLE001
+            log.warning(
+                "TurnAuditWrapper._record_cancelled failed for tenant=%s conv=%s",
+                self._tenant_id, self._conversation_id, exc_info=True,
+            )
+
+    async def aclose(self) -> None:
+        """Called by FastAPI's StreamingResponse when the client
+        disconnects mid-stream. Forwards close to the underlying iterator
+        AND records a cancellation row if no terminal event fired."""
+        if not self._terminal_recorded:
+            self._record_cancelled()
+        inner_close = getattr(self._events, "aclose", None)
+        if inner_close is not None:
+            try:
+                await inner_close()
+            except Exception:  # noqa: BLE001
+                log.warning("inner loop aclose failed", exc_info=True)

--- a/api/agent/circuit_breaker.py
+++ b/api/agent/circuit_breaker.py
@@ -90,9 +90,17 @@ def is_breaker_tripped(cfg: Optional[dict] = None) -> bool:
 
 
 def _global_spend_last_24h() -> float:
-    """Sum agent_conversations.cost_usd over the rolling 24h window.
-    Indexed by ts; SQLite handles this cheaply for the volumes we
-    expect (< 10K rows/day at full saturation)."""
+    """Sum agent_conversations.cost_usd over the rolling 24h window for
+    assistant rows only.
+
+    The role filter is defensive (PR #408 review pickup): today error
+    rows have cost_usd IS NULL (COALESCE turns that into 0), so the
+    constraint is a no-op against current data. But if a future phase
+    starts charging on a different role (e.g. partial-cost rows for
+    cancellations), the breaker would incorrectly attribute that spend.
+    Pinning the filter now keeps the breaker reading only what it
+    intends to read.
+    """
     now = datetime.now(timezone.utc)
     cutoff = (now - timedelta(hours=24)).isoformat()
     con = get_db()
@@ -100,7 +108,7 @@ def _global_spend_last_24h() -> float:
         row = con.execute(
             "SELECT COALESCE(SUM(cost_usd), 0) AS total "
             "FROM agent_conversations "
-            "WHERE ts >= ?",
+            "WHERE ts >= ? AND role = 'assistant'",
             (cutoff,),
         ).fetchone()
     finally:

--- a/api/agent/circuit_breaker.py
+++ b/api/agent/circuit_breaker.py
@@ -1,0 +1,115 @@
+"""Global circuit breaker for the copilot — Phase 5 of epic #400.
+
+The breaker is the operator's emergency kill-switch. Two trip sources:
+
+  1. EXPLICIT — `cfg.agent.breaker_open = true` in config.json. Flipped
+     by hand when something looks off in metrics (cost spike, weird
+     error rate, suspect prompt injection). Persists across restarts.
+  2. AUTOMATIC — global spend in the rolling 24h window crossed the
+     daily cap from `cfg.agent.global_daily_usd_cap`. Re-checked on
+     every turn pre-flight via is_breaker_tripped(). Resets implicitly
+     when the 24h tail rolls past the spike (no manual intervention).
+
+When tripped, GET /agent/status returns `reason="breaker_open"` and
+POST /agent/turn 503s with the same closed-enum reason. Per-tenant
+quota checks (api/agent/quotas.py) are independent — they 429, not
+503. The two layers compose:
+
+  - breaker_open ⇒ entire feature halted, no turns for anyone
+  - quota_exceeded ⇒ one tenant blocked, others unaffected
+
+The §12 rollout plan mentions a `$5/día` cap "as kill-switch implícito"
+for the first week. That's exactly what `global_daily_usd_cap` is.
+
+Pre-reg §13.5: closed-enum reasons only. NEVER leak the operator's
+config path, the env var name, or numeric thresholds via the wire.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from api.config import load_config
+from db.connection import get_db
+
+log = logging.getLogger("api.agent.circuit_breaker")
+
+
+# Default global cap. Used if cfg.agent.global_daily_usd_cap is missing
+# or non-numeric. Conservative — the rollout plan starts at $5/día.
+DEFAULT_GLOBAL_DAILY_USD_CAP = 5.00
+
+
+# Closed-enum reason surfaced to the wire when the breaker is open.
+REASON_BREAKER_OPEN = "breaker_open"
+
+
+def is_breaker_tripped(cfg: Optional[dict] = None) -> bool:
+    """Return True if any trip source fired. Cheap-on-success: the
+    explicit flag is a dict lookup; the automatic spend check is one
+    SELECT against agent_conversations with a covering index.
+
+    Conservative on DB failure: if the spend query fails, we DON'T trip
+    the breaker (we'd cut everyone off on a DB hiccup). We log + return
+    False, mirroring quotas.record_spend's fail-quiet discipline. The
+    spike would still get caught on the next turn after the DB recovers.
+    """
+    cfg = cfg if cfg is not None else load_config()
+    agent_cfg = cfg.get("agent") or {}
+
+    # 1. Explicit operator trip — flag wins regardless of spend.
+    if agent_cfg.get("breaker_open") is True:
+        return True
+
+    # 2. Automatic spend trip. Read the cap from cfg; fall back to the
+    # conservative default if missing or malformed.
+    raw_cap = agent_cfg.get("global_daily_usd_cap", DEFAULT_GLOBAL_DAILY_USD_CAP)
+    try:
+        cap = float(raw_cap)
+    except (TypeError, ValueError):
+        cap = DEFAULT_GLOBAL_DAILY_USD_CAP
+
+    if cap <= 0:
+        # An operator who sets cap=0 intends "no spend allowed" — that's
+        # the explicit trip, route it through the same enum.
+        return True
+
+    try:
+        spent_24h = _global_spend_last_24h()
+    except Exception:  # noqa: BLE001
+        log.warning(
+            "is_breaker_tripped: 24h spend query failed; failing open (not tripping). "
+            "If this persists, the breaker is effectively disabled — operator should "
+            "investigate the agent_conversations table.",
+            exc_info=True,
+        )
+        return False
+
+    return spent_24h >= cap
+
+
+def _global_spend_last_24h() -> float:
+    """Sum agent_conversations.cost_usd over the rolling 24h window.
+    Indexed by ts; SQLite handles this cheaply for the volumes we
+    expect (< 10K rows/day at full saturation)."""
+    now = datetime.now(timezone.utc)
+    cutoff = (now - timedelta(hours=24)).isoformat()
+    con = get_db()
+    try:
+        row = con.execute(
+            "SELECT COALESCE(SUM(cost_usd), 0) AS total "
+            "FROM agent_conversations "
+            "WHERE ts >= ?",
+            (cutoff,),
+        ).fetchone()
+    finally:
+        con.close()
+    return float(dict(row)["total"] or 0.0)
+
+
+def current_global_spend_24h() -> float:
+    """Read-only accessor for the metrics endpoint. Same query as the
+    internal helper; promoted to public so callers don't pierce the
+    underscore convention."""
+    return _global_spend_last_24h()

--- a/api/agent/config.py
+++ b/api/agent/config.py
@@ -24,8 +24,9 @@ log = logging.getLogger("api.agent.config")
 
 # Closed enum of user-safe status reasons. Never expand this with an
 # operator-only string (env var name, path, secret name, etc).
-_REASON_OK = "ok"
-_REASON_DISABLED = "agent_disabled"
+_REASON_OK            = "ok"
+_REASON_DISABLED      = "agent_disabled"
+_REASON_BREAKER_OPEN  = "breaker_open"   # Phase 5: global circuit breaker
 
 
 @dataclass(frozen=True)
@@ -40,12 +41,19 @@ def get_agent_status(cfg: Optional[dict] = None) -> AgentStatus:
     """Resolve the agent's runtime status.
 
     Precedence (any disabling source wins):
-      1. cfg["agent"]["enabled"] is explicitly False  → operator-disabled
+      1. cfg["agent"]["enabled"] is explicitly False  → agent_disabled
       2. ANTHROPIC_API_KEY missing or empty            → treated identically
          (we deliberately collapse "key missing" into the same reason as
          "operator disabled" so the wire format never leaks the existence
          of an env var named ANTHROPIC_API_KEY)
-      3. Otherwise                                     → enabled
+      3. Global circuit breaker tripped (explicit cfg.agent.breaker_open
+         OR automatic 24h global spend cap exceeded) → breaker_open
+      4. Otherwise                                     → enabled
+
+    breaker_open is intentionally a DIFFERENT closed-enum reason from
+    agent_disabled — the frontend can render different UX ("system
+    temporarily halted" vs "feature off") and the operator-facing
+    metrics page can tell the two states apart.
     """
     cfg = cfg if cfg is not None else load_config()
     agent_cfg = cfg.get("agent") or {}
@@ -55,5 +63,13 @@ def get_agent_status(cfg: Optional[dict] = None) -> AgentStatus:
     api_key = (os.environ.get("ANTHROPIC_API_KEY") or "").strip()
     if not api_key:
         return AgentStatus(enabled=False, reason=_REASON_DISABLED)
+
+    # Local import to avoid the circular: circuit_breaker reads cfg via
+    # api.config, which this module also imports — and a top-level
+    # import would also force every Phase 0 test to set up a DB before
+    # status could be probed.
+    from api.agent.circuit_breaker import is_breaker_tripped
+    if is_breaker_tripped(cfg):
+        return AgentStatus(enabled=False, reason=_REASON_BREAKER_OPEN)
 
     return AgentStatus(enabled=True, reason=_REASON_OK)

--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -241,6 +241,20 @@ async def run_turn(
     tools = _build_anthropic_tools(surface)
     hops = 0
 
+    # PR #408 review fix: accumulate usage + cost across all hops of the
+    # turn. Anthropic bills per API call — a multi-hop turn fires N+1
+    # calls (N tool_use intermediate + 1 final text). The original
+    # implementation emitted only the final hop's cost in MessageEnd,
+    # undercharging the tenant quota by 30-60% on turns with multiple
+    # tool calls. Accumulating here keeps quota + breaker honest.
+    total_usage = {
+        "input_tokens":                0,
+        "output_tokens":               0,
+        "cache_read_input_tokens":     0,
+        "cache_creation_input_tokens": 0,
+    }
+    total_cost_usd = 0.0
+
     while True:
         # Open a fresh stream for each "model turn" in the agentic loop.
         try:
@@ -271,18 +285,24 @@ async def run_turn(
             )
             return
 
-        usage_dict = {
+        hop_usage = {
             "input_tokens":                getattr(final.usage, "input_tokens", 0) or 0,
             "output_tokens":               getattr(final.usage, "output_tokens", 0) or 0,
             "cache_read_input_tokens":     getattr(final.usage, "cache_read_input_tokens", 0) or 0,
             "cache_creation_input_tokens": getattr(final.usage, "cache_creation_input_tokens", 0) or 0,
         }
+        # Accumulate this hop's usage + cost into the per-turn totals.
+        # MessageEnd (below, on the final hop) emits the sum so audit /
+        # quota / breaker see the true cost — not just the last call.
+        for k in total_usage:
+            total_usage[k] += hop_usage[k]
+        total_cost_usd += _estimate_cost_usd(model, hop_usage)
 
         if final.stop_reason != "tool_use":
             yield MessageEnd(
-                usage=usage_dict,
+                usage=total_usage,
                 stop_reason=final.stop_reason,
-                cost_usd=_estimate_cost_usd(model, usage_dict),
+                cost_usd=total_cost_usd,
             )
             return
 

--- a/api/agent/proposals.py
+++ b/api/agent/proposals.py
@@ -328,18 +328,41 @@ def mark_proposal_result(
     result:      str,
     http_status: Optional[int] = None,
 ) -> None:
-    """Update the result column. result ∈ ok/error/conflict/expired."""
-    con = get_db()
+    """Update the result column. result ∈ ok / error / state_drift /
+    role_required / expired.
+
+    Best-effort: a DB write that fails AFTER the downstream action
+    succeeded (e.g. the position closed but we can't record the
+    audit/idempotency state) is logged at WARN and swallowed. We do NOT
+    raise because the action ALREADY happened — propagating an exception
+    here turns a successful close into a 500 response, making the user
+    think nothing happened when in fact everything happened except the
+    bookkeeping.
+
+    PR #406 review issue 4 follow-up: if reconciliation matters more
+    than a missing audit row, the operator can run a one-off script to
+    cross-check positions.exit_reason='MANUAL_AGENT' against
+    agent_side_effects rows with result IS NULL — they should match.
+    """
     try:
-        con.execute(
-            "UPDATE agent_side_effects "
-            "SET result = ?, http_status = ? "
-            "WHERE idempotency_key = ?",
-            (result, http_status, proposal_id),
+        con = get_db()
+        try:
+            con.execute(
+                "UPDATE agent_side_effects "
+                "SET result = ?, http_status = ? "
+                "WHERE idempotency_key = ?",
+                (result, http_status, proposal_id),
+            )
+            con.commit()
+        finally:
+            con.close()
+    except Exception:  # noqa: BLE001
+        log.warning(
+            "mark_proposal_result failed for proposal_id=%s — audit drift; "
+            "the downstream action already ran but this row stays NULL. "
+            "Reconcile via agent_side_effects + positions cross-check.",
+            proposal_id, exc_info=True,
         )
-        con.commit()
-    finally:
-        con.close()
 
 
 def is_expired(proposal_row: dict) -> bool:

--- a/api/agent/quotas.py
+++ b/api/agent/quotas.py
@@ -1,0 +1,261 @@
+"""Per-tenant spend quotas for the copilot — Phase 5 of epic #400.
+
+Two windows enforced per tenant:
+
+  - daily: resets at midnight UTC. Default cap $1.00/day (configurable
+    via `agent_quotas.daily_usd_cap` per tenant; operator override via
+    a one-off UPDATE on the row).
+  - monthly: resets on the 1st (UTC). Default cap $20.00/month, derived
+    from 31 days × daily_cap + slack. Tracked for cost telemetry but
+    not enforced as a hard 429 today — the daily cap is the spend
+    governor; the monthly column exists so the metrics endpoint can
+    report on it.
+
+Pre-reg §9.1: "Quota counters reset on read, not via cron." When
+check_and_charge fires, it first reads the current row, compares
+window_start to "now", and if the window has elapsed it zeroes the
+counter + updates the start IN THE SAME TRANSACTION as the charge.
+No cron, no race between reset and increment.
+
+Failure mode:
+  - daily exceeded → QuotaExceeded raised at the boundary. Router
+    translates to HTTP 429 detail="quota_exceeded".
+  - DB write fails after a charge → logged but does not raise; the
+    audit row already carries the cost, so reconciliation is possible
+    via offline scan. Same fail-quiet discipline as audit.record_turn.
+
+Why this lives in its own module:
+  - keeps the router thin; the router just calls check_quota_pretrun()
+    and record_spend(); the SQL details are encapsulated here.
+  - tests can monkeypatch the public functions without faking sqlite.
+  - a future "burst credit" or "weekend reduced cap" policy lives here
+    without touching the request path.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from db.connection import get_db
+
+log = logging.getLogger("api.agent.quotas")
+
+
+# Defaults applied when a tenant has no row yet. The first turn for a
+# tenant triggers an INSERT with these values.
+DEFAULT_DAILY_USD_CAP   = 1.00
+DEFAULT_MONTHLY_USD_CAP = 20.00
+
+
+# ── Closed-enum reasons surfaced to the wire ──────────────────────────
+
+
+REASON_OK              = "ok"
+REASON_DAILY_EXCEEDED  = "quota_exceeded"  # daily cap
+
+
+class QuotaExceeded(Exception):
+    """Raised by check_quota_pretrun when the daily cap is at or beyond
+    the limit. The router catches and translates to 429."""
+
+    def __init__(self, *, daily_used: float, daily_cap: float):
+        super().__init__(f"daily quota exceeded: {daily_used:.4f} >= {daily_cap:.4f}")
+        self.daily_used = daily_used
+        self.daily_cap  = daily_cap
+
+
+# ── Public API ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class QuotaSnapshot:
+    """Per-tenant quota state at a point in time. Returned by the
+    metrics endpoint and by check_quota_pretrun for callers that want
+    headroom for a 'remaining' display."""
+    tenant_id:               int
+    daily_usd_used:          float
+    daily_usd_cap:           float
+    daily_window_start:      str
+    monthly_usd_used:        float
+    monthly_window_start:    str
+
+
+def check_quota_pretrun(tenant_id: int) -> QuotaSnapshot:
+    """Pre-flight check before running an agent turn. Idempotent — does
+    NOT charge anything; only reads, resets stale windows, and decides.
+
+    Raises QuotaExceeded if `daily_usd_used >= daily_usd_cap` (after
+    any due window reset). The caller does not need to short-circuit
+    on a "negative remaining" check — the threshold is enforced here.
+    """
+    row = _read_or_seed_row(tenant_id)
+    return _materialize_snapshot(row)
+
+
+def record_spend(tenant_id: int, cost_usd: float) -> None:
+    """Charge `cost_usd` against the tenant's daily + monthly counters
+    AFTER a turn completed. Best-effort: failures are logged, not raised
+    (same discipline as audit.record_turn — a charge miss is annoying;
+    a 500 to the user is worse).
+
+    The function refuses to record a negative or zero charge (we get
+    cost_usd=0 from the loop when the model is the cheap fake or when
+    the cost calculator can't find pricing — no point burning a write).
+    """
+    if cost_usd is None or cost_usd <= 0:
+        return
+    try:
+        _apply_spend(tenant_id, float(cost_usd))
+    except Exception:  # noqa: BLE001
+        log.warning(
+            "record_spend failed for tenant=%s cost_usd=%.4f — quota write dropped",
+            tenant_id, cost_usd, exc_info=True,
+        )
+
+
+def get_snapshot(tenant_id: int) -> QuotaSnapshot:
+    """Read-only accessor used by the metrics endpoint. Same windowing
+    logic as check_quota_pretrun but does NOT raise on exceeded — the
+    admin wants to SEE the breach, not be blocked from reading it."""
+    row = _read_or_seed_row(tenant_id)
+    return _to_snapshot(row)
+
+
+# ── Implementation ────────────────────────────────────────────────────
+
+
+def _now_utc() -> datetime:
+    """Test seam: monkeypatch this in tests to advance the clock."""
+    return datetime.now(timezone.utc)
+
+
+def _today_iso() -> str:
+    """ISO date for window comparison. UTC. Format: 'YYYY-MM-DD'."""
+    return _now_utc().date().isoformat()
+
+
+def _this_month_iso() -> str:
+    """First day of the current UTC month. Format: 'YYYY-MM-01'."""
+    n = _now_utc()
+    return f"{n.year:04d}-{n.month:02d}-01"
+
+
+def _read_or_seed_row(tenant_id: int) -> sqlite3.Row:
+    """Return the agent_quotas row for `tenant_id`. INSERT default
+    values if absent. Resets stale daily/monthly windows IN-LINE so
+    the returned row already reflects the current window."""
+    con = get_db()
+    try:
+        today = _today_iso()
+        month = _this_month_iso()
+        row = con.execute(
+            "SELECT * FROM agent_quotas WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        if row is None:
+            con.execute(
+                """INSERT INTO agent_quotas
+                   (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
+                    monthly_usd_used, monthly_window_start)
+                   VALUES (?, 0, ?, ?, 0, ?)""",
+                (tenant_id, DEFAULT_DAILY_USD_CAP, today, month),
+            )
+            con.commit()
+            row = con.execute(
+                "SELECT * FROM agent_quotas WHERE tenant_id = ?",
+                (tenant_id,),
+            ).fetchone()
+            return row
+
+        # Window resets — done in SQL so the read-then-write is atomic
+        # under the connection's write lock (sqlite is serialized at
+        # connection level for writes).
+        d = dict(row)
+        needs_reset = (d["daily_window_start"] != today
+                       or d["monthly_window_start"] != month)
+        if needs_reset:
+            new_daily   = 0 if d["daily_window_start"]   != today else d["daily_usd_used"]
+            new_monthly = 0 if d["monthly_window_start"] != month else d["monthly_usd_used"]
+            con.execute(
+                """UPDATE agent_quotas
+                   SET daily_usd_used = ?, daily_window_start = ?,
+                       monthly_usd_used = ?, monthly_window_start = ?
+                   WHERE tenant_id = ?""",
+                (new_daily, today, new_monthly, month, tenant_id),
+            )
+            con.commit()
+            row = con.execute(
+                "SELECT * FROM agent_quotas WHERE tenant_id = ?",
+                (tenant_id,),
+            ).fetchone()
+        return row
+    finally:
+        con.close()
+
+
+def _to_snapshot(row: sqlite3.Row) -> QuotaSnapshot:
+    d = dict(row)
+    return QuotaSnapshot(
+        tenant_id=d["tenant_id"],
+        daily_usd_used=float(d["daily_usd_used"] or 0),
+        daily_usd_cap=float(d["daily_usd_cap"] or DEFAULT_DAILY_USD_CAP),
+        daily_window_start=d["daily_window_start"],
+        monthly_usd_used=float(d["monthly_usd_used"] or 0),
+        monthly_window_start=d["monthly_window_start"],
+    )
+
+
+def _materialize_snapshot(row: sqlite3.Row) -> QuotaSnapshot:
+    """Convert a row to a snapshot AND enforce the daily threshold.
+    Separate from _to_snapshot so the metrics endpoint (read-only) can
+    bypass the raise."""
+    snap = _to_snapshot(row)
+    if snap.daily_usd_used >= snap.daily_usd_cap:
+        raise QuotaExceeded(
+            daily_used=snap.daily_usd_used,
+            daily_cap=snap.daily_usd_cap,
+        )
+    return snap
+
+
+def _apply_spend(tenant_id: int, cost_usd: float) -> None:
+    """Increment daily + monthly counters atomically. Resets first if
+    a window passed (mirrors _read_or_seed_row's reset logic)."""
+    con = get_db()
+    try:
+        today = _today_iso()
+        month = _this_month_iso()
+        row = con.execute(
+            "SELECT * FROM agent_quotas WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        if row is None:
+            # Tenant's very first turn (paid path didn't read first —
+            # rare, but possible if check_quota_pretrun fails open on
+            # a DB hiccup). Seed + charge in one go.
+            con.execute(
+                """INSERT INTO agent_quotas
+                   (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
+                    monthly_usd_used, monthly_window_start)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (tenant_id, cost_usd, DEFAULT_DAILY_USD_CAP, today, cost_usd, month),
+            )
+            con.commit()
+            return
+
+        d = dict(row)
+        daily   = (0 if d["daily_window_start"]   != today else d["daily_usd_used"])   + cost_usd
+        monthly = (0 if d["monthly_window_start"] != month else d["monthly_usd_used"]) + cost_usd
+        con.execute(
+            """UPDATE agent_quotas
+               SET daily_usd_used = ?, daily_window_start = ?,
+                   monthly_usd_used = ?, monthly_window_start = ?
+               WHERE tenant_id = ?""",
+            (daily, today, monthly, month, tenant_id),
+        )
+        con.commit()
+    finally:
+        con.close()

--- a/api/agent/quotas.py
+++ b/api/agent/quotas.py
@@ -156,8 +156,15 @@ def _read_or_seed_row(tenant_id: int) -> sqlite3.Row:
             (tenant_id,),
         ).fetchone()
         if row is None:
+            # INSERT OR IGNORE handles the concurrent-first-turn race:
+            # if two parallel requests for the same brand-new tenant_id
+            # both see row=None, the second INSERT silently no-ops on
+            # the PRIMARY KEY violation instead of raising IntegrityError
+            # (which would surface as 500 to the user). PR #408 review
+            # pickup. The SELECT immediately below reads the row that
+            # actually landed regardless of who won the race.
             con.execute(
-                """INSERT INTO agent_quotas
+                """INSERT OR IGNORE INTO agent_quotas
                    (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
                     monthly_usd_used, monthly_window_start)
                    VALUES (?, 0, ?, ?, 0, ?)""",
@@ -235,16 +242,27 @@ def _apply_spend(tenant_id: int, cost_usd: float) -> None:
         if row is None:
             # Tenant's very first turn (paid path didn't read first —
             # rare, but possible if check_quota_pretrun fails open on
-            # a DB hiccup). Seed + charge in one go.
-            con.execute(
-                """INSERT INTO agent_quotas
+            # a DB hiccup). Seed + charge in one go. INSERT OR IGNORE
+            # protects against the parallel-first-charge race the same
+            # way _read_or_seed_row does (PR #408 review pickup).
+            cur = con.execute(
+                """INSERT OR IGNORE INTO agent_quotas
                    (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
                     monthly_usd_used, monthly_window_start)
                    VALUES (?, ?, ?, ?, ?, ?)""",
                 (tenant_id, cost_usd, DEFAULT_DAILY_USD_CAP, today, cost_usd, month),
             )
             con.commit()
-            return
+            # cur.rowcount tells us which branch fired: 1 = we inserted
+            # (charge already booked, done), 0 = a parallel writer beat
+            # us so we re-read and fall through to the UPDATE path to
+            # apply OUR cost on top of theirs.
+            if cur.rowcount == 1:
+                return
+            row = con.execute(
+                "SELECT * FROM agent_quotas WHERE tenant_id = ?",
+                (tenant_id,),
+            ).fetchone()
 
         d = dict(row)
         daily   = (0 if d["daily_window_start"]   != today else d["daily_usd_used"])   + cost_usd

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -33,6 +33,7 @@ from api.agent.clients import get_anthropic_client
 from api.agent.config import get_agent_status
 from api.agent.loop import run_turn
 from api.agent.models import ALLOWED_MODELS, default_model_for_surface
+from api.agent.quotas import QuotaExceeded, check_quota_pretrun
 from api.agent.proposals import (
     ACTION_APPLY_TUNE,
     ACTION_CLOSE_POSITION,
@@ -44,7 +45,7 @@ from api.agent.proposals import (
     verify_proposal,
 )
 from api.agent.streaming import sse_serialize
-from auth.dependencies import get_current_tenant_id, get_current_user
+from auth.dependencies import get_current_tenant_id, get_current_user, require_role
 from auth.models import User
 
 log = logging.getLogger("api.agent.router")
@@ -128,6 +129,17 @@ async def post_agent_turn(
     model = body.model or default_model_for_surface(body.surface)
     if model not in ALLOWED_MODELS:
         raise HTTPException(status_code=400, detail="model_not_allowed")
+
+    # Phase 5: per-tenant daily spend quota. Distinct from the global
+    # breaker (which lives inside get_agent_status above) — quota is
+    # one-tenant-blocked-others-fine, breaker is everyone-halted.
+    # Raised as 429 with closed-enum detail so the frontend can render
+    # a per-tenant message ("agotaste tu presupuesto diario") different
+    # from the global breaker message ("el sistema está pausado").
+    try:
+        check_quota_pretrun(tenant_id)
+    except QuotaExceeded:
+        raise HTTPException(status_code=429, detail="quota_exceeded")
 
     # Convert the request's messages into the API's `messages` array.
     # The frontend owns the transcript and resends it every turn (same
@@ -360,3 +372,131 @@ def _execute_proposed_action(
     # Unknown action — closed enum, should never happen because the
     # propose handlers wrote it.
     raise HTTPException(status_code=400, detail="unknown_action")
+
+
+# ── /agent/metrics (Phase 5) ───────────────────────────────────────────
+
+
+@router.get(
+    "/agent/metrics",
+    summary="Operator-facing copilot metrics (admin only)",
+    dependencies=[Depends(require_role("admin"))],
+)
+def get_agent_metrics(
+    tenant_id: int = Depends(get_current_tenant_id),  # noqa: ARG001
+):
+    """Return operator dashboard data for the copilot.
+
+    Admin-only — role gate via require_role("admin"); a viewer-role
+    request returns 403. The tenant_id dep stays in the signature so
+    AuthMiddleware still resolves the user (otherwise the role check
+    would have nothing to read), but we don't actually USE the value —
+    this endpoint reports across all tenants, not per-tenant.
+
+    Shape (closed for the admin UI / debug panel):
+
+        {
+          "breaker": {
+            "tripped":          bool,
+            "reason":           "ok" | "breaker_open" | "agent_disabled",
+            "global_24h_usd":   float,
+          },
+          "today": {
+            "turn_count":       int,
+            "error_count":      int,
+            "refused_count":    int,
+            "total_usd":        float,
+          },
+          "top_tenants": [
+            {"tenant_id": int, "turn_count": int, "usd_24h": float},
+            ...   # top 10 by spend in last 24h
+          ],
+          "error_breakdown_24h": [
+            {"reason": str, "count": int},
+            ...   # closed-enum reasons surfaced as ErrorEvent
+          ],
+        }
+
+    Pre-reg §13.5 still applies — these numbers come from
+    agent_conversations, which only stores closed-enum reasons +
+    redacted content_summary, so this endpoint cannot accidentally
+    leak user prompts or API keys.
+    """
+    from datetime import datetime, timedelta, timezone
+    from api.agent.circuit_breaker import current_global_spend_24h
+    import btc_api
+
+    status = get_agent_status()
+    breaker_state = {
+        "tripped":          (not status.enabled and status.reason == "breaker_open"),
+        "reason":           status.reason,
+        "global_24h_usd":   current_global_spend_24h(),
+    }
+
+    cutoff_iso = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+    today_iso  = datetime.now(timezone.utc).date().isoformat() + "T00:00:00+00:00"
+
+    con = btc_api.get_db()
+    try:
+        today_row = con.execute(
+            "SELECT "
+            "  COUNT(*) AS turn_count, "
+            "  SUM(CASE WHEN role = 'error' THEN 1 ELSE 0 END) AS error_count, "
+            "  SUM(CASE WHEN refused = 1 THEN 1 ELSE 0 END) AS refused_count, "
+            "  COALESCE(SUM(cost_usd), 0) AS total_usd "
+            "FROM agent_conversations WHERE ts >= ?",
+            (today_iso,),
+        ).fetchone()
+        today = dict(today_row) if today_row else {
+            "turn_count": 0, "error_count": 0, "refused_count": 0, "total_usd": 0,
+        }
+
+        top_rows = con.execute(
+            "SELECT tenant_id, "
+            "       COUNT(*) AS turn_count, "
+            "       COALESCE(SUM(cost_usd), 0) AS usd_24h "
+            "FROM agent_conversations "
+            "WHERE ts >= ? "
+            "GROUP BY tenant_id "
+            "ORDER BY usd_24h DESC "
+            "LIMIT 10",
+            (cutoff_iso,),
+        ).fetchall()
+        top_tenants = [dict(r) for r in top_rows]
+
+        err_rows = con.execute(
+            "SELECT content_json AS reason_json, COUNT(*) AS count "
+            "FROM agent_conversations "
+            "WHERE ts >= ? AND role = 'error' "
+            "GROUP BY content_json "
+            "ORDER BY count DESC "
+            "LIMIT 20",
+            (cutoff_iso,),
+        ).fetchall()
+        # content_json is a JSON-encoded string of the closed-enum
+        # reason (audit.record_turn wraps with json.dumps). Decode to
+        # surface the raw enum value on the wire.
+        import json as _json
+        error_breakdown_24h = []
+        for r in err_rows:
+            d = dict(r)
+            raw = d.get("reason_json")
+            try:
+                reason = _json.loads(raw) if raw else "unknown"
+            except (TypeError, ValueError):
+                reason = "unknown"
+            error_breakdown_24h.append({"reason": reason, "count": d["count"]})
+    finally:
+        con.close()
+
+    return {
+        "breaker":             breaker_state,
+        "today": {
+            "turn_count":    int(today.get("turn_count")    or 0),
+            "error_count":   int(today.get("error_count")   or 0),
+            "refused_count": int(today.get("refused_count") or 0),
+            "total_usd":     float(today.get("total_usd")   or 0),
+        },
+        "top_tenants":         top_tenants,
+        "error_breakdown_24h": error_breakdown_24h,
+    }

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -382,16 +382,15 @@ def _execute_proposed_action(
     summary="Operator-facing copilot metrics (admin only)",
     dependencies=[Depends(require_role("admin"))],
 )
-def get_agent_metrics(
-    tenant_id: int = Depends(get_current_tenant_id),  # noqa: ARG001
-):
+def get_agent_metrics():
     """Return operator dashboard data for the copilot.
 
     Admin-only — role gate via require_role("admin"); a viewer-role
-    request returns 403. The tenant_id dep stays in the signature so
-    AuthMiddleware still resolves the user (otherwise the role check
-    would have nothing to read), but we don't actually USE the value —
-    this endpoint reports across all tenants, not per-tenant.
+    request returns 403. PR #408 review pickup: the previous version
+    had a Depends(get_current_tenant_id) in the signature "to ensure
+    AuthMiddleware resolves the user", but require_role already
+    resolves the User on its own — the extra dep was cargo cult, and
+    this endpoint reports across all tenants anyway.
 
     Shape (closed for the admin UI / debug panel):
 
@@ -402,6 +401,10 @@ def get_agent_metrics(
             "global_24h_usd":   float,
           },
           "today": {
+            # since_midnight_utc — distinct window from the *_24h fields
+            # below. At 23:00 UTC, `today` reports the last 23 hours
+            # while `*_24h` reports the rolling 24h. Both are intentional
+            # and the admin UI should label them as such.
             "turn_count":       int,
             "error_count":      int,
             "refused_count":    int,
@@ -409,11 +412,11 @@ def get_agent_metrics(
           },
           "top_tenants": [
             {"tenant_id": int, "turn_count": int, "usd_24h": float},
-            ...   # top 10 by spend in last 24h
+            ...   # top 10 by spend in last rolling 24h
           ],
           "error_breakdown_24h": [
             {"reason": str, "count": int},
-            ...   # closed-enum reasons surfaced as ErrorEvent
+            ...   # closed-enum reasons surfaced as ErrorEvent (24h rolling)
           ],
         }
 

--- a/api/agent/streaming.py
+++ b/api/agent/streaming.py
@@ -7,9 +7,13 @@ with a `type` field that the frontend's `useAgentStream` hook switches on.
 Pre-reg §6.2. The event-type enum is closed:
 
     text_delta | tool_use_start | tool_use_result | message_end | error
+                                                                   keepalive
+
+Phase 5 adds the `keepalive` heartbeat — see sse_serialize() docstring.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from dataclasses import asdict
@@ -28,6 +32,17 @@ from api.agent.loop import (
 log = logging.getLogger("api.agent.streaming")
 
 
+# Default heartbeat cadence. Tunable via the optional `keepalive_seconds`
+# kwarg on sse_serialize so tests don't have to actually sleep 30 sec.
+# Chosen as a sweet-spot vs the nginx / cloudflare idle defaults:
+#   - nginx default `proxy_read_timeout` is 60s
+#   - cloudflare's free-tier idle is 100s
+# 30s is safely under both; if a tool call spans a few model
+# heartbeat-less seconds, the keepalive frame keeps the connection
+# alive without flooding the wire.
+DEFAULT_KEEPALIVE_SECONDS = 30.0
+
+
 def _sse_frame(event_type: str, payload: dict) -> bytes:
     """Format one SSE frame. UTF-8 bytes ready to yield from FastAPI's
     StreamingResponse. We use the `data:`-only form (no `event:` line)
@@ -38,9 +53,53 @@ def _sse_frame(event_type: str, payload: dict) -> bytes:
     return f"data: {json.dumps(payload_with_type)}\n\n".encode("utf-8")
 
 
-async def sse_serialize(events: AsyncIterator[LoopEvent]) -> AsyncIterator[bytes]:
-    """Consume loop events, yield SSE-framed bytes."""
-    async for ev in events:
+async def sse_serialize(
+    events: AsyncIterator[LoopEvent],
+    *,
+    keepalive_seconds: float = DEFAULT_KEEPALIVE_SECONDS,
+) -> AsyncIterator[bytes]:
+    """Consume loop events, yield SSE-framed bytes.
+
+    Phase 5 of #400: emit a `keepalive` frame whenever the upstream
+    iterator stays silent for `keepalive_seconds`. The frame is a
+    sentinel — the frontend hook ignores it but the underlying TCP
+    write resets the idle timer on every intermediate proxy (nginx,
+    cloudflare). Without it, a tool call that takes 45-60s makes the
+    stream look dead to the proxy and the user gets a 504.
+
+    Implementation note: naive `wait_for(events.__anext__())` would
+    CANCEL the in-flight read on every timeout, leaving the async
+    generator in an inconsistent state (the next __anext__ might raise
+    or skip the event the generator was about to yield). We instead
+    schedule a single Task for the read and wait on it WITHOUT
+    cancelling — if the wait times out, the task survives, we yield a
+    keepalive, and the next iteration awaits the SAME task. The task
+    is only ever consumed once, when it actually completes.
+    """
+    pending: asyncio.Task | None = None
+    while True:
+        if pending is None:
+            pending = asyncio.create_task(events.__anext__())
+        # asyncio.wait does NOT cancel the task on timeout — it just
+        # returns (done, pending) sets. We poll until the task lands
+        # in `done`; each timeout that doesn't complete the task is a
+        # keepalive opportunity.
+        done, _ = await asyncio.wait({pending}, timeout=keepalive_seconds)
+        if not done:
+            # Heartbeat. NOT a terminal frame; the loop continues with
+            # the same pending task still in flight.
+            yield _sse_frame("keepalive", {})
+            continue
+        # The task completed. Pull its result and clear the slot.
+        completed = pending
+        pending = None
+        try:
+            ev = completed.result()
+        except StopAsyncIteration:
+            return
+        # The `async for` model would have skipped a frame on a
+        # StopAsyncIteration; we already handled it above. Below we
+        # dispatch on the same closed event type set.
         if isinstance(ev, TextDelta):
             yield _sse_frame("text_delta", {"text": ev.text})
         elif isinstance(ev, ToolUseStart):

--- a/frontend/src/agent/types.ts
+++ b/frontend/src/agent/types.ts
@@ -54,6 +54,17 @@ export interface AgentErrorEvent {
 }
 
 /**
+ * Phase 5: periodic heartbeat. Emitted by the server when the upstream
+ * model + tool pipeline stays silent for ~30s so intermediate proxies
+ * (nginx, cloudflare) don't kill the connection as idle. The hook
+ * IGNORES this frame entirely — it's a TCP / SSE keepalive only, no
+ * UI effect.
+ */
+export interface AgentKeepaliveEvent {
+  type: 'keepalive';
+}
+
+/**
  * Phase 3 of epic #400 — emitted when a propose_* tool ran and the
  * server signed a side-effect envelope. The frontend echoes
  * `signed_payload` back verbatim to POST /agent/proposals/{id}/confirm
@@ -79,7 +90,8 @@ export type AgentStreamEvent =
   | AgentToolUseResult
   | AgentProposalEvent
   | AgentMessageEnd
-  | AgentErrorEvent;
+  | AgentErrorEvent
+  | AgentKeepaliveEvent;
 
 /**
  * UI-side state of a proposal attached to an assistant message.

--- a/frontend/src/agent/useAgentStream.ts
+++ b/frontend/src/agent/useAgentStream.ts
@@ -269,6 +269,11 @@ function applyEvent(
       // the row and move on.
       break;
 
+    case 'keepalive':
+      // Phase 5: TCP heartbeat from the server during long tool calls.
+      // Purely a proxy-keepalive signal — no UI effect.
+      break;
+
     case 'error':
       // Replace the placeholder (which is "" so far on a fast-error
       // path) with the friendly user_message. The closed-enum reason

--- a/tests/test_agent_breaker.py
+++ b/tests/test_agent_breaker.py
@@ -190,3 +190,49 @@ def test_current_global_spend_24h_sums_window(tmp_db):
     _seed_spend(99.0, hours_ago=30)  # outside window
     total = current_global_spend_24h()
     assert abs(total - 2.00) < 1e-9
+
+
+def test_breaker_spend_excludes_non_assistant_rows(tmp_db):
+    """PR #408 review pickup: the breaker's spend query filters to
+    role='assistant' so a future phase that writes cost_usd on other
+    role rows (e.g. 'partial' for cancellations) doesn't accidentally
+    contribute to the breaker. Today, error rows have cost_usd IS NULL
+    (which COALESCEs to 0), but we want the filter explicit before that
+    invariant ever changes."""
+    import btc_api
+    from datetime import datetime, timedelta, timezone
+    from api.agent.circuit_breaker import current_global_spend_24h
+
+    ts = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    con = btc_api.get_db()
+    try:
+        # An assistant row with $1.00 cost (counts).
+        con.execute(
+            "INSERT INTO agent_conversations "
+            "(tenant_id, surface, conversation_id, ts, role, model, "
+            " input_tokens, output_tokens, cache_read_input_tokens, "
+            " cache_creation_input_tokens, latency_ms, cost_usd) "
+            "VALUES (1, 'dock', 'c1', ?, 'assistant', 'claude-sonnet-4-6', "
+            "        100, 50, 0, 0, 1000, 1.00)",
+            (ts,),
+        )
+        # An error row WITH a non-NULL cost_usd of $99 — hypothetical
+        # future schema where cancelled turns carry a partial cost.
+        # Today's audit code writes cost_usd=NULL for errors, but the
+        # filter must hold even if that changes.
+        con.execute(
+            "INSERT INTO agent_conversations "
+            "(tenant_id, surface, conversation_id, ts, role, model, "
+            " input_tokens, output_tokens, cache_read_input_tokens, "
+            " cache_creation_input_tokens, latency_ms, cost_usd) "
+            "VALUES (1, 'dock', 'c2', ?, 'error', 'claude-sonnet-4-6', "
+            "        0, 0, 0, 0, 100, 99.00)",
+            (ts,),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    total = current_global_spend_24h()
+    # Only the assistant row counts; the error row's $99 is excluded.
+    assert abs(total - 1.00) < 1e-9

--- a/tests/test_agent_breaker.py
+++ b/tests/test_agent_breaker.py
@@ -1,0 +1,192 @@
+"""Phase 5 of epic #400 — global circuit breaker.
+
+Covers:
+  - Explicit flag: cfg.agent.breaker_open=true → tripped
+  - Automatic trip: 24h global spend >= cap → tripped
+  - Negative / zero cap is interpreted as "no spend allowed" → tripped
+  - DB failure during spend lookup → NOT tripped (fail-open, logged)
+  - get_agent_status reflects the breaker reason
+  - The status endpoint never leaks the cap value or the env-var name
+  - /agent/turn 503s when the breaker is tripped (path identical to
+    agent_disabled, but reason enum differs)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def _seed_spend(amount_usd: float, *, hours_ago: float = 1):
+    """Insert one agent_conversations row with the given cost_usd and
+    a ts the given hours in the past."""
+    import btc_api
+    ts = (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+    con = btc_api.get_db()
+    try:
+        con.execute(
+            "INSERT INTO agent_conversations "
+            "(tenant_id, surface, conversation_id, ts, role, model, "
+            " input_tokens, output_tokens, cache_read_input_tokens, "
+            " cache_creation_input_tokens, latency_ms, cost_usd) "
+            "VALUES (1, 'dock', 'c1', ?, 'assistant', 'claude-sonnet-4-6', "
+            "        100, 50, 0, 0, 1000, ?)",
+            (ts, amount_usd),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+# ── Explicit trip ──────────────────────────────────────────────────
+
+
+def test_explicit_flag_trips_breaker(tmp_db):
+    from api.agent.circuit_breaker import is_breaker_tripped
+
+    cfg = {"agent": {"enabled": True, "breaker_open": True}}
+    assert is_breaker_tripped(cfg) is True
+
+
+def test_explicit_flag_false_does_not_trip(tmp_db):
+    from api.agent.circuit_breaker import is_breaker_tripped
+
+    cfg = {"agent": {"enabled": True, "breaker_open": False}}
+    assert is_breaker_tripped(cfg) is False
+
+
+def test_zero_cap_is_treated_as_explicit_trip(tmp_db):
+    """An operator who sets global_daily_usd_cap=0 means 'allow no
+    spend' — the breaker fires before any turn runs."""
+    from api.agent.circuit_breaker import is_breaker_tripped
+
+    cfg = {"agent": {"enabled": True, "global_daily_usd_cap": 0}}
+    assert is_breaker_tripped(cfg) is True
+
+
+# ── Automatic spend trip ───────────────────────────────────────────
+
+
+def test_automatic_trip_when_24h_spend_exceeds_cap(tmp_db):
+    """Seed >= $5 in the last 24h → breaker trips when default cap is
+    in effect."""
+    _seed_spend(3.00, hours_ago=2)
+    _seed_spend(2.50, hours_ago=20)
+    # Total in 24h window = $5.50; default cap is $5.00
+    from api.agent.circuit_breaker import is_breaker_tripped
+
+    cfg = {"agent": {"enabled": True}}  # no cap → DEFAULT_GLOBAL_DAILY_USD_CAP
+    assert is_breaker_tripped(cfg) is True
+
+
+def test_automatic_trip_respects_explicit_cap(tmp_db):
+    """A higher operator-set cap ($10) leaves the $5.50 spend below
+    threshold; breaker stays closed."""
+    _seed_spend(3.00, hours_ago=2)
+    _seed_spend(2.50, hours_ago=20)
+    from api.agent.circuit_breaker import is_breaker_tripped
+
+    cfg = {"agent": {"enabled": True, "global_daily_usd_cap": 10.00}}
+    assert is_breaker_tripped(cfg) is False
+
+
+def test_spend_older_than_24h_does_not_count(tmp_db):
+    """A $100 spike 25h ago must NOT trip — the window is rolling 24h."""
+    _seed_spend(100.00, hours_ago=25)
+    from api.agent.circuit_breaker import is_breaker_tripped
+
+    cfg = {"agent": {"enabled": True}}
+    assert is_breaker_tripped(cfg) is False
+
+
+def test_db_failure_fails_open(tmp_db, monkeypatch):
+    """The breaker logic must NOT cut everyone off on a DB hiccup —
+    it logs and returns False. We don't seed any spend; instead we
+    monkeypatch the spend helper to raise."""
+    from api.agent import circuit_breaker as cb
+
+    def _boom():
+        raise RuntimeError("simulated db down")
+
+    monkeypatch.setattr(cb, "_global_spend_last_24h", _boom)
+    cfg = {"agent": {"enabled": True}}
+    assert cb.is_breaker_tripped(cfg) is False
+
+
+def test_malformed_cap_falls_back_to_default(tmp_db):
+    """An operator who typo'd the cap (string 'asdf', None) must not
+    crash — fall back to the safer default."""
+    from api.agent.circuit_breaker import is_breaker_tripped, DEFAULT_GLOBAL_DAILY_USD_CAP
+
+    _seed_spend(DEFAULT_GLOBAL_DAILY_USD_CAP + 0.01, hours_ago=1)
+    cfg = {"agent": {"enabled": True, "global_daily_usd_cap": "asdf"}}
+    assert is_breaker_tripped(cfg) is True  # fall back to $5, exceeded
+
+
+# ── Integration with /agent/status ─────────────────────────────────
+
+
+def test_status_returns_breaker_open_when_tripped(tmp_db, monkeypatch):
+    """get_agent_status surfaces the breaker as its own closed-enum
+    reason, distinct from agent_disabled."""
+    from api.agent.config import get_agent_status
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake-test")
+    cfg = {"agent": {"enabled": True, "breaker_open": True}}
+    s = get_agent_status(cfg)
+    assert s.enabled is False
+    assert s.reason == "breaker_open"
+
+
+def test_status_disabled_wins_over_breaker(tmp_db, monkeypatch):
+    """Precedence: agent_disabled has higher precedence than
+    breaker_open because the feature being off is a stronger signal
+    than the rate-limit. The wire response should reflect that."""
+    from api.agent.config import get_agent_status
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake-test")
+    cfg = {"agent": {"enabled": False, "breaker_open": True}}
+    s = get_agent_status(cfg)
+    assert s.reason == "agent_disabled"
+
+
+def test_status_reason_does_not_leak_threshold(tmp_db, monkeypatch):
+    """Belt-and-suspenders: even when the breaker IS tripped, the wire
+    reason is just 'breaker_open' — never a numeric cap, never the env
+    var name. Pre-reg §13.5."""
+    from api.agent.config import get_agent_status
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-fake-test")
+    _seed_spend(99.99, hours_ago=1)
+    cfg = {"agent": {"enabled": True, "global_daily_usd_cap": 1.00}}
+    s = get_agent_status(cfg)
+    assert s.reason == "breaker_open"
+    # Wire fields are .enabled and .reason. Neither should contain
+    # any sensitive substring.
+    payload = f"{s.enabled} {s.reason}"
+    for forbidden in ("99.99", "1.00", "global_daily_usd_cap", "ANTHROPIC_API_KEY"):
+        assert forbidden not in payload
+
+
+# ── current_global_spend_24h (read-only accessor) ─────────────────
+
+
+def test_current_global_spend_24h_sums_window(tmp_db):
+    from api.agent.circuit_breaker import current_global_spend_24h
+
+    _seed_spend(1.23, hours_ago=1)
+    _seed_spend(0.77, hours_ago=10)
+    _seed_spend(99.0, hours_ago=30)  # outside window
+    total = current_global_spend_24h()
+    assert abs(total - 2.00) < 1e-9

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -401,6 +401,74 @@ async def test_run_turn_upstream_429_emits_error_no_raise(tmp_db):
 # ── Cost model ─────────────────────────────────────────────────────────
 
 
+@pytest.mark.anyio
+async def test_message_end_cost_and_usage_sum_across_hops(tmp_db, monkeypatch):
+    """A multi-hop turn (model calls a tool → gets result → emits text)
+    triggers TWO Anthropic API calls. MessageEnd.cost_usd MUST be the
+    SUM of both hops' costs, not just the last hop's. Same for usage.
+
+    Without this invariant:
+      - quota counters undercharge by 30-60% on multi-hop turns,
+      - circuit breaker (which sums cost_usd over 24h) trips slower
+        than the actual spend warrants,
+      - operator metrics undercount turn cost.
+
+    PR #408 review fix.
+    """
+    from api.agent.loop import (
+        run_turn, MessageEnd, _estimate_cost_usd,
+    )
+    from api.agent.tools import handlers as h
+
+    def _stub_positions(*, tenant_id):
+        return {"positions": []}
+    monkeypatch.setitem(h.TOOL_HANDLERS, "get_positions", _stub_positions)
+
+    c = FakeAnthropicClient()
+    # Hop 1: tool_use(get_positions) with usage 100 in / 50 out.
+    c.queue_turn(
+        FakeTurnBuilder()
+        .tool_use("get_positions", {}, tool_use_id="toolu_1")
+        .stop_tool_use()
+        .usage(input_tokens=100, output_tokens=50)
+        .build()
+    )
+    # Hop 2: final text with usage 200 in / 100 out.
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("Listo, no tienes posiciones abiertas.")
+        .end_turn()
+        .usage(input_tokens=200, output_tokens=100)
+        .build()
+    )
+
+    msgs = [{"role": "user", "content": "qué posiciones tengo"}]
+    events = await _collect(run_turn(
+        client=c, model="claude-sonnet-4-6", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+
+    ends = [e for e in events if isinstance(e, MessageEnd)]
+    assert len(ends) == 1
+    end = ends[0]
+
+    # Expected: usage is the per-field SUM across both hops.
+    assert end.usage["input_tokens"]  == 300   # 100 + 200
+    assert end.usage["output_tokens"] == 150   # 50  + 100
+
+    # Expected: cost is the SUM of per-hop costs (not just the last).
+    hop1 = _estimate_cost_usd("claude-sonnet-4-6",
+                               {"input_tokens": 100, "output_tokens": 50})
+    hop2 = _estimate_cost_usd("claude-sonnet-4-6",
+                               {"input_tokens": 200, "output_tokens": 100})
+    expected_total = hop1 + hop2
+    assert end.cost_usd == pytest.approx(expected_total)
+    # And explicitly NOT the last-hop-only undercharge that the bug
+    # produced — guards against a regression that silently flips back.
+    assert end.cost_usd != pytest.approx(hop2)
+    assert end.cost_usd > hop2  # accumulated value strictly larger
+
+
 def test_cost_estimation_matches_published_pricing():
     """The cost formula uses the published per-1M USD pricing for
     Sonnet 4.6 / Haiku 4.5 / Opus 4.7. If the cached pricing in

--- a/tests/test_agent_metrics.py
+++ b/tests/test_agent_metrics.py
@@ -1,0 +1,384 @@
+"""Phase 5 of epic #400 — metrics endpoint + router 429/503 + pickups.
+
+Covers:
+  - GET /agent/metrics requires admin role (403 for viewer)
+  - GET /agent/metrics returns the documented shape
+  - POST /agent/conversations/{id}/turn 503s when breaker is tripped
+  - POST /agent/conversations/{id}/turn 429s when tenant quota exceeded
+  - sse_serialize emits a keepalive frame after the idle window
+  - TurnAuditWrapper records a cancellation row when the iterator ends
+    without a terminal MessageEnd/ErrorEvent
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+# ── Fixtures ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def _fake_user(*, id: int = 1, role: str = "admin"):
+    from auth.models import User
+    return User(
+        id=id, email=f"u{id}@example.com", role=role, is_active=True,
+        created_at="2026-05-19T00:00:00+00:00",
+        password_changed_at="2026-05-19T00:00:00+00:00",
+    )
+
+
+@pytest.fixture
+def admin_client(tmp_db, monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+    from auth.dependencies import get_current_tenant_id, get_current_user
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
+    monkeypatch.setenv("AGENT_PROPOSAL_SECRET", "test-only-secret")
+    btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 1
+    btc_api.app.dependency_overrides[get_current_user] = lambda: _fake_user(id=1, role="admin")
+    try:
+        yield TestClient(btc_api.app)
+    finally:
+        btc_api.app.dependency_overrides.pop(get_current_tenant_id, None)
+        btc_api.app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture
+def viewer_client(tmp_db, monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+    from auth.dependencies import get_current_tenant_id, get_current_user
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
+    btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 2
+    btc_api.app.dependency_overrides[get_current_user] = lambda: _fake_user(id=2, role="viewer")
+    try:
+        yield TestClient(btc_api.app)
+    finally:
+        btc_api.app.dependency_overrides.pop(get_current_tenant_id, None)
+        btc_api.app.dependency_overrides.pop(get_current_user, None)
+
+
+def _seed_turn(*, tenant_id: int = 1, cost_usd: float = 0.10, role: str = "assistant",
+               hours_ago: float = 1, refused: bool = False,
+               content_summary: str | None = None):
+    import btc_api
+    import json as _json
+    ts = (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+    con = btc_api.get_db()
+    try:
+        con.execute(
+            "INSERT INTO agent_conversations "
+            "(tenant_id, surface, conversation_id, ts, role, model, "
+            " input_tokens, output_tokens, cache_read_input_tokens, "
+            " cache_creation_input_tokens, latency_ms, cost_usd, "
+            " content_json, refused) "
+            "VALUES (?, 'dock', 'c1', ?, ?, 'claude-sonnet-4-6', "
+            "        100, 50, 0, 0, 1000, ?, ?, ?)",
+            (tenant_id, ts, role, cost_usd,
+             _json.dumps(content_summary) if content_summary else None,
+             1 if refused else 0),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+# ── GET /agent/metrics ─────────────────────────────────────────────
+
+
+def test_metrics_requires_admin(viewer_client):
+    """Viewer-role gets 403; the closed-enum detail mentions 'admin'
+    but doesn't leak the cap, env-var name, etc."""
+    resp = viewer_client.get("/agent/metrics")
+    assert resp.status_code == 403
+    body = resp.json()
+    # require_role's detail is "role 'admin' required" — admin keyword
+    # is fine to leak (it's the closed-enum role name), but no secrets.
+    assert "admin" in body.get("detail", "")
+    assert "ANTHROPIC_API_KEY" not in str(body)
+
+
+def test_metrics_returns_documented_shape(admin_client):
+    """Empty DB → all-zero metrics with the documented shape."""
+    resp = admin_client.get("/agent/metrics")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {
+        "breaker", "today", "top_tenants", "error_breakdown_24h",
+    }
+    assert set(body["breaker"].keys()) == {"tripped", "reason", "global_24h_usd"}
+    assert body["breaker"]["tripped"] is False
+    assert body["breaker"]["reason"] == "ok"
+    assert body["breaker"]["global_24h_usd"] == 0.0
+    assert body["today"] == {
+        "turn_count": 0, "error_count": 0, "refused_count": 0, "total_usd": 0.0,
+    }
+    assert body["top_tenants"] == []
+    assert body["error_breakdown_24h"] == []
+
+
+def test_metrics_aggregates_today_correctly(admin_client):
+    """Seed: 2 assistant turns (cost $0.05 + $0.10), 1 error, 1 refused.
+    Metrics reflect each."""
+    _seed_turn(tenant_id=1, cost_usd=0.05, role="assistant", hours_ago=1)
+    _seed_turn(tenant_id=1, cost_usd=0.10, role="assistant", hours_ago=2)
+    _seed_turn(tenant_id=1, cost_usd=0.0,  role="error", hours_ago=3,
+                content_summary="upstream")
+    _seed_turn(tenant_id=2, cost_usd=0.0,  role="error", hours_ago=4,
+                refused=True, content_summary="too_many_tool_hops")
+
+    resp = admin_client.get("/agent/metrics")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["today"]["turn_count"] == 4
+    assert body["today"]["error_count"] == 2
+    assert body["today"]["refused_count"] == 1
+    assert abs(body["today"]["total_usd"] - 0.15) < 1e-9
+
+    # top_tenants sorted desc by usd_24h
+    assert len(body["top_tenants"]) == 2
+    assert body["top_tenants"][0]["tenant_id"] == 1
+    assert body["top_tenants"][1]["tenant_id"] == 2
+
+    reasons = {e["reason"] for e in body["error_breakdown_24h"]}
+    assert reasons == {"upstream", "too_many_tool_hops"}
+
+
+def test_metrics_breaker_field_reflects_status(admin_client, monkeypatch):
+    """When breaker is tripped, the field reflects it without raising."""
+    import api.agent.config as agent_cfg
+    monkeypatch.setattr(
+        agent_cfg, "load_config",
+        lambda: {"agent": {"enabled": True, "breaker_open": True}},
+    )
+    resp = admin_client.get("/agent/metrics")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["breaker"]["tripped"] is True
+    assert body["breaker"]["reason"] == "breaker_open"
+
+
+# ── /turn pre-flight quota + breaker ──────────────────────────────
+
+
+def test_turn_503_when_breaker_open(admin_client, monkeypatch):
+    """POST /agent/conversations/.../turn returns 503 with detail=
+    'breaker_open' when the global breaker is tripped. The path lives
+    in get_agent_status, so this also locks the integration."""
+    import api.agent.config as agent_cfg
+    monkeypatch.setattr(
+        agent_cfg, "load_config",
+        lambda: {"agent": {"enabled": True, "breaker_open": True}},
+    )
+    resp = admin_client.post(
+        "/agent/conversations/c1/turn",
+        json={"surface": "dock", "messages": [{"role": "user", "content": "hola"}]},
+    )
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "breaker_open"}
+
+
+def test_turn_429_when_tenant_quota_exceeded(admin_client):
+    """Seed tenant 1 at cap → POST /turn returns 429 quota_exceeded.
+
+    Overrides get_anthropic_client because the test runner does not
+    have the anthropic SDK installed; the real Depends would 503
+    before the quota check runs. The fake never actually has to do
+    anything — the 429 fires inside the handler, before the loop runs.
+    """
+    import btc_api
+    from api.agent.clients import get_anthropic_client
+    from api.agent import quotas as _quotas
+
+    btc_api.app.dependency_overrides[get_anthropic_client] = lambda: object()
+    try:
+        today = _quotas._today_iso()
+        month = _quotas._this_month_iso()
+        con = btc_api.get_db()
+        try:
+            con.execute(
+                """INSERT INTO agent_quotas
+                   (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
+                    monthly_usd_used, monthly_window_start)
+                   VALUES (1, 1.00, 1.00, ?, 1.00, ?)""",
+                (today, month),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+        resp = admin_client.post(
+            "/agent/conversations/c1/turn",
+            json={"surface": "dock", "messages": [{"role": "user", "content": "hola"}]},
+        )
+        assert resp.status_code == 429
+        assert resp.json() == {"detail": "quota_exceeded"}
+    finally:
+        btc_api.app.dependency_overrides.pop(get_anthropic_client, None)
+
+
+# ── sse_serialize keepalive ────────────────────────────────────────
+
+
+def test_sse_serialize_emits_keepalive_after_idle(tmp_db):
+    """A slow producer (idle for >= keepalive_seconds between events)
+    must get a keepalive frame inserted. Use a tiny timeout so the test
+    doesn't actually wait 30s."""
+    from api.agent.streaming import sse_serialize
+    from api.agent.loop import TextDelta, MessageEnd
+
+    async def _slow_events():
+        # Frame 1: immediate
+        yield TextDelta(text="hi")
+        # Frame 2: after 200ms idle → keepalive will fire if cadence < 200ms
+        await asyncio.sleep(0.20)
+        yield MessageEnd(
+            usage={"input_tokens": 0, "output_tokens": 0,
+                    "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+            stop_reason="end_turn",
+            cost_usd=0.0,
+        )
+
+    async def _drive():
+        frames: list[bytes] = []
+        async for f in sse_serialize(_slow_events(), keepalive_seconds=0.05):
+            frames.append(f)
+        return frames
+
+    frames = asyncio.run(_drive())
+    rendered = b"".join(frames).decode("utf-8")
+    # Includes the text_delta + at least one keepalive + the message_end.
+    assert '"type": "text_delta"' in rendered
+    assert '"type": "keepalive"' in rendered
+    assert '"type": "message_end"' in rendered
+
+
+def test_sse_serialize_no_keepalive_when_events_flow(tmp_db):
+    """Back-to-back events with no idle gap → no keepalive frame."""
+    from api.agent.streaming import sse_serialize
+    from api.agent.loop import TextDelta, MessageEnd
+
+    async def _fast_events():
+        yield TextDelta(text="a")
+        yield TextDelta(text="b")
+        yield MessageEnd(
+            usage={"input_tokens": 0, "output_tokens": 0,
+                    "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+            stop_reason="end_turn",
+            cost_usd=0.0,
+        )
+
+    async def _drive():
+        frames: list[bytes] = []
+        async for f in sse_serialize(_fast_events(), keepalive_seconds=10.0):
+            frames.append(f)
+        return frames
+
+    frames = asyncio.run(_drive())
+    rendered = b"".join(frames).decode("utf-8")
+    assert '"type": "keepalive"' not in rendered
+
+
+# ── TurnAuditWrapper cancellation row ──────────────────────────────
+
+
+def test_audit_wrapper_records_cancelled_when_iterator_ends_early(tmp_db):
+    """If the producer ends without emitting MessageEnd/ErrorEvent
+    (cancellation, disconnect, abrupt close), the wrapper records a
+    synthetic 'cancelled' error row so the audit table reflects the
+    failure mode."""
+    import btc_api
+    from api.agent.audit import TurnAuditWrapper
+
+    async def _empty_events():
+        # Empty body — yield NOTHING, then end (StopAsyncIteration).
+        if False:  # pragma: no cover — ensures async generator
+            yield None
+        return
+
+    wrapper = TurnAuditWrapper(
+        _empty_events(),
+        tenant_id=1, surface="dock", conversation_id="conv-cancel",
+        model="claude-sonnet-4-6",
+    )
+
+    async def _drive():
+        try:
+            async for _ in wrapper:
+                pass
+        except StopAsyncIteration:
+            pass
+
+    asyncio.run(_drive())
+
+    # Audit row exists with role='error' and content_summary='cancelled'.
+    con = btc_api.get_db()
+    try:
+        row = con.execute(
+            "SELECT role, content_json FROM agent_conversations "
+            "WHERE conversation_id = 'conv-cancel'",
+        ).fetchone()
+    finally:
+        con.close()
+    assert row is not None
+    d = dict(row)
+    assert d["role"] == "error"
+    import json as _json
+    assert _json.loads(d["content_json"]) == "cancelled"
+
+
+def test_audit_wrapper_does_not_double_record_on_normal_end(tmp_db):
+    """A clean MessageEnd → exactly ONE row (the assistant audit), NOT
+    one + cancellation. Belt-and-suspenders against the new aclose
+    path firing redundantly."""
+    import btc_api
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import MessageEnd
+
+    async def _normal_events():
+        yield MessageEnd(
+            usage={"input_tokens": 0, "output_tokens": 0,
+                    "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+            stop_reason="end_turn",
+            cost_usd=0.05,
+        )
+
+    wrapper = TurnAuditWrapper(
+        _normal_events(),
+        tenant_id=1, surface="dock", conversation_id="conv-normal",
+        model="claude-sonnet-4-6",
+    )
+
+    async def _drive():
+        async for _ in wrapper:
+            pass
+        # Simulate FastAPI calling aclose on response teardown.
+        await wrapper.aclose()
+
+    asyncio.run(_drive())
+
+    con = btc_api.get_db()
+    try:
+        rows = con.execute(
+            "SELECT role FROM agent_conversations WHERE conversation_id = 'conv-normal'",
+        ).fetchall()
+    finally:
+        con.close()
+    assert len(rows) == 1
+    assert dict(rows[0])["role"] == "assistant"

--- a/tests/test_agent_quotas.py
+++ b/tests/test_agent_quotas.py
@@ -1,0 +1,253 @@
+"""Phase 5 of epic #400 — per-tenant spend quotas.
+
+Covers:
+  - First-tenant seed (no row → INSERT defaults on read)
+  - Daily window reset on a fresh day (zero counter, advance window_start)
+  - Monthly window reset on a fresh month (independent of daily)
+  - check_quota_pretrun raises QuotaExceeded at the threshold
+  - record_spend increments daily + monthly
+  - record_spend swallows DB errors (audit-style fail-quiet)
+  - Zero / negative cost_usd is a no-op (no row write, no exception)
+  - get_snapshot does NOT raise on exceeded (admin can read past breach)
+"""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+# ── First-tenant seed ──────────────────────────────────────────────
+
+
+def test_check_quota_pretrun_seeds_a_new_tenant(tmp_db):
+    """No row in agent_quotas → INSERT with default cap, daily_used=0."""
+    from api.agent.quotas import check_quota_pretrun, DEFAULT_DAILY_USD_CAP
+
+    snap = check_quota_pretrun(tenant_id=42)
+    assert snap.tenant_id == 42
+    assert snap.daily_usd_used == 0.0
+    assert snap.daily_usd_cap == DEFAULT_DAILY_USD_CAP
+    assert snap.monthly_usd_used == 0.0
+
+
+def test_check_quota_pretrun_idempotent_on_same_day(tmp_db):
+    """Calling twice in a row reads the same row — does NOT re-seed."""
+    from api.agent.quotas import check_quota_pretrun
+
+    s1 = check_quota_pretrun(tenant_id=7)
+    s2 = check_quota_pretrun(tenant_id=7)
+    assert s1.daily_window_start == s2.daily_window_start
+
+
+# ── Window resets ──────────────────────────────────────────────────
+
+
+def test_daily_window_reset_on_a_new_day(tmp_db, monkeypatch):
+    """Seed a tenant yesterday with usage > 0 → next day's check sees
+    daily_usd_used=0 and the window_start advances to today."""
+    import btc_api
+    from api.agent import quotas
+
+    # Seed manually with a yesterday window_start.
+    yesterday = "2026-05-17"
+    today = "2026-05-19"
+    monkeypatch.setattr(quotas, "_now_utc",
+                         lambda: datetime(2026, 5, 19, 12, tzinfo=timezone.utc))
+    con = btc_api.get_db()
+    try:
+        con.execute(
+            """INSERT INTO agent_quotas
+               (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
+                monthly_usd_used, monthly_window_start)
+               VALUES (1, 0.75, 1.0, ?, 5.0, '2026-05-01')""",
+            (yesterday,),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    snap = quotas.check_quota_pretrun(tenant_id=1)
+    assert snap.daily_usd_used == 0.0
+    assert snap.daily_window_start == today
+    # Monthly is untouched — same month.
+    assert snap.monthly_usd_used == 5.0
+
+
+def test_monthly_window_reset_on_a_new_month(tmp_db, monkeypatch):
+    """First check in a new month → monthly_usd_used resets, daily too
+    (since the day also changed)."""
+    import btc_api
+    from api.agent import quotas
+
+    monkeypatch.setattr(quotas, "_now_utc",
+                         lambda: datetime(2026, 6, 1, 8, tzinfo=timezone.utc))
+    con = btc_api.get_db()
+    try:
+        con.execute(
+            """INSERT INTO agent_quotas
+               (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
+                monthly_usd_used, monthly_window_start)
+               VALUES (2, 0.90, 1.0, '2026-05-31', 19.50, '2026-05-01')""",
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    snap = quotas.check_quota_pretrun(tenant_id=2)
+    assert snap.daily_usd_used == 0.0
+    assert snap.monthly_usd_used == 0.0
+    assert snap.monthly_window_start == "2026-06-01"
+
+
+# ── Threshold ──────────────────────────────────────────────────────
+
+
+def test_check_quota_pretrun_raises_when_daily_at_cap(tmp_db):
+    """daily_usd_used >= daily_usd_cap → QuotaExceeded with exact figures
+    on the exception."""
+    import btc_api
+    from api.agent.quotas import QuotaExceeded, check_quota_pretrun
+    from api.agent import quotas as _quotas
+
+    today = _quotas._today_iso()
+    month = _quotas._this_month_iso()
+    con = btc_api.get_db()
+    try:
+        con.execute(
+            """INSERT INTO agent_quotas
+               (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
+                monthly_usd_used, monthly_window_start)
+               VALUES (9, 1.00, 1.00, ?, 1.00, ?)""",
+            (today, month),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    with pytest.raises(QuotaExceeded) as exc:
+        check_quota_pretrun(tenant_id=9)
+    assert exc.value.daily_used == 1.00
+    assert exc.value.daily_cap == 1.00
+
+
+def test_check_quota_pretrun_does_not_raise_when_below_cap(tmp_db):
+    """daily_usd_used < daily_usd_cap → returns snapshot normally."""
+    import btc_api
+    from api.agent.quotas import check_quota_pretrun
+    from api.agent import quotas as _quotas
+
+    today = _quotas._today_iso()
+    month = _quotas._this_month_iso()
+    con = btc_api.get_db()
+    try:
+        con.execute(
+            """INSERT INTO agent_quotas
+               (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
+                monthly_usd_used, monthly_window_start)
+               VALUES (3, 0.99, 1.00, ?, 0.99, ?)""",
+            (today, month),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    snap = check_quota_pretrun(tenant_id=3)
+    assert snap.daily_usd_used == 0.99
+
+
+# ── record_spend ──────────────────────────────────────────────────
+
+
+def test_record_spend_increments_both_counters(tmp_db):
+    from api.agent.quotas import record_spend, get_snapshot
+
+    # Seed tenant via pretrun.
+    from api.agent.quotas import check_quota_pretrun
+    check_quota_pretrun(tenant_id=5)
+
+    record_spend(tenant_id=5, cost_usd=0.12)
+    record_spend(tenant_id=5, cost_usd=0.08)
+
+    snap = get_snapshot(tenant_id=5)
+    assert abs(snap.daily_usd_used - 0.20) < 1e-9
+    assert abs(snap.monthly_usd_used - 0.20) < 1e-9
+
+
+def test_record_spend_ignores_zero_and_negative(tmp_db):
+    """Defensive: cost_usd=0 (fake/cheap-model paths) and negative
+    (impossible but guard against) must not write a row."""
+    from api.agent.quotas import record_spend, get_snapshot, check_quota_pretrun
+
+    check_quota_pretrun(tenant_id=6)
+    record_spend(tenant_id=6, cost_usd=0.0)
+    record_spend(tenant_id=6, cost_usd=-1.0)
+
+    snap = get_snapshot(tenant_id=6)
+    assert snap.daily_usd_used == 0.0
+
+
+def test_record_spend_swallows_db_errors(tmp_db, monkeypatch):
+    """A DB-layer failure during charge must NOT raise — audit miss is
+    annoying, but a raised exception turns a successful turn into a 500."""
+    from api.agent import quotas
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated db hiccup")
+
+    monkeypatch.setattr(quotas, "_apply_spend", _boom)
+    # Must not raise.
+    quotas.record_spend(tenant_id=99, cost_usd=0.01)
+
+
+def test_record_spend_for_unseen_tenant_inserts_row(tmp_db):
+    """If record_spend fires before check_quota_pretrun ever ran for a
+    tenant (rare: the pre-flight failed open on a DB hiccup but the turn
+    completed), the INSERT path seeds + charges in one statement."""
+    from api.agent.quotas import record_spend, get_snapshot
+
+    record_spend(tenant_id=77, cost_usd=0.05)
+    snap = get_snapshot(tenant_id=77)
+    assert snap.tenant_id == 77
+    assert abs(snap.daily_usd_used - 0.05) < 1e-9
+    assert abs(snap.monthly_usd_used - 0.05) < 1e-9
+
+
+# ── get_snapshot vs check_quota_pretrun ────────────────────────────
+
+
+def test_get_snapshot_does_not_raise_on_exceeded(tmp_db):
+    """The metrics endpoint reads via get_snapshot; it must see the
+    breach state instead of being blocked by QuotaExceeded."""
+    import btc_api
+    from api.agent.quotas import get_snapshot
+    from api.agent import quotas as _quotas
+
+    today = _quotas._today_iso()
+    month = _quotas._this_month_iso()
+    con = btc_api.get_db()
+    try:
+        con.execute(
+            """INSERT INTO agent_quotas
+               (tenant_id, daily_usd_used, daily_usd_cap, daily_window_start,
+                monthly_usd_used, monthly_window_start)
+               VALUES (50, 2.00, 1.00, ?, 2.00, ?)""",
+            (today, month),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+    snap = get_snapshot(tenant_id=50)  # must NOT raise
+    assert snap.daily_usd_used == 2.00
+    assert snap.daily_usd_cap == 1.00  # capped at, breach shown


### PR DESCRIPTION
## Summary

Phase 5A of epic #400 — the observability + cost-governance half of Phase 5. Phase 5B (hallucination guard, safety regression, prompt cache verification tests) ships separately as a tests-only PR.

This PR is the prerequisite for Phase 6 rollout: without per-tenant quotas + a global kill-switch, flipping `cfg.agent.enabled=true` to production is uncomfortably exposed to a cost spike or a runaway prompt.

## What lands

**Per-tenant quotas** (`api/agent/quotas.py`, new)
- `check_quota_pretrun(tenant_id)` runs before the loop. Raises `QuotaExceeded` → 429 detail=`quota_exceeded`.
- `record_spend(tenant_id, cost_usd)` charges after `MessageEnd`. Fail-quiet on DB error.
- Daily + monthly counters with computed-on-read window reset (no cron).
- `DEFAULT_DAILY_USD_CAP=$1.00` seed on first turn; operator can override per-tenant.

**Global circuit breaker** (`api/agent/circuit_breaker.py`, new)
- Explicit trip: `cfg.agent.breaker_open=true`.
- Auto trip: rolling 24h global spend ≥ `cfg.agent.global_daily_usd_cap` (default $5).
- `get_agent_status()` surfaces a new closed-enum reason `breaker_open` (distinct from `agent_disabled`).
- `/turn` 503s when tripped.
- Fail-OPEN on DB hiccup (never cut everyone off on transient infra error).

**GET /agent/metrics** (admin-only)
- `Depends(require_role("admin"))` — viewer gets 403.
- Returns: `{breaker, today, top_tenants, error_breakdown_24h}`.
- Aggregates from `agent_conversations` + `circuit_breaker.current_global_spend_24h()`.

**Bundled pickups from previous reviews**
- SSE keepalive frame every 30s (Phase 2B deferred). Naive `wait_for(__anext__())` cancels the in-flight read; we use a persistent `asyncio.Task` instead.
- `TurnAuditWrapper` cancellation row (Phase 2B deferred). Client disconnect now leaves an audit trail.
- `mark_proposal_result` fail-quiet (Phase 3 deferred). A DB hiccup after the action already ran no longer turns a successful close into a 500.

## Tests
- 115 backend agent tests passing (added: 11 quotas, 12 breaker, 10 metrics/integration)
- 93 frontend tests passing (added `keepalive` case to `AgentStreamEvent` + no-op handler)
- TS clean

## Out of scope (Phase 5B)
- §11.1 Safety regression — refusal asserts on direction-asking prompts
- §11.4 Hallucination guard — text-postprocess: every `position_id`/`tune_id`/`symbol` must come from a prior `tool_result`
- §11.6 Prompt cache verification — `cache_creation > 0` turn 1, `cache_read > 0` turn 2 against `FakeAnthropicClient`
- §11.8 Expand graceful-failure coverage (429/503/tool exception/too-many-hops paths)

## Test plan
- [ ] CI green
- [ ] Manual: set `AGENT_PROPOSAL_SECRET` + `ANTHROPIC_API_KEY`, flip `cfg.agent.enabled=true` for a test tenant; verify dock works, run a few turns, hit `/agent/metrics` and confirm the spend totals.
- [ ] Manual: flip `cfg.agent.breaker_open=true` mid-session; next `/turn` should 503 with `breaker_open`; status should match.
- [ ] Manual: set `daily_usd_cap=0.001` on the test tenant; one turn should saturate; next turn 429s with `quota_exceeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)