### PR TITLE
feat(agent): Fase 1 multi-provider — LLMProvider abstraction + Anthropic adapter

### DIFF
--- a/api/agent/clients.py
+++ b/api/agent/clients.py
@@ -1,26 +1,29 @@
-"""Lazy construction of the Anthropic SDK client.
+"""FastAPI dependency that returns the active LLMProvider.
 
-This module exists as a FastAPI dependency seam so tests can override
-the production AsyncAnthropic with FakeAnthropicClient via
-`app.dependency_overrides[get_anthropic_client] = lambda: fake`. Phase 2
-of epic #400.
+Phase 1 of the multi-provider epic relocated the SDK construction logic
+into `api.agent.providers.anthropic_adapter`. This module now exists
+only as a thin shim so the router's `Depends(get_anthropic_client)`
+signature keeps working without changes — the dependency still does the
+same job (gate on agent_status, then return the provider for the active
+default model) but it returns an `LLMProvider` instead of a raw
+`AsyncAnthropic`.
 
-In production: returns a configured `anthropic.AsyncAnthropic`. The SDK
-is imported lazily — until ANTHROPIC_API_KEY is configured and the
-status endpoint reports enabled, the import is never triggered, so
-operators that never enable the copilot don't carry the dependency
-cost.
+The function is still named `get_anthropic_client` for backward
+compatibility — every endpoint test that does
+`app.dependency_overrides[get_anthropic_client] = lambda: fake`
+keeps working. A future PR may rename to `get_llm_provider` once the
+multi-provider epic stabilizes; deferred.
 
-Failure modes:
-  - SDK not installed → 503 agent_disabled (treated identically to "key
-    missing", same closed-enum reason).
-  - Key not in env → handled upstream by get_agent_status; this
-    function only runs after that check, so the env var is guaranteed.
+Failure modes (unchanged from Phase 0):
+  - agent_status disabled → 503 with closed-enum reason.
+  - SDK not installed → 503 agent_disabled (no leak of dependency).
+  - Provider for the default model can't resolve a key → handled
+    upstream by get_agent_status's §2.7 dual-key check; we never get
+    here in that case.
 """
 from __future__ import annotations
 
 import logging
-import os
 
 from fastapi import HTTPException
 
@@ -28,35 +31,42 @@ log = logging.getLogger("api.agent.clients")
 
 
 def get_anthropic_client():
-    """FastAPI dependency that returns a configured Anthropic async client.
+    """FastAPI dependency that returns the active LLMProvider.
 
-    In tests, override via `app.dependency_overrides[get_anthropic_client]`
-    with a function that returns a FakeAnthropicClient instance.
+    PHASE 1 NOTE: returns an LLMProvider, not a raw Anthropic SDK
+    client. The name is kept for backward-compat with the 13+ test
+    `dependency_overrides[get_anthropic_client]` call sites. Tests
+    inject `FakeAnthropicProvider` which implements the protocol.
 
-    Failure-mode correctness (PR #404 review issue #1, blocker): FastAPI
-    resolves ALL `Depends(...)` before executing the handler body. That
-    means this function runs BEFORE the in-handler `get_agent_status()`
-    check. If we read `os.environ["ANTHROPIC_API_KEY"]` blind here and
-    the key is missing, we KeyError → 500 with stack trace → leak the
-    env-var name on the wire. Exactly the bug Phase 0 closed for the
-    legacy /agent/chat.
-
-    Defense: gate on the same closed-enum status resolver before doing
-    any env read. When disabled, 503 with the closed-enum reason; only
-    proceed to construct the SDK client when status is enabled.
+    Returns the provider whose default surface model the registry
+    resolves. Today that's always Anthropic (default for `dock` is
+    `claude-sonnet-4-6`). Phase 3 of the multi-provider epic flips
+    the default to DeepSeek and this resolver follows.
     """
-    # Local import to dodge the circular: api.agent.config doesn't import
-    # this module, but api.agent.router imports both.
+    # Local import to dodge circulars (api.agent.config doesn't import
+    # this module, but the router imports both).
     from api.agent.config import get_agent_status  # noqa: PLC0415
     status = get_agent_status()
     if not status.enabled:
         raise HTTPException(status_code=503, detail=status.reason)
 
+    # Resolve the provider for the default surface model. We use "dock"
+    # as the canonical reference surface — the actual model the request
+    # ends up using may differ (the router supports per-request model
+    # override), but the dep injection happens before the body sees the
+    # request, so we resolve against the default at this point.
+    from api.agent.models import default_model_for_surface  # noqa: PLC0415
+    from api.agent.providers.registry import (  # noqa: PLC0415
+        UnknownProviderError, get_provider_for_model,
+    )
+    default_model = default_model_for_surface("dock")
     try:
-        from anthropic import AsyncAnthropic  # noqa: PLC0415
-    except ImportError as e:
-        log.error("anthropic SDK not installed: %s", e)
-        # Same closed-enum reason — the wire format never reveals
-        # whether it's a missing dependency vs a missing secret.
+        return get_provider_for_model(default_model)
+    except UnknownProviderError:
+        log.error("default model %s has no registered provider", default_model)
         raise HTTPException(status_code=503, detail="agent_disabled")
-    return AsyncAnthropic(api_key=os.environ["ANTHROPIC_API_KEY"].strip())
+    except ImportError as e:
+        # The provider's SDK (anthropic, etc) isn't installed — same
+        # closed-enum response as Phase 0's "key missing".
+        log.error("provider SDK not installed: %s", e)
+        raise HTTPException(status_code=503, detail="agent_disabled")

--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -43,6 +43,11 @@ from functools import lru_cache
 from typing import Any, AsyncIterator, Optional
 
 from api.agent.prompts import build_system_blocks
+from api.agent.providers.base import (
+    LLMStreamEnd,
+    LLMTextDelta,
+    LLMToolUseStart,
+)
 from api.agent.tools.handlers import dispatch_tool
 from api.agent.tools.registry import tools_for_surface
 
@@ -107,101 +112,71 @@ LoopEvent = (
 )
 
 
-# ── Tool schema builder (registry → Anthropic tools array) ──────────────
+# ── Tool schema cache ──────────────────────────────────────────────────
 
 
-@lru_cache(maxsize=8)
-def _build_anthropic_tools(surface: str) -> tuple[dict, ...]:
-    """Convert the per-surface tool subset into the JSON Schema shape the
-    Messages API expects.
+@lru_cache(maxsize=16)
+def _cached_formatted_tools(surface: str, provider_name: str) -> tuple[dict, ...]:
+    """Cache the formatted tools array keyed on (surface, provider name).
 
-    Cached on `surface` because Pydantic's model_json_schema() is not
-    free and the tool catalog is immutable at runtime (any catalog edit
-    requires a process restart). maxsize=8 comfortably covers the 5
-    declared surfaces + headroom (PR #404 review pickup).
+    Phase 1 of the multi-provider epic: this replaces the previous
+    `_build_anthropic_tools(surface)` cache which assumed only one
+    provider. Now keyed on (surface, provider_name) because different
+    providers emit different wire shapes from the same ToolSpec.
 
-    Returns a tuple wrapper so callers can't reassign list elements.
-    NOTE: the inner dicts remain mutable; callers MUST treat the return
-    value as read-only — mutating any nested schema (e.g.
-    `tools[0]["input_schema"]["properties"]["foo"] = ...`) corrupts the
-    cache for every subsequent request. We don't deepcopy on every call
-    because that would defeat the cache; the discipline lives at the
-    call sites (PR #405 review issue 3).
+    `maxsize=16` covers 5 surfaces × up to 3 providers + headroom.
+
+    Returns a tuple so callers can't reassign elements. NOTE: inner
+    dicts remain mutable; callers MUST treat as read-only — mutating
+    any nested schema corrupts the cache for every subsequent request.
     """
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
     specs = tools_for_surface(surface)
-    out = []
-    for spec in specs:
-        # Pydantic schemas → JSON Schema. We strip `title` keys for cache
-        # determinism (Pydantic injects "title" inferred from field
-        # names; removing them keeps the bytes stable across pydantic
-        # versions). DETERMINISTIC SERIALIZATION is the spine of the
-        # prompt cache strategy — pre-reg §7.5 silent invalidators.
-        schema = spec.schema.model_json_schema()
-        _strip_titles(schema)
-        out.append({
-            "name": spec.name,
-            "description": spec.description,
-            "input_schema": schema,
-        })
-    return tuple(out)
+    if provider_name == "anthropic":
+        # Construct a no-client adapter just for formatting. format_tools
+        # doesn't need the SDK; this avoids pulling in anthropic just to
+        # serialize a JSON schema.
+        return tuple(AnthropicProvider().format_tools(specs))
+    # Phase 2 of the multi-provider epic adds:
+    # if provider_name == "deepseek":
+    #     return tuple(DeepSeekProvider().format_tools(specs))
+    raise ValueError(
+        f"unknown provider name for tool formatting: {provider_name!r}"
+    )
 
 
-def _strip_titles(node: Any) -> None:
-    """Recursively remove `title` keys from a JSON-schema dict tree."""
-    if isinstance(node, dict):
-        node.pop("title", None)
-        for v in node.values():
-            _strip_titles(v)
-    elif isinstance(node, list):
-        for v in node:
-            _strip_titles(v)
+# Backward-compat shim: a couple of older tests imported
+# `_build_anthropic_tools` directly. The Phase 1 refactor split it into
+# `_cached_formatted_tools(surface, provider_name)`. Tests that still
+# use the old name get the Anthropic-shape result by default.
+def _build_anthropic_tools(surface: str) -> tuple[dict, ...]:
+    return _cached_formatted_tools(surface, "anthropic")
 
 
-# ── Cost model (token counts → USD) ─────────────────────────────────────
+# ── Cost calculator (compat shim) ──────────────────────────────────────
 #
-# Pricing in USD per 1M tokens, copied from the claude-api skill. Update
-# this map deliberately when bumping the anthropic SDK pin (pre-reg
-# §12.7 — Buffers internos).
+# Phase 1 of the multi-provider epic: pricing tables moved to each
+# provider's module (api/agent/providers/anthropic_adapter.py:MODEL_PRICING
+# for Anthropic). The loop no longer owns the numbers.
 #
-# This dict is the canonical pricing source for the cost calculator.
-# Context-window capacities (1M / 1M / 200K) and the human-readable
-# "Opus is bigger, Haiku is cheaper" framing live in the api/agent/models.py
-# docstring — model selection logic + the cost-model dict are different
-# concerns, but pricing $$/$$/per-1M numbers must NOT be duplicated to
-# both files (PR #407 review issue 2). If Anthropic ships a price change,
-# the only number to update is here.
-#
-# Cached snapshot 2026-04-29:
-#   - claude-opus-4-7   — $5.00 in / $25.00 out, 1M ctx
-#   - claude-sonnet-4-6 — $3.00 in / $15.00 out, 1M ctx
-#   - claude-haiku-4-5  — $1.00 in / $5.00  out, 200K ctx
-_MODEL_PRICING = {
-    "claude-opus-4-7":   {"in": 5.00, "out": 25.00},
-    "claude-sonnet-4-6": {"in": 3.00, "out": 15.00},
-    "claude-haiku-4-5":  {"in": 1.00, "out":  5.00},
-}
+# `_estimate_cost_usd` remains exported as a backward-compat shim because
+# test_agent_loop.py::test_cost_estimation_matches_published_pricing
+# imports it directly. The shim dispatches to whichever provider claims
+# the model — by prefix match against ALLOWED_MODELS.
 
 
 def _estimate_cost_usd(model: str, usage: dict) -> float:
-    """Compute the USD cost of a turn from `response.usage`. Cache reads
-    are billed at ~0.1× input; cache writes (creation) at ~1.25×.
+    """Compute the USD cost for one hop's `usage`. Dispatches to the
+    provider that owns the model via the registry.
+
+    Returns 0.0 if no provider claims the model (silent fallback —
+    matches pre-refactor behavior for unknown model ids).
     """
-    p = _MODEL_PRICING.get(model)
-    if not p:
-        return 0.0
-    in_per_m = p["in"]
-    out_per_m = p["out"]
-    in_uncached = (usage.get("input_tokens") or 0)
-    cache_read = (usage.get("cache_read_input_tokens") or 0)
-    cache_creation = (usage.get("cache_creation_input_tokens") or 0)
-    out_tokens = (usage.get("output_tokens") or 0)
-    cost = (
-        in_uncached * in_per_m
-        + cache_read * in_per_m * 0.1
-        + cache_creation * in_per_m * 1.25
-        + out_tokens * out_per_m
-    ) / 1_000_000.0
-    return round(cost, 6)
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+    if model.startswith("claude-"):
+        return AnthropicProvider().estimate_cost(model, usage)
+    # Phase 2 adds: if model.startswith("deepseek-"): ...
+    return 0.0
 
 
 # ── Loop ────────────────────────────────────────────────────────────────
@@ -225,6 +200,13 @@ async def run_turn(
     across turns; this function only handles one user-turn → final-text
     cycle.
 
+    Note on `client`: as of Phase 1 of the multi-provider epic, the
+    `client` parameter is actually an `LLMProvider` (not the
+    anthropic.AsyncAnthropic SDK client anymore). The parameter name is
+    preserved to minimize churn across the 13+ test call sites; a future
+    PR may rename. The provider's `stream(...)` method yields LLMEvent
+    instances which this loop translates to LoopEvent.
+
     Pre-reg §6.1.
     """
     if len(messages) > MAX_TURNS_PER_CONVERSATION:
@@ -237,12 +219,14 @@ async def run_turn(
         )
         return
 
-    system_blocks = build_system_blocks(surface)
-    tools = _build_anthropic_tools(surface)
+    provider = client  # local alias for readability — see docstring
+    raw_blocks = build_system_blocks(surface)
+    system_blocks = provider.format_system_blocks(raw_blocks)
+    tools = list(_cached_formatted_tools(surface, provider.name))
     hops = 0
 
     # PR #408 review fix: accumulate usage + cost across all hops of the
-    # turn. Anthropic bills per API call — a multi-hop turn fires N+1
+    # turn. The model bills per API call — a multi-hop turn fires N+1
     # calls (N tool_use intermediate + 1 final text). The original
     # implementation emitted only the final hop's cost in MessageEnd,
     # undercharging the tenant quota by 30-60% on turns with multiple
@@ -256,25 +240,32 @@ async def run_turn(
     total_cost_usd = 0.0
 
     while True:
-        # Open a fresh stream for each "model turn" in the agentic loop.
+        # Open a fresh stream for each model turn in the agentic loop.
+        # The provider yields LLMEvent dataclasses; we translate to the
+        # LoopEvent vocabulary (TextDelta / ToolUseStart / MessageEnd).
+        hop_usage: dict = {}
+        final_stop_reason: str = ""
+        final_content: list = []
         try:
-            async with client.messages.stream(
+            async for ev in provider.stream(
                 model=model,
-                max_tokens=max_tokens,
-                system=system_blocks,
-                tools=tools,
+                system_blocks=system_blocks,
                 messages=messages,
-            ) as stream:
-                async for event in stream:
-                    if event.type == "content_block_start":
-                        cb = event.content_block
-                        if cb is not None and cb.type == "tool_use":
-                            yield ToolUseStart(tool=cb.name or "")
-                    elif event.type == "content_block_delta":
-                        d = event.delta
-                        if d is not None and d.type == "text_delta" and d.text:
-                            yield TextDelta(text=d.text)
-                final = await stream.get_final_message()
+                tools=tools,
+                max_tokens=max_tokens,
+            ):
+                if isinstance(ev, LLMTextDelta):
+                    yield TextDelta(text=ev.text)
+                elif isinstance(ev, LLMToolUseStart):
+                    yield ToolUseStart(tool=ev.name)
+                elif isinstance(ev, LLMStreamEnd):
+                    hop_usage = ev.usage
+                    final_stop_reason = ev.stop_reason
+                    final_content = ev.content
+                # Other LLMEvent types (LLMReasoningDelta, LLMToolUseEnd)
+                # are silently dropped in Phase 1. Phase 3 of the
+                # multi-provider epic wires LLMReasoningDelta to a new
+                # LoopEvent + SSE frame.
         except Exception as e:  # noqa: BLE001
             log.warning("agent loop upstream error: %s", e, exc_info=True)
             yield ErrorEvent(
@@ -285,23 +276,17 @@ async def run_turn(
             )
             return
 
-        hop_usage = {
-            "input_tokens":                getattr(final.usage, "input_tokens", 0) or 0,
-            "output_tokens":               getattr(final.usage, "output_tokens", 0) or 0,
-            "cache_read_input_tokens":     getattr(final.usage, "cache_read_input_tokens", 0) or 0,
-            "cache_creation_input_tokens": getattr(final.usage, "cache_creation_input_tokens", 0) or 0,
-        }
         # Accumulate this hop's usage + cost into the per-turn totals.
         # MessageEnd (below, on the final hop) emits the sum so audit /
         # quota / breaker see the true cost — not just the last call.
         for k in total_usage:
-            total_usage[k] += hop_usage[k]
-        total_cost_usd += _estimate_cost_usd(model, hop_usage)
+            total_usage[k] += int(hop_usage.get(k, 0) or 0)
+        total_cost_usd += provider.estimate_cost(model, hop_usage)
 
-        if final.stop_reason != "tool_use":
+        if final_stop_reason != "tool_use":
             yield MessageEnd(
                 usage=total_usage,
-                stop_reason=final.stop_reason,
+                stop_reason=final_stop_reason,
                 cost_usd=total_cost_usd,
             )
             return
@@ -322,13 +307,13 @@ async def run_turn(
         # See pre-reg §6.1 — splitting per tool_use is a wire-format error.
         messages.append({
             "role": "assistant",
-            "content": _blocks_to_api_shape(final.content),
+            "content": provider.blocks_to_api_shape(final_content),
         })
 
         # Collect tool_results for ALL tool_use blocks in this turn into
         # ONE user message. The API rejects a turn that splits
         # tool_results across multiple user messages.
-        tool_uses = [b for b in final.content if b.type == "tool_use"]
+        tool_uses = [b for b in final_content if b.type == "tool_use"]
         tool_results = []
         for tu in tool_uses:
             result_json = dispatch_tool(
@@ -386,21 +371,7 @@ async def run_turn(
         # Loop back: send the tool_results to the model.
 
 
-def _blocks_to_api_shape(blocks: list) -> list[dict]:
-    """Convert the SDK's typed content blocks (or our fake's) into the
-    plain-dict shape the API accepts in the `messages` array.
-
-    The API doesn't accept the typed objects directly when echoed back —
-    it wants the raw dict form."""
-    out = []
-    for b in blocks:
-        if b.type == "text":
-            out.append({"type": "text", "text": b.text or ""})
-        elif b.type == "tool_use":
-            out.append({
-                "type":  "tool_use",
-                "id":    b.id,
-                "name":  b.name,
-                "input": b.input or {},
-            })
-    return out
+# Phase 1 of the multi-provider epic: `_blocks_to_api_shape` moved to
+# `AnthropicProvider.blocks_to_api_shape`. The loop now delegates via
+# `provider.blocks_to_api_shape(content)` so each provider owns the
+# coercion from its content-block shape back to wire-dict form.

--- a/api/agent/prompts/system.py
+++ b/api/agent/prompts/system.py
@@ -117,41 +117,34 @@ def build_tool_docs(specs: Iterable[ToolSpec] | None = None) -> str:
 # ── Block assembly ──────────────────────────────────────────────────────
 
 
-def build_system_blocks(surface: str) -> list[dict]:
-    """Return the system prompt as a list of cache_control'd text blocks,
-    in the canonical render order:
+def build_system_blocks(surface: str) -> list[str]:
+    """Return the system prompt as a list of plain text blocks, in the
+    canonical render order:
 
       [persona, tool_docs, invariants, surface_micro_prompt]
 
-    Each block is marked `cache_control: {type: "ephemeral"}` so the
-    Anthropic API will serve it from cache on subsequent turns of the
-    same conversation (and across conversations on the same surface,
-    because surface 1-3 are surface-independent).
+    The list is provider-neutral: each entry is just the text. The
+    active LLMProvider's `format_system_blocks(...)` translates this
+    list into the wire shape for its API — Anthropic wraps each entry
+    in `{"type": "text", "text": ..., "cache_control": {"type": "ephemeral"}}`,
+    DeepSeek concatenates into a single user-prompt block, etc.
 
-    The Messages API accepts up to 4 cache_control breakpoints per
-    request; we use exactly that.
+    Pre-reg of multi-provider epic, §2.2 (cache strategy divergent):
+    the cache_control discipline is provider-specific, so it lives in
+    the adapter, not in the prompt assembly.
+
+    Determinism contract: same surface → byte-identical strings across
+    calls. The prompt cache (Anthropic) and the auto-cache (DeepSeek)
+    both rely on this — silent invalidators (whitespace drift, dict
+    ordering, locale-dependent string ops) break BOTH providers'
+    cache hit rates. Phase 1 doesn't change the determinism story;
+    block contents are unchanged from epic #400.
     """
     from api.agent.prompts.surfaces import for_surface
     surface_specs = tools_for_surface(surface)
     return [
-        {
-            "type": "text",
-            "text": PERSONA_AND_SAFETY,
-            "cache_control": {"type": "ephemeral"},
-        },
-        {
-            "type": "text",
-            "text": build_tool_docs(surface_specs),
-            "cache_control": {"type": "ephemeral"},
-        },
-        {
-            "type": "text",
-            "text": INVARIANTS,
-            "cache_control": {"type": "ephemeral"},
-        },
-        {
-            "type": "text",
-            "text": for_surface(surface),
-            "cache_control": {"type": "ephemeral"},
-        },
+        PERSONA_AND_SAFETY,
+        build_tool_docs(surface_specs),
+        INVARIANTS,
+        for_surface(surface),
     ]

--- a/api/agent/providers/__init__.py
+++ b/api/agent/providers/__init__.py
@@ -1,0 +1,44 @@
+"""Provider abstraction layer for the copilot.
+
+Phase 1 of the multi-provider epic (post-#400). The loop talks to an
+LLMProvider; the provider knows the wire format of its SDK / HTTP
+endpoint. Adding a new provider means dropping a new module here and
+registering it — no changes to the loop, audit, quotas, breaker, or
+proposals layer.
+
+Layers (lowest → highest):
+  - base.py: LLMProvider protocol + LLMEvent closed-enum dataclasses
+  - anthropic_adapter.py: wraps anthropic.AsyncAnthropic
+  - registry.py: maps model id prefix → provider instance
+
+Pre-reg: docs/superpowers/specs/es/2026-05-20-multi-provider-copilot-pre-reg.md
+"""
+from __future__ import annotations
+
+from api.agent.providers.base import (
+    LLMEvent,
+    LLMProvider,
+    LLMReasoningDelta,
+    LLMStreamEnd,
+    LLMTextDelta,
+    LLMToolUseEnd,
+    LLMToolUseStart,
+)
+from api.agent.providers.registry import (
+    PROVIDER_BY_PREFIX,
+    UnknownProviderError,
+    get_provider_for_model,
+)
+
+__all__ = [
+    "LLMEvent",
+    "LLMProvider",
+    "LLMReasoningDelta",
+    "LLMStreamEnd",
+    "LLMTextDelta",
+    "LLMToolUseEnd",
+    "LLMToolUseStart",
+    "PROVIDER_BY_PREFIX",
+    "UnknownProviderError",
+    "get_provider_for_model",
+]

--- a/api/agent/providers/anthropic_adapter.py
+++ b/api/agent/providers/anthropic_adapter.py
@@ -1,0 +1,257 @@
+"""Anthropic adapter — wraps anthropic.AsyncAnthropic in the LLMProvider
+contract. Phase 1 of the multi-provider epic.
+
+This module owns:
+  - The Anthropic SDK import (lazy)
+  - `cache_control: ephemeral` injection into system blocks
+  - Anthropic-shape tool schema (`{name, description, input_schema}`)
+  - Anthropic event type translation (content_block_start /
+    content_block_delta / message_delta / message_stop → LLMEvent)
+  - Anthropic pricing table + cost calculation
+  - Coercion of SDK typed content blocks back to dict shape for
+    re-sending in the next turn's `messages` array
+
+Phase 1 is BEHAVIORALLY IDEMPOTENT — every Anthropic test that passed
+before this refactor must still pass after, byte-identical wire output.
+The translation here is a relocation of code that was previously in
+api/agent/loop.py + api/agent/prompts/system.py, not a redesign.
+
+Pre-reg §3 of docs/superpowers/specs/es/2026-05-20-multi-provider-copilot-pre-reg.md
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, AsyncIterator
+
+from api.agent.providers.base import (
+    LLMEvent,
+    LLMStreamEnd,
+    LLMTextDelta,
+    LLMToolUseEnd,
+    LLMToolUseStart,
+)
+
+log = logging.getLogger("api.agent.providers.anthropic")
+
+
+# ── Pricing ─────────────────────────────────────────────────────────
+
+
+# USD per 1M tokens. Cached snapshot 2026-04-29:
+#   - claude-opus-4-7   — $5.00 in / $25.00 out, 1M ctx
+#   - claude-sonnet-4-6 — $3.00 in / $15.00 out, 1M ctx
+#   - claude-haiku-4-5  — $1.00 in / $5.00  out, 200K ctx
+#
+# Cache reads are billed at ~0.1× input; cache writes (creation) at
+# ~1.25× input. The cost calc below applies those multipliers.
+#
+# Phase 1 relocation: this used to live in api/agent/loop.py as
+# `_MODEL_PRICING`. Moved here per the multi-provider spec — each
+# provider owns its own pricing table.
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    "claude-opus-4-7":   {"in": 5.00, "out": 25.00},
+    "claude-sonnet-4-6": {"in": 3.00, "out": 15.00},
+    "claude-haiku-4-5":  {"in": 1.00, "out":  5.00},
+}
+
+
+# ── The adapter ─────────────────────────────────────────────────────
+
+
+class AnthropicProvider:
+    """LLMProvider implementation wrapping anthropic.AsyncAnthropic.
+
+    Constructed lazily by the registry; the actual SDK import is
+    deferred until `stream()` runs, so tests can use a fake provider
+    without anthropic installed in the test environment.
+    """
+
+    name = "anthropic"
+
+    def __init__(self, *, client: Any | None = None) -> None:
+        """`client` is an already-constructed AsyncAnthropic instance.
+        Tests inject a FakeAnthropicClient that mirrors the SDK's
+        `messages.stream(...)` surface. Production resolves the real
+        client via the registry's factory."""
+        self._client = client
+
+    # ── Discovery ───────────────────────────────────────────────────
+
+    def supports_model(self, model: str) -> bool:
+        return model.startswith("claude-")
+
+    def has_api_key(self) -> bool:
+        return bool((os.environ.get("ANTHROPIC_API_KEY") or "").strip())
+
+    # ── Wire-format translators ─────────────────────────────────────
+
+    def format_system_blocks(self, blocks: list[str]) -> list[dict]:
+        """Each block becomes a `text` block with cache_control:ephemeral.
+        Anthropic accepts up to 4 cache_control breakpoints; the caller
+        is responsible for not exceeding that (build_system_blocks emits
+        exactly 4 today)."""
+        return [
+            {
+                "type":          "text",
+                "text":          block,
+                "cache_control": {"type": "ephemeral"},
+            }
+            for block in blocks
+        ]
+
+    def format_tools(self, specs: tuple) -> list[dict]:
+        """Convert a tuple of ToolSpec into Anthropic's tools array.
+
+        Anthropic shape: `[{name, description, input_schema}, ...]`.
+        Strips `title` keys from the JSON schema for cache determinism
+        (Pydantic injects them inferred from field names; removing them
+        keeps the bytes stable across pydantic versions).
+        """
+        out = []
+        for spec in specs:
+            schema = spec.schema.model_json_schema()
+            _strip_titles(schema)
+            out.append({
+                "name":         spec.name,
+                "description":  spec.description,
+                "input_schema": schema,
+            })
+        return out
+
+    # ── Streaming ───────────────────────────────────────────────────
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        system_blocks: list[dict],
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: int,
+    ) -> AsyncIterator[LLMEvent]:
+        """Open one streaming connection against `anthropic.messages.stream`.
+
+        Yields:
+          - LLMTextDelta for each text chunk
+          - LLMToolUseStart when a tool_use block opens
+          - LLMStreamEnd as the terminal event with usage + content
+
+        Phase 1 note: we don't yield LLMToolUseEnd today — the loop
+        reads tool_use blocks off LLMStreamEnd.content (matches the
+        pre-refactor behavior). Phase 2's DeepSeek adapter MUST emit
+        LLMToolUseEnd since DS streams tool_calls differently.
+        """
+        if self._client is None:
+            raise RuntimeError(
+                "AnthropicProvider used without a client. The registry "
+                "factory must construct one with the SDK or tests must "
+                "inject a fake."
+            )
+
+        async with self._client.messages.stream(
+            model=model,
+            max_tokens=max_tokens,
+            system=system_blocks,
+            tools=tools,
+            messages=messages,
+        ) as stream:
+            async for event in stream:
+                if event.type == "content_block_start":
+                    cb = event.content_block
+                    if cb is not None and cb.type == "tool_use":
+                        yield LLMToolUseStart(
+                            id=cb.id or "",
+                            name=cb.name or "",
+                        )
+                elif event.type == "content_block_delta":
+                    d = event.delta
+                    if d is not None and d.type == "text_delta" and d.text:
+                        yield LLMTextDelta(text=d.text)
+            final = await stream.get_final_message()
+
+        usage_dict = {
+            "input_tokens":                getattr(final.usage, "input_tokens", 0) or 0,
+            "output_tokens":               getattr(final.usage, "output_tokens", 0) or 0,
+            "cache_read_input_tokens":     getattr(final.usage, "cache_read_input_tokens", 0) or 0,
+            "cache_creation_input_tokens": getattr(final.usage, "cache_creation_input_tokens", 0) or 0,
+        }
+        yield LLMStreamEnd(
+            stop_reason=final.stop_reason,
+            usage=usage_dict,
+            content=list(final.content),
+        )
+
+    # ── Re-send shape ───────────────────────────────────────────────
+
+    def blocks_to_api_shape(self, blocks: list) -> list[dict]:
+        """Coerce the SDK's typed content blocks back to the dict form
+        the API accepts in the next request's `messages` array.
+
+        Mirrors the pre-refactor `_blocks_to_api_shape` in loop.py."""
+        out = []
+        for b in blocks:
+            if b.type == "text":
+                out.append({"type": "text", "text": b.text or ""})
+            elif b.type == "tool_use":
+                out.append({
+                    "type":  "tool_use",
+                    "id":    b.id,
+                    "name":  b.name,
+                    "input": b.input or {},
+                })
+        return out
+
+    # ── Cost ────────────────────────────────────────────────────────
+
+    def estimate_cost(self, model: str, usage: dict) -> float:
+        """Per-hop USD cost. The loop sums across hops; this returns
+        the cost of a SINGLE hop given its `usage` dict.
+
+        Cache discount applies here (read at 0.1×, creation at 1.25×).
+        """
+        p = MODEL_PRICING.get(model)
+        if not p:
+            return 0.0
+        in_per_m = p["in"]
+        out_per_m = p["out"]
+        in_uncached = (usage.get("input_tokens") or 0)
+        cache_read = (usage.get("cache_read_input_tokens") or 0)
+        cache_creation = (usage.get("cache_creation_input_tokens") or 0)
+        out_tokens = (usage.get("output_tokens") or 0)
+        cost = (
+            in_uncached * in_per_m
+            + cache_read * in_per_m * 0.1
+            + cache_creation * in_per_m * 1.25
+            + out_tokens * out_per_m
+        ) / 1_000_000.0
+        return round(cost, 6)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _strip_titles(node: Any) -> None:
+    """Recursively remove `title` keys from a JSON-schema dict tree.
+    Cache-prefix determinism — Pydantic injects titles, we strip them
+    so the bytes don't shift across Pydantic versions. Pre-reg §7.5.
+    """
+    if isinstance(node, dict):
+        node.pop("title", None)
+        for v in node.values():
+            _strip_titles(v)
+    elif isinstance(node, list):
+        for v in node:
+            _strip_titles(v)
+
+
+def build_anthropic_client() -> Any:
+    """Construct an AsyncAnthropic against ANTHROPIC_API_KEY. Imported
+    lazily so the dependency isn't loaded until a real Anthropic call
+    is in flight.
+
+    Called from the registry's factory; tests bypass this by injecting
+    a fake provider directly.
+    """
+    from anthropic import AsyncAnthropic  # noqa: PLC0415
+    return AsyncAnthropic(api_key=os.environ["ANTHROPIC_API_KEY"].strip())

--- a/api/agent/providers/base.py
+++ b/api/agent/providers/base.py
@@ -1,0 +1,170 @@
+"""LLMProvider protocol + the internal event types adapters yield.
+
+Two layers of events flow through the agent system:
+
+  LLMEvent (this module): what the provider adapter yields per stream
+  chunk. Provider-agnostic — TextDelta is TextDelta whether it came
+  from Anthropic or DeepSeek. The loop consumes LLMEvents.
+
+  LoopEvent (api/agent/loop.py): what the loop yields to the streaming
+  layer. Provider-agnostic AND server-side-aware — includes
+  ToolUseResult (after the loop dispatches and gets the result),
+  ProposalEvent (after the loop detects an _proposal envelope), and
+  MessageEnd (after the loop sums multi-hop usage).
+
+The split is intentional: the provider doesn't invent proposals
+(server-side concern, fired post-dispatch); the loop doesn't format
+wire (provider-side concern, lives in the adapter).
+
+Pre-reg §3.2 + §3.3 of the multi-provider spec.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Protocol
+
+
+# ── LLMEvent closed enum ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LLMTextDelta:
+    """Streaming text chunk from the model's final content."""
+    text: str
+
+
+@dataclass(frozen=True)
+class LLMToolUseStart:
+    """The model started emitting a tool_use block. Adapter yields this
+    when the tool name first becomes known (Anthropic's
+    content_block_start with type=tool_use)."""
+    id: str          # tool_use_id from the wire (toolu_* in Anthropic)
+    name: str        # tool name
+
+
+@dataclass(frozen=True)
+class LLMToolUseEnd:
+    """The model finished emitting a tool_use block. `input` is the
+    fully parsed kwarg dict (adapter accumulates the JSON delta stream
+    and parses at the end)."""
+    id: str
+    name: str
+    input: dict
+
+
+@dataclass(frozen=True)
+class LLMReasoningDelta:
+    """Streaming chunk of reasoning content. Today only DeepSeek-R1
+    emits this; the loop in Phase 1 doesn't act on it (Phase 3 wires
+    it into a new SSE event type for the frontend). Kept in the
+    closed enum from Phase 1 so adapters don't have to grow it later
+    and risk breaking parity."""
+    text: str
+
+
+@dataclass(frozen=True)
+class LLMStreamEnd:
+    """The model finished the turn (either to emit tool_use, hit max
+    tokens, or to deliver final text). `content` is the assistant
+    message's raw content blocks (used by the loop to re-append on
+    multi-hop turns and to walk tool_use blocks for dispatch)."""
+    stop_reason: str  # "end_turn" | "tool_use" | "max_tokens" | ...
+    usage: dict       # {input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens}
+    content: list     # list of SDK content blocks (or fake equivalents)
+
+
+LLMEvent = (
+    LLMTextDelta
+    | LLMToolUseStart
+    | LLMToolUseEnd
+    | LLMReasoningDelta
+    | LLMStreamEnd
+)
+
+
+# ── The provider protocol ────────────────────────────────────────────
+
+
+class LLMProvider(Protocol):
+    """The interface the loop consumes. Each concrete adapter (Anthropic,
+    DeepSeek, etc.) implements all methods.
+
+    `name` is the canonical provider name ("anthropic" | "deepseek" | ...).
+    It's persisted in the audit table's `provider` column (added in
+    Fase 4 of the multi-provider epic) so per-provider telemetry works.
+    """
+
+    name: str
+
+    def supports_model(self, model: str) -> bool:
+        """True if this provider should be used for `model`. Used by
+        the registry's tie-breaker — usually delegated to a prefix
+        match against `name`."""
+        ...
+
+    def has_api_key(self) -> bool:
+        """True if the provider's API key is configured (env var set,
+        non-empty). Read by api/agent/config.get_agent_status to decide
+        whether the default provider can serve traffic."""
+        ...
+
+    def format_system_blocks(self, blocks: list[str]) -> list[dict]:
+        """Convert provider-neutral text blocks into the wire shape the
+        provider expects. Anthropic adds cache_control:ephemeral to each
+        block; DeepSeek emits a single concatenated text block.
+
+        Pre-reg §2.2 (cache strategy divergent).
+        """
+        ...
+
+    def format_tools(self, specs: tuple) -> list[dict]:
+        """Convert a tuple of ToolSpec into the provider's tool-array
+        wire shape.
+
+          Anthropic: [{name, description, input_schema}, ...]
+          OpenAI/DeepSeek: [{type:"function", function:{name, description, parameters}}, ...]
+
+        The `specs` argument is a tuple (not list) so it's hashable —
+        the caller may wrap this call in an lru_cache keyed on
+        (surface, provider.name).
+        """
+        ...
+
+    def stream(
+        self,
+        *,
+        model: str,
+        system_blocks: list[dict],
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: int,
+    ) -> AsyncIterator[LLMEvent]:
+        """Open a streaming connection. Yields LLMEvent instances until
+        the model emits an LLMStreamEnd. The caller is responsible for
+        consuming the stream fully (or closing on cancel).
+
+        The implementation handles SDK-specific event types internally
+        and only emits the protocol's LLMEvent dataclasses on the wire.
+        """
+        ...
+
+    def blocks_to_api_shape(self, blocks: list) -> list[dict]:
+        """Convert the provider's content blocks (as returned in
+        LLMStreamEnd.content) back into the dict shape that goes into
+        the next request's `messages` array.
+
+        Anthropic's SDK gives us typed objects (TextBlock, ToolUseBlock)
+        that the API doesn't accept when echoed back — they need to be
+        coerced to {"type": "...", ...} dicts. DeepSeek/OpenAI already
+        returns dict-shaped content, so this is a no-op there."""
+        ...
+
+    def estimate_cost(self, model: str, usage: dict) -> float:
+        """Compute USD cost for one hop, given the wire-reported usage.
+
+        Each provider owns its pricing table (Anthropic in
+        api/agent/providers/anthropic_adapter.py, DeepSeek in its own
+        module). The loop sums across hops and emits the total on
+        MessageEnd. Pre-reg §2.4 (cost model per-provider).
+        """
+        ...

--- a/api/agent/providers/registry.py
+++ b/api/agent/providers/registry.py
@@ -1,0 +1,74 @@
+"""Provider registry — maps model id prefix → provider instance.
+
+Convention (pre-reg §2.6 of the multi-provider spec, formalized in
+PR #411 review):
+
+  - Each provider declares a canonical prefix for its model ids.
+  - Adding a new provider means:
+      1. Implement `LLMProvider` in api/agent/providers/{vendor}_adapter.py.
+      2. Register the prefix in `PROVIDER_BY_PREFIX` below.
+      3. Add its model ids to `ALLOWED_MODELS` in api/agent/models.py.
+      4. Parametrize §11 tests with a `Fake{Vendor}Provider`.
+
+Invariants enforced in CI by tests/test_provider_registry.py:
+  - Every model in ALLOWED_MODELS matches exactly one PROVIDER_BY_PREFIX
+    prefix.
+  - Every prefix has at least one model in ALLOWED_MODELS (no orphans).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger("api.agent.providers.registry")
+
+
+class UnknownProviderError(ValueError):
+    """Raised when get_provider_for_model can't resolve a model id to a
+    known prefix. The router catches this and returns 400."""
+
+
+# ── Prefix → factory mapping ────────────────────────────────────────
+
+
+def _anthropic_factory() -> Any:
+    """Lazy: construct AnthropicProvider with a real SDK client. The
+    SDK import happens inside build_anthropic_client; tests that don't
+    have the anthropic package installed never hit this path because
+    they inject a FakeAnthropicProvider via dependency_overrides."""
+    from api.agent.providers.anthropic_adapter import (
+        AnthropicProvider, build_anthropic_client,
+    )
+    return AnthropicProvider(client=build_anthropic_client())
+
+
+PROVIDER_BY_PREFIX: dict[str, Any] = {
+    "claude": _anthropic_factory,
+    # Phase 2 of the multi-provider epic adds:
+    # "deepseek": _deepseek_factory,
+}
+
+
+# ── Resolver ─────────────────────────────────────────────────────────
+
+
+def get_provider_for_model(model: str) -> Any:
+    """Resolve a model id to its provider instance.
+
+    Iterates `PROVIDER_BY_PREFIX` in declaration order and uses the
+    first matching prefix. Raises `UnknownProviderError` if no prefix
+    matches — that's a 400, not a 500. The router translates.
+
+    Note: this calls the factory fresh on every invocation. Production
+    use should NOT rely on this for caching the SDK client itself —
+    the factory is cheap (it just news up an AsyncAnthropic), but if
+    a future provider has expensive setup, wrap it in lru_cache HERE,
+    not at the call site.
+    """
+    for prefix, factory in PROVIDER_BY_PREFIX.items():
+        if model.startswith(f"{prefix}-"):
+            return factory()
+    raise UnknownProviderError(
+        f"no provider registered for model {model!r}; "
+        f"add a prefix to PROVIDER_BY_PREFIX"
+    )

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -327,6 +327,15 @@ class FakeAnthropicProvider:
         # actually sent (model id, tools list, message history, etc).
         self.calls: list[dict] = []
         self._queued: list[FakeStream] = []
+        # PR #412 review pickup 3: cache the real adapter once at
+        # construction time. format_system_blocks / format_tools /
+        # blocks_to_api_shape / estimate_cost all delegate to it — no
+        # need to re-instantiate per call. Constructing AnthropicProvider
+        # without a client is cheap (no SDK import), but the readability
+        # win is real: the fake declaratively says "I am Anthropic-
+        # shaped for wire concerns, custom for stream()".
+        from api.agent.providers.anthropic_adapter import AnthropicProvider
+        self._real_adapter = AnthropicProvider()
 
     # ── Test queueing API (unchanged from FakeAnthropicClient) ──────
 
@@ -373,22 +382,19 @@ class FakeAnthropicProvider:
         return True
 
     def format_system_blocks(self, blocks: list[str]) -> list[dict]:
-        # Delegate to the real adapter — the fake should produce
-        # byte-identical wire shape so cache verification tests pass.
-        from api.agent.providers.anthropic_adapter import AnthropicProvider
-        return AnthropicProvider().format_system_blocks(blocks)
+        # Byte-identical wire shape — cache verification tests assert
+        # the cache_control:ephemeral wrapping that the real adapter
+        # produces.
+        return self._real_adapter.format_system_blocks(blocks)
 
     def format_tools(self, specs: tuple) -> list[dict]:
-        from api.agent.providers.anthropic_adapter import AnthropicProvider
-        return AnthropicProvider().format_tools(specs)
+        return self._real_adapter.format_tools(specs)
 
     def blocks_to_api_shape(self, blocks: list) -> list[dict]:
-        from api.agent.providers.anthropic_adapter import AnthropicProvider
-        return AnthropicProvider().blocks_to_api_shape(blocks)
+        return self._real_adapter.blocks_to_api_shape(blocks)
 
     def estimate_cost(self, model: str, usage: dict) -> float:
-        from api.agent.providers.anthropic_adapter import AnthropicProvider
-        return AnthropicProvider().estimate_cost(model, usage)
+        return self._real_adapter.estimate_cost(model, usage)
 
     async def stream(
         self,

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -299,31 +299,36 @@ class FakeStream:
         return self._final
 
 
-class FakeMessages:
-    """Mirror of `client.messages.*`. Phase 2 only uses `stream(**kwargs)`."""
+class FakeAnthropicProvider:
+    """Test double that satisfies the LLMProvider protocol.
 
-    def __init__(self, client: "FakeAnthropicClient"):
-        self._client = client
+    Phase 1 of the multi-provider epic. Previously this was
+    `FakeAnthropicClient` — a mock of `anthropic.AsyncAnthropic`. With
+    the loop now consuming an LLMProvider directly (no more
+    `client.messages.stream(...)` indirection), the fake implements the
+    protocol's `stream(...)` method directly and yields LLMEvent
+    instances on the wire.
 
-    def stream(self, **kwargs):
-        # Record the kwargs so tests can assert what the loop sent
-        # (model, system layout, tools, messages, etc).
-        self._client.calls.append(kwargs)
-        return self._client._next_stream()
+    The Anthropic-shape event TYPES (content_block_start, etc) still
+    live inside the builder pattern below — they remain the natural way
+    to express "the model emits text + tool_use" — but this provider
+    translates them to LLMEvent before yielding. That keeps the test
+    DX identical while making the fake provider-shaped.
 
-
-class FakeAnthropicClient:
-    """Drop-in replacement for `anthropic.AsyncAnthropic` in tests.
-
-    Each test queues one FakeStream per expected turn. If the loop opens
-    more streams than queued, the fake raises a loud error — silent
-    fall-through to "default response" is the kind of bug we won't catch.
+    Backward-compat: `FakeAnthropicClient` is an alias preserved at the
+    bottom of this module so existing test imports keep working.
     """
 
-    def __init__(self):
-        self.messages = FakeMessages(self)
+    name = "anthropic"
+
+    def __init__(self) -> None:
+        # Recording surface: each call to stream() appends its kwargs
+        # here. Tests assert against this list to verify what the loop
+        # actually sent (model id, tools list, message history, etc).
         self.calls: list[dict] = []
         self._queued: list[FakeStream] = []
+
+    # ── Test queueing API (unchanged from FakeAnthropicClient) ──────
 
     def queue_turn(self, built: tuple[list, "FakeFinalMessage"]) -> None:
         events, final = built
@@ -353,11 +358,95 @@ class FakeAnthropicClient:
     def _next_stream(self) -> FakeStream:
         if not self._queued:
             raise RuntimeError(
-                "FakeAnthropicClient: no queued turns. The loop opened "
+                "FakeAnthropicProvider: no queued turns. The loop opened "
                 "more streams than the test queued — likely a runaway "
                 "tool-use cycle. Inspect self.calls to see what was sent."
             )
         return self._queued.pop(0)
+
+    # ── LLMProvider protocol ──────────────────────────────────────
+
+    def supports_model(self, model: str) -> bool:
+        return model.startswith("claude-")
+
+    def has_api_key(self) -> bool:
+        return True
+
+    def format_system_blocks(self, blocks: list[str]) -> list[dict]:
+        # Delegate to the real adapter — the fake should produce
+        # byte-identical wire shape so cache verification tests pass.
+        from api.agent.providers.anthropic_adapter import AnthropicProvider
+        return AnthropicProvider().format_system_blocks(blocks)
+
+    def format_tools(self, specs: tuple) -> list[dict]:
+        from api.agent.providers.anthropic_adapter import AnthropicProvider
+        return AnthropicProvider().format_tools(specs)
+
+    def blocks_to_api_shape(self, blocks: list) -> list[dict]:
+        from api.agent.providers.anthropic_adapter import AnthropicProvider
+        return AnthropicProvider().blocks_to_api_shape(blocks)
+
+    def estimate_cost(self, model: str, usage: dict) -> float:
+        from api.agent.providers.anthropic_adapter import AnthropicProvider
+        return AnthropicProvider().estimate_cost(model, usage)
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        system_blocks: list[dict],
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: int,
+    ):
+        """Yield LLMEvent instances translated from the next queued
+        FakeStream's Anthropic-shape events. Records the call kwargs
+        on `self.calls` so tests can assert against the wire shape.
+        """
+        # Lazy import — keeps test collection cheap when this module
+        # is touched but `stream` is never invoked.
+        from api.agent.providers.base import (
+            LLMStreamEnd, LLMTextDelta, LLMToolUseStart,
+        )
+
+        self.calls.append({
+            "model":         model,
+            "system_blocks": system_blocks,
+            "messages":      messages,
+            "tools":         tools,
+            "max_tokens":    max_tokens,
+        })
+        fake_stream = self._next_stream()
+        async with fake_stream as s:
+            async for ev in s:
+                if ev.type == "content_block_start":
+                    cb = ev.content_block
+                    if cb is not None and cb.type == "tool_use":
+                        yield LLMToolUseStart(
+                            id=cb.id or "", name=cb.name or "",
+                        )
+                elif ev.type == "content_block_delta":
+                    d = ev.delta
+                    if d is not None and d.type == "text_delta" and d.text:
+                        yield LLMTextDelta(text=d.text)
+            final = await s.get_final_message()
+        usage_dict = {
+            "input_tokens":                getattr(final.usage, "input_tokens", 0) or 0,
+            "output_tokens":               getattr(final.usage, "output_tokens", 0) or 0,
+            "cache_read_input_tokens":     getattr(final.usage, "cache_read_input_tokens", 0) or 0,
+            "cache_creation_input_tokens": getattr(final.usage, "cache_creation_input_tokens", 0) or 0,
+        }
+        yield LLMStreamEnd(
+            stop_reason=final.stop_reason,
+            usage=usage_dict,
+            content=list(final.content),
+        )
+
+
+# Backward-compat alias for existing tests that import FakeAnthropicClient.
+# The two names refer to the same class; new tests should use the
+# *Provider name to make the LLM-abstraction explicit.
+FakeAnthropicClient = FakeAnthropicProvider
 
 
 # Cheap self-test at import — failures here surface as ImportError at

--- a/tests/test_agent_cache_verification.py
+++ b/tests/test_agent_cache_verification.py
@@ -52,12 +52,24 @@ def test_system_blocks_have_four_cache_breakpoints():
     """Anthropic Messages API accepts up to 4 cache_control breakpoints
     per request. We use exactly four — one per layer. Adding a 5th
     would silently lose the last one; dropping below 4 wastes cache
-    headroom."""
-    from api.agent.prompts.system import build_system_blocks
+    headroom.
 
-    blocks = build_system_blocks("dock")
-    assert len(blocks) == 4
-    for b in blocks:
+    Phase 1 of multi-provider epic: cache_control wrapping moved from
+    build_system_blocks (now returns plain strings) to the
+    AnthropicProvider.format_system_blocks adapter. The wire shape that
+    reaches the Anthropic API still has 4 cache_control'd blocks; this
+    test verifies the full pipeline.
+    """
+    from api.agent.prompts.system import build_system_blocks
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+
+    raw_blocks = build_system_blocks("dock")
+    assert len(raw_blocks) == 4
+    assert all(isinstance(b, str) for b in raw_blocks)
+
+    wire_blocks = AnthropicProvider().format_system_blocks(raw_blocks)
+    assert len(wire_blocks) == 4
+    for b in wire_blocks:
         assert b["type"] == "text"
         assert b.get("cache_control") == {"type": "ephemeral"}, (
             f"block missing cache_control: {b!r}"
@@ -77,13 +89,14 @@ def test_system_blocks_order_is_canonical():
     from api.agent.prompts.surfaces import for_surface
 
     blocks = build_system_blocks("dock")
-    assert blocks[0]["text"] == PERSONA_AND_SAFETY
+    # Phase 1 of multi-provider epic: blocks are now plain strings.
+    assert blocks[0] == PERSONA_AND_SAFETY
     # Block 1 is the tool docs — built from the surface's tool subset.
     # We only assert the header line is present (the rest is
     # registry-derived and tested in test_agent_models.py).
-    assert "TOOLS DISPONIBLES" in blocks[1]["text"]
-    assert blocks[2]["text"] == INVARIANTS
-    assert blocks[3]["text"] == for_surface("dock")
+    assert "TOOLS DISPONIBLES" in blocks[1]
+    assert blocks[2] == INVARIANTS
+    assert blocks[3] == for_surface("dock")
 
 
 # ── 2. Wire-reported cache usage ────────────────────────────────

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -498,13 +498,29 @@ def test_cost_estimation_matches_published_pricing():
 # ── System prompt blocks are cache-control'd ───────────────────────────
 
 
-def test_system_blocks_carry_cache_control():
-    """All four blocks must have cache_control: {type: ephemeral} so the
-    Anthropic API serves them from cache. Pre-reg §7.5 silent invariant."""
+def test_system_blocks_carry_cache_control_after_anthropic_formatting():
+    """Phase 1 of the multi-provider epic split this invariant: the
+    cache_control:ephemeral wrapping moved out of build_system_blocks
+    (now provider-neutral, returns list[str]) and into the AnthropicProvider's
+    format_system_blocks. The end-to-end wire shape that goes to the
+    Anthropic Messages API still has the 4 cache_control'd text blocks.
+
+    This test verifies the full pipeline: build_system_blocks →
+    AnthropicProvider.format_system_blocks → wire shape with
+    cache_control on each of the 4 blocks. Other providers (DeepSeek,
+    Phase 2) have their own formatting tests in their own files.
+    """
     from api.agent.prompts import build_system_blocks
-    blocks = build_system_blocks("dock")
-    assert len(blocks) == 4
-    for b in blocks:
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+
+    raw_blocks = build_system_blocks("dock")
+    assert isinstance(raw_blocks, list)
+    assert len(raw_blocks) == 4
+    assert all(isinstance(b, str) for b in raw_blocks)
+
+    wire_blocks = AnthropicProvider().format_system_blocks(raw_blocks)
+    assert len(wire_blocks) == 4
+    for b in wire_blocks:
         assert b["type"] == "text"
         assert b["cache_control"] == {"type": "ephemeral"}
 
@@ -512,7 +528,9 @@ def test_system_blocks_carry_cache_control():
 def test_system_blocks_are_deterministic_across_calls():
     """Same surface → byte-identical output across calls. If this fails,
     the cache prefix shifts on every turn and the spec §14 cache-hit-rate
-    target ≥70% is unreachable."""
+    target ≥70% is unreachable. This invariant is provider-neutral —
+    determinism of the raw text drives BOTH Anthropic's cache_control
+    breakpoints AND DeepSeek's auto-prefix cache."""
     from api.agent.prompts import build_system_blocks
     a = build_system_blocks("dock")
     b = build_system_blocks("dock")

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,211 @@
+"""Phase 1 of the multi-provider epic — provider registry + adapter tests.
+
+Two layers of coverage here:
+
+  1. REGISTRY INVARIANTS — the §2.6 contract is enforced in CI:
+     - Every model in ALLOWED_MODELS matches exactly one prefix in
+       PROVIDER_BY_PREFIX.
+     - Every prefix has at least one model in ALLOWED_MODELS (no
+       orphans).
+     - get_provider_for_model raises UnknownProviderError on a prefix
+       that doesn't match anything registered.
+
+  2. ADAPTER UNIT TESTS — AnthropicProvider's individual methods,
+     decoupled from the loop:
+     - format_system_blocks adds cache_control:ephemeral.
+     - format_tools emits {name, description, input_schema} shape.
+     - estimate_cost uses the published per-model pricing table.
+     - blocks_to_api_shape coerces typed blocks to dict shape.
+
+If §11 critical tests pass for the loop AND these unit tests pass for
+the adapter, the abstraction is wired correctly. Adding Phase 2's
+DeepSeek adapter only needs an equivalent test file for that adapter.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── Registry invariants ──────────────────────────────────────────
+
+
+def test_every_allowed_model_resolves_to_a_provider():
+    """For each model in ALLOWED_MODELS, get_provider_for_model returns
+    a valid provider. No orphan models."""
+    from api.agent.models import ALLOWED_MODELS
+    from api.agent.providers.registry import (
+        PROVIDER_BY_PREFIX, get_provider_for_model,
+    )
+
+    for model in ALLOWED_MODELS:
+        # We don't actually call the factory (which constructs an SDK
+        # client and needs the env var); we only verify the prefix
+        # resolves to a known entry in PROVIDER_BY_PREFIX.
+        matched = [p for p in PROVIDER_BY_PREFIX if model.startswith(f"{p}-")]
+        assert len(matched) == 1, (
+            f"model {model!r} matches {len(matched)} prefixes "
+            f"({matched}); expected exactly 1"
+        )
+
+
+def test_no_orphan_prefixes():
+    """Every prefix in PROVIDER_BY_PREFIX must have at least one model
+    in ALLOWED_MODELS. An orphan prefix is dead code — it would never
+    fire because no model id reaches it."""
+    from api.agent.models import ALLOWED_MODELS
+    from api.agent.providers.registry import PROVIDER_BY_PREFIX
+
+    for prefix in PROVIDER_BY_PREFIX:
+        matched = [m for m in ALLOWED_MODELS if m.startswith(f"{prefix}-")]
+        assert matched, (
+            f"prefix {prefix!r} has no matching models in ALLOWED_MODELS"
+        )
+
+
+def test_unknown_model_id_raises_unknown_provider_error():
+    """A model id that doesn't match any prefix triggers
+    UnknownProviderError. The router catches this and returns 400."""
+    from api.agent.providers.registry import (
+        UnknownProviderError, get_provider_for_model,
+    )
+
+    with pytest.raises(UnknownProviderError):
+        get_provider_for_model("gpt-5-turbo")
+    with pytest.raises(UnknownProviderError):
+        get_provider_for_model("totally-fake-model")
+
+
+def test_get_provider_for_model_for_claude_resolves(monkeypatch):
+    """For a real claude model id, the registry calls the Anthropic
+    factory. We can't easily test against the real SDK in a test
+    environment without anthropic installed; we monkeypatch the
+    factory to return a sentinel and verify dispatch."""
+    from api.agent.providers import registry
+
+    sentinel = object()
+    monkeypatch.setitem(
+        registry.PROVIDER_BY_PREFIX, "claude", lambda: sentinel,
+    )
+    assert registry.get_provider_for_model("claude-sonnet-4-6") is sentinel
+    assert registry.get_provider_for_model("claude-opus-4-7") is sentinel
+
+
+# ── AnthropicProvider unit tests ─────────────────────────────────
+
+
+def test_anthropic_provider_supports_claude_models_only():
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+    p = AnthropicProvider()
+    assert p.supports_model("claude-sonnet-4-6") is True
+    assert p.supports_model("claude-opus-4-7") is True
+    assert p.supports_model("deepseek-chat") is False
+    assert p.supports_model("gpt-5") is False
+
+
+def test_anthropic_provider_format_system_blocks_wraps_each_with_cache_control():
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+    p = AnthropicProvider()
+    out = p.format_system_blocks(["hello", "world"])
+    assert out == [
+        {"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": "world", "cache_control": {"type": "ephemeral"}},
+    ]
+
+
+def test_anthropic_provider_format_tools_emits_anthropic_shape():
+    """The tool array must have {name, description, input_schema} per
+    tool. The input_schema is a JSON schema with `title` keys stripped
+    (determinism contract — see §7.5 of epic #400)."""
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+    from api.agent.tools.registry import tools_for_surface
+
+    specs = tools_for_surface("dock")
+    out = AnthropicProvider().format_tools(specs)
+    assert len(out) == len(specs)
+    for tool in out:
+        assert set(tool.keys()) == {"name", "description", "input_schema"}
+        # title stripping: walk the schema and assert no `title` keys remain.
+        _assert_no_title(tool["input_schema"])
+
+
+def _assert_no_title(node):
+    """Recursive assertion: no `title` key in the JSON schema tree."""
+    if isinstance(node, dict):
+        assert "title" not in node, f"unstripped title in node: {node}"
+        for v in node.values():
+            _assert_no_title(v)
+    elif isinstance(node, list):
+        for v in node:
+            _assert_no_title(v)
+
+
+def test_anthropic_provider_estimate_cost_matches_known_pricing():
+    """1M input + 1M output on Sonnet should be exactly $18 — same
+    numbers as the legacy _MODEL_PRICING / _estimate_cost_usd from
+    epic #400."""
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+    p = AnthropicProvider()
+    cost = p.estimate_cost(
+        "claude-sonnet-4-6",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    assert cost == pytest.approx(18.0)
+
+
+def test_anthropic_provider_estimate_cost_returns_zero_for_unknown_model():
+    """Defensive fallback — same behavior as the pre-refactor cost
+    helper. An unknown model id (typo, deprecated, not yet added)
+    returns 0.0 instead of raising. Phase 1 of the multi-provider epic
+    preserves this contract; future epic could decide differently."""
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+    assert AnthropicProvider().estimate_cost("claude-bogus-99", {}) == 0.0
+
+
+def test_anthropic_provider_blocks_to_api_shape_coerces_typed_blocks():
+    """SDK content blocks are typed objects (TextBlock, ToolUseBlock)
+    that the API rejects when echoed back. The adapter coerces them
+    to the {type, text} / {type, id, name, input} dict shape that
+    `messages` accepts on the next turn."""
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+
+    class FakeTextBlock:
+        type = "text"
+        text = "hi"
+
+    class FakeToolUseBlock:
+        type = "tool_use"
+        id = "toolu_1"
+        name = "get_positions"
+        input = {"window": "7d"}
+
+    out = AnthropicProvider().blocks_to_api_shape(
+        [FakeTextBlock(), FakeToolUseBlock()],
+    )
+    assert out == [
+        {"type": "text", "text": "hi"},
+        {"type": "tool_use", "id": "toolu_1", "name": "get_positions",
+         "input": {"window": "7d"}},
+    ]
+
+
+# ── LLMProvider protocol — adapter conforms ────────────────────
+
+
+def test_anthropic_provider_conforms_to_llmprovider_protocol():
+    """Structural protocol check — every method that LLMProvider
+    declares must be callable on AnthropicProvider. If somebody
+    accidentally renames a method on the adapter (or on the protocol),
+    this test fires."""
+    import inspect
+    from api.agent.providers.anthropic_adapter import AnthropicProvider
+    from api.agent.providers.base import LLMProvider
+
+    required = [
+        m for m in dir(LLMProvider)
+        if not m.startswith("_")
+    ]
+    p = AnthropicProvider()
+    for method_name in required:
+        assert hasattr(p, method_name), (
+            f"AnthropicProvider missing {method_name!r} required by LLMProvider"
+        )


### PR DESCRIPTION
## Summary

Fase 1 of the multi-provider epic (spec at `docs/superpowers/specs/es/2026-05-20-multi-provider-copilot-pre-reg.md`). **Mechanical refactor only** — moves Anthropic-specific concerns into a provider adapter. No DeepSeek yet (Fase 2). Phase 1 is behaviorally idempotent: every test from epic #400 still passes.

## What lands

**`api/agent/providers/` (new module)**
- `base.py` — `LLMProvider` protocol + closed-enum `LLMEvent` dataclasses (`LLMTextDelta`, `LLMToolUseStart`, `LLMToolUseEnd`, `LLMReasoningDelta`, `LLMStreamEnd`)
- `anthropic_adapter.py` — `AnthropicProvider` class. Owns `cache_control:ephemeral` wrapping, Anthropic tool schema shape, SDK stream iteration, the `MODEL_PRICING` table + cost calc, content block coercion
- `registry.py` — `PROVIDER_BY_PREFIX = {"claude": _anthropic_factory}`, `get_provider_for_model()` with `UnknownProviderError` for orphans. Convention from spec §2.6 formalized
- `__init__.py` — public exports

**Refactors**
- `api/agent/prompts/system.py` — `build_system_blocks` now returns `list[str]` (provider-neutral); the adapter adds cache_control
- `api/agent/loop.py` — `run_turn` consumes `provider.stream()` instead of `client.messages.stream()`. `_cached_formatted_tools(surface, provider_name)` replaces `_build_anthropic_tools(surface)`. Cost calc dispatches via provider
- `api/agent/clients.py` — thin shim resolving the default surface's provider via the registry. Function name preserved for backward-compat with 13+ test override sites
- `tests/_fakes.py` — `FakeAnthropicClient` → `FakeAnthropicProvider` implementing `LLMProvider`. Backward-compat alias preserved

**3 existing tests updated** (assertion shape, not invariant):
- `test_system_blocks_carry_cache_control_after_anthropic_formatting`
- `test_system_blocks_have_four_cache_breakpoints`
- `test_system_blocks_order_is_canonical`

Each now verifies the full pipeline `build_system_blocks → provider.format_system_blocks → cache_control'd wire blocks` instead of asserting `cache_control` on `build_system_blocks` directly.

**`tests/test_provider_registry.py` (new — 11 tests)**
- Registry invariants: every `ALLOWED_MODELS` entry resolves to exactly one prefix; every prefix has at least one model (no orphans); unknown model raises `UnknownProviderError`
- `AnthropicProvider` unit tests: each protocol method tested independently of the loop
- Protocol conformance: every public method on `LLMProvider` exists on `AnthropicProvider`

## Tests
- **171 backend** agent tests passing (11 new, 160 existing unchanged), 1 skipped (live)
- **94 frontend** tests passing (untouched)
- TS clean

## Out of scope (Fase 2)
- DeepSeek adapter (deepseek-chat V3 only) — `api/agent/providers/deepseek_adapter.py`
- Rename `run_turn` `client` param to `provider` — natural inflection point when Fase 2 needs to touch call sites anyway

## Test plan
- [ ] CI green
- [ ] Manual review of `base.py` to verify the protocol is the right shape (this is the architectural decision; everything else is mechanical translation)
- [ ] Manual verify `tests/test_provider_registry.py` invariants would catch a future regression (e.g. add an orphan prefix and see the test fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)