### PR TITLE
feat(agent): Fase 2 multi-provider — DeepSeek adapter (chat V3)

### DIFF
--- a/api/agent/config.py
+++ b/api/agent/config.py
@@ -42,10 +42,12 @@ def get_agent_status(cfg: Optional[dict] = None) -> AgentStatus:
 
     Precedence (any disabling source wins):
       1. cfg["agent"]["enabled"] is explicitly False  → agent_disabled
-      2. ANTHROPIC_API_KEY missing or empty            → treated identically
-         (we deliberately collapse "key missing" into the same reason as
-         "operator disabled" so the wire format never leaks the existence
-         of an env var named ANTHROPIC_API_KEY)
+      2. Default model's provider has no API key       → agent_disabled
+         (§2.7 of the multi-provider epic: we check the key of the
+         provider that serves the default surface model — NOT "any
+         key set". If the default is deepseek-chat and only
+         ANTHROPIC_API_KEY is set, status returns disabled BEFORE
+         the first turn fails inside the adapter.)
       3. Global circuit breaker tripped (explicit cfg.agent.breaker_open
          OR automatic 24h global spend cap exceeded) → breaker_open
       4. Otherwise                                     → enabled
@@ -54,14 +56,21 @@ def get_agent_status(cfg: Optional[dict] = None) -> AgentStatus:
     agent_disabled — the frontend can render different UX ("system
     temporarily halted" vs "feature off") and the operator-facing
     metrics page can tell the two states apart.
+
+    Wire-format invariant (pre-reg §13.5): the response never leaks
+    env-var names. "Key missing" and "operator disabled" collapse
+    into agent_disabled.
     """
     cfg = cfg if cfg is not None else load_config()
     agent_cfg = cfg.get("agent") or {}
     if agent_cfg.get("enabled") is False:
         return AgentStatus(enabled=False, reason=_REASON_DISABLED)
 
-    api_key = (os.environ.get("ANTHROPIC_API_KEY") or "").strip()
-    if not api_key:
+    # §2.7: check the API key of the default model's provider, not
+    # ANTHROPIC_API_KEY directly. The default surface is "dock";
+    # whichever provider serves dock today determines the key we
+    # need.
+    if not _default_provider_has_key():
         return AgentStatus(enabled=False, reason=_REASON_DISABLED)
 
     # Local import to avoid the circular: circuit_breaker reads cfg via
@@ -73,3 +82,27 @@ def get_agent_status(cfg: Optional[dict] = None) -> AgentStatus:
         return AgentStatus(enabled=False, reason=_REASON_BREAKER_OPEN)
 
     return AgentStatus(enabled=True, reason=_REASON_OK)
+
+
+def _default_provider_has_key() -> bool:
+    """True if the provider that serves the default surface ("dock") has
+    its API key configured. Decoupled from the status function so the
+    import chain is testable in isolation.
+
+    Returns False on any resolution error (unknown provider, SDK import
+    failure, etc) — collapses every failure mode into the same
+    agent_disabled closed-enum reason.
+    """
+    try:
+        from api.agent.models import default_model_for_surface
+        from api.agent.providers.registry import (
+            UnknownProviderError, get_provider_class_for_model,
+        )
+        default_model = default_model_for_surface("dock")
+        provider_cls = get_provider_class_for_model(default_model)
+        # Construct a no-key instance. has_api_key() reads from the
+        # right env var for the provider's vendor.
+        return provider_cls().has_api_key()
+    except Exception:  # noqa: BLE001
+        log.warning("_default_provider_has_key resolution failed", exc_info=True)
+        return False

--- a/api/agent/loop.py
+++ b/api/agent/loop.py
@@ -119,10 +119,10 @@ LoopEvent = (
 def _cached_formatted_tools(surface: str, provider_name: str) -> tuple[dict, ...]:
     """Cache the formatted tools array keyed on (surface, provider name).
 
-    Phase 1 of the multi-provider epic: this replaces the previous
-    `_build_anthropic_tools(surface)` cache which assumed only one
-    provider. Now keyed on (surface, provider_name) because different
-    providers emit different wire shapes from the same ToolSpec.
+    Fase 2 of the multi-provider epic + PR #412 review pickup 1:
+    dispatches via the registry's get_provider_class_for_name helper
+    instead of hardcoded if/elif. Adding a new provider only needs an
+    entry in the registry — this function doesn't change.
 
     `maxsize=16` covers 5 surfaces × up to 3 providers + headroom.
 
@@ -130,19 +130,12 @@ def _cached_formatted_tools(surface: str, provider_name: str) -> tuple[dict, ...
     dicts remain mutable; callers MUST treat as read-only — mutating
     any nested schema corrupts the cache for every subsequent request.
     """
-    from api.agent.providers.anthropic_adapter import AnthropicProvider
-    specs = tools_for_surface(surface)
-    if provider_name == "anthropic":
-        # Construct a no-client adapter just for formatting. format_tools
-        # doesn't need the SDK; this avoids pulling in anthropic just to
-        # serialize a JSON schema.
-        return tuple(AnthropicProvider().format_tools(specs))
-    # Phase 2 of the multi-provider epic adds:
-    # if provider_name == "deepseek":
-    #     return tuple(DeepSeekProvider().format_tools(specs))
-    raise ValueError(
-        f"unknown provider name for tool formatting: {provider_name!r}"
-    )
+    from api.agent.providers.registry import get_provider_class_for_name
+    provider_cls = get_provider_class_for_name(provider_name)
+    # Construct a no-client/no-key adapter instance just for formatting.
+    # format_tools doesn't need the SDK or API key — pure Pydantic →
+    # JSON schema serialization.
+    return tuple(provider_cls().format_tools(tools_for_surface(surface)))
 
 
 # Backward-compat shim: a couple of older tests imported
@@ -169,14 +162,22 @@ def _estimate_cost_usd(model: str, usage: dict) -> float:
     """Compute the USD cost for one hop's `usage`. Dispatches to the
     provider that owns the model via the registry.
 
-    Returns 0.0 if no provider claims the model (silent fallback —
-    matches pre-refactor behavior for unknown model ids).
+    Fase 2 of the multi-provider epic + PR #412 review pickup 1:
+    uses get_provider_class_for_model to resolve the adapter class
+    without constructing an SDK client. Returns 0.0 if no provider
+    claims the model (silent fallback — matches pre-refactor behavior
+    for unknown model ids; an unknown model in the hot path means a
+    config mistake, but we don't want to crash cost calculation
+    over it).
     """
-    from api.agent.providers.anthropic_adapter import AnthropicProvider
-    if model.startswith("claude-"):
-        return AnthropicProvider().estimate_cost(model, usage)
-    # Phase 2 adds: if model.startswith("deepseek-"): ...
-    return 0.0
+    from api.agent.providers.registry import (
+        UnknownProviderError, get_provider_class_for_model,
+    )
+    try:
+        cls = get_provider_class_for_model(model)
+    except UnknownProviderError:
+        return 0.0
+    return cls().estimate_cost(model, usage)
 
 
 # ── Loop ────────────────────────────────────────────────────────────────
@@ -304,17 +305,26 @@ async def run_turn(
             return
 
         # Append the assistant message ONCE (carries all tool_use blocks).
-        # See pre-reg §6.1 — splitting per tool_use is a wire-format error.
-        messages.append({
-            "role": "assistant",
-            "content": provider.blocks_to_api_shape(final_content),
-        })
+        # Anthropic: one message with content=[blocks]. DeepSeek: one
+        # message with content=str + tool_calls=[]. Provider knows.
+        # See pre-reg §6.1 — for Anthropic, splitting tool_use across
+        # messages is a wire-format error.
+        # Reconstruct a stream_end-like with .content for the helper.
+        from api.agent.providers.base import LLMStreamEnd as _LLMStreamEnd
+        _se = _LLMStreamEnd(
+            stop_reason=final_stop_reason,
+            usage=hop_usage,
+            content=final_content,
+        )
+        messages.append(provider.to_assistant_message(_se))
 
-        # Collect tool_results for ALL tool_use blocks in this turn into
-        # ONE user message. The API rejects a turn that splits
-        # tool_results across multiple user messages.
+        # Collect tool_results for ALL tool_use blocks in this turn.
+        # The shape of "what gets appended" diverges per provider:
+        # Anthropic → 1 user message with all tool_result blocks;
+        # DeepSeek → N tool messages, one per tool_call. The provider's
+        # to_tool_result_messages handles that translation.
         tool_uses = [b for b in final_content if b.type == "tool_use"]
-        tool_results = []
+        tool_uses_with_results: list[tuple] = []
         for tu in tool_uses:
             result_json = dispatch_tool(
                 tu.name or "", tu.input or {},
@@ -360,13 +370,8 @@ async def run_turn(
                 model_visible = {k: v for k, v in parsed.items() if k != "_proposal"}
                 content_for_model = json.dumps(model_visible, default=str)
 
-            tool_results.append({
-                "type":          "tool_result",
-                "tool_use_id":   tu.id,
-                "content":       content_for_model,
-                "is_error":      is_error,
-            })
-        messages.append({"role": "user", "content": tool_results})
+            tool_uses_with_results.append((tu, content_for_model, is_error))
+        messages.extend(provider.to_tool_result_messages(tool_uses_with_results))
 
         # Loop back: send the tool_results to the model.
 

--- a/api/agent/models.py
+++ b/api/agent/models.py
@@ -59,6 +59,12 @@ ALLOWED_MODELS: frozenset[str] = frozenset({
     "claude-sonnet-4-6",
     "claude-haiku-4-5",
     "claude-opus-4-7",
+    # Fase 2 of the multi-provider epic: deepseek-chat (V3). Default
+    # surface mappings still point at claude-* models — DeepSeek is
+    # opt-in via per-turn `model` override until Fase 3 migrates
+    # defaults after parity validation.
+    "deepseek-chat",
+    # "deepseek-reasoner",  # Fase 3 adds R1 (reasoning_content event).
 })
 
 

--- a/api/agent/providers/__init__.py
+++ b/api/agent/providers/__init__.py
@@ -23,10 +23,15 @@ from api.agent.providers.base import (
     LLMTextDelta,
     LLMToolUseEnd,
     LLMToolUseStart,
+    SyntheticTextBlock,
+    SyntheticToolUseBlock,
 )
 from api.agent.providers.registry import (
     PROVIDER_BY_PREFIX,
+    PROVIDER_NAME_BY_PREFIX,
     UnknownProviderError,
+    get_provider_class_for_model,
+    get_provider_class_for_name,
     get_provider_for_model,
 )
 
@@ -39,6 +44,11 @@ __all__ = [
     "LLMToolUseEnd",
     "LLMToolUseStart",
     "PROVIDER_BY_PREFIX",
+    "PROVIDER_NAME_BY_PREFIX",
+    "SyntheticTextBlock",
+    "SyntheticToolUseBlock",
     "UnknownProviderError",
+    "get_provider_class_for_model",
+    "get_provider_class_for_name",
     "get_provider_for_model",
 ]

--- a/api/agent/providers/anthropic_adapter.py
+++ b/api/agent/providers/anthropic_adapter.py
@@ -182,13 +182,49 @@ class AnthropicProvider:
             content=list(final.content),
         )
 
-    # ── Re-send shape ───────────────────────────────────────────────
+    # ── Re-send shape (Anthropic wire) ──────────────────────────────
 
+    def to_assistant_message(self, stream_end) -> dict:
+        """Anthropic shape: one assistant message whose `content` is a
+        list of typed blocks. The SDK returns typed objects; we coerce
+        to {type, text} / {type, id, name, input} dicts that the API
+        accepts when echoed back on the next turn."""
+        content = []
+        for b in stream_end.content:
+            if b.type == "text":
+                content.append({"type": "text", "text": b.text or ""})
+            elif b.type == "tool_use":
+                content.append({
+                    "type":  "tool_use",
+                    "id":    b.id,
+                    "name":  b.name,
+                    "input": b.input or {},
+                })
+        return {"role": "assistant", "content": content}
+
+    def to_tool_result_messages(
+        self, tool_uses_with_results: list[tuple],
+    ) -> list[dict]:
+        """Anthropic: ONE user message with a list of tool_result blocks.
+        Splitting tool_results across messages is a wire-format error
+        per pre-reg §6.1 of epic #400."""
+        blocks = []
+        for tu, content, is_error in tool_uses_with_results:
+            blocks.append({
+                "type":          "tool_result",
+                "tool_use_id":   tu.id,
+                "content":       content,
+                "is_error":      is_error,
+            })
+        return [{"role": "user", "content": blocks}]
+
+    # Backward-compat shim — kept for one PR to avoid churning test
+    # call sites that imported this helper directly. To be deleted in
+    # Fase 3 of the multi-provider epic.
     def blocks_to_api_shape(self, blocks: list) -> list[dict]:
-        """Coerce the SDK's typed content blocks back to the dict form
-        the API accepts in the next request's `messages` array.
-
-        Mirrors the pre-refactor `_blocks_to_api_shape` in loop.py."""
+        """Deprecated: use to_assistant_message instead. Returns just
+        the `content` portion (the list of blocks) for callers that
+        wrap it in their own message dict."""
         out = []
         for b in blocks:
             if b.type == "text":

--- a/api/agent/providers/base.py
+++ b/api/agent/providers/base.py
@@ -24,6 +24,33 @@ from dataclasses import dataclass
 from typing import Any, AsyncIterator, Protocol
 
 
+# ── Synthetic content blocks ─────────────────────────────────────────
+
+
+# Adapters that don't get typed objects from their SDK (e.g. DeepSeek,
+# which is OpenAI-shape JSON) synthesize block instances of these
+# dataclasses and put them in LLMStreamEnd.content. The loop reads
+# `.type` and dispatches generically; `to_assistant_message` knows how
+# to serialize them back out to its wire shape. The Anthropic adapter
+# uses the SDK's TextBlock/ToolUseBlock instances directly — those
+# happen to expose the same attribute names, so the loop's reads
+# work either way.
+
+
+@dataclass(frozen=True)
+class SyntheticTextBlock:
+    text: str
+    type: str = "text"
+
+
+@dataclass(frozen=True)
+class SyntheticToolUseBlock:
+    id: str
+    name: str
+    input: dict
+    type: str = "tool_use"
+
+
 # ── LLMEvent closed enum ─────────────────────────────────────────────
 
 
@@ -148,15 +175,40 @@ class LLMProvider(Protocol):
         """
         ...
 
-    def blocks_to_api_shape(self, blocks: list) -> list[dict]:
-        """Convert the provider's content blocks (as returned in
-        LLMStreamEnd.content) back into the dict shape that goes into
-        the next request's `messages` array.
+    def to_assistant_message(self, stream_end: "LLMStreamEnd") -> dict:
+        """Build the full assistant message dict to append to the
+        conversation history for the next hop.
 
-        Anthropic's SDK gives us typed objects (TextBlock, ToolUseBlock)
-        that the API doesn't accept when echoed back — they need to be
-        coerced to {"type": "...", ...} dicts. DeepSeek/OpenAI already
-        returns dict-shaped content, so this is a no-op there."""
+        Anthropic shape:
+            {"role": "assistant",
+             "content": [{"type": "text", "text": "..."},
+                         {"type": "tool_use", "id": "...", "name": "...", "input": {...}}]}
+
+        DeepSeek shape:
+            {"role": "assistant",
+             "content": "<all text concatenated>",
+             "tool_calls": [{"id": "...", "type": "function",
+                             "function": {"name": "...", "arguments": "<json string>"}}]}
+
+        The loop appends the return value directly to `messages` —
+        provider owns the full shape.
+        """
+        ...
+
+    def to_tool_result_messages(
+        self, tool_uses_with_results: list[tuple],
+    ) -> list[dict]:
+        """Build the message(s) to append after dispatching tools.
+
+        `tool_uses_with_results` is a list of `(tool_use_block, content_string,
+        is_error)` tuples — one per dispatched tool in the hop.
+
+        Anthropic returns ONE user message with a list of tool_result
+        content blocks (the API rejects splitting across messages).
+
+        DeepSeek (OpenAI-shape) returns N messages with `role="tool"`,
+        one per tool_call, each with the tool_call_id reference.
+        """
         ...
 
     def estimate_cost(self, model: str, usage: dict) -> float:

--- a/api/agent/providers/deepseek_adapter.py
+++ b/api/agent/providers/deepseek_adapter.py
@@ -1,0 +1,408 @@
+"""DeepSeek adapter — implements LLMProvider over DeepSeek's
+OpenAI-compatible Chat Completions API (https://api.deepseek.com/v1).
+
+Fase 2 of the multi-provider epic. This module owns:
+  - Single concatenated system block (DeepSeek has no client-side
+    cache_control; the prefix gets auto-cached if stable).
+  - OpenAI-shape tool wire format `{type:"function", function:{name,
+    description, parameters}}`.
+  - SSE streaming via httpx, parsing OpenAI-style delta chunks into
+    LLMEvent instances.
+  - Synthetic content blocks (SyntheticTextBlock + SyntheticToolUseBlock)
+    that pass through the loop's `.type`/`.id`/`.name`/`.input` reads
+    just like Anthropic's typed objects.
+  - DeepSeek pricing table (V3 only in Fase 2; R1/reasoner in Fase 3).
+  - Translation between Anthropic-shape messages (the loop's internal
+    lingua franca through Fase 1) and DeepSeek-shape messages on the
+    way to the HTTP call (the wire). The loop's messages are in the
+    ACTIVE provider's shape — DS messages have role=tool + tool_calls
+    on assistant.
+
+Why httpx over the openai SDK:
+  - Keeps cost model fully under our control (no per-1M discount
+    surprises baked into a client lib).
+  - Avoids pulling openai for a non-OpenAI provider; cleaner deps.
+  - DeepSeek's stream format is simple enough that 100 lines of
+    SSE parsing is straightforward.
+  - The R1 reasoner extension in Fase 3 needs `reasoning_content`
+    parsing which the openai SDK may or may not surface; doing our
+    own parser future-proofs that.
+
+Pricing (Fase 2 spec §2.4):
+  - deepseek-chat (V3): $0.27 / $1.10 per 1M tok (in/out)
+  - deepseek-reasoner (R1): $0.55 / $2.19 per 1M tok (in/out) — added in Fase 3
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, AsyncIterator
+
+from api.agent.providers.base import (
+    LLMEvent,
+    LLMStreamEnd,
+    LLMTextDelta,
+    LLMToolUseStart,
+    SyntheticTextBlock,
+    SyntheticToolUseBlock,
+)
+
+log = logging.getLogger("api.agent.providers.deepseek")
+
+
+# ── Pricing ─────────────────────────────────────────────────────────
+
+
+# USD per 1M tokens. Cached snapshot 2026-04-29 from DeepSeek's
+# published pricing page.
+#
+# DeepSeek auto-caches stable prefixes but does NOT report cache stats
+# in `usage`. The PR #411 review pickup 2 (acknowledged in spec §6):
+# our cost estimate treats all input as fresh. The audit ends up
+# over-estimating spend vs the DeepSeek Console billing. Conservative
+# (safe — breaker trips before real spend reaches the cap); operator
+# compares at bake close to calibrate.
+#
+# Fase 3 adds deepseek-reasoner (R1).
+MODEL_PRICING: dict[str, dict[str, float]] = {
+    "deepseek-chat":     {"in": 0.27,  "out":  1.10},
+    # "deepseek-reasoner": {"in": 0.55,  "out":  2.19},  # Fase 3
+}
+
+
+# ── HTTP client construction ──────────────────────────────────────
+
+
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+
+
+def build_deepseek_client_kwargs() -> dict:
+    """Construct kwargs for DeepSeekProvider.__init__ in production.
+
+    Returns a dict with `api_key` from DEEPSEEK_API_KEY env var. The
+    registry's factory unpacks this. Tests inject FakeDeepSeekProvider
+    directly via dependency_overrides and never hit this path.
+    """
+    return {
+        "api_key": (os.environ.get("DEEPSEEK_API_KEY") or "").strip(),
+    }
+
+
+# ── The adapter ─────────────────────────────────────────────────────
+
+
+class DeepSeekProvider:
+    """LLMProvider implementation over DeepSeek's Chat Completions API.
+
+    Constructed by the registry's factory with an api_key (which may be
+    empty — has_api_key() reflects that). For format_*/estimate_cost
+    operations, no key is needed (the adapter just serializes shapes).
+    """
+
+    name = "deepseek"
+
+    def __init__(self, *, api_key: str = "") -> None:
+        self._api_key = api_key
+
+    # ── Discovery ───────────────────────────────────────────────────
+
+    def supports_model(self, model: str) -> bool:
+        return model.startswith("deepseek-")
+
+    def has_api_key(self) -> bool:
+        """Env-driven (mirrors AnthropicProvider's pattern): the instance
+        may have been constructed without a key for cheap operations
+        like format_tools/estimate_cost. The status check just wants to
+        know "is the vendor's env var configured at all?"."""
+        return bool((os.environ.get("DEEPSEEK_API_KEY") or "").strip())
+
+    # ── Wire-format translators ─────────────────────────────────────
+
+    def format_system_blocks(self, blocks: list[str]) -> list[dict]:
+        """DeepSeek (OpenAI-shape) accepts EITHER one system message
+        with concatenated text OR multiple system messages. We use a
+        SINGLE concatenated block — separators between the four logical
+        sections are preserved with double-newline. Single block has
+        two benefits:
+          1. Auto-cache hits more reliably (DS caches the longest
+             stable prefix; a single block IS the prefix).
+          2. We don't have to teach the loop that DS messages have
+             multiple system slots — at the wire level there's just
+             one system message.
+
+        The provider-neutral `cache_control` discipline (spec §2.2)
+        means the operator doesn't see breakpoints — DS auto-caches
+        whatever is stable.
+        """
+        if not blocks:
+            return []
+        concatenated = "\n\n".join(blocks)
+        return [{"role": "system", "content": concatenated}]
+
+    def format_tools(self, specs: tuple) -> list[dict]:
+        """OpenAI / DeepSeek shape:
+            {"type": "function",
+             "function": {"name": "...", "description": "...", "parameters": {...JSON schema...}}}
+
+        We strip `title` keys from the parameters schema the same way
+        AnthropicProvider does — for cache prefix determinism.
+        """
+        out = []
+        for spec in specs:
+            schema = spec.schema.model_json_schema()
+            _strip_titles(schema)
+            out.append({
+                "type": "function",
+                "function": {
+                    "name":        spec.name,
+                    "description": spec.description,
+                    "parameters":  schema,
+                },
+            })
+        return out
+
+    # ── Streaming ───────────────────────────────────────────────────
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        system_blocks: list[dict],
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: int,
+    ) -> AsyncIterator[LLMEvent]:
+        """Open one streaming connection against DeepSeek's chat completions.
+
+        Yields:
+          - LLMTextDelta on each `delta.content` chunk
+          - LLMToolUseStart on first `delta.tool_calls[i]` chunk
+            (when name first becomes known)
+          - LLMStreamEnd as terminal, with usage + synthesized content blocks
+
+        DeepSeek streams tool_calls as a sequence of partial deltas:
+          - First delta has `id` + `function.name` (sometimes empty args)
+          - Subsequent deltas accumulate `function.arguments` as a string
+            that ultimately parses to JSON
+          - When `finish_reason: "tool_calls"` arrives, all tool_calls
+            are complete
+
+        We accumulate per-index, parse on completion, synthesize a
+        SyntheticToolUseBlock with the parsed input dict.
+        """
+        import httpx
+
+        if not self._api_key:
+            raise RuntimeError(
+                "DeepSeekProvider has no API key. The registry factory "
+                "must read DEEPSEEK_API_KEY or tests must inject "
+                "FakeDeepSeekProvider directly."
+            )
+
+        # The DS wire wants `messages` to include the system message(s)
+        # as the first element(s). The loop's `messages` array is just
+        # the conversation; we prepend the system blocks.
+        wire_messages: list[dict] = list(system_blocks) + list(messages)
+
+        body = {
+            "model":      model,
+            "messages":   wire_messages,
+            "tools":      tools,
+            "max_tokens": max_tokens,
+            "stream":     True,
+        }
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type":  "application/json",
+        }
+
+        # Accumulators for the in-flight stream.
+        text_buf = ""
+        # tool_calls keyed by index → {id, name, arguments (str)}
+        tool_calls: dict[int, dict] = {}
+        announced: set[int] = set()  # which indices we already yielded ToolUseStart for
+        finish_reason: str | None = None
+        prompt_tokens = 0
+        completion_tokens = 0
+
+        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=120.0)) as client:
+            async with client.stream(
+                "POST", f"{DEEPSEEK_BASE_URL}/chat/completions",
+                json=body, headers=headers,
+            ) as resp:
+                if resp.status_code != 200:
+                    err_body = await resp.aread()
+                    raise RuntimeError(
+                        f"DeepSeek API returned {resp.status_code}: "
+                        f"{err_body[:200]!r}"
+                    )
+                async for line in resp.aiter_lines():
+                    if not line or not line.startswith("data: "):
+                        continue
+                    payload_str = line[len("data: "):]
+                    if payload_str.strip() == "[DONE]":
+                        break
+                    try:
+                        chunk = json.loads(payload_str)
+                    except json.JSONDecodeError:
+                        log.warning("DeepSeek: malformed SSE chunk: %s", payload_str[:100])
+                        continue
+
+                    # Usage chunks (DS sends these on the last few chunks).
+                    usage = chunk.get("usage")
+                    if usage:
+                        prompt_tokens = int(usage.get("prompt_tokens") or 0)
+                        completion_tokens = int(usage.get("completion_tokens") or 0)
+
+                    choices = chunk.get("choices") or []
+                    if not choices:
+                        continue
+                    choice0 = choices[0]
+                    fr = choice0.get("finish_reason")
+                    if fr:
+                        finish_reason = fr
+
+                    delta = choice0.get("delta") or {}
+                    if "content" in delta and delta["content"] is not None:
+                        text_buf += delta["content"]
+                        yield LLMTextDelta(text=delta["content"])
+
+                    for tc in (delta.get("tool_calls") or []):
+                        idx = int(tc.get("index", 0))
+                        bucket = tool_calls.setdefault(idx, {
+                            "id": "", "name": "", "arguments": "",
+                        })
+                        if tc.get("id"):
+                            bucket["id"] = tc["id"]
+                        fn = tc.get("function") or {}
+                        if fn.get("name"):
+                            bucket["name"] = fn["name"]
+                        if fn.get("arguments"):
+                            bucket["arguments"] += fn["arguments"]
+                        # Yield ToolUseStart the moment we have both id+name.
+                        if (idx not in announced
+                                and bucket["id"] and bucket["name"]):
+                            announced.add(idx)
+                            yield LLMToolUseStart(
+                                id=bucket["id"], name=bucket["name"],
+                            )
+
+        # Synthesize content blocks for the loop's reading conventions.
+        content: list = []
+        if text_buf:
+            content.append(SyntheticTextBlock(text=text_buf))
+        for idx in sorted(tool_calls):
+            tc = tool_calls[idx]
+            try:
+                parsed = json.loads(tc["arguments"]) if tc["arguments"] else {}
+            except json.JSONDecodeError:
+                log.warning(
+                    "DeepSeek: tool_call %s arguments not parseable JSON: %s",
+                    tc.get("name"), tc.get("arguments", "")[:100],
+                )
+                parsed = {}
+            content.append(SyntheticToolUseBlock(
+                id=tc["id"], name=tc["name"], input=parsed,
+            ))
+
+        # Normalize finish_reason to the loop's vocabulary. The loop
+        # checks `stop_reason != "tool_use"` to decide whether to
+        # dispatch and loop. DS uses "tool_calls"; map to "tool_use".
+        stop_reason = "tool_use" if finish_reason == "tool_calls" else (
+            finish_reason or "end_turn"
+        )
+        usage_dict = {
+            "input_tokens":                prompt_tokens,
+            "output_tokens":               completion_tokens,
+            # DeepSeek's auto-cache discount is NOT reported in usage.
+            # We can't tell from the response how much was cached vs
+            # fresh. Cost estimate treats all input as fresh — known
+            # over-estimate, documented in spec §6.
+            "cache_read_input_tokens":     0,
+            "cache_creation_input_tokens": 0,
+        }
+        yield LLMStreamEnd(
+            stop_reason=stop_reason,
+            usage=usage_dict,
+            content=content,
+        )
+
+    # ── Re-send shape (DeepSeek wire) ────────────────────────────────
+
+    def to_assistant_message(self, stream_end) -> dict:
+        """OpenAI / DeepSeek shape for the assistant message: a single
+        `content` string + an optional `tool_calls` array.
+
+        text blocks → concatenated content string
+        tool_use blocks → tool_calls entries with arguments as JSON STRING
+        """
+        content_text = ""
+        tool_calls: list[dict] = []
+        for b in stream_end.content:
+            if b.type == "text":
+                content_text += (b.text or "")
+            elif b.type == "tool_use":
+                tool_calls.append({
+                    "id":   b.id,
+                    "type": "function",
+                    "function": {
+                        "name":      b.name,
+                        # DS expects the arguments as a STRING; we
+                        # serialize the dict back to JSON for the wire.
+                        "arguments": json.dumps(b.input or {}, default=str),
+                    },
+                })
+        msg: dict = {"role": "assistant", "content": content_text}
+        if tool_calls:
+            msg["tool_calls"] = tool_calls
+        return msg
+
+    def to_tool_result_messages(
+        self, tool_uses_with_results: list[tuple],
+    ) -> list[dict]:
+        """DeepSeek: ONE tool message per tool_call. The tool_call_id
+        field correlates the result back to the assistant's tool_calls
+        entry."""
+        out: list[dict] = []
+        for tu, content, is_error in tool_uses_with_results:
+            out.append({
+                "role":         "tool",
+                "tool_call_id": tu.id,
+                "content":      content,
+            })
+        return out
+
+    # ── Cost ────────────────────────────────────────────────────────
+
+    def estimate_cost(self, model: str, usage: dict) -> float:
+        """Per-hop USD cost. DS doesn't report cache breakdown, so
+        ALL input tokens are charged as fresh (over-estimate vs real
+        billing; documented spec §6 risk + bake-close reconciliation
+        in the runbook of Fase 5)."""
+        p = MODEL_PRICING.get(model)
+        if not p:
+            return 0.0
+        in_per_m = p["in"]
+        out_per_m = p["out"]
+        in_tokens = (usage.get("input_tokens") or 0)
+        out_tokens = (usage.get("output_tokens") or 0)
+        cost = (
+            in_tokens * in_per_m + out_tokens * out_per_m
+        ) / 1_000_000.0
+        return round(cost, 6)
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _strip_titles(node: Any) -> None:
+    """Recursively remove `title` keys from a JSON-schema dict tree.
+    Same cache-prefix determinism rationale as AnthropicProvider."""
+    if isinstance(node, dict):
+        node.pop("title", None)
+        for v in node.values():
+            _strip_titles(v)
+    elif isinstance(node, list):
+        for v in node:
+            _strip_titles(v)

--- a/api/agent/providers/registry.py
+++ b/api/agent/providers/registry.py
@@ -42,11 +42,69 @@ def _anthropic_factory() -> Any:
     return AnthropicProvider(client=build_anthropic_client())
 
 
+def _deepseek_factory() -> Any:
+    """Lazy: construct DeepSeekProvider. DS uses raw httpx (no SDK to
+    import), so the factory only needs DEEPSEEK_API_KEY at construction
+    time. Tests inject FakeDeepSeekProvider via dependency_overrides
+    and never hit this path."""
+    from api.agent.providers.deepseek_adapter import (
+        DeepSeekProvider, build_deepseek_client_kwargs,
+    )
+    return DeepSeekProvider(**build_deepseek_client_kwargs())
+
+
 PROVIDER_BY_PREFIX: dict[str, Any] = {
-    "claude": _anthropic_factory,
-    # Phase 2 of the multi-provider epic adds:
-    # "deepseek": _deepseek_factory,
+    "claude":   _anthropic_factory,
+    "deepseek": _deepseek_factory,
 }
+
+
+# Prefix → canonical provider name. Necessary because the prefix is a
+# property of the model ID series (claude-*, deepseek-*) while the name
+# is a property of the vendor (anthropic, deepseek). For DeepSeek these
+# happen to coincide; for Anthropic they don't. Single source of truth
+# for both directions of the mapping.
+PROVIDER_NAME_BY_PREFIX: dict[str, str] = {
+    "claude":   "anthropic",
+    "deepseek": "deepseek",
+}
+
+
+# Mapping from provider name → adapter class, for callers that need
+# to call non-stream methods (format_system_blocks, format_tools,
+# estimate_cost) WITHOUT constructing an SDK client. Phase 2 of the
+# multi-provider epic + PR #412 review pickup 1: cleaner than the
+# previous if/elif by provider_name in loop.py.
+def get_provider_class_for_name(provider_name: str):
+    """Return the adapter CLASS (not an instance) for cheap operations
+    like tool formatting and cost calculation. Caller is responsible
+    for constructing an instance (cheap — no SDK required for these
+    methods)."""
+    if provider_name == "anthropic":
+        from api.agent.providers.anthropic_adapter import AnthropicProvider
+        return AnthropicProvider
+    if provider_name == "deepseek":
+        from api.agent.providers.deepseek_adapter import DeepSeekProvider
+        return DeepSeekProvider
+    raise UnknownProviderError(
+        f"no provider class registered for name {provider_name!r}"
+    )
+
+
+def get_provider_class_for_model(model: str):
+    """Convenience: resolve a model id to its adapter CLASS in one step.
+
+    Use this for cost calculation, tool formatting — anything that
+    needs the provider's logic but NOT a live SDK connection. The
+    caller can construct an instance cheaply (no API key validation,
+    no SDK import for the connection layer).
+    """
+    for prefix, name in PROVIDER_NAME_BY_PREFIX.items():
+        if model.startswith(f"{prefix}-"):
+            return get_provider_class_for_name(name)
+    raise UnknownProviderError(
+        f"no provider class for model {model!r}"
+    )
 
 
 # ── Resolver ─────────────────────────────────────────────────────────

--- a/api/agent/safety.py
+++ b/api/agent/safety.py
@@ -126,17 +126,34 @@ def collect_grounding_from_tool_results(
     seen_symbols:      set[str] = set()
 
     for msg in messages:
-        if msg.get("role") != "user":
+        # Two message shapes to handle (Fase 2 of multi-provider epic):
+        #
+        # Anthropic shape:
+        #   {"role": "user",
+        #    "content": [{"type": "tool_result", "tool_use_id": ..., "content": ...}, ...]}
+        #
+        # DeepSeek (OpenAI) shape:
+        #   {"role": "tool", "tool_call_id": ..., "content": "..."}
+        role = msg.get("role")
+        haystacks: list = []  # list of (raw_content) to scan
+
+        if role == "user":
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if (isinstance(block, dict)
+                            and block.get("type") == "tool_result"):
+                        haystacks.append(block.get("content"))
+        elif role == "tool":
+            # DeepSeek-shape: content is a string carrying the JSON of
+            # the tool result directly (no nested block list).
+            haystacks.append(msg.get("content"))
+        else:
             continue
-        content = msg.get("content")
-        if not isinstance(content, list):
-            continue
-        for block in content:
-            if not isinstance(block, dict) or block.get("type") != "tool_result":
-                continue
-            raw = block.get("content")
-            # Anthropic tool_result content can be a string OR a list of
-            # text blocks. We coerce both shapes to a single haystack.
+
+        for raw in haystacks:
+            # Both Anthropic and DS may have string OR list-of-text-blocks
+            # content. Coerce both shapes to a single haystack string.
             if isinstance(raw, list):
                 hay = " ".join(
                     (b.get("text") or "") for b in raw if isinstance(b, dict)

--- a/tests/_fakes.py
+++ b/tests/_fakes.py
@@ -393,6 +393,14 @@ class FakeAnthropicProvider:
     def blocks_to_api_shape(self, blocks: list) -> list[dict]:
         return self._real_adapter.blocks_to_api_shape(blocks)
 
+    def to_assistant_message(self, stream_end) -> dict:
+        return self._real_adapter.to_assistant_message(stream_end)
+
+    def to_tool_result_messages(
+        self, tool_uses_with_results: list[tuple],
+    ) -> list[dict]:
+        return self._real_adapter.to_tool_result_messages(tool_uses_with_results)
+
     def estimate_cost(self, model: str, usage: dict) -> float:
         return self._real_adapter.estimate_cost(model, usage)
 
@@ -453,6 +461,161 @@ class FakeAnthropicProvider:
 # The two names refer to the same class; new tests should use the
 # *Provider name to make the LLM-abstraction explicit.
 FakeAnthropicClient = FakeAnthropicProvider
+
+
+# ── FakeDeepSeekProvider (Fase 2 of the multi-provider epic) ────────
+
+
+class FakeDeepSeekProvider:
+    """Test double for DeepSeekProvider. Reuses the FakeTurnBuilder DX
+    (queue_turn / queue_error / .calls list) so tests describe one
+    model turn in the same vocabulary regardless of provider.
+
+    The fake's stream() translates the builder's Anthropic-shape events
+    to LLMEvents — identical translation logic to FakeAnthropicProvider.
+    Where the providers diverge is in:
+      - format_system_blocks (single concatenated block vs 4 cache_control'd)
+      - format_tools (OpenAI function shape vs Anthropic input_schema)
+      - to_assistant_message (content string + tool_calls vs blocks list)
+      - to_tool_result_messages (N role=tool messages vs 1 user with blocks)
+      - estimate_cost (DS pricing)
+
+    All those delegations route to the REAL DeepSeekProvider via
+    self._real_adapter (same pattern as FakeAnthropicProvider). Tests
+    that exercise the wire shape get byte-identical output to what
+    production would send.
+
+    The REAL DeepSeek SSE parsing logic (httpx + tool_calls accumulation)
+    is NOT exercised through this fake — that's tested directly against
+    DeepSeekProvider with a synthetic httpx mock in
+    tests/test_provider_deepseek.py (Fase 2).
+    """
+
+    name = "deepseek"
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self._queued: list[FakeStream] = []
+        # Construct a no-key adapter for wire-shape methods. has_api_key
+        # is env-driven, so this works as long as DEEPSEEK_API_KEY is
+        # set in the test env (most tests don't need it because they
+        # bypass the registry and inject this fake directly).
+        from api.agent.providers.deepseek_adapter import DeepSeekProvider
+        self._real_adapter = DeepSeekProvider()
+
+    # ── Test queueing API (mirrors FakeAnthropicProvider) ──────────
+
+    def queue_turn(self, built: tuple[list, "FakeFinalMessage"]) -> None:
+        events, final = built
+        self._queued.append(FakeStream(events=events, final=final))
+
+    def queue_error(self, exc: Exception, *, mid_stream: bool = False) -> None:
+        if mid_stream:
+            events, final = (
+                FakeTurnBuilder()
+                .text("partial chunk").text(" before drop")
+                .end_turn()
+                .build()
+            )
+            self._queued.append(FakeStream(
+                events=events, final=final, raise_mid_stream=exc,
+            ))
+        else:
+            self._queued.append(FakeStream(
+                events=[],
+                final=FakeFinalMessage(),
+                raise_on_enter=exc,
+            ))
+
+    def _next_stream(self) -> FakeStream:
+        if not self._queued:
+            raise RuntimeError(
+                "FakeDeepSeekProvider: no queued turns. The loop opened "
+                "more streams than the test queued — likely a runaway "
+                "tool-use cycle. Inspect self.calls to see what was sent."
+            )
+        return self._queued.pop(0)
+
+    # ── LLMProvider protocol ──────────────────────────────────────
+
+    def supports_model(self, model: str) -> bool:
+        return model.startswith("deepseek-")
+
+    def has_api_key(self) -> bool:
+        return True
+
+    def format_system_blocks(self, blocks: list[str]) -> list[dict]:
+        return self._real_adapter.format_system_blocks(blocks)
+
+    def format_tools(self, specs: tuple) -> list[dict]:
+        return self._real_adapter.format_tools(specs)
+
+    def to_assistant_message(self, stream_end) -> dict:
+        return self._real_adapter.to_assistant_message(stream_end)
+
+    def to_tool_result_messages(
+        self, tool_uses_with_results: list[tuple],
+    ) -> list[dict]:
+        return self._real_adapter.to_tool_result_messages(tool_uses_with_results)
+
+    def estimate_cost(self, model: str, usage: dict) -> float:
+        return self._real_adapter.estimate_cost(model, usage)
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        system_blocks: list[dict],
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: int,
+    ):
+        """Translate the builder's Anthropic-shape events to LLMEvents.
+        Identical translation as FakeAnthropicProvider — the fakes
+        agree on the internal LLMEvent contract; only the WIRE shapes
+        differ, and those are exercised by the format_* / to_* methods.
+
+        The final block list yielded in LLMStreamEnd.content carries
+        the builder's typed objects (FakeContentBlock with .type/.text/
+        .id/.name/.input attributes). The loop reads attributes
+        generically, so this works without DS-specific synthesis.
+        """
+        from api.agent.providers.base import (
+            LLMStreamEnd, LLMTextDelta, LLMToolUseStart,
+        )
+
+        self.calls.append({
+            "model":         model,
+            "system_blocks": system_blocks,
+            "messages":      messages,
+            "tools":         tools,
+            "max_tokens":    max_tokens,
+        })
+        fake_stream = self._next_stream()
+        async with fake_stream as s:
+            async for ev in s:
+                if ev.type == "content_block_start":
+                    cb = ev.content_block
+                    if cb is not None and cb.type == "tool_use":
+                        yield LLMToolUseStart(
+                            id=cb.id or "", name=cb.name or "",
+                        )
+                elif ev.type == "content_block_delta":
+                    d = ev.delta
+                    if d is not None and d.type == "text_delta" and d.text:
+                        yield LLMTextDelta(text=d.text)
+            final = await s.get_final_message()
+        usage_dict = {
+            "input_tokens":                getattr(final.usage, "input_tokens", 0) or 0,
+            "output_tokens":               getattr(final.usage, "output_tokens", 0) or 0,
+            "cache_read_input_tokens":     0,  # DS doesn't report cache stats
+            "cache_creation_input_tokens": 0,
+        }
+        yield LLMStreamEnd(
+            stop_reason=final.stop_reason,
+            usage=usage_dict,
+            content=list(final.content),
+        )
 
 
 # Cheap self-test at import — failures here surface as ImportError at

--- a/tests/test_agent_hallucination.py
+++ b/tests/test_agent_hallucination.py
@@ -148,6 +148,48 @@ def test_grounding_scan_handles_anthropic_tool_result_block_list_form():
     assert 5 in g["position_ids"]
 
 
+def test_grounding_scan_handles_deepseek_role_tool_messages():
+    """Fase 2 of multi-provider epic: DeepSeek puts tool results in
+    `{"role": "tool", "tool_call_id": ..., "content": "..."}` messages,
+    NOT in user messages with tool_result blocks. The hallucination
+    guard's grounding scan must surface IDs from both shapes."""
+    from api.agent.safety import collect_grounding_from_tool_results
+    # Mixed transcript — initial user, assistant with tool_calls, then
+    # DS-shape tool result, then assistant final text.
+    messages = [
+        {"role": "user", "content": "qué tengo"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "call_1", "type": "function",
+                          "function": {"name": "get_positions",
+                                        "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_1",
+         "content": '{"positions": [{"id": 88, "symbol": "ETHUSDT"}]}'},
+    ]
+    g = collect_grounding_from_tool_results(messages)
+    assert 88 in g["position_ids"]
+    assert "ETH" in g["symbols"]
+
+
+def test_grounding_scan_mixed_provider_shapes_in_one_history():
+    """Defensive — if a transcript ever combined Anthropic and DS shapes
+    (e.g. mid-conversation provider switch, never happens today but
+    locks the invariant), both still contribute to grounding."""
+    from api.agent.safety import collect_grounding_from_tool_results
+    messages = [
+        {"role": "user", "content": [{
+            "type": "tool_result", "tool_use_id": "toolu_1",
+            "content": '{"positions": [{"id": 10, "symbol": "BTCUSDT"}]}',
+        }]},
+        {"role": "tool", "tool_call_id": "call_2",
+         "content": '{"positions": [{"id": 20, "symbol": "ADAUSDT"}]}'},
+    ]
+    g = collect_grounding_from_tool_results(messages)
+    assert 10 in g["position_ids"]
+    assert 20 in g["position_ids"]
+    assert "BTC" in g["symbols"]
+    assert "ADA" in g["symbols"]
+
+
 # ── Public API: assert_text_grounded ─────────────────────────────
 
 

--- a/tests/test_agent_models.py
+++ b/tests/test_agent_models.py
@@ -49,13 +49,20 @@ def test_surface_model_defaults_snapshot():
 def test_allowed_models_snapshot():
     """Closed allowlist of accepted model IDs. Adding a new model is
     deliberate. Removing one is even more so — it can break in-flight
-    overrides."""
+    overrides.
+
+    Fase 2 of the multi-provider epic added `deepseek-chat`. The
+    defaults still point at Anthropic models; DS is opt-in via the
+    per-turn `model` override field on /agent/conversations/{id}/turn.
+    Fase 3 will add `deepseek-reasoner` (R1) and migrate defaults.
+    """
     from api.agent.models import ALLOWED_MODELS
 
     assert ALLOWED_MODELS == frozenset({
         "claude-sonnet-4-6",
         "claude-haiku-4-5",
         "claude-opus-4-7",
+        "deepseek-chat",
     })
 
 

--- a/tests/test_provider_deepseek.py
+++ b/tests/test_provider_deepseek.py
@@ -251,7 +251,317 @@ def test_deepseek_provider_conforms_to_llmprovider_protocol():
         )
 
 
-# ── 4. E2E through run_turn with FakeDeepSeekProvider ───────────
+# ── 4. SSE parsing — direct against DeepSeekProvider.stream() ───
+#
+# The FakeDeepSeekProvider bypasses the SSE accumulation logic entirely
+# (it translates FakeTurnBuilder events directly to LLMEvents). These
+# tests exercise the REAL DeepSeekProvider.stream() by mocking httpx
+# to return a pre-canonicalized SSE chunk list. The DS wire is what's
+# under test here, not our internal contract.
+#
+# PR #413 review pickup (prerequisite for Fase 3): without these
+# tests, the first real DS turn in production would be the first
+# test of the SSE accumulator. The cases covered match the failure
+# modes the reviewer enumerated:
+#   - tool_calls fragmented across N chunks (arguments string assembly)
+#   - 2 tool_calls in parallel (per-index bucketing)
+#   - text + tool_use interleaved
+#   - finish_reason early vs at-end ordering
+
+
+class _FakeHTTPXResponse:
+    """Minimal mock of httpx.Response in the streaming context. Supports
+    .status_code + async aiter_lines() returning the queued SSE lines."""
+
+    def __init__(self, *, status_code: int, lines: list[str]):
+        self.status_code = status_code
+        self._lines = lines
+
+    async def aread(self) -> bytes:
+        # Only called on non-200 path.
+        return b'{"error": "test"}'
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+
+class _FakeStreamCM:
+    """async-with context manager for httpx.AsyncClient.stream()."""
+
+    def __init__(self, response: _FakeHTTPXResponse):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *a):
+        return None
+
+
+class _FakeHTTPXClient:
+    """async-with context manager replacing httpx.AsyncClient. Returns
+    a stream() method that itself returns _FakeStreamCM."""
+
+    def __init__(self, response: _FakeHTTPXResponse, *,
+                 calls_recorder: list | None = None):
+        self._response = response
+        self._calls_recorder = calls_recorder if calls_recorder is not None else []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return None
+
+    def stream(self, method: str, url: str, *, json=None, headers=None):
+        self._calls_recorder.append({
+            "method": method, "url": url, "json": json, "headers": headers,
+        })
+        return _FakeStreamCM(self._response)
+
+
+def _install_fake_httpx(monkeypatch, *, lines: list[str], status_code: int = 200):
+    """Monkeypatch httpx.AsyncClient with a fake that returns the given
+    SSE lines. Returns the calls_recorder list so tests can inspect
+    what was actually sent on the wire."""
+    import httpx
+    response = _FakeHTTPXResponse(status_code=status_code, lines=lines)
+    calls_recorder: list = []
+    # httpx.AsyncClient(timeout=...) returns the client; we need a
+    # factory that captures the timeout but returns our fake.
+    def _factory(*a, **kw):
+        return _FakeHTTPXClient(response, calls_recorder=calls_recorder)
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+    return calls_recorder
+
+
+@pytest.mark.anyio
+async def test_deepseek_stream_text_only(monkeypatch):
+    """Two text chunks + finish → LLMTextDelta x 2 + LLMStreamEnd with
+    stop_reason='end_turn' (DS sends 'stop')."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    from api.agent.providers.base import (
+        LLMStreamEnd, LLMTextDelta, SyntheticTextBlock,
+    )
+
+    lines = [
+        'data: {"choices":[{"delta":{"content":"Hola "}}]}',
+        'data: {"choices":[{"delta":{"content":"mundo"}}]}',
+        'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":50,"completion_tokens":10}}',
+        'data: [DONE]',
+    ]
+    _install_fake_httpx(monkeypatch, lines=lines)
+
+    p = DeepSeekProvider(api_key="sk-fake")
+    events = []
+    async for ev in p.stream(
+        model="deepseek-chat", system_blocks=[], messages=[],
+        tools=[], max_tokens=4096,
+    ):
+        events.append(ev)
+
+    text_deltas = [e for e in events if isinstance(e, LLMTextDelta)]
+    ends = [e for e in events if isinstance(e, LLMStreamEnd)]
+    assert "".join(d.text for d in text_deltas) == "Hola mundo"
+    assert len(ends) == 1
+    end = ends[0]
+    assert end.stop_reason == "stop"
+    assert end.usage["input_tokens"] == 50
+    assert end.usage["output_tokens"] == 10
+    assert len(end.content) == 1
+    assert isinstance(end.content[0], SyntheticTextBlock)
+    assert end.content[0].text == "Hola mundo"
+
+
+@pytest.mark.anyio
+async def test_deepseek_stream_accumulates_tool_call_fragmented_arguments(monkeypatch):
+    """DS streams tool_calls.function.arguments across N chunks. The
+    adapter accumulates them into a single SyntheticToolUseBlock with
+    the parsed input dict. This is the highest-risk path of the SSE
+    parser — PR #413 review prerequisite."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    from api.agent.providers.base import (
+        LLMStreamEnd, LLMToolUseStart, SyntheticToolUseBlock,
+    )
+
+    lines = [
+        # First delta: id + name, empty args
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_positions","arguments":""}}]}}]}',
+        # Subsequent deltas: args string grows
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"win"}}]}}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"dow\\":\\"7d\\"}"}}]}}]}',
+        # Finish + usage
+        'data: {"choices":[{"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":120,"completion_tokens":30}}',
+        'data: [DONE]',
+    ]
+    _install_fake_httpx(monkeypatch, lines=lines)
+
+    p = DeepSeekProvider(api_key="sk-fake")
+    events = []
+    async for ev in p.stream(
+        model="deepseek-chat", system_blocks=[], messages=[],
+        tools=[], max_tokens=4096,
+    ):
+        events.append(ev)
+
+    starts = [e for e in events if isinstance(e, LLMToolUseStart)]
+    ends = [e for e in events if isinstance(e, LLMStreamEnd)]
+    assert len(starts) == 1
+    assert starts[0].id == "call_1"
+    assert starts[0].name == "get_positions"
+    assert len(ends) == 1
+    end = ends[0]
+    # finish_reason=tool_calls normalizes to stop_reason=tool_use for
+    # the loop's vocabulary.
+    assert end.stop_reason == "tool_use"
+    # Content has ONE SyntheticToolUseBlock with PARSED input dict.
+    tool_blocks = [b for b in end.content if isinstance(b, SyntheticToolUseBlock)]
+    assert len(tool_blocks) == 1
+    assert tool_blocks[0].id == "call_1"
+    assert tool_blocks[0].name == "get_positions"
+    assert tool_blocks[0].input == {"window": "7d"}
+
+
+@pytest.mark.anyio
+async def test_deepseek_stream_parallel_tool_calls_bucketed_by_index(monkeypatch):
+    """DS can emit multiple tool_calls in parallel. The adapter buckets
+    by `index` so their arguments don't blend into one another. Each
+    bucket synthesizes its own SyntheticToolUseBlock."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    from api.agent.providers.base import (
+        LLMStreamEnd, LLMToolUseStart, SyntheticToolUseBlock,
+    )
+
+    lines = [
+        # Both tool_calls start in different deltas (real DS behavior)
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"get_positions","arguments":""}}]}}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_b","type":"function","function":{"name":"get_kill_switch_state","arguments":""}}]}}]}',
+        # Args for both, interleaved
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]}}]}',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{}"}}]}}]}',
+        'data: {"choices":[{"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":80,"completion_tokens":20}}',
+        'data: [DONE]',
+    ]
+    _install_fake_httpx(monkeypatch, lines=lines)
+
+    p = DeepSeekProvider(api_key="sk-fake")
+    events = []
+    async for ev in p.stream(
+        model="deepseek-chat", system_blocks=[], messages=[],
+        tools=[], max_tokens=4096,
+    ):
+        events.append(ev)
+
+    starts = [e for e in events if isinstance(e, LLMToolUseStart)]
+    # Order: started in chunk-arrival order (a then b).
+    assert [s.id for s in starts] == ["call_a", "call_b"]
+    assert [s.name for s in starts] == ["get_positions", "get_kill_switch_state"]
+
+    end = next(e for e in events if isinstance(e, LLMStreamEnd))
+    tool_blocks = [b for b in end.content if isinstance(b, SyntheticToolUseBlock)]
+    # Bucketed by index → 2 distinct blocks, NOT merged.
+    assert len(tool_blocks) == 2
+    by_id = {b.id: b for b in tool_blocks}
+    assert by_id["call_a"].name == "get_positions"
+    assert by_id["call_a"].input == {}
+    assert by_id["call_b"].name == "get_kill_switch_state"
+    assert by_id["call_b"].input == {}
+
+
+@pytest.mark.anyio
+async def test_deepseek_stream_malformed_tool_args_swallows_with_warn(monkeypatch, caplog):
+    """If DS streams arguments that don't parse as JSON (provider bug,
+    truncated stream, etc), the adapter logs a warning + synthesizes
+    the block with input={}. Doesn't crash the stream."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    from api.agent.providers.base import LLMStreamEnd, SyntheticToolUseBlock
+
+    lines = [
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_bad","function":{"name":"get_positions","arguments":""}}]}}]}',
+        # Truncated / malformed JSON — never closes the brace
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{unclosed"}}]}}]}',
+        'data: {"choices":[{"finish_reason":"tool_calls"}]}',
+        'data: [DONE]',
+    ]
+    _install_fake_httpx(monkeypatch, lines=lines)
+
+    p = DeepSeekProvider(api_key="sk-fake")
+    events = []
+    async for ev in p.stream(
+        model="deepseek-chat", system_blocks=[], messages=[],
+        tools=[], max_tokens=4096,
+    ):
+        events.append(ev)
+
+    end = next(e for e in events if isinstance(e, LLMStreamEnd))
+    tool_blocks = [b for b in end.content if isinstance(b, SyntheticToolUseBlock)]
+    assert len(tool_blocks) == 1
+    # Defensive: malformed args → empty dict, not a crash.
+    assert tool_blocks[0].input == {}
+    # Log captured the warn (DS bug debuggability).
+    assert any("not parseable JSON" in r.message for r in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_deepseek_stream_non_200_status_raises(monkeypatch):
+    """A 429 / 503 / 4xx from DS surfaces as RuntimeError. The loop's
+    catch-all converts to ErrorEvent reason='upstream' (verified by
+    the existing test_upstream_mid_stream_drop_emits_friendly_error
+    pattern in test_agent_graceful_failures.py)."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+
+    _install_fake_httpx(monkeypatch, lines=[], status_code=429)
+
+    p = DeepSeekProvider(api_key="sk-fake")
+    with pytest.raises(RuntimeError, match="429"):
+        async for _ in p.stream(
+            model="deepseek-chat", system_blocks=[], messages=[],
+            tools=[], max_tokens=4096,
+        ):
+            pass
+
+
+@pytest.mark.anyio
+async def test_deepseek_stream_sends_correct_wire_body(monkeypatch):
+    """Sanity check on the request body the adapter sends to DS.
+    Verifies: model echoed, messages prepended with system blocks,
+    tools passed through, stream=True, Authorization header set."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+
+    lines = [
+        'data: {"choices":[{"delta":{"content":"ok"}}]}',
+        'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}',
+        'data: [DONE]',
+    ]
+    calls = _install_fake_httpx(monkeypatch, lines=lines)
+
+    p = DeepSeekProvider(api_key="sk-test-key")
+    async for _ in p.stream(
+        model="deepseek-chat",
+        system_blocks=[{"role": "system", "content": "you are X"}],
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[{"type": "function", "function": {"name": "f"}}],
+        max_tokens=2048,
+    ):
+        pass
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["method"] == "POST"
+    assert "/chat/completions" in call["url"]
+    assert call["headers"]["Authorization"] == "Bearer sk-test-key"
+    body = call["json"]
+    assert body["model"] == "deepseek-chat"
+    assert body["max_tokens"] == 2048
+    assert body["stream"] is True
+    # System blocks prepended to messages — first item is system,
+    # second is the user msg.
+    assert body["messages"][0]["role"] == "system"
+    assert body["messages"][1]["role"] == "user"
+
+
+# ── 5. E2E through run_turn with FakeDeepSeekProvider ───────────
 
 
 @pytest.fixture

--- a/tests/test_provider_deepseek.py
+++ b/tests/test_provider_deepseek.py
@@ -1,0 +1,380 @@
+"""Fase 2 of the multi-provider epic — DeepSeek adapter tests.
+
+Layered like test_provider_registry.py:
+
+  1. UNIT TESTS for DeepSeekProvider methods that don't need HTTP
+     (supports_model, has_api_key, format_system_blocks, format_tools,
+     to_assistant_message, to_tool_result_messages, estimate_cost).
+
+  2. STREAM PARSING TESTS for DeepSeekProvider.stream() with a mocked
+     httpx response. Exercises:
+       - Text content delta accumulation
+       - Tool_calls delta accumulation across chunks
+       - finish_reason="tool_calls" → stop_reason="tool_use" mapping
+       - Synthesized SyntheticTextBlock + SyntheticToolUseBlock in
+         LLMStreamEnd.content
+
+  3. E2E PARITY TESTS driving run_turn through FakeDeepSeekProvider.
+     Same scenarios as test_agent_loop.py's Anthropic path, but with
+     deepseek-chat. Locks the contract that the loop is provider-
+     agnostic above the protocol layer.
+
+  4. WIRE-SHAPE VERIFICATION: when a DS turn dispatches tools, the
+     messages list mutated by the loop has the correct DS shape
+     (role=tool messages, assistant tool_calls). The hallucination
+     guard's grounding scan works for both shapes (verified separately
+     in test_agent_hallucination.py).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests._fakes import FakeDeepSeekProvider, FakeTurnBuilder
+
+
+# ── 1. Unit tests ────────────────────────────────────────────────
+
+
+def test_deepseek_supports_only_deepseek_models():
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    p = DeepSeekProvider()
+    assert p.supports_model("deepseek-chat") is True
+    assert p.supports_model("deepseek-reasoner") is True
+    assert p.supports_model("claude-sonnet-4-6") is False
+    assert p.supports_model("gpt-5") is False
+
+
+def test_deepseek_has_api_key_reads_env(monkeypatch):
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    assert DeepSeekProvider().has_api_key() is False
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-fake")
+    assert DeepSeekProvider().has_api_key() is True
+
+
+def test_deepseek_format_system_blocks_concatenates_into_single_block():
+    """DeepSeek doesn't support per-block cache_control. We collapse
+    the 4 logical blocks into ONE system message with double-newline
+    separators so the wire prefix is a single contiguous string —
+    maximizes auto-cache hit."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    out = DeepSeekProvider().format_system_blocks(
+        ["persona text", "tool docs text", "invariants text", "surface text"]
+    )
+    assert len(out) == 1
+    msg = out[0]
+    assert msg["role"] == "system"
+    expected = "persona text\n\ntool docs text\n\ninvariants text\n\nsurface text"
+    assert msg["content"] == expected
+
+
+def test_deepseek_format_system_blocks_empty():
+    """No blocks → no system messages. Defensive — the caller would
+    normally pass 4 blocks but we don't want to emit a stub on an
+    empty input."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    assert DeepSeekProvider().format_system_blocks([]) == []
+
+
+def test_deepseek_format_tools_emits_openai_shape():
+    """OpenAI/DeepSeek shape: top-level type=function + nested function
+    object with name/description/parameters."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    from api.agent.tools.registry import tools_for_surface
+
+    specs = tools_for_surface("dock")
+    out = DeepSeekProvider().format_tools(specs)
+    assert len(out) == len(specs)
+    for tool in out:
+        assert tool["type"] == "function"
+        assert set(tool["function"].keys()) == {"name", "description", "parameters"}
+        # Title stripping (cache determinism).
+        _assert_no_title(tool["function"]["parameters"])
+
+
+def _assert_no_title(node):
+    if isinstance(node, dict):
+        assert "title" not in node, f"unstripped title: {node}"
+        for v in node.values():
+            _assert_no_title(v)
+    elif isinstance(node, list):
+        for v in node:
+            _assert_no_title(v)
+
+
+def test_deepseek_estimate_cost_matches_published_pricing():
+    """deepseek-chat: $0.27/1M in, $1.10/1M out. 1M in + 1M out = $1.37."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    cost = DeepSeekProvider().estimate_cost(
+        "deepseek-chat",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    assert cost == pytest.approx(1.37)
+
+
+def test_deepseek_estimate_cost_ignores_cache_breakdown():
+    """DS doesn't report cache stats — our estimate treats all input
+    as fresh. Documented overestimate vs DS Console (spec §6 risk)."""
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    # Even if the caller passes cache_read tokens, they're ignored.
+    cost_no_cache = DeepSeekProvider().estimate_cost(
+        "deepseek-chat",
+        {"input_tokens": 1_000_000, "output_tokens": 0},
+    )
+    cost_with_cache = DeepSeekProvider().estimate_cost(
+        "deepseek-chat",
+        {"input_tokens": 1_000_000, "output_tokens": 0,
+         "cache_read_input_tokens": 500_000, "cache_creation_input_tokens": 0},
+    )
+    # Identical — cache_read tokens don't get any discount in our calc.
+    assert cost_no_cache == cost_with_cache
+    assert cost_no_cache == pytest.approx(0.27)
+
+
+def test_deepseek_estimate_cost_returns_zero_for_unknown_model():
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    assert DeepSeekProvider().estimate_cost("deepseek-future", {}) == 0.0
+
+
+# ── 2. Message shape translation ─────────────────────────────────
+
+
+def test_deepseek_to_assistant_message_with_only_text():
+    from api.agent.providers.base import LLMStreamEnd, SyntheticTextBlock
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+
+    se = LLMStreamEnd(
+        stop_reason="end_turn",
+        usage={"input_tokens": 0, "output_tokens": 0,
+               "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+        content=[SyntheticTextBlock(text="Hola mundo")],
+    )
+    out = DeepSeekProvider().to_assistant_message(se)
+    assert out == {"role": "assistant", "content": "Hola mundo"}
+    # No tool_calls key when there are no tool_use blocks.
+    assert "tool_calls" not in out
+
+
+def test_deepseek_to_assistant_message_with_tool_use():
+    from api.agent.providers.base import (
+        LLMStreamEnd, SyntheticTextBlock, SyntheticToolUseBlock,
+    )
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+
+    se = LLMStreamEnd(
+        stop_reason="tool_use",
+        usage={"input_tokens": 0, "output_tokens": 0,
+               "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0},
+        content=[
+            SyntheticTextBlock(text="Voy a mirar tus posiciones"),
+            SyntheticToolUseBlock(id="call_1", name="get_positions", input={"window": "7d"}),
+        ],
+    )
+    out = DeepSeekProvider().to_assistant_message(se)
+    assert out["role"] == "assistant"
+    assert out["content"] == "Voy a mirar tus posiciones"
+    assert len(out["tool_calls"]) == 1
+    tc = out["tool_calls"][0]
+    assert tc["id"] == "call_1"
+    assert tc["type"] == "function"
+    assert tc["function"]["name"] == "get_positions"
+    # DS expects arguments as a STRING (JSON-encoded).
+    assert isinstance(tc["function"]["arguments"], str)
+    assert json.loads(tc["function"]["arguments"]) == {"window": "7d"}
+
+
+def test_deepseek_to_tool_result_messages_emits_one_per_tool():
+    from api.agent.providers.base import SyntheticToolUseBlock
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+
+    tu1 = SyntheticToolUseBlock(id="call_1", name="get_positions", input={})
+    tu2 = SyntheticToolUseBlock(id="call_2", name="get_kill_switch_state", input={})
+    out = DeepSeekProvider().to_tool_result_messages([
+        (tu1, '{"positions": []}', False),
+        (tu2, '{"portfolio_tier": "NORMAL"}', False),
+    ])
+    # DS emits N tool messages — NOT one user message with N blocks.
+    assert len(out) == 2
+    assert out[0] == {
+        "role": "tool", "tool_call_id": "call_1",
+        "content": '{"positions": []}',
+    }
+    assert out[1] == {
+        "role": "tool", "tool_call_id": "call_2",
+        "content": '{"portfolio_tier": "NORMAL"}',
+    }
+
+
+# ── 3. Registry + protocol ───────────────────────────────────────
+
+
+def test_deepseek_provider_class_resolves_via_registry():
+    from api.agent.providers.registry import get_provider_class_for_name
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    assert get_provider_class_for_name("deepseek") is DeepSeekProvider
+
+
+def test_deepseek_model_resolves_via_class_helper():
+    from api.agent.providers.registry import get_provider_class_for_model
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+    assert get_provider_class_for_model("deepseek-chat") is DeepSeekProvider
+
+
+def test_estimate_cost_dispatches_deepseek_model_via_loop_shim():
+    """The loop's _estimate_cost_usd shim uses the registry to find
+    the right adapter. A deepseek-chat model id should land in DS
+    pricing, not Anthropic's."""
+    from api.agent.loop import _estimate_cost_usd
+
+    cost_ds = _estimate_cost_usd(
+        "deepseek-chat",
+        {"input_tokens": 1_000_000, "output_tokens": 1_000_000},
+    )
+    # $1.37 (DS pricing) — significantly lower than the $18 Anthropic
+    # Sonnet number locked in test_cost_estimation_matches_published_pricing.
+    assert cost_ds == pytest.approx(1.37)
+
+
+def test_deepseek_provider_conforms_to_llmprovider_protocol():
+    """Same structural protocol check we have for AnthropicProvider —
+    every public method on LLMProvider exists on DeepSeekProvider."""
+    from api.agent.providers.base import LLMProvider
+    from api.agent.providers.deepseek_adapter import DeepSeekProvider
+
+    required = [m for m in dir(LLMProvider) if not m.startswith("_")]
+    p = DeepSeekProvider()
+    for method_name in required:
+        assert hasattr(p, method_name), (
+            f"DeepSeekProvider missing {method_name!r} required by LLMProvider"
+        )
+
+
+# ── 4. E2E through run_turn with FakeDeepSeekProvider ───────────
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+async def _collect(events_iter):
+    out = []
+    async for ev in events_iter:
+        out.append(ev)
+    return out
+
+
+@pytest.mark.anyio
+async def test_deepseek_simple_text_turn(tmp_db):
+    """A text-only turn with deepseek-chat completes end-to-end:
+    TextDelta events + MessageEnd with DS cost calculated."""
+    from api.agent.loop import run_turn, TextDelta, MessageEnd
+
+    c = FakeDeepSeekProvider()
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("Hola ").text("desde DeepSeek")
+        .end_turn()
+        .usage(input_tokens=100, output_tokens=20)
+        .build()
+    )
+
+    msgs = [{"role": "user", "content": "saluda"}]
+    events = await _collect(run_turn(
+        client=c, model="deepseek-chat", surface="dock",
+        messages=msgs, tenant_id=1,
+    ))
+
+    text_deltas = [e for e in events if isinstance(e, TextDelta)]
+    ends = [e for e in events if isinstance(e, MessageEnd)]
+    assert "".join(d.text for d in text_deltas) == "Hola desde DeepSeek"
+    assert len(ends) == 1
+    # Cost: 100 in × $0.27/1M + 20 out × $1.10/1M = $0.000049
+    assert ends[0].cost_usd == pytest.approx(
+        (100 * 0.27 + 20 * 1.10) / 1_000_000.0, rel=1e-3,
+    )
+    # DS doesn't report cache stats; both fields are 0.
+    assert ends[0].usage["cache_read_input_tokens"] == 0
+
+
+@pytest.mark.anyio
+async def test_deepseek_tool_use_turn_appends_role_tool_messages(tmp_db, monkeypatch):
+    """A tool_use turn through deepseek-chat: the loop appends an
+    assistant message with `tool_calls` + N `role=tool` messages
+    (one per tool dispatched). NOT one user message with tool_result
+    blocks — that's Anthropic shape.
+    """
+    from api.agent.loop import run_turn, ToolUseStart, ToolUseResult, MessageEnd
+    from api.agent.tools import handlers as h
+
+    captured = {}
+
+    def _stub_get_positions(*, tenant_id):
+        captured["tenant_id"] = tenant_id
+        return {"positions": [{"id": 7, "symbol": "BTCUSDT"}]}
+    monkeypatch.setitem(h.TOOL_HANDLERS, "get_positions", _stub_get_positions)
+
+    c = FakeDeepSeekProvider()
+    # Hop 1: tool_use
+    c.queue_turn(
+        FakeTurnBuilder()
+        .tool_use("get_positions", {}, tool_use_id="call_1")
+        .stop_tool_use()
+        .usage(input_tokens=50, output_tokens=10)
+        .build()
+    )
+    # Hop 2: final text
+    c.queue_turn(
+        FakeTurnBuilder()
+        .text("Tu posición #7 de BTC sigue abierta.")
+        .end_turn()
+        .usage(input_tokens=80, output_tokens=20)
+        .build()
+    )
+
+    msgs = [{"role": "user", "content": "qué posiciones tengo"}]
+    events = await _collect(run_turn(
+        client=c, model="deepseek-chat", surface="dock",
+        messages=msgs, tenant_id=42,
+    ))
+
+    starts = [e for e in events if isinstance(e, ToolUseStart)]
+    results = [e for e in events if isinstance(e, ToolUseResult)]
+    ends = [e for e in events if isinstance(e, MessageEnd)]
+    assert [s.tool for s in starts] == ["get_positions"]
+    assert [r.status for r in results] == ["ok"]
+    assert len(ends) == 1
+    # Cost sums across both hops. estimate_cost rounds each hop to
+    # 6 decimals before the loop sums; the test mirrors that to avoid
+    # float epsilon mismatch (sum-of-rounded != round-of-sum).
+    h1 = round((50 * 0.27 + 10 * 1.10) / 1_000_000.0, 6)
+    h2 = round((80 * 0.27 + 20 * 1.10) / 1_000_000.0, 6)
+    assert ends[0].cost_usd == pytest.approx(h1 + h2, abs=1e-7)
+    # Tenant binding worked.
+    assert captured["tenant_id"] == 42
+
+    # Wire-shape verification: messages array has DeepSeek shape now.
+    # [0] = initial user
+    # [1] = assistant with tool_calls (string content + list tool_calls)
+    # [2] = role=tool message with result (ONE message per tool)
+    # [3] = assistant with final text
+    assert msgs[1]["role"] == "assistant"
+    assert "tool_calls" in msgs[1]
+    assert len(msgs[1]["tool_calls"]) == 1
+    assert msgs[1]["tool_calls"][0]["function"]["name"] == "get_positions"
+
+    assert msgs[2]["role"] == "tool"
+    assert msgs[2]["tool_call_id"] == "call_1"
+    # The result content is a JSON string (NOT a list of blocks like
+    # Anthropic does).
+    assert isinstance(msgs[2]["content"], str)
+    parsed_result = json.loads(msgs[2]["content"])
+    assert parsed_result["positions"][0]["id"] == 7


### PR DESCRIPTION
## Summary

Fase 2 of the multi-provider epic. Plugs **deepseek-chat (V3)** as opt-in via per-turn `model` override. **Defaults remain on Anthropic** — Fase 3 migrates them after parity validation. The structural divergence (DS uses `role=tool` + `tool_calls` on assistant vs Anthropic's nested content blocks) is handled in the adapter's `to_assistant_message` + `to_tool_result_messages` — the loop stays provider-agnostic.

## Protocol extensions (`api/agent/providers/base.py`)
- **SyntheticTextBlock + SyntheticToolUseBlock** dataclasses. Adapters without SDK-typed objects (DS, future OpenAI) synthesize blocks with the same attributes the loop reads.
- **`to_assistant_message(stream_end) -> dict`** — full assistant message in provider's wire shape. Replaces `blocks_to_api_shape` (kept as deprecated shim for one PR).
- **`to_tool_result_messages(tool_uses_with_results) -> list[dict]`** — Anthropic emits 1 user message; DS emits N tool messages.

## `api/agent/providers/deepseek_adapter.py` (NEW)
- httpx-based SSE client against `api.deepseek.com/v1/chat/completions` (no SDK dep).
- `format_system_blocks`: single concatenated block (DS doesn't support per-block `cache_control`; auto-cache uses the longest stable prefix).
- `format_tools`: OpenAI function shape `{type:"function", function:{name, description, parameters}}`. Title-stripping mirrors Anthropic.
- `stream(...)`: accumulates `tool_calls` deltas (DS streams arguments as a string across multiple chunks), parses on completion, synthesizes content blocks. Maps `finish_reason='tool_calls'` → `stop_reason='tool_use'` for the loop's vocabulary.
- `to_assistant_message`: synthesizes `{content: string, tool_calls: [...]}`. Arguments serialized as JSON STRING (DS wire contract).
- `to_tool_result_messages`: ONE `{role: 'tool', tool_call_id, content}` per dispatched tool.
- `estimate_cost`: deepseek-chat at $0.27 / $1.10 per 1M. DS doesn't report cache stats; estimate treats all input as fresh (documented overestimate vs DS Console, spec §6).

## §2.7 status check (finally wired)
`api/agent/config._default_provider_has_key()` resolves the provider for the dock default model and checks its `has_api_key()`. Status returns `agent_disabled` when the default's key is missing, regardless of other providers' keys.

## Registry helpers (PR #412 review pickup 1)
- `get_provider_class_for_name(name)` — returns adapter CLASS without SDK construction.
- `get_provider_class_for_model(model)` — convenience: prefix → class.
- `_estimate_cost_usd` + `_cached_formatted_tools` in loop.py dispatch via these helpers (no more hardcoded if/elif).

## Hallucination guard (`api/agent/safety.py`)
`collect_grounding_from_tool_results` now scans BOTH shapes: Anthropic user-message-with-tool_result-blocks AND DeepSeek `role='tool'` messages.

## Tests
- **190 backend** tests passing (28 net new), 1 skipped (live)
- **94 frontend** tests passing (untouched)
- TS clean

Test file `tests/test_provider_deepseek.py` (17 tests):
- 8 unit (supports_model, has_api_key, format_system_blocks, format_tools, estimate_cost x3, unknown model)
- 3 wire-shape (to_assistant_message text-only / with tool_use; to_tool_result_messages)
- 3 registry (class for name, class for model, loop shim routes DS)
- 1 protocol conformance
- 2 E2E through `run_turn` with FakeDeepSeekProvider (text turn + tool_use turn with full wire verification)

Plus 2 new grounding tests in `test_agent_hallucination.py` for DS `role=tool` + mixed-shape transcripts.

## Out of scope (Fase 3)
- `deepseek-reasoner` (R1) + `reasoning_content` SSE event type
- `SURFACE_MODEL_DEFAULTS` migration to DS (split into PR 3a UX + PR 3b defaults per spec §4)
- Per-provider daily caps in circuit breaker (PR #411 §8 pickup)
- DS auto-cache discount + off-peak modeling in `estimate_cost` (spec §6 risk pickup)
- `reasoning_tokens INTEGER` column in `agent_conversations`

## Test plan
- [ ] CI green
- [ ] Manual review of `deepseek_adapter.py:stream(...)` — the SSE accumulation logic is the highest-risk code in this PR
- [ ] Verify that a real `DEEPSEEK_API_KEY` could be set (no need to actually call DS) and the wire format would be accepted by their endpoint — `test_deepseek_format_tools_emits_openai_shape` locks the shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)