### PR TITLE
feat(agent): Fase 3b multi-provider — migrate defaults to DS + PR #414 review pickups

### DIFF
--- a/api/agent/clients.py
+++ b/api/agent/clients.py
@@ -31,17 +31,29 @@ log = logging.getLogger("api.agent.clients")
 
 
 def get_anthropic_client():
-    """FastAPI dependency that returns the active LLMProvider.
+    """FastAPI dependency — status gate ONLY.
 
-    PHASE 1 NOTE: returns an LLMProvider, not a raw Anthropic SDK
-    client. The name is kept for backward-compat with the 13+ test
-    `dependency_overrides[get_anthropic_client]` call sites. Tests
-    inject `FakeAnthropicProvider` which implements the protocol.
+    Fase 3b of the multi-provider epic + PR #415 review issue (critical
+    bug): the dep no longer returns a provider instance. The handler
+    resolves the provider PER-REQUEST via
+    `api.agent.router._resolve_provider_for_model(body.model)` so an
+    override like `body.model = "claude-opus-4-7"` actually routes to
+    AnthropicProvider, regardless of what the surface default points
+    to. Pre-fix, the dep resolved the default's provider (DS post-
+    migration) and the override path silently routed claude-* model
+    ids to DeepSeek's API → 400 → friendly fallback. Operator who
+    relied on Opus override discovered the bug in production.
 
-    Returns the provider whose default surface model the registry
-    resolves. Today that's always Anthropic (default for `dock` is
-    `claude-sonnet-4-6`). Phase 3 of the multi-provider epic flips
-    the default to DeepSeek and this resolver follows.
+    The function name stays `get_anthropic_client` for backward-compat
+    with 13+ test `dependency_overrides[get_anthropic_client]` call
+    sites. The override semantics also shift:
+      - Pre-fix: override replaces the provider used in the loop.
+      - Post-fix: override is just a status-gate bypass (return value
+        unused). To swap the provider, monkeypatch
+        `api.agent.router._resolve_provider_for_model` instead.
+
+    Returns True on success (sentinel — the value is unused; the act
+    of resolving without raising IS the OK signal).
     """
     # Local import to dodge circulars (api.agent.config doesn't import
     # this module, but the router imports both).
@@ -49,24 +61,4 @@ def get_anthropic_client():
     status = get_agent_status()
     if not status.enabled:
         raise HTTPException(status_code=503, detail=status.reason)
-
-    # Resolve the provider for the default surface model. We use "dock"
-    # as the canonical reference surface — the actual model the request
-    # ends up using may differ (the router supports per-request model
-    # override), but the dep injection happens before the body sees the
-    # request, so we resolve against the default at this point.
-    from api.agent.models import default_model_for_surface  # noqa: PLC0415
-    from api.agent.providers.registry import (  # noqa: PLC0415
-        UnknownProviderError, get_provider_for_model,
-    )
-    default_model = default_model_for_surface("dock")
-    try:
-        return get_provider_for_model(default_model)
-    except UnknownProviderError:
-        log.error("default model %s has no registered provider", default_model)
-        raise HTTPException(status_code=503, detail="agent_disabled")
-    except ImportError as e:
-        # The provider's SDK (anthropic, etc) isn't installed — same
-        # closed-enum response as Phase 0's "key missing".
-        log.error("provider SDK not installed: %s", e)
-        raise HTTPException(status_code=503, detail="agent_disabled")
+    return True

--- a/api/agent/models.py
+++ b/api/agent/models.py
@@ -42,12 +42,27 @@ from __future__ import annotations
 # The invariant check below + test_models_invariants in
 # tests/test_agent_models.py catches the first two; a snapshot test on
 # the tool subset catches drift in the third.
+# Fase 3b of the multi-provider epic: defaults migrated to DeepSeek.
+# Anthropic models stay in ALLOWED_MODELS as per-turn override targets.
+# Operator can flip back via the override field on /agent/conversations
+# /{id}/turn or by patching this dict in a follow-up if DS bake reveals
+# quality regression.
+#
+# Selection rationale:
+#   - dock / symbol_detail / historial: deepseek-chat (V3). Fast, cheap,
+#     conversational. Most turns are short Q&A or browse-the-history
+#     reads — no benefit from R1's chain-of-thought tax.
+#   - kill_switch / autotune: deepseek-reasoner (R1). These surfaces
+#     ask "should I do X to my portfolio?" — analytical, multi-step
+#     reasoning is the value. The collapsible reasoning panel lets the
+#     operator audit the model's chain-of-thought before confirming
+#     a proposal.
 SURFACE_MODEL_DEFAULTS: dict[str, str] = {
-    "dock":          "claude-sonnet-4-6",
-    "symbol_detail": "claude-haiku-4-5",
-    "kill_switch":   "claude-sonnet-4-6",
-    "autotune":      "claude-sonnet-4-6",
-    "historial":     "claude-haiku-4-5",
+    "dock":          "deepseek-chat",
+    "symbol_detail": "deepseek-chat",
+    "kill_switch":   "deepseek-reasoner",
+    "autotune":      "deepseek-reasoner",
+    "historial":     "deepseek-chat",
 }
 
 

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -33,6 +33,10 @@ from api.agent.clients import get_anthropic_client
 from api.agent.config import get_agent_status
 from api.agent.loop import run_turn
 from api.agent.models import ALLOWED_MODELS, default_model_for_surface
+from api.agent.providers.registry import (
+    UnknownProviderError,
+    get_provider_for_model,
+)
 from api.agent.quotas import QuotaExceeded, check_quota_pretrun
 from api.agent.proposals import (
     ACTION_APPLY_TUNE,
@@ -51,6 +55,26 @@ from auth.models import User
 log = logging.getLogger("api.agent.router")
 
 router = APIRouter(tags=["agent"])
+
+
+# ── Provider resolution seam (Fase 3b review fix) ───────────────────────
+#
+# Why this is a module-level function instead of inline `get_provider_for
+# _model(...)` in the handler: tests monkeypatch this to inject fakes.
+# The previous fixture pattern (`dependency_overrides[get_anthropic_client]
+# = lambda: fake`) doesn't work for per-request resolution because the dep
+# only fires once with no model context. This indirection lets tests
+# route by model id:
+#
+#     def _stub_resolve(model):
+#         if model.startswith("claude-"): return FakeAnthropicProvider()
+#         if model.startswith("deepseek-"): return FakeDeepSeekProvider()
+#         raise UnknownProviderError(model)
+#     monkeypatch.setattr(router, "_resolve_provider_for_model", _stub_resolve)
+#
+# Production behavior delegates to the registry unchanged.
+def _resolve_provider_for_model(model: str):
+    return get_provider_for_model(model)
 
 
 # ── /agent/status (Phase 0) ────────────────────────────────────────────
@@ -110,7 +134,7 @@ async def post_agent_turn(
     ),
     body: _AgentTurnRequest = ...,  # noqa: B008
     tenant_id: int = Depends(get_current_tenant_id),
-    client = Depends(get_anthropic_client),  # noqa: B008
+    _agent_gate = Depends(get_anthropic_client),  # noqa: B008, ARG001
 ):
     """Stream a single user-turn through the model + tool loop.
 
@@ -119,9 +143,18 @@ async def post_agent_turn(
     (text_delta / tool_use_start / tool_use_result / message_end / error).
 
     Pre-reg §4.4. Auth: cookie JWT → tenant_id. The model never sees
-    tenant_id; every tool call is bound server-side. The Anthropic
-    client is injected via Depends so tests override with a fake.
+    tenant_id; every tool call is bound server-side. Provider is
+    resolved per-request via `_resolve_provider_for_model(model)` so
+    a `body.model` override routes to the correct adapter regardless
+    of what the surface default points to (PR #415 review fix).
+
+    `_agent_gate` is the status-gate dep — its return value is unused
+    but the Depends() call still fires the 503-on-disabled check
+    before the handler body runs.
     """
+    # Double-check status (the dep already did this, but being explicit
+    # here means a future refactor that drops the dep doesn't silently
+    # bypass the gate).
     status = get_agent_status()
     if not status.enabled:
         raise HTTPException(status_code=503, detail=status.reason)
@@ -129,6 +162,20 @@ async def post_agent_turn(
     model = body.model or default_model_for_surface(body.surface)
     if model not in ALLOWED_MODELS:
         raise HTTPException(status_code=400, detail="model_not_allowed")
+
+    # Resolve provider per-request based on the active model. The
+    # override path (body.model="claude-opus-4-7" when default is
+    # deepseek-chat) routes through this and lands on AnthropicProvider,
+    # not whatever the dock default points to (PR #415 review fix).
+    try:
+        client = _resolve_provider_for_model(model)
+    except UnknownProviderError:
+        raise HTTPException(status_code=400, detail="model_not_allowed")
+    except ImportError as e:
+        # Provider SDK missing in this deploy — same closed-enum
+        # response as "key missing" (Phase 0 §3.3 leak guard).
+        log.error("provider SDK not installed for %s: %s", model, e)
+        raise HTTPException(status_code=503, detail="agent_disabled")
 
     # Phase 5: per-tenant daily spend quota. Distinct from the global
     # breaker (which lives inside get_agent_status above) — quota is

--- a/frontend/src/agent/useAgentStream.test.tsx
+++ b/frontend/src/agent/useAgentStream.test.tsx
@@ -160,6 +160,52 @@ describe('useAgentStream', () => {
     expect(asst.reasoning).not.toContain('Recomiendo');
   });
 
+  it('accumulates reasoning across multi-hop turns into a single channel', async () => {
+    // PR #414 review pickup 2: a multi-hop turn with reasoning before
+    // each tool_use should accumulate ALL reasoning chunks into ONE
+    // msg.reasoning field (plain concat, no separator).
+    //
+    // If a future PR wants per-hop separation (msg.reasoning_per_hop:
+    // string[]), this test should fail and be updated deliberately.
+    // For now, the contract is "one flat string per assistant message".
+    stubFetchOnce(sseReadable([
+      // Hop 1 reasoning
+      { type: 'reasoning_delta', text: 'Primero ' },
+      { type: 'reasoning_delta', text: 'necesito ver las posiciones. ' },
+      { type: 'tool_use_start', tool: 'get_positions' },
+      { type: 'tool_use_result', tool: 'get_positions', status: 'ok' },
+      // Hop 2 reasoning (after tool result)
+      { type: 'reasoning_delta', text: 'Veo BTCUSDT en verde. ' },
+      { type: 'reasoning_delta', text: 'Recomiendo mantener.' },
+      { type: 'text_delta', text: 'Mantén tu posición de BTC.' },
+      {
+        type: 'message_end',
+        usage: { input_tokens: 200, output_tokens: 50, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        stop_reason: 'end_turn',
+        cost_usd: 0.0005,
+      },
+    ]));
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+
+    await act(async () => {
+      await result.current.sendTurn('analiza');
+    });
+
+    const asst = result.current.msgs[1];
+    expect(asst.role).toBe('assistant');
+    // Text channel only has the final answer.
+    expect(asst.text).toBe('Mantén tu posición de BTC.');
+    // Reasoning channel: all chunks concatenated in arrival order,
+    // no separators between hops. Operator sees the full chain-of-
+    // thought as one continuous block.
+    expect(asst.reasoning).toBe(
+      'Primero necesito ver las posiciones. Veo BTCUSDT en verde. Recomiendo mantener.'
+    );
+    // Tool chip rendered (provider exercised the dispatch path).
+    expect(asst.tool_chips).toHaveLength(1);
+    expect(asst.tool_chips![0]).toEqual({ tool: 'get_positions', status: 'ok' });
+  });
+
   it('does not initialize reasoning when no reasoning_delta arrives', async () => {
     // For non-reasoning models (Anthropic, deepseek-chat), the message
     // never gets a reasoning field. The UI conditional `if (reasoning &&

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -210,9 +210,15 @@ const DockMessage: React.FC<DockMessageProps> = ({
         {reasoning && reasoning.length > 0 && (
           <details className={styles.reasoning}>
             <summary className={styles.reasoningSummary}>Razonamiento</summary>
-            <div className={styles.reasoningBody}>
-              <DockText text={reasoning} />
-            </div>
+            {/* PR #414 review pickup 3: reasoning is the model's
+                internal chain-of-thought, not formatted output for the
+                user. Render as PLAIN TEXT so literal ** marks (which
+                R1 uses for emphasis in its own prose) survive verbatim.
+                Using DockText/FormattedText here would interpret them
+                as bold and the operator loses fidelity of the
+                reasoning's structure. white-space: pre-wrap in the CSS
+                preserves newlines + indentation. */}
+            <div className={styles.reasoningBody}>{reasoning}</div>
           </details>
         )}
         {toolChips && toolChips.length > 0 && (

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -568,9 +568,11 @@ const CopilotMessage: React.FC<CopilotMessageProps> = ({
         {reasoning && reasoning.length > 0 && (
           <details className={styles.reasoning}>
             <summary className={styles.reasoningSummary}>Razonamiento</summary>
-            <div className={styles.reasoningBody}>
-              <FormattedText text={reasoning} />
-            </div>
+            {/* PR #414 review pickup 3: render as PLAIN TEXT (no
+                markdown parsing). Reasoning is the model's chain-of-
+                thought, not formatted output for the user. Same
+                rationale as AgentDock — see comment there. */}
+            <div className={styles.reasoningBody}>{reasoning}</div>
           </details>
         )}
         {toolChips && toolChips.length > 0 && (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,11 +68,19 @@ def _agent_enabled_in_tests(monkeypatch):
     the override in config.json. Without this fixture, every endpoint
     test that POSTs to /agent/* would 503 with reason=agent_disabled.
 
-    Tests that explicitly verify the disabled state
-    (test_endpoint_503_when_status_disabled, test_status_disabled_wins_
-    over_breaker, etc.) re-override load_config inside the test body —
-    pytest applies the last monkeypatch.setattr in scope, so those work
-    correctly on top of this fixture.
+    Fase 3b of the multi-provider epic migrated defaults to DeepSeek.
+    The §2.7 status check (api/agent/config._default_provider_has_key)
+    now reads DEEPSEEK_API_KEY (because the default surface model is
+    `deepseek-chat`). The autouse fixture sets BOTH provider API keys
+    so a test that does NOT explicitly delete either env var ends up
+    in the enabled state regardless of which provider serves the
+    default surface.
+
+    Tests that explicitly verify the disabled state (e.g.
+    test_endpoint_503_when_status_disabled,
+    test_status_disabled_wins_over_breaker) re-override load_config
+    inside the test body — pytest applies the last monkeypatch.setattr
+    in scope, so those work correctly on top of this fixture.
     """
     import api.agent.config as _agent_config
 
@@ -89,6 +97,12 @@ def _agent_enabled_in_tests(monkeypatch):
         return cfg
 
     monkeypatch.setattr(_agent_config, "load_config", _enabled_load_config)
+    # Make BOTH provider keys present so the §2.7 default-key check
+    # passes regardless of which surface's default is being tested.
+    # Individual tests that exercise the missing-key path delete the
+    # relevant var via monkeypatch.delenv in their own body.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-stub")
+    monkeypatch.setenv("DEEPSEEK_API_KEY",  "sk-ds-test-stub")
     yield
 
 

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -652,12 +652,31 @@ def anyio_backend():
 @pytest.fixture
 def authed_client(tmp_path, monkeypatch):
     """TestClient with the agent dependencies overridden: tenant_id=1,
-    api-key-check bypassed, and the Anthropic client swapped for a
-    FakeAnthropicClient that the test mutates."""
+    api-key-check bypassed, and a `_resolve_provider_for_model` stub
+    that routes by model prefix.
+
+    Fase 3b PR #415 review fix: provider resolution moved to per-request
+    in the router. Tests can no longer just inject a single FakeProvider
+    via dependency_overrides — they must route by model id. This fixture
+    sets up a smart resolver:
+
+      - `claude-*` model IDs → return the shared FakeAnthropicProvider
+        (the one yielded to the test so it can `.queue_turn(...)` it).
+      - `deepseek-*` model IDs → return a FakeDeepSeekProvider also
+        constructed by the fixture (accessible via the `ds_fake`
+        attribute the fixture yields).
+
+    Backward compat: most existing tests use the surface default (which
+    is now deepseek-chat post-Fase-3b). The smart resolver routes to
+    the DS fake by default. Tests that explicitly pass model="claude-*"
+    via body.model route to the Anthropic fake. Tests assert on
+    `fake_client.calls` for Anthropic and on `ds_fake.calls` for DS.
+    """
     import btc_api
     from fastapi.testclient import TestClient
     from auth.dependencies import get_current_tenant_id
     from api.agent.clients import get_anthropic_client
+    from api.agent import router as _router
 
     db_path = str(tmp_path / "signals.db")
     monkeypatch.setattr(btc_api, "DB_FILE", db_path)
@@ -665,10 +684,30 @@ def authed_client(tmp_path, monkeypatch):
         delattr(btc_api, "_db_conn")
     btc_api.init_db()
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-test-key")
+    monkeypatch.setenv("DEEPSEEK_API_KEY",  "sk-ds-fake-test-key")
 
+    from tests._fakes import FakeDeepSeekProvider
     fake_client = FakeAnthropicClient()
+    ds_fake = FakeDeepSeekProvider()
+    # Attach the DS fake as an attribute so tests that need it can
+    # reach it (`fake.ds_fake`) without changing the 2-tuple yield
+    # shape that the 7 existing call sites destructure as
+    # `client, fake = authed_client`.
+    fake_client.ds_fake = ds_fake  # type: ignore[attr-defined]
+
+    def _smart_resolve(model: str):
+        if model.startswith("claude-"):
+            return fake_client
+        if model.startswith("deepseek-"):
+            return ds_fake
+        from api.agent.providers.registry import UnknownProviderError
+        raise UnknownProviderError(f"no fake for model {model!r}")
+
+    monkeypatch.setattr(_router, "_resolve_provider_for_model", _smart_resolve)
     btc_api.app.dependency_overrides[get_current_tenant_id] = lambda: 1
-    btc_api.app.dependency_overrides[get_anthropic_client] = lambda: fake_client
+    # Bypass the status-gate dep (no key check, no breaker check). Tests
+    # that exercise the gate's failure modes override this themselves.
+    btc_api.app.dependency_overrides[get_anthropic_client] = lambda: True
     try:
         yield TestClient(btc_api.app), fake_client
     finally:
@@ -685,10 +724,16 @@ def test_endpoint_streams_text_deltas_as_sse_frames(authed_client):
         .usage(input_tokens=10, output_tokens=2)
         .build()
     )
+    # Fase 3b PR #415 review fix: defaults now route to DS. We queue
+    # on the Anthropic fake (`fake`), so force Anthropic routing via
+    # explicit model override. Decouples this test from default
+    # migrations — the invariant under test (SSE wire format) is
+    # provider-agnostic.
     resp = client.post(
         "/agent/conversations/test-conv-1/turn",
         json={
             "surface":  "dock",
+            "model":    "claude-sonnet-4-6",
             "messages": [{"role": "user", "content": "saluda"}],
         },
     )
@@ -879,6 +924,84 @@ def test_endpoint_503_when_api_key_missing_via_direct_curl(authed_client, monkey
         )
 
 
+def test_override_model_routes_to_correct_provider_post_migration(authed_client):
+    """PR #415 review CRITICAL BUG fix: provider must be resolved
+    per-REQUEST based on the active model id, not per-DEFAULT-SURFACE.
+
+    Pre-fix scenario (Fase 3b without this fix):
+      1. Default surface 'dock' resolves to 'deepseek-chat' (DS).
+      2. Operator POSTs body.model='claude-opus-4-7' (override).
+      3. Depends(get_anthropic_client) resolved DS adapter (default).
+      4. run_turn(client=DS, model='claude-opus-4-7') called.
+      5. DS adapter sent claude-opus-4-7 to api.deepseek.com → 400 → user sees
+         friendly fallback "El copiloto está saturado...".
+      6. Override path silently broken.
+
+    Post-fix: the handler calls _resolve_provider_for_model(model) AFTER
+    determining the model (default or override). This test asserts the
+    Anthropic fake was used when body.model='claude-sonnet-4-6' on a
+    dock surface (whose default is deepseek-chat). Without the fix,
+    the DS fake would have been used and the assertion below would
+    not match.
+    """
+    client, fake = authed_client
+    fake.queue_turn(
+        FakeTurnBuilder()
+        .text("Anthropic respondió.")
+        .end_turn()
+        .usage(input_tokens=10, output_tokens=5)
+        .build()
+    )
+    # Surface defaults to deepseek-chat but we OVERRIDE with claude.
+    resp = client.post(
+        "/agent/conversations/override-route-test/turn",
+        json={
+            "surface":  "dock",
+            "model":    "claude-sonnet-4-6",  # override the DS default
+            "messages": [{"role": "user", "content": "x"}],
+        },
+    )
+    assert resp.status_code == 200
+    _ = resp.text  # drain
+
+    # The Anthropic fake's stream() was called — calls list has the
+    # request kwargs we just sent. The DS fake's stream() was NOT
+    # called — its calls list stays empty.
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["model"] == "claude-sonnet-4-6"
+    assert len(fake.ds_fake.calls) == 0
+
+
+def test_default_model_routes_to_ds_provider_post_migration(authed_client):
+    """Companion to the override test: when NO model override is
+    given, the dock default 'deepseek-chat' resolves to the DS fake.
+    If this test fails, the default migration in Fase 3b didn't take
+    effect end-to-end (the loop is still seeing claude-sonnet-4-6
+    somehow)."""
+    client, fake = authed_client
+    fake.ds_fake.queue_turn(
+        FakeTurnBuilder()
+        .text("DeepSeek respondió.")
+        .end_turn()
+        .usage(input_tokens=10, output_tokens=5)
+        .build()
+    )
+    resp = client.post(
+        "/agent/conversations/default-route-test/turn",
+        json={
+            "surface":  "dock",   # no model override
+            "messages": [{"role": "user", "content": "x"}],
+        },
+    )
+    assert resp.status_code == 200
+    _ = resp.text
+
+    assert len(fake.ds_fake.calls) == 1
+    assert fake.ds_fake.calls[0]["model"] == "deepseek-chat"
+    # And the Anthropic fake never ran.
+    assert len(fake.calls) == 0
+
+
 def test_endpoint_400_when_conversation_id_invalid(authed_client):
     """PR #404 review issue 3: conversation_id must be alphanumeric +
     _-, max 128 chars. Blocks pollution and minor DoS."""
@@ -913,7 +1036,9 @@ def test_endpoint_audits_isolated_per_tenant(authed_client, monkeypatch):
     import btc_api
     from auth.dependencies import get_current_tenant_id
 
-    # First turn as tenant=1
+    # First turn as tenant=1. Fase 3b PR #415 review fix: explicit
+    # claude model override so the smart resolver routes to the
+    # Anthropic fake we just queued on (the test pre-dates DS defaults).
     client, fake = authed_client
     fake.queue_turn(
         FakeTurnBuilder().text("turn-1").end_turn().usage(input_tokens=10).build()
@@ -922,6 +1047,7 @@ def test_endpoint_audits_isolated_per_tenant(authed_client, monkeypatch):
         "/agent/conversations/iso-conv/turn",
         json={
             "surface":  "dock",
+            "model":    "claude-sonnet-4-6",
             "messages": [{"role": "user", "content": "msg-1"}],
         },
     )
@@ -937,6 +1063,7 @@ def test_endpoint_audits_isolated_per_tenant(authed_client, monkeypatch):
         "/agent/conversations/iso-conv-tenant2/turn",
         json={
             "surface":  "dock",
+            "model":    "claude-sonnet-4-6",
             "messages": [{"role": "user", "content": "msg-2"}],
         },
     )

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -768,10 +768,17 @@ def test_endpoint_audits_each_completed_turn(authed_client):
         .usage(input_tokens=150, output_tokens=12, cache_read=120)
         .build()
     )
+    # Fase 3b of multi-provider epic: defaults migrated to DS, so we
+    # explicitly request claude-sonnet-4-6 via the per-turn override
+    # to match what the FakeAnthropicProvider (injected via fixture)
+    # can actually cost. Decouples the test from default migrations
+    # — the audit invariant tested here (one row per turn, correct
+    # tenant/surface/cost shape) is provider-agnostic.
     resp = client.post(
         "/agent/conversations/test-conv-audit-1/turn",
         json={
             "surface":  "kill_switch",
+            "model":    "claude-sonnet-4-6",
             "messages": [{"role": "user", "content": "estado"}],
         },
     )
@@ -841,8 +848,12 @@ def test_endpoint_audits_error_turns(authed_client):
 def test_endpoint_503_when_api_key_missing_via_direct_curl(authed_client, monkeypatch):
     """PR #404 review issue 1 (BLOCKER): FastAPI resolves Depends() BEFORE
     the handler body. Without the status guard inside get_anthropic_client,
-    a direct POST with ANTHROPIC_API_KEY missing would 500 with a
-    KeyError stack trace — re-leaking the env-var name that #381 closed.
+    a direct POST with the default provider's API key missing would 500
+    with a stack trace — re-leaking the env-var name that #381 closed.
+
+    Fase 3b of multi-provider epic: default migrated to DeepSeek, so the
+    test deletes DEEPSEEK_API_KEY (the default's key per §2.7) to trip
+    the disabled path.
 
     This test reverts the dependency_overrides on get_anthropic_client so
     the real resolver runs, then unsets the env var. Must 503 with the
@@ -853,7 +864,7 @@ def test_endpoint_503_when_api_key_missing_via_direct_curl(authed_client, monkey
     client, _fake = authed_client
     # Revert the test fake so the real resolver runs.
     btc_api.app.dependency_overrides.pop(get_anthropic_client, None)
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
 
     resp = client.post(
         "/agent/conversations/bypass-test/turn",
@@ -862,7 +873,7 @@ def test_endpoint_503_when_api_key_missing_via_direct_curl(authed_client, monkey
     assert resp.status_code == 503
     assert resp.json() == {"detail": "agent_disabled"}
     # And the body must not leak the env-var name on this path either.
-    for forbidden in ("ANTHROPIC_API_KEY", ".env", "restart"):
+    for forbidden in ("ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY", ".env", "restart"):
         assert forbidden not in resp.text, (
             f"/agent/conversations bypass-test leaked {forbidden!r}: {resp.text!r}"
         )

--- a/tests/test_agent_models.py
+++ b/tests/test_agent_models.py
@@ -28,12 +28,16 @@ from typing import FrozenSet
 # Canonical mapping locked. If this matrix needs to change, do it
 # deliberately — DO NOT silently update both sides without a
 # corresponding commit message explaining why and what it costs.
+# Fase 3b of the multi-provider epic migrated the defaults to DeepSeek.
+# Anthropic models remain in ALLOWED_MODELS as override targets — the
+# operator can pick claude-* on a per-turn basis. Snapshot below
+# reflects the post-migration state.
 EXPECTED_SURFACE_MODELS: dict[str, str] = {
-    "dock":          "claude-sonnet-4-6",
-    "symbol_detail": "claude-haiku-4-5",
-    "kill_switch":   "claude-sonnet-4-6",
-    "autotune":      "claude-sonnet-4-6",
-    "historial":     "claude-haiku-4-5",
+    "dock":          "deepseek-chat",
+    "symbol_detail": "deepseek-chat",
+    "kill_switch":   "deepseek-reasoner",
+    "autotune":      "deepseek-reasoner",
+    "historial":     "deepseek-chat",
 }
 
 

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -49,28 +49,34 @@ def test_agent_status_enabled_when_api_key_set(client, monkeypatch):
     assert body == {"enabled": True, "reason": "ok"}
 
 
-# ── /agent/status: disabled when ANTHROPIC_API_KEY is missing ───────────
+# ── /agent/status: disabled when the default provider's API key is missing ─
+#
+# Fase 3b of the multi-provider epic: defaults migrated to DeepSeek,
+# so the §2.7 status check reads DEEPSEEK_API_KEY (the dock default's
+# provider). These tests delete DEEPSEEK_API_KEY instead of the
+# Anthropic one. If a future PR flips defaults back, update these.
 
 
-def test_agent_status_disabled_when_api_key_missing(client, monkeypatch):
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+def test_agent_status_disabled_when_default_provider_key_missing(client, monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     resp = client.get("/agent/status")
     assert resp.status_code == 200
     body = resp.json()
     assert body == {"enabled": False, "reason": "agent_disabled"}
 
 
-def test_agent_status_disabled_when_api_key_empty(client, monkeypatch):
-    """Empty string is treated identically to missing — see config.py."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+def test_agent_status_disabled_when_default_provider_key_empty(client, monkeypatch):
+    """Empty string is treated identically to missing — see
+    DeepSeekProvider.has_api_key reads via os.environ.get(...).strip()."""
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "")
     resp = client.get("/agent/status")
     assert resp.status_code == 200
     assert resp.json() == {"enabled": False, "reason": "agent_disabled"}
 
 
-def test_agent_status_disabled_when_api_key_whitespace(client, monkeypatch):
+def test_agent_status_disabled_when_default_provider_key_whitespace(client, monkeypatch):
     """Whitespace-only is treated as missing — operator typo guard."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "   ")
     resp = client.get("/agent/status")
     assert resp.status_code == 200
     assert resp.json() == {"enabled": False, "reason": "agent_disabled"}
@@ -119,8 +125,12 @@ def test_agent_status_body_never_leaks_env_var_names_or_paths(client, monkeypatc
 
 
 def test_agent_chat_503_body_no_longer_leaks(client, monkeypatch):
-    """The legacy /agent/chat endpoint also stops leaking — pre-reg §3.3."""
-    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    """The legacy /agent/chat endpoint also stops leaking — pre-reg §3.3.
+
+    Fase 3b of the multi-provider epic: default provider migrated to
+    DeepSeek, so we delete DEEPSEEK_API_KEY to trip the disabled path.
+    """
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     resp = client.post(
         "/agent/chat",
         json={"system": "test", "messages": [{"role": "user", "content": "hi"}]},


### PR DESCRIPTION
## Summary

Fase 3b of the multi-provider epic. **Migrates `SURFACE_MODEL_DEFAULTS` to DeepSeek across all 5 surfaces.** Anthropic models stay in `ALLOWED_MODELS` as per-turn override targets. Plus the 2 review pickups raised on PR #414 (multi-hop reasoning test + plain-text reasoning panel).

## Migration matrix

| Surface | Was | Now | Why |
|---|---|---|---|
| `dock` | claude-sonnet-4-6 | **deepseek-chat** | Fast conversational |
| `symbol_detail` | claude-haiku-4-5 | **deepseek-chat** | Fast scoped |
| `kill_switch` | claude-sonnet-4-6 | **deepseek-reasoner** | Analytical, operator audits chain-of-thought |
| `autotune` | claude-sonnet-4-6 | **deepseek-reasoner** | Analytical (same) |
| `historial` | claude-haiku-4-5 | **deepseek-chat** | Passive read |

Rationale documented in `api/agent/models.py` above the dict.

## Review pickups applied

**Issue 2 — multi-hop reasoning accumulation test**
New `useAgentStream.test.tsx::test_reasoning_accumulates_across_multi_hop_turn`. Drives a turn with reasoning chunks before each tool_use + final text, asserts all reasoning chunks land in ONE `msg.reasoning` string (plain concat, no separator). If a future PR adopts per-hop separation, this test fails deliberately.

**Issue 3 — plain-text reasoning panel**
Replaced `<DockText/>` and `<FormattedText/>` inside the `<details>` reasoning panel with raw `{reasoning}` text. R1's reasoning is chain-of-thought, NOT formatted output for the user — rendering through the markdown parser would consume literal `**` marks. CSS `white-space: pre-wrap` preserves newlines.

## Test infrastructure updates

`tests/conftest.py` autouse fixture now sets BOTH `ANTHROPIC_API_KEY` + `DEEPSEEK_API_KEY` stubs so the §2.7 default-provider-key check passes regardless of which provider serves the active default. Tests exercising the missing-key path delete the relevant var explicitly.

4 existing tests updated to track the default migration:
- `test_agent_models.py`: EXPECTED_SURFACE_MODELS snapshot
- `test_agent_status.py`: 4 tests now delete DEEPSEEK_API_KEY (was Anthropic) since §2.7 checks the default provider
- `test_agent_loop.py::test_endpoint_audits_each_completed_turn`: passes `model: "claude-sonnet-4-6"` explicitly via the per-turn override so the FakeAnthropicProvider can cost it
- `test_agent_loop.py::test_endpoint_503_when_api_key_missing_via_direct_curl`: deletes DEEPSEEK_API_KEY; forbidden-leak guard now covers both env-var names

## Tests
- **200 backend** tests passing, 1 skipped (live)
- **97 frontend** tests passing (1 new — multi-hop reasoning)
- TS clean

## Out of scope (Fase 4)
- `reasoning_tokens INTEGER` column in `agent_conversations` (review issue 4). DS aggregates reasoning into `completion_tokens` today; no breakdown to capture. Revisit if DS splits.
- CSS extraction to a shared module (review issue 1). 3 instances of the pattern now (`.toolChip`, `.toolConfirm`, `.reasoning`). Natural to extract before the future epic that mounts kill_switch/autotune/historial surfaces.

## Test plan
- [ ] CI green
- [ ] Manual: with both DEEPSEEK_API_KEY and ANTHROPIC_API_KEY set, `curl /agent/status` returns `{enabled: true}`; remove DEEPSEEK_API_KEY and it returns `agent_disabled` (the §2.7 path)
- [ ] Manual: a normal dock turn now routes to DeepSeek by default — verify `agent_conversations.model = 'deepseek-chat'` for that row
- [ ] Manual: with `model: "claude-opus-4-7"` override on the turn body, the request still works (override path intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)