### PR TITLE
fix(auth): add /agent/status to public-path whitelist

### DIFF
--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -103,7 +103,7 @@ _PUBLIC_PATHS_EXACT: frozenset = frozenset({
     # closed-enum `{enabled, reason}` shape and NEVER leaks env-var
     # names / paths (locked by test_agent_status_body_never_leaks_*).
     # Without this entry, curl /agent/status returns 401 — caught by
-    # papá during Fase 5 rollout smoke. The test that should have
+    # the operator during Fase 5 rollout smoke. The test that should have
     # caught this earlier (test_agent_status_does_not_require_auth)
     # was passing in CI because conftest's autouse fixture activates
     # the test bypass; updated alongside this fix to disable bypass

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -96,6 +96,19 @@ _PUBLIC_PATHS_EXACT: frozenset = frozenset({
     #   here is a no-op once setup is done, but harmless.
     "/setup",
     "/setup/status",
+    # /agent/status (added 2026-05-20, post-multi-provider rollout fix):
+    # MUST be public — the frontend's `useAgentEnabled` hook reads it
+    # at App boot BEFORE the login redirect resolves to decide whether
+    # to render the AgentDock at all. The endpoint itself returns the
+    # closed-enum `{enabled, reason}` shape and NEVER leaks env-var
+    # names / paths (locked by test_agent_status_body_never_leaks_*).
+    # Without this entry, curl /agent/status returns 401 — caught by
+    # papá during Fase 5 rollout smoke. The test that should have
+    # caught this earlier (test_agent_status_does_not_require_auth)
+    # was passing in CI because conftest's autouse fixture activates
+    # the test bypass; updated alongside this fix to disable bypass
+    # for the public-path tests so the whitelist is exercised for real.
+    "/agent/status",
 })
 _PUBLIC_PATH_PREFIXES: tuple[str, ...] = (
     "/docs",

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -190,8 +190,27 @@ def test_agent_status_reason_field_is_closed_enum(client, monkeypatch):
 
 def test_agent_status_does_not_require_auth(client, monkeypatch):
     """The frontend reads /agent/status before login completes in some
-    flows; the endpoint must respond without an auth cookie."""
+    flows; the endpoint must respond without an auth cookie.
+
+    This test DISABLES the conftest test bypass (AUTH_TEST_BYPASS_ROLE)
+    so the AuthMiddleware actually runs as it would in production.
+    Without this, the test would pass even if /agent/status was NOT in
+    the public-path whitelist — the bypass would let any path through.
+
+    Bug history: pre-2026-05-20 fix, /agent/status was NOT in
+    _PUBLIC_PATHS_EXACT. Tests passed via the bypass; papá's prod
+    smoke during Fase 5 rollout caught the 401 with curl. Test now
+    forces the middleware to exercise the whitelist for real.
+    """
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ds-fake")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake")
-    # No login, no cookies — should still succeed.
+    # Kill the conftest bypass so AuthMiddleware enforces the whitelist.
+    monkeypatch.delenv("AUTH_TEST_BYPASS_ROLE", raising=False)
+    # No login, no cookies — should still succeed via the whitelist.
     resp = client.get("/agent/status")
-    assert resp.status_code == 200
+    assert resp.status_code == 200, (
+        f"GET /agent/status returned {resp.status_code} ({resp.text!r}). "
+        f"This usually means /agent/status is missing from "
+        f"auth/middleware.py:_PUBLIC_PATHS_EXACT. The endpoint MUST be "
+        f"public — the frontend hits it before the login flow resolves."
+    )

--- a/tests/test_agent_status.py
+++ b/tests/test_agent_status.py
@@ -214,3 +214,24 @@ def test_agent_status_does_not_require_auth(client, monkeypatch):
         f"auth/middleware.py:_PUBLIC_PATHS_EXACT. The endpoint MUST be "
         f"public — the frontend hits it before the login flow resolves."
     )
+
+
+def test_protected_paths_still_require_auth(client, monkeypatch):
+    """Negative guard — the whitelist must stay restrictive.
+
+    Defends against the failure mode where someone copy-pastes the
+    /agent/status whitelist entry and accidentally adds a path that
+    should NOT be public (e.g. /positions, /admin/*, /health/symbols).
+
+    Same bypass-disable pattern as the test above so the middleware
+    actually runs. Picks /positions as the canary because it returns
+    tenant-scoped data and must never be reachable without a JWT.
+    """
+    monkeypatch.delenv("AUTH_TEST_BYPASS_ROLE", raising=False)
+    resp = client.get("/positions")
+    assert resp.status_code == 401, (
+        f"GET /positions returned {resp.status_code} ({resp.text!r}) "
+        f"without an auth cookie. /positions is tenant-scoped and MUST "
+        f"require auth. Did somebody accidentally add it (or a prefix "
+        f"that covers it) to auth/middleware.py:_PUBLIC_PATHS_EXACT?"
+    )


### PR DESCRIPTION
## Summary
- `/agent/status` returns 401 in production because it's missing from `auth/middleware.py:_PUBLIC_PATHS_EXACT`. The endpoint docstring claims it's public; the middleware disagrees.
- Frontend's `useAgentEnabled` hook reads it at App boot before login resolves → without this fix, the AgentDock never mounts in prod.
- Test that should have caught this was passing because `conftest.py`'s autouse fixture sets `AUTH_TEST_BYPASS_ROLE=admin`, bypassing AuthMiddleware entirely. Test now disables the bypass to exercise the whitelist for real.

## Background

Found during Fase 5 (multi-provider epic) rollout smoke on prod:
```
$ curl http://localhost:8100/agent/status
{"detail":"not authenticated"}
```

Expected per the runbook (`docs/rollouts/2026-05-20-multi-provider-flip.md` §1.3):
```
{"enabled": true, "reason": "ok"}
```

Body never leaks env-var names or paths — locked by `test_agent_status_body_never_leaks_env_var_names_or_paths` + closed-enum invariant `test_agent_status_reason_field_is_closed_enum`. Safe to expose unauthenticated.

## Test plan
- [x] `python -m pytest tests/test_agent_status.py -v` → 10/10 pass
- [ ] After deploy: `curl http://localhost:8100/agent/status` returns `{"enabled": true, "reason": "ok"}` on prod
- [ ] Continue with `§2` of the Fase 5 runbook (post-flip smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)