### PR TITLE
fix(agent): factories return 400 model_not_allowed when API key missing

### DIFF
--- a/api/agent/providers/registry.py
+++ b/api/agent/providers/registry.py
@@ -18,6 +18,7 @@ Invariants enforced in CI by tests/test_provider_registry.py:
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 log = logging.getLogger("api.agent.providers.registry")
@@ -35,7 +36,16 @@ def _anthropic_factory() -> Any:
     """Lazy: construct AnthropicProvider with a real SDK client. The
     SDK import happens inside build_anthropic_client; tests that don't
     have the anthropic package installed never hit this path because
-    they inject a FakeAnthropicProvider via dependency_overrides."""
+    they inject a FakeAnthropicProvider via dependency_overrides.
+
+    Deploys that omit ANTHROPIC_API_KEY (DS-only setup per multi-provider
+    runbook §0.2) raise UnknownProviderError here so the router maps to
+    400 model_not_allowed instead of leaking KeyError/ImportError 500s.
+    """
+    if not (os.environ.get("ANTHROPIC_API_KEY") or "").strip():
+        raise UnknownProviderError(
+            "ANTHROPIC_API_KEY not configured — claude-* models unavailable"
+        )
     from api.agent.providers.anthropic_adapter import (
         AnthropicProvider, build_anthropic_client,
     )
@@ -46,7 +56,18 @@ def _deepseek_factory() -> Any:
     """Lazy: construct DeepSeekProvider. DS uses raw httpx (no SDK to
     import), so the factory only needs DEEPSEEK_API_KEY at construction
     time. Tests inject FakeDeepSeekProvider via dependency_overrides
-    and never hit this path."""
+    and never hit this path.
+
+    Same env-var guard as the Anthropic factory: missing key surfaces
+    as 400 model_not_allowed via the router. /agent/status normally
+    short-circuits to agent_disabled before reaching this path when
+    DS is the default provider, but the guard is defensive against
+    surface defaults rotating in the future.
+    """
+    if not (os.environ.get("DEEPSEEK_API_KEY") or "").strip():
+        raise UnknownProviderError(
+            "DEEPSEEK_API_KEY not configured — deepseek-* models unavailable"
+        )
     from api.agent.providers.deepseek_adapter import (
         DeepSeekProvider, build_deepseek_client_kwargs,
     )

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -75,6 +75,37 @@ def test_unknown_model_id_raises_unknown_provider_error():
         get_provider_for_model("totally-fake-model")
 
 
+def test_anthropic_factory_raises_unknown_provider_when_key_missing(monkeypatch):
+    """Deploys that don't set ANTHROPIC_API_KEY (DS-only setup per
+    runbook §0.2) must surface as 400 model_not_allowed on claude-*
+    overrides — NOT 500 KeyError from os.environ[...] in the SDK
+    client constructor. Symmetric to DS path.
+    """
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    from api.agent.providers.registry import (
+        PROVIDER_BY_PREFIX, UnknownProviderError,
+    )
+
+    with pytest.raises(UnknownProviderError):
+        PROVIDER_BY_PREFIX["claude"]()
+
+
+def test_deepseek_factory_raises_unknown_provider_when_key_missing(monkeypatch):
+    """Symmetric defensive coverage: DEEPSEEK_API_KEY missing must
+    raise UnknownProviderError, not propagate the ValueError that
+    DeepSeekProvider._ensure_api_key throws at construction.
+    Normally /agent/status short-circuits to agent_disabled before
+    reaching this path, but the factory must still fail safe.
+    """
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    from api.agent.providers.registry import (
+        PROVIDER_BY_PREFIX, UnknownProviderError,
+    )
+
+    with pytest.raises(UnknownProviderError):
+        PROVIDER_BY_PREFIX["deepseek"]()
+
+
 def test_get_provider_for_model_for_claude_resolves(monkeypatch):
     """For a real claude model id, the registry calls the Anthropic
     factory. We can't easily test against the real SDK in a test


### PR DESCRIPTION
## Summary
- Override path POST `/agent/conversations/{id}/turn` with `model=claude-*` on a deploy that omits `ANTHROPIC_API_KEY` hit `os.environ[...]` in `build_anthropic_client()` and propagated a raw `KeyError` 500.
- Multi-provider runbook §0.2 documents this scenario as expected to return **400 `model_not_allowed`** (closed-enum), not 500.
- Both factories in `api/agent/providers/registry.py` now guard on env-var presence and raise `UnknownProviderError` before any SDK import or client construction. The router already maps `UnknownProviderError → 400 model_not_allowed`, so the existing closed-enum response is preserved.
- Symmetric DS guard added even though `/agent/status` short-circuits to `agent_disabled` earlier when DS is the default (defensive against surface defaults rotating).

## Background
Found by smoke §2.4 against `trading.sdar.dev` after PR #418 (`/agent/status` whitelist fix) shipped. The prod `.env` deliberately omits `ANTHROPIC_API_KEY` (DS-only deploy, per runbook §0.2). Server log:

```
File "/var/www/trading/api/agent/providers/anthropic_adapter.py", line 293, in build_anthropic_client
    return AsyncAnthropic(api_key=os.environ["ANTHROPIC_API_KEY"].strip())
KeyError: 'ANTHROPIC_API_KEY'
```

## Why factories vs. adapters
Fixing at the factory layer (rather than `build_anthropic_client`) keeps the env-var policy + the SDK import lazy in the **same** place. The factory was already the lazy-construction seam; gating on env presence there means the SDK never imports if the deploy can't use it.

## Test plan
- [x] `python -m pytest tests/test_provider_registry.py -v` → 13/13 pass (incl. 2 new tests for missing-key paths)
- [x] `python -m pytest tests/test_provider_registry.py tests/test_provider_deepseek.py tests/test_agent_loop.py tests/test_agent_status.py tests/test_agent_breaker.py tests/test_agent_metrics.py -k 'not trio'` → 97/97 pass
- [ ] After deploy: `fetch('/api/agent/conversations/x/turn', body={model: 'claude-sonnet-4-6', ...})` returns 400 with `{"detail":"model_not_allowed"}` (verified end-to-end against `trading.sdar.dev` via Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)