### PR TITLE
fix(deploy): exclude config.json + backups from rsync --delete

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,8 @@ jobs:
             --exclude='.worktrees/' --exclude='Backtesting_BTCUSDT/' \
             --exclude='Dashboard/' --exclude='docs/' --exclude='*.bat' \
             --exclude='*.ps1' --exclude='.env' --exclude='.env.*' \
-            --exclude='.claude/' \
+            --exclude='.claude/' --exclude='config.json' \
+            --exclude='config.json.*.bak' \
             --exclude='data/*.json' --exclude='data/*.csv' \
             --exclude='data/*.xlsx' --exclude='data/backtest/' \
             ./ ubuntu@${HOST}:/var/www/trading/


### PR DESCRIPTION
## Summary
- `deploy.yml`'s rsync uses `--delete` and is missing `--exclude='config.json'`. Since `config.json` is gitignored locally (operator per-deploy state per multi-provider runbook §1.1), every push to main wipes it from the server.
- Result observed today: PR #419 mergeó → deploy corrió → `/var/www/trading/config.json` borrado → `agent.enabled` revertido al default `false` → Dock se ocultó del dashboard hasta restore manual.
- Same root cause would silently revert any future operator state stored in `config.json` (e.g. `breaker_open`, future per-tenant overrides).

## Change
Two lines added to the backend rsync block:

```diff
-            --exclude='.claude/' \
+            --exclude='.claude/' --exclude='config.json' \
+            --exclude='config.json.*.bak' \
```

`config.json.*.bak` covers operator-side backups produced by the manual flip script the runbook (and the smoke today) used.

## Symmetry argument
`.env`, `*.db`, `data/*.json`, `data/*.csv`, `data/*.xlsx` are already excluded for exactly the same reason: operator/runtime state that the repo doesn't ship and rsync `--delete` must not eat. `config.json` is in the same category — the exclude list was just incomplete.

## Test plan
- [x] `git diff .github/workflows/deploy.yml` — minimal, only adds excludes
- [ ] After this merges + deploys: confirm `config.json` survives on the server. Operator can verify by running `ssh <host> 'ls -la /var/www/trading/config.json'` before vs after the next deploy.
- [ ] Future deploys should preserve any future operator-set `agent.*` overrides.

## Followup deferred
Atomic deploy (`releases/<sha>` + symlink swap) eliminates the whole class of `--delete`-wipes-state bugs. It was tried in #377 and reverted (bootstrap.yml DISABLED). Reviving that is the long-term fix; this PR is the surgical patch for the immediate symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)