### PR TITLE
fix(prefs/frontend): UserMenu Conexiones click no longer races onClose

### DIFF
--- a/api/user_preferences.py
+++ b/api/user_preferences.py
@@ -119,3 +119,55 @@ def put_preferences(
         masked_nc = {**nc, "telegram_bot_token": _mask_token(nc["telegram_bot_token"])}
         row = {**row, "notify_channels": masked_nc}
     return {"ok": True, "preferences": row}
+
+
+@router.post(
+    "/test",
+    summary="Send a test message to current tenant's Telegram",
+    dependencies=[Depends(verify_api_key)],
+)
+def post_preferences_test(tenant_id: int = Depends(get_current_tenant_id)):
+    """Verifica end-to-end que las credenciales de Telegram del usuario
+    funcionan, mandando un mensaje 'ping' a su bot.
+
+    Bypassa notify() y dispatch_signal_to_users a propósito (spec §Backend
+    Option 2):
+      - Evita dedup edge-cases (signal event_type tiene dedup_window=0 hoy,
+        pero el bypass blinda contra cambios futuros del default).
+      - Evita side-effect en NotificationBell: cada test press NO crea una
+        row en notifications_sent.
+      - No aplica filtros del usuario (symbol_filter / min_score) — esos
+        aplican a signals reales, no a "verificá tu config".
+
+    Trade-off: NO ejercita el dispatcher per-user. Aceptable porque el
+    dispatcher tiene cobertura propia (tests/test_multi_tenant_b4_signal_
+    routing.py).
+    """
+    from api.config import load_config
+    from db.user_preferences import db_get_user_preferences as _db_get
+    from notifier.channels.telegram import TelegramChannel
+
+    prefs = _db_get(tenant_id) or {}
+    notify_channels = prefs.get("notify_channels") or {}
+    base_cfg = load_config()
+    user_cfg = {**base_cfg, **notify_channels}
+
+    token = (user_cfg.get("telegram_bot_token") or "").strip()
+    chat_id = (user_cfg.get("telegram_chat_id") or "").strip()
+    if not token or not chat_id:
+        return {"ok": False, "receipts": [], "reason": "no_telegram_configured"}
+
+    channel = TelegramChannel(user_cfg)
+    receipt = channel.send(
+        "*Crypto Scanner — prueba de conexión*\n"
+        "Si ves este mensaje, tu bot y chat están bien configurados. ✅"
+    )
+    return {
+        "ok": receipt.status == "ok",
+        "receipts": [{
+            "channel": receipt.channel,
+            "status": receipt.status,
+            "error": receipt.error,
+        }],
+        "reason": None,
+    }

--- a/api/user_preferences.py
+++ b/api/user_preferences.py
@@ -39,38 +39,6 @@ class PreferencesPutBody(BaseModel):
     )
 
 
-@router.get("", summary="Get preferences for current tenant (defaults if unset)")
-def get_preferences(tenant_id: int = Depends(get_current_tenant_id)):
-    row = db_get_user_preferences(tenant_id)
-    if row is None:
-        # Return sensible defaults — per pre-reg §3.2
-        return {
-            "tenant_id": tenant_id,
-            "symbol_filter": None,
-            "min_score": _DEFAULT_MIN_SCORE,
-            "notify_channels": None,
-        }
-    return row
-
-
-@router.put(
-    "",
-    summary="Upsert preferences for current tenant",
-    dependencies=[Depends(verify_api_key)],
-)
-def put_preferences(
-    body: PreferencesPutBody,
-    tenant_id: int = Depends(get_current_tenant_id),
-):
-    row = db_upsert_user_preferences(
-        tenant_id,
-        symbol_filter=body.symbol_filter,
-        min_score=body.min_score,
-        notify_channels=body.notify_channels,
-    )
-    return {"ok": True, "preferences": row}
-
-
 def _mask_token(token: str) -> str:
     """Mask a Telegram bot token, preserving first 10 + last 4 chars.
 
@@ -89,3 +57,58 @@ def _mask_token(token: str) -> str:
     if not token or len(token) < 10:
         return ""
     return f"{token[:10]}****{token[-4:]}"
+
+
+@router.get("", summary="Get preferences for current tenant (defaults if unset)")
+def get_preferences(tenant_id: int = Depends(get_current_tenant_id)):
+    row = db_get_user_preferences(tenant_id)
+    if row is None:
+        # Return sensible defaults — per pre-reg §3.2
+        return {
+            "tenant_id": tenant_id,
+            "symbol_filter": None,
+            "min_score": _DEFAULT_MIN_SCORE,
+            "notify_channels": None,
+        }
+    # Mask telegram_bot_token in the response to reduce XSS blast radius.
+    # See spec §Security note.
+    nc = row.get("notify_channels") or None
+    if nc and nc.get("telegram_bot_token"):
+        nc = {**nc, "telegram_bot_token": _mask_token(nc["telegram_bot_token"])}
+        row = {**row, "notify_channels": nc}
+    return row
+
+
+@router.put(
+    "",
+    summary="Upsert preferences for current tenant",
+    dependencies=[Depends(verify_api_key)],
+)
+def put_preferences(
+    body: PreferencesPutBody,
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    # If the submitted telegram_bot_token contains the mask marker '****',
+    # the user did NOT retype it — preserve the existing DB value. This
+    # supports the UX pattern "pre-fill masked value, only update if user
+    # types something new". See spec §Security note.
+    notify_channels = body.notify_channels
+    if notify_channels and "****" in (notify_channels.get("telegram_bot_token") or ""):
+        existing = db_get_user_preferences(tenant_id)
+        existing_token = (
+            (existing or {}).get("notify_channels") or {}
+        ).get("telegram_bot_token", "")
+        notify_channels = {**notify_channels, "telegram_bot_token": existing_token}
+
+    row = db_upsert_user_preferences(
+        tenant_id,
+        symbol_filter=body.symbol_filter,
+        min_score=body.min_score,
+        notify_channels=notify_channels,
+    )
+    # Re-fetch + mask before returning (consistency with GET).
+    fresh = db_get_user_preferences(tenant_id)
+    if fresh and fresh.get("notify_channels", {}).get("telegram_bot_token"):
+        nc = fresh["notify_channels"]
+        fresh = {**fresh, "notify_channels": {**nc, "telegram_bot_token": _mask_token(nc["telegram_bot_token"])}}
+    return {"ok": True, "preferences": fresh}

--- a/api/user_preferences.py
+++ b/api/user_preferences.py
@@ -69,3 +69,23 @@ def put_preferences(
         notify_channels=body.notify_channels,
     )
     return {"ok": True, "preferences": row}
+
+
+def _mask_token(token: str) -> str:
+    """Mask a Telegram bot token, preserving first 10 + last 4 chars.
+
+    Real Telegram tokens have shape `<bot_id>:<35-char-secret>` (~46 chars
+    total). Output: first 10 chars + "****" + last 4 chars.
+
+    Defensive: `len < 10` returns "" instead of partial mask. Real tokens
+    are never shorter than 10 chars; this guard only fires for garbage
+    (empty, corrupt, manually-truncated). Returning "" makes the masked
+    field indistinguishable from "not configured" in those cases — accept-
+    able because the path is not reachable in prod with valid creds.
+
+    Spec ref: docs/superpowers/specs/es/2026-05-21-telegram-per-user-
+    config-pre-reg.md §Security note.
+    """
+    if not token or len(token) < 10:
+        return ""
+    return f"{token[:10]}****{token[-4:]}"

--- a/api/user_preferences.py
+++ b/api/user_preferences.py
@@ -143,21 +143,24 @@ def post_preferences_test(tenant_id: int = Depends(get_current_tenant_id)):
     dispatcher tiene cobertura propia (tests/test_multi_tenant_b4_signal_
     routing.py).
     """
-    from api.config import load_config
-    from db.user_preferences import db_get_user_preferences as _db_get
-    from notifier.channels.telegram import TelegramChannel
+    from notifier.channels.telegram import TelegramChannel  # noqa: PLC0415
 
-    prefs = _db_get(tenant_id) or {}
+    prefs = db_get_user_preferences(tenant_id) or {}
     notify_channels = prefs.get("notify_channels") or {}
-    base_cfg = load_config()
-    user_cfg = {**base_cfg, **notify_channels}
 
-    token = (user_cfg.get("telegram_bot_token") or "").strip()
-    chat_id = (user_cfg.get("telegram_chat_id") or "").strip()
+    token = (notify_channels.get("telegram_bot_token") or "").strip()
+    chat_id = (notify_channels.get("telegram_chat_id") or "").strip()
     if not token or not chat_id:
         return {"ok": False, "receipts": [], "reason": "no_telegram_configured"}
 
-    channel = TelegramChannel(user_cfg)
+    # Build a MINIMAL cfg with only the user's own credentials — no fall-through
+    # to base_cfg's system-level telegram_chat_id (which would silently route to
+    # the operator's chat). Spec §Backend: "this endpoint verifies the user's own
+    # setup; system defaults should never satisfy the pre-flight guard."
+    channel = TelegramChannel({
+        "telegram_bot_token": token,
+        "telegram_chat_id": chat_id,
+    })
     receipt = channel.send(
         "*Crypto Scanner — prueba de conexión*\n"
         "Si ves este mensaje, tu bot y chat están bien configurados. ✅"

--- a/api/user_preferences.py
+++ b/api/user_preferences.py
@@ -25,6 +25,13 @@ log = logging.getLogger("api.user_preferences")
 router = APIRouter(prefix="/preferences", tags=["preferences"])
 
 
+# Marker used to redact the secret portion of a telegram_bot_token in API
+# responses. The `put_preferences` handler also uses this marker to detect
+# "user submitted the masked value verbatim (didn't retype)" → preserve
+# existing DB token rather than overwrite. Both call sites MUST use this
+# constant — string drift would silently break preserve-detection.
+_MASK_MARKER = "****"
+
 # Default min_score matches schema default + current global default in code.
 _DEFAULT_MIN_SCORE = 4
 
@@ -56,7 +63,7 @@ def _mask_token(token: str) -> str:
     """
     if not token or len(token) < 10:
         return ""
-    return f"{token[:10]}****{token[-4:]}"
+    return f"{token[:10]}{_MASK_MARKER}{token[-4:]}"
 
 
 @router.get("", summary="Get preferences for current tenant (defaults if unset)")
@@ -93,7 +100,7 @@ def put_preferences(
     # supports the UX pattern "pre-fill masked value, only update if user
     # types something new". See spec §Security note.
     notify_channels = body.notify_channels
-    if notify_channels and "****" in (notify_channels.get("telegram_bot_token") or ""):
+    if notify_channels and _MASK_MARKER in (notify_channels.get("telegram_bot_token") or ""):
         existing = db_get_user_preferences(tenant_id)
         existing_token = (
             (existing or {}).get("notify_channels") or {}
@@ -106,9 +113,9 @@ def put_preferences(
         min_score=body.min_score,
         notify_channels=notify_channels,
     )
-    # Re-fetch + mask before returning (consistency with GET).
-    fresh = db_get_user_preferences(tenant_id)
-    if fresh and fresh.get("notify_channels", {}).get("telegram_bot_token"):
-        nc = fresh["notify_channels"]
-        fresh = {**fresh, "notify_channels": {**nc, "telegram_bot_token": _mask_token(nc["telegram_bot_token"])}}
-    return {"ok": True, "preferences": fresh}
+    # Mask the bot_token in the response for consistency with GET.
+    if row and (row.get("notify_channels") or {}).get("telegram_bot_token"):
+        nc = row["notify_channels"]
+        masked_nc = {**nc, "telegram_bot_token": _mask_token(nc["telegram_bot_token"])}
+        row = {**row, "notify_channels": masked_nc}
+    return {"ok": True, "preferences": row}

--- a/docs/superpowers/plans/2026-05-21-telegram-multitenant-phase-a.md
+++ b/docs/superpowers/plans/2026-05-21-telegram-multitenant-phase-a.md
@@ -1,0 +1,445 @@
+# Telegram Multi-Tenant Phase A — Backend Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Plan has no code changes — solo operational steps con checkpoints de verificación. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Samuel recibe señales del scanner en su chat personal de Telegram, vía la ruta per-user (`dispatch_signal_to_users`), no por broadcast global. Funciona hoy con `tenant_id=1`; deja la arquitectura lista para usuarios futuros (cada uno con su propio chat_id en `user_preferences`).
+
+**Architecture:** Pure config + DB row update — **sin code changes**. Token globalmente vía `_env_map` (`api/config.py:105-112`), chat_id per-tenant vía `PUT /api/preferences` que persiste a `user_preferences.notify_channels_json`. Cada signal con `score ≥ 4` (default) dispara `push_telegram_direct` → `dispatch_signal_to_users` → `TelegramChannel.send`.
+
+**Tech Stack:** Bash/SSH al server EC2 (`aws-server`), JS fetch desde browser Playwright (cookie JWT activa de Samuel), curl, journalctl.
+
+**Spec:** [`docs/superpowers/specs/es/2026-05-21-telegram-multitenant-phase-a-pre-reg.md`](../specs/es/2026-05-21-telegram-multitenant-phase-a-pre-reg.md) (commit `f0dc654`).
+
+---
+
+## File / state changes summary
+
+- **Files created:** ninguno.
+- **Files modified in repo:** ninguno (Phase A es zero-code).
+- **Server state modified:**
+  - `/var/www/trading/.env`: una línea nueva `TRADING_TELEGRAM_BOT_TOKEN=<token>`. El archivo no está en repo (gitignored + excluido del rsync deploy).
+  - Proceso `trading-spacial` (systemd): restart para releer `.env`.
+- **DB row modified:** `signals.db` tabla `user_preferences`, UPSERT row con `tenant_id=1`. Columnas tocadas: `notify_channels_json` ← `{"telegram_chat_id": "<chat_id>"}`, `min_score` ← `4` (explícito).
+
+---
+
+## Pre-conditions (verificar antes de empezar)
+
+- [ ] **PC1: Branch en main + sync con remote**
+
+```bash
+git checkout main && git pull --ff-only origin main
+```
+
+Expected: branch `main`, fast-forward sin conflictos. (Solo housekeeping — Phase A no toca repo, pero queremos partir de main limpio.)
+
+- [ ] **PC2: Service en prod healthy**
+
+```bash
+ssh aws-server "systemctl is-active trading-spacial && curl -fsS http://localhost:8100/health"
+```
+
+Expected: `active` + `{"healthy":true,...}`. Si no, NO seguir — investigar antes.
+
+- [ ] **PC3: Sesión Playwright activa con cookie JWT de Samuel**
+
+Verificar con `browser_evaluate`:
+
+```js
+async () => {
+  const r = await fetch('/api/auth/me', { credentials: 'include' });
+  return { status: r.status, body: await r.json() };
+}
+```
+
+Expected: 200 + `body.email === 'sssamuelll@gmail.com'`. Si 401: Samuel se loguea en el browser antes de seguir.
+
+---
+
+### Task 1: Pre-check de `user_preferences` para `tenant_id=1` (Owner: Claude)
+
+**Files / state read:**
+- DB: `user_preferences` table, row con `tenant_id=1`.
+
+**Why this matters:** §5 del spec exige `min_score: 4` explícito en el PUT para evitar F8 (min_score residual de tests previos bloqueando signals). Este task captura el estado actual para saber si hay row existente.
+
+- [ ] **Step 1.1: GET preferences actual via Playwright**
+
+```js
+async () => {
+  const r = await fetch('/api/preferences', { credentials: 'include' });
+  return { status: r.status, body: await r.json() };
+}
+```
+
+Expected: 200 + body con shape `{tenant_id: 1, symbol_filter: ..., min_score: ..., notify_channels: ...}`.
+
+- [ ] **Step 1.2: Capturar `min_score` y `notify_channels` actuales para registro**
+
+Anotar en este chat los valores observados:
+- `current.min_score`: ___ (esperado: probably `4`, pero podría ser 8 o algo residual).
+- `current.notify_channels`: ___ (esperado: `null`, no había prefs).
+
+Si `min_score !== 4` o `notify_channels` ya tiene `telegram_chat_id`, **flag para Samuel antes del PUT en Task 4**.
+
+---
+
+### Task 2: Bot creation + chat_id discovery (Owner: Samuel)
+
+**Files / state created:**
+- Telegram side: un nuevo bot bajo la cuenta de @BotFather.
+- Información: token + chat_id de Samuel para usar en Task 3 y 4.
+
+- [ ] **Step 2.1: Crear bot vía @BotFather**
+
+En Telegram, abrir chat con [@BotFather](https://t.me/BotFather):
+
+1. `/newbot`
+2. Responder con nombre amigable (ej: "Crypto Scanner – Samuel").
+3. Responder con username terminado en `bot` (ej: `samuel_crypto_scanner_bot`).
+4. BotFather responde con token tipo `123456789:ABCdefGHIjkl-MNOpqrs_TUVwxyz`.
+
+Guardar token en buffer local (no pegarlo en este chat).
+
+- [ ] **Step 2.2: Iniciar conversación con el bot**
+
+En Telegram, buscar el username del bot (`@samuel_crypto_scanner_bot` o el que hayas elegido) y mandar `/start`. Telegram requiere que el usuario inicie la conversación primero — el bot NO puede DM-ear a alguien que no le mandó algo antes.
+
+- [ ] **Step 2.3: Obtener chat_id vía getUpdates**
+
+En el browser, abrir (reemplazando `<TOKEN>`):
+
+```
+https://api.telegram.org/bot<TOKEN>/getUpdates
+```
+
+Expected: JSON con shape:
+
+```json
+{
+  "ok": true,
+  "result": [
+    {
+      "update_id": ...,
+      "message": {
+        "message_id": ...,
+        "from": {...},
+        "chat": {
+          "id": 123456789,
+          ...
+        },
+        "text": "/start",
+        ...
+      }
+    }
+  ]
+}
+```
+
+Copiar `result[0].message.chat.id` (entero positivo para chats 1-a-1, ej `123456789`). **Importante:** se va a persistir como **string** en `notify_channels_json` — el `TelegramChannel.send` (`notifier/channels/telegram.py:26`) hace `.strip()` que crashea sobre int.
+
+Guardar chat_id en buffer local (no pegarlo en este chat).
+
+---
+
+### Task 3: Token al `.env` del server + restart (Owner: Samuel)
+
+**Files / state modified:**
+- `/var/www/trading/.env`: append `TRADING_TELEGRAM_BOT_TOKEN=<token>`.
+- Proceso `trading-spacial`: restart para releer.
+
+- [ ] **Step 3.1: Append robusto del token al `.env`**
+
+Desde tu shell local (Samuel reemplaza `<token>` por el real, NO copiar acá):
+
+```bash
+ssh aws-server "sudo sh -c 'printf \"\\nTRADING_TELEGRAM_BOT_TOKEN=%s\\n\" \"<token>\" >> /var/www/trading/.env'"
+```
+
+El `\n` líder garantiza separación aunque el último byte del `.env` previo no fuera newline (mitiga F6 del spec).
+
+- [ ] **Step 3.2: Verificar que la línea existe (key-only check, sin valor)**
+
+```bash
+ssh aws-server "sudo grep -c '^TRADING_TELEGRAM_BOT_TOKEN=' /var/www/trading/.env"
+```
+
+Expected: `1`. Si `0` o `≥2`, F6 — investigar antes de seguir.
+
+- [ ] **Step 3.3: Restart del service**
+
+```bash
+ssh aws-server "sudo systemctl restart trading-spacial"
+```
+
+Expected: comando vuelve sin error (exit 0). 2-3s downtime nominal.
+
+- [ ] **Step 3.4: Wait + verificar service healthy post-restart**
+
+```bash
+sleep 15 && ssh aws-server "systemctl is-active trading-spacial && curl -fsS http://localhost:8100/health"
+```
+
+Expected: `active` + `{"healthy":true,...}`. Cold start con DB warmup puede tardar ~10s, por eso el `sleep 15`. Si `is-active` ≠ `active` tras los 15s, ir a F6 del spec (logs + retry).
+
+---
+
+### Task 4: PUT chat_id a preferences via Playwright (Owner: Claude)
+
+**Files / state modified:**
+- DB: `user_preferences` UPSERT row para `tenant_id=1`. `notify_channels_json` ← `{"telegram_chat_id": "<chat_id>"}`. `min_score` ← `4`.
+
+- [ ] **Step 4.1: Capturar CSRF token desde document.cookie**
+
+```js
+async () => {
+  const csrf = document.cookie
+    .split('; ')
+    .find(c => c.startsWith('csrf_token='))
+    ?.split('=')[1];
+  return { csrf_present: Boolean(csrf), csrf_len: csrf?.length };
+}
+```
+
+Expected: `csrf_present: true`, `csrf_len: ~43` (Fernet token length). Si false, refrescar dashboard en Playwright.
+
+- [ ] **Step 4.2: PUT con min_score: 4 explícito y notify_channels seteado**
+
+Samuel **pasa el chat_id por chat** acá (es seguro: no es secreto — es un identificador de su cuenta de Telegram que igual aparece en getUpdates si alguien tiene el token).
+
+Reemplazar `<CHAT_ID>` por el valor real (string, e.g. `"123456789"`):
+
+```js
+async () => {
+  const csrf = document.cookie.split('; ').find(c => c.startsWith('csrf_token='))?.split('=')[1];
+  const r = await fetch('/api/preferences', {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+    body: JSON.stringify({
+      min_score: 4,
+      notify_channels: { telegram_chat_id: '<CHAT_ID>' }
+    })
+  });
+  return { status: r.status, body: await r.json() };
+}
+```
+
+Expected:
+- `status: 200`
+- `body.ok: true`
+- `body.preferences.tenant_id: 1`
+- `body.preferences.min_score: 4`
+- `body.preferences.notify_channels.telegram_chat_id: "<CHAT_ID>"` (string)
+
+- [ ] **Step 4.3: Re-GET para confirmar persistencia (defensa contra Pydantic-passthrough sin DB commit)**
+
+```js
+async () => {
+  const r = await fetch('/api/preferences', { credentials: 'include' });
+  return await r.json();
+}
+```
+
+Expected: misma shape que en Step 4.2 — `notify_channels.telegram_chat_id: "<CHAT_ID>"` + `min_score: 4`. Si difiere, hay bug en el UPSERT — abort + investigar.
+
+---
+
+### Task 5: Force scan + verify dispatch (Owner: Claude + Samuel)
+
+**Why force vs wait:** Force evita 5 min de espera por el próximo ciclo. Pero hay caveat: si el último signal del símbolo fue hace <30 min, F7 (dedup) lo bloquea. Solución: probar con varios símbolos hasta encontrar uno fresh.
+
+- [ ] **Step 5.1: Trigger force scan vía Playwright**
+
+```js
+async () => {
+  const csrf = document.cookie.split('; ').find(c => c.startsWith('csrf_token='))?.split('=')[1];
+  const t0 = performance.now();
+  const r = await fetch('/api/scan', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'X-CSRF-Token': csrf }
+  });
+  const dt = Math.round(performance.now() - t0);
+  const body = await r.json();
+  return {
+    status: r.status,
+    elapsed_ms: dt,
+    scanned: body.scanned,
+    high_score_signals: body.results?.filter(x => (x.score || 0) >= 4)
+      .map(x => ({ symbol: x.symbol, score: x.score, señal: x.señal }))
+  };
+}
+```
+
+Expected: `status: 200`, `scanned: 10`, y `high_score_signals` con al menos 1 entry con `señal: true`. Si vacío, esperar 5 min al próximo ciclo natural (paso 5.1.b abajo).
+
+- [ ] **Step 5.1.b (fallback): Si force scan no produjo signals, esperar al próximo ciclo natural**
+
+Setup background monitor en `journalctl` esperando el próximo `dispatch:` line:
+
+```bash
+ssh aws-server "sudo journalctl -u trading-spacial -f --since 'now'" 2>&1 | grep --line-buffered -E 'dispatch: user_id=1|senal duplicada|senal'
+```
+
+Dejar correr 5-10 min. Salir con Ctrl+C cuando aparezca un evento.
+
+- [ ] **Step 5.2: Verificar dispatch en journalctl (acceptance gate 1)**
+
+```bash
+ssh aws-server "sudo journalctl -u trading-spacial --since '5 minutes ago' --no-pager | grep -E 'dispatch: user_id=1.*receipts=[1-9]'"
+```
+
+Expected: al menos 1 línea con shape:
+```
+dispatch: user_id=1 symbol=<X> score=<Y> receipts=1
+```
+
+El pattern `receipts=[1-9]` excluye:
+- Skip lines (que también empiezan con `dispatch: user_id=1` pero terminan en `skipped — symbol=...`).
+- `receipts=0` (indicaría canal mal configurado — F3 del spec).
+
+Si solo aparecen skip lines: F8 (min_score residual no aplicó) o F7 (dedup activo). Diagnóstico: re-leer line completa.
+
+Si solo aparecen `receipts=0`: F3 (token no llegó al proceso post-restart) o F4 (chat_id mal en prefs). Ir al journalctl del TelegramChannel:
+
+```bash
+ssh aws-server "sudo journalctl -u trading-spacial --since '5 minutes ago' --no-pager | grep -iE 'telegram|chat not found|unauthorized'"
+```
+
+- [ ] **Step 5.3: Samuel confirma recepción en Telegram (acceptance gate 2)**
+
+Samuel chequea su chat con el bot. Expected: al menos 1 mensaje con shape de signal (símbolo + score + precio + dirección LONG/SHORT + niveles SL/TP). Si no llegó:
+- Si journalctl mostró `receipts=1` pero no llegó a Telegram → race condition rara, esperar 30s.
+- Si journalctl mostró 401/400 → F4/F5 del spec.
+
+- [ ] **Step 5.4: Verificar persistencia de la row en DB (acceptance gate 3)**
+
+```bash
+ssh aws-server "cd /var/www/trading && .venv/bin/python -c '
+import sqlite3, json
+con = sqlite3.connect(\"signals.db\")
+con.row_factory = sqlite3.Row
+row = con.execute(\"SELECT tenant_id, min_score, notify_channels_json, updated_at FROM user_preferences WHERE tenant_id=1\").fetchone()
+if row:
+    d = dict(row)
+    d[\"notify_channels_parsed\"] = json.loads(d[\"notify_channels_json\"])
+    print(d)
+else:
+    print(\"NO ROW — PUT did not persist\")
+'"
+```
+
+Expected:
+```python
+{
+  'tenant_id': 1,
+  'min_score': 4,
+  'notify_channels_json': '{"telegram_chat_id": "<CHAT_ID>"}',
+  'notify_channels_parsed': {'telegram_chat_id': '<CHAT_ID>'},
+  'updated_at': '<ISO ts cercano al PUT>',
+}
+```
+
+Si falta o difiere: bug grave en UPSERT — abort + investigar en `db/user_preferences.py:db_upsert_user_preferences`.
+
+---
+
+### Task 6: Cierre — task list + memory update (Owner: Claude)
+
+- [ ] **Step 6.1: Marcar task #19 (Phase A execución) como completada**
+
+Vía `TaskUpdate` tool.
+
+- [ ] **Step 6.2: Guardar memoria de continuidad para sesiones futuras**
+
+Crear `memory/project_telegram_phase_a_done.md` con resumen de qué quedó:
+
+```markdown
+---
+name: telegram-phase-a-done
+description: Phase A del epic Telegram multi-tenant shippeado YYYY-MM-DD — Samuel recibe señales vía dispatch_per_user
+metadata:
+  type: project
+---
+
+Phase A del epic Telegram multi-tenant completado YYYY-MM-DD-HH:MM UTC.
+
+Estado:
+- `TRADING_TELEGRAM_BOT_TOKEN` en `/var/www/trading/.env` (no en repo, no en transcript).
+- `user_preferences` row para `tenant_id=1` (Simon): `min_score=4`, `notify_channels.telegram_chat_id=<set>`.
+- Dispatch verificado end-to-end: journalctl receipt=1 + Telegram recibido + DB row persistido.
+
+Out-of-scope que sigue pendiente (sub-proyectos B y C del mismo epic):
+- Phase B: frontend UI self-service para gestionar prefs (sin spec todavía).
+- Phase C: bot webhook + deep-link invites (deferido hasta Epic B #253 onboarding).
+
+Spec/plan refs:
+- Spec: [[telegram-multitenant-phase-a-pre-reg]]
+- Plan: docs/superpowers/plans/2026-05-21-telegram-multitenant-phase-a.md
+```
+
+Update `MEMORY.md` con la línea nueva.
+
+- [ ] **Step 6.3: Commit del plan a main**
+
+El plan en sí ya está committed cuando se escribió. No hay code change.
+
+---
+
+## Acceptance gates (re-stated)
+
+Phase A se considera completado cuando los **3 son verdaderos simultáneamente**:
+
+| Gate | Comando / verificación | Pasa cuando |
+|---|---|---|
+| Backend dispatch | `journalctl ... \| grep -E 'dispatch: user_id=1.*receipts=[1-9]'` | Al menos 1 línea para signal real (no /webhook/test) |
+| Telegram recepción | Samuel chequea en su chat del bot | Al menos 1 mensaje con shape de signal |
+| DB persistencia | Python query a `user_preferences` | Row con `tenant_id=1`, `min_score=4`, `notify_channels.telegram_chat_id` seteado |
+
+---
+
+## Rollback (si necesario)
+
+Reversible 100%:
+
+```bash
+# 1. Borrar token del .env
+ssh aws-server "sudo sed -i '/^TRADING_TELEGRAM_BOT_TOKEN=/d' /var/www/trading/.env && sudo systemctl restart trading-spacial"
+
+# 2. Borrar chat_id del prefs (set notify_channels a null)
+# Vía browser_evaluate:
+async () => {
+  const csrf = document.cookie.split('; ').find(c => c.startsWith('csrf_token='))?.split('=')[1];
+  return await fetch('/api/preferences', {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+    body: JSON.stringify({ notify_channels: null })
+  }).then(r => r.json());
+}
+```
+
+Estado pre-Phase-A queda restaurado: sin token global, sin row de prefs (efectivamente).
+
+---
+
+## Failure mode quick reference (full table en spec §7)
+
+| Símptoma | Probable causa | Task affected | Fix |
+|---|---|---|---|
+| `receipts=0` en journalctl | Token no leyó del .env | 3.4 → 5.2 | Re-restart |
+| `chat not found` 400 | chat_id mal | 4.2 → 5.2 | Re-PUT |
+| `Unauthorized` 401 | Token mal copiado | 3.1 → 5.2 | Re-issue en BotFather |
+| Service no levanta | .env syntax | 3.3 → 3.4 | Editar manual, retry |
+| Solo skip lines en journalctl | min_score residual O dedup | 5.2 | F7/F8 del spec |
+| Service no healthy en 15s | Cold start lento O algo serio | 3.4 | Logs + retry |
+
+---
+
+## Out of scope (recordatorio)
+
+- Code changes — NONE en Phase A (delegado a Phase B y C).
+- Frontend UI — Phase B.
+- Bot webhook + auto-discovery — Phase C.
+- Multi-user testing — single user (Simon) hasta Epic B.

--- a/docs/superpowers/plans/2026-05-21-telegram-multitenant-phase-a.md
+++ b/docs/superpowers/plans/2026-05-21-telegram-multitenant-phase-a.md
@@ -1,5 +1,7 @@
 # Telegram Multi-Tenant Phase A — Backend Wiring Implementation Plan
 
+> ⚠️ **SUPERSEDED 2026-05-21** by [`2026-05-21-telegram-per-user-config.md`](2026-05-21-telegram-per-user-config.md). Operator redirect mid-execution invirtió el modelo (bot per-user, config UI-driven). Spec asociado en `specs/es/2026-05-21-telegram-per-user-config-pre-reg.md`. Este plan queda como artefacto histórico.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Plan has no code changes — solo operational steps con checkpoints de verificación. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Samuel recibe señales del scanner en su chat personal de Telegram, vía la ruta per-user (`dispatch_signal_to_users`), no por broadcast global. Funciona hoy con `tenant_id=1`; deja la arquitectura lista para usuarios futuros (cada uno con su propio chat_id en `user_preferences`).

--- a/docs/superpowers/plans/2026-05-21-telegram-per-user-config.md
+++ b/docs/superpowers/plans/2026-05-21-telegram-per-user-config.md
@@ -1,0 +1,1771 @@
+# Telegram per-user config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) o superpowers:executing-plans para ejecutar este plan task-por-task. Steps usan checkbox (`- [ ]`) para tracking.
+
+**Goal:** Cada operador del sistema configura su propio bot de Telegram (token + chat_id) desde el dashboard, sin SSH ni admin work. Después de save+test exitoso, recibe automáticamente cada signal con `score ≥ min_score` en SU bot.
+
+**Architecture:** El backend bypassa `notify()` para `/preferences/test` y llama `TelegramChannel.send()` directo (evita dedup edge-cases + side-effect en NotificationBell). El frontend reusa el item placeholder "Conexiones" en `UserMenu.tsx:31` que ya existe wirearlo + abre nuevo slide-out `ConnectionsPanel`. Tokens enmascarados en GET response (XSS blast-radius mitigation).
+
+**Tech Stack:** Python 3.11 (FastAPI, pydantic, pytest), TypeScript/React (vitest), Playwright (e2e), httpx para Telegram Bot API.
+
+**Spec:** [`docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md`](../specs/es/2026-05-21-telegram-per-user-config-pre-reg.md) (commit `142bbf5`).
+
+---
+
+## File structure
+
+### Archivos creados (NEW)
+
+| Path | Responsabilidad |
+|---|---|
+| `frontend/src/components/ConnectionsPanel.tsx` | Slide-out panel desde user dropdown; sección "Telegram" con form + 3 botones (Guardar, Probar, Eliminar). |
+| `frontend/src/components/ConnectionsPanel.module.css` | Estilos (mismo patrón slide-out from right que `ConfigPanel.module.css`). |
+| `frontend/src/components/ConnectionsPanel.test.tsx` | 8 vitest tests del componente. |
+| `frontend/src/components/UserMenu.test.tsx` | 2 vitest tests del badge condicional. |
+| `tests/test_api_user_preferences.py` | 9 pytest tests del backend (masking + endpoint /test). |
+
+### Archivos modificados
+
+| Path | Cambio |
+|---|---|
+| `api/user_preferences.py` | + `_mask_token()` helper; modificar GET para masking; modificar PUT para detect-masked-and-skip; agregar `POST /preferences/test`. |
+| `db/user_preferences.py` | Posiblemente cero cambios — el masking vive en API layer, el DB layer sigue devolviendo plain. (Verificar en Task 3.) |
+| `frontend/src/types.ts` | + interface `TestDeliveryResponse` + interface `NotifyChannels`. |
+| `frontend/src/api.ts` | + wrapper `testPreferencesDelivery()`. |
+| `frontend/src/components/UserMenu.tsx` | Wirear `onClick` al item "Conexiones"; badge `'1'` condicional según `notify_channels.telegram_bot_token`. |
+| `frontend/src/App.tsx` | Extender `OverlayKind` con `'connections'`; render del `<ConnectionsPanel>`; cerrar UserMenu al click. |
+
+### Branch
+
+`feat/telegram-per-user-config` — un solo branch + un solo PR cubriendo backend + frontend + tests. Justification: el frontend depende del backend, pero el feature es shippeable de una pieza. Si el reviewer pide split, hacemos split en review.
+
+---
+
+## Pre-conditions
+
+- [ ] **PC1: Branch nueva desde main sync**
+
+```bash
+git checkout main && git pull --ff-only origin main && git checkout -b feat/telegram-per-user-config
+```
+
+Expected: branch `feat/telegram-per-user-config`, parte de main al día.
+
+- [ ] **PC2: Test baseline passing**
+
+```bash
+python -m pytest tests/test_provider_registry.py tests/test_api_user_preferences.py -k "not trio" 2>&1 | tail -3
+```
+
+Expected: tests/test_api_user_preferences.py no existe todavía → pytest errores "no tests collected" pero `test_provider_registry.py` 13/13 pass. OK arrancar.
+
+- [ ] **PC3: Frontend test baseline passing**
+
+```bash
+cd frontend && npm test -- --run --reporter=verbose 2>&1 | tail -10
+```
+
+Expected: la suite existente verde. Si algo rojo, abort + investigar antes de agregar más tests.
+
+---
+
+### Task 1: Backend — `_mask_token` helper + tests
+
+**Files:**
+- Modify: `api/user_preferences.py` (agregar helper al final del module-level scope).
+- Create: `tests/test_api_user_preferences.py`.
+
+- [ ] **Step 1.1: Crear test file con failing tests para `_mask_token`**
+
+Create `tests/test_api_user_preferences.py`:
+
+```python
+"""Tests for api/user_preferences.py — masking + /preferences/test endpoint.
+
+Covers:
+- _mask_token helper invariants.
+- GET /api/preferences masks telegram_bot_token in response.
+- PUT /api/preferences preserves masked token, replaces unmasked.
+- POST /api/preferences/test: no-creds early-return, happy path, dedup-bypass,
+  no-write-to-notifications_sent, isolated per tenant.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── _mask_token helper ──────────────────────────────────────────────
+
+
+def test_mask_token_real_telegram_token():
+    """Real Telegram tokens are ~46 chars (<bot_id>:<35-char-secret>).
+    Mask should preserve first 10 + last 4 chars with **** between."""
+    from api.user_preferences import _mask_token
+    token = "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12"
+    assert _mask_token(token) == "123456789:****gH12"
+
+
+def test_mask_token_empty_returns_empty():
+    """Empty input → empty output (no masking artifacts on empty)."""
+    from api.user_preferences import _mask_token
+    assert _mask_token("") == ""
+
+
+def test_mask_token_short_input_returns_empty():
+    """Inputs shorter than 10 chars are treated as garbage and return ""
+    (defensive: real tokens are always ≥10 chars; this guard prevents
+    leaking partial credentials via mask='****X' for X<10 chars)."""
+    from api.user_preferences import _mask_token
+    assert _mask_token("123") == ""
+    assert _mask_token("123456789") == ""  # exactly 9, still under threshold
+```
+
+- [ ] **Step 1.2: Run tests — verify FAIL**
+
+```bash
+python -m pytest tests/test_api_user_preferences.py -v
+```
+
+Expected: 3 tests FAIL con `ImportError: cannot import name '_mask_token'` (la función no existe todavía).
+
+- [ ] **Step 1.3: Implementar `_mask_token` en `api/user_preferences.py`**
+
+Agregar al final del módulo (después de `put_preferences`):
+
+```python
+def _mask_token(token: str) -> str:
+    """Mask a Telegram bot token, preserving first 10 + last 4 chars.
+
+    Real Telegram tokens have shape `<bot_id>:<35-char-secret>` (~46 chars
+    total). Output: first 10 chars + "****" + last 4 chars.
+
+    Defensive: `len < 10` returns "" instead of partial mask. Real tokens
+    are never shorter than 10 chars; this guard only fires for garbage
+    (empty, corrupt, manually-truncated). Returning "" makes the masked
+    field indistinguishable from "not configured" in those cases — accept-
+    able because the path is not reachable in prod with valid creds.
+
+    Spec ref: docs/superpowers/specs/es/2026-05-21-telegram-per-user-
+    config-pre-reg.md §Security note.
+    """
+    if not token or len(token) < 10:
+        return ""
+    return f"{token[:10]}****{token[-4:]}"
+```
+
+- [ ] **Step 1.4: Run tests — verify PASS**
+
+```bash
+python -m pytest tests/test_api_user_preferences.py -v
+```
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add api/user_preferences.py tests/test_api_user_preferences.py
+git commit -m "feat(prefs): _mask_token helper for telegram_bot_token
+
+Preserves first 10 + last 4 chars (e.g. '123456789:****gH12'). Returns
+empty string for inputs <10 chars (defensive, real tokens are ~46 chars).
+
+Pre-reg: docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md"
+```
+
+---
+
+### Task 2: Backend — GET masks token + PUT preserves masked
+
+**Files:**
+- Modify: `api/user_preferences.py` (modify `get_preferences` + `put_preferences`).
+- Modify: `tests/test_api_user_preferences.py` (add 3 tests).
+
+- [ ] **Step 2.1: Agregar failing tests al test file**
+
+Append to `tests/test_api_user_preferences.py`:
+
+```python
+# ── GET /api/preferences masking ────────────────────────────────────
+
+
+@pytest.fixture
+def seeded_user_with_telegram(tmp_path, monkeypatch):
+    """Fresh DB con user_id=1 + notify_channels con telegram creds populados.
+    Devuelve el TestClient configurado para auth bypass (admin role)."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from db.auth_schema import init_auth_db
+    from db.schema import init_db
+    from db.connection import get_db
+    from db.user_preferences import db_upsert_user_preferences
+
+    db_path = str(tmp_path / "test_prefs.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    init_db()
+    init_auth_db()
+
+    con = get_db()
+    con.execute(
+        "INSERT INTO users (id, email, password_hash, role, is_active, "
+        "created_at, password_changed_at) VALUES "
+        "(1, 'a@example.com', 'h', 'admin', 1, "
+        "'2026-05-21T00:00:00+00:00', '2026-05-21T00:00:00+00:00')"
+    )
+    con.commit()
+    con.close()
+
+    db_upsert_user_preferences(
+        1,
+        notify_channels={
+            "telegram_bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12",
+            "telegram_chat_id":   "987654321",
+        },
+    )
+
+    return TestClient(btc_api.app)
+
+
+def test_get_preferences_masks_telegram_bot_token(seeded_user_with_telegram):
+    """GET response should return masked token, not plain — defense against
+    XSS exfiltration of credentials."""
+    client = seeded_user_with_telegram
+    r = client.get("/preferences")
+    assert r.status_code == 200
+    data = r.json()
+    masked = data["notify_channels"]["telegram_bot_token"]
+    assert masked == "123456789:****gH12"
+    assert "ABCdefGHI" not in masked, "secret portion should not leak"
+
+
+def test_get_preferences_chat_id_not_masked(seeded_user_with_telegram):
+    """chat_id is not secret (visible in any getUpdates response); pass through."""
+    client = seeded_user_with_telegram
+    r = client.get("/preferences")
+    assert r.json()["notify_channels"]["telegram_chat_id"] == "987654321"
+
+
+# ── PUT /api/preferences preserves masked token ──────────────────────
+
+
+def test_put_preserves_token_when_value_contains_mask_marker(seeded_user_with_telegram):
+    """If user submits the masked value (didn't retype), DB token stays unchanged."""
+    client = seeded_user_with_telegram
+    masked = "123456789:****gH12"
+    r = client.put("/preferences", json={
+        "notify_channels": {
+            "telegram_bot_token": masked,
+            "telegram_chat_id":   "111222333",  # changed
+        },
+    })
+    assert r.status_code == 200
+
+    # Re-fetch raw from DB (bypass masking) to verify token preserved
+    from db.user_preferences import db_get_user_preferences
+    row = db_get_user_preferences(1)
+    nc = row["notify_channels"]
+    assert nc["telegram_bot_token"] == "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12"
+    assert nc["telegram_chat_id"] == "111222333"
+
+
+def test_put_replaces_token_when_value_unmasked(seeded_user_with_telegram):
+    """If user submits a plain token (no ****), DB updates to the new value."""
+    client = seeded_user_with_telegram
+    r = client.put("/preferences", json={
+        "notify_channels": {
+            "telegram_bot_token": "111111111:NEWXYZabcDEFghiJKLmnoPQRstuVWXyzABCDE",
+            "telegram_chat_id":   "987654321",
+        },
+    })
+    assert r.status_code == 200
+
+    from db.user_preferences import db_get_user_preferences
+    row = db_get_user_preferences(1)
+    assert row["notify_channels"]["telegram_bot_token"] == "111111111:NEWXYZabcDEFghiJKLmnoPQRstuVWXyzABCDE"
+```
+
+- [ ] **Step 2.2: Run tests — verify FAIL**
+
+```bash
+python -m pytest tests/test_api_user_preferences.py::test_get_preferences_masks_telegram_bot_token tests/test_api_user_preferences.py::test_put_preserves_token_when_value_contains_mask_marker -v
+```
+
+Expected: ambos FAIL (GET devuelve token plain; PUT sobreescribe con masked).
+
+- [ ] **Step 2.3: Modificar `get_preferences` en `api/user_preferences.py`**
+
+Encontrar:
+
+```python
+@router.get("", summary="Get preferences for current tenant (defaults if unset)")
+def get_preferences(tenant_id: int = Depends(get_current_tenant_id)):
+    row = db_get_user_preferences(tenant_id)
+    if row is None:
+        return {
+            "tenant_id": tenant_id,
+            "symbol_filter": None,
+            "min_score": _DEFAULT_MIN_SCORE,
+            "notify_channels": None,
+        }
+    return row
+```
+
+Reemplazar con:
+
+```python
+@router.get("", summary="Get preferences for current tenant (defaults if unset)")
+def get_preferences(tenant_id: int = Depends(get_current_tenant_id)):
+    row = db_get_user_preferences(tenant_id)
+    if row is None:
+        return {
+            "tenant_id": tenant_id,
+            "symbol_filter": None,
+            "min_score": _DEFAULT_MIN_SCORE,
+            "notify_channels": None,
+        }
+    # Mask telegram_bot_token in the response to reduce XSS blast radius.
+    # See spec §Security note.
+    nc = row.get("notify_channels") or None
+    if nc and nc.get("telegram_bot_token"):
+        nc = {**nc, "telegram_bot_token": _mask_token(nc["telegram_bot_token"])}
+        row = {**row, "notify_channels": nc}
+    return row
+```
+
+- [ ] **Step 2.4: Modificar `put_preferences` en `api/user_preferences.py`**
+
+Encontrar:
+
+```python
+@router.put(
+    "",
+    summary="Upsert preferences for current tenant",
+    dependencies=[Depends(verify_api_key)],
+)
+def put_preferences(
+    body: PreferencesPutBody,
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    row = db_upsert_user_preferences(
+        tenant_id,
+        symbol_filter=body.symbol_filter,
+        min_score=body.min_score,
+        notify_channels=body.notify_channels,
+    )
+    return {"ok": True, "preferences": row}
+```
+
+Reemplazar con:
+
+```python
+@router.put(
+    "",
+    summary="Upsert preferences for current tenant",
+    dependencies=[Depends(verify_api_key)],
+)
+def put_preferences(
+    body: PreferencesPutBody,
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    # If the submitted telegram_bot_token contains the mask marker '****',
+    # the user did NOT retype it — preserve the existing DB value. This
+    # supports the UX pattern "pre-fill masked value, only update if user
+    # types something new". See spec §Security note.
+    notify_channels = body.notify_channels
+    if notify_channels and "****" in (notify_channels.get("telegram_bot_token") or ""):
+        existing = db_get_user_preferences(tenant_id)
+        existing_token = (
+            (existing or {}).get("notify_channels") or {}
+        ).get("telegram_bot_token", "")
+        notify_channels = {**notify_channels, "telegram_bot_token": existing_token}
+
+    row = db_upsert_user_preferences(
+        tenant_id,
+        symbol_filter=body.symbol_filter,
+        min_score=body.min_score,
+        notify_channels=notify_channels,
+    )
+    # Re-fetch + mask before returning (consistency with GET).
+    fresh = db_get_user_preferences(tenant_id)
+    if fresh and fresh.get("notify_channels", {}).get("telegram_bot_token"):
+        nc = fresh["notify_channels"]
+        fresh = {**fresh, "notify_channels": {**nc, "telegram_bot_token": _mask_token(nc["telegram_bot_token"])}}
+    return {"ok": True, "preferences": fresh}
+```
+
+- [ ] **Step 2.5: Run tests — verify PASS**
+
+```bash
+python -m pytest tests/test_api_user_preferences.py -v
+```
+
+Expected: 7/7 PASS (3 originales + 4 nuevos).
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add api/user_preferences.py tests/test_api_user_preferences.py
+git commit -m "feat(prefs): mask telegram_bot_token in GET, preserve on PUT
+
+Reduces XSS exfiltration blast radius (~90%) without schema change. GET
+returns '<10chars>****<4chars>'; PUT detects masked value and preserves
+existing DB token instead of overwriting with the placeholder.
+
+Pre-reg: docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md §Security note"
+```
+
+---
+
+### Task 3: Backend — `POST /preferences/test` endpoint
+
+**Files:**
+- Modify: `api/user_preferences.py` (agregar endpoint).
+- Modify: `tests/test_api_user_preferences.py` (agregar 5 tests).
+
+- [ ] **Step 3.1: Agregar failing tests al test file**
+
+Append to `tests/test_api_user_preferences.py`:
+
+```python
+# ── POST /api/preferences/test ──────────────────────────────────────
+
+
+def test_test_endpoint_no_channels_returns_no_telegram_configured(tmp_path, monkeypatch):
+    """User without notify_channels → {ok: false, reason: 'no_telegram_configured'}."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from db.auth_schema import init_auth_db
+    from db.schema import init_db
+    from db.connection import get_db
+
+    db_path = str(tmp_path / "test_prefs_no_channels.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    init_db()
+    init_auth_db()
+    con = get_db()
+    con.execute(
+        "INSERT INTO users (id, email, password_hash, role, is_active, "
+        "created_at, password_changed_at) VALUES "
+        "(1, 'a@example.com', 'h', 'admin', 1, "
+        "'2026-05-21T00:00:00+00:00', '2026-05-21T00:00:00+00:00')"
+    )
+    con.commit()
+    con.close()
+
+    client = TestClient(btc_api.app)
+    r = client.post("/preferences/test")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"ok": False, "receipts": [], "reason": "no_telegram_configured"}
+
+
+def test_test_endpoint_only_token_returns_no_telegram_configured(seeded_user_with_telegram, monkeypatch):
+    """Token set but chat_id missing → still no_telegram_configured."""
+    from db.user_preferences import db_upsert_user_preferences
+    db_upsert_user_preferences(1, notify_channels={"telegram_bot_token": "xxx:yyy"})
+
+    client = seeded_user_with_telegram
+    r = client.post("/preferences/test")
+    assert r.json()["reason"] == "no_telegram_configured"
+
+
+def test_test_endpoint_with_telegram_routes_correctly(seeded_user_with_telegram, monkeypatch):
+    """Happy path: token + chat_id set → TelegramChannel.send called with user_cfg.
+    Mock requests.post to avoid hitting real Telegram API."""
+    sent_payloads = []
+    class _FakeResp:
+        ok = True
+        status_code = 200
+        text = "ok"
+    def _fake_post(url, json=None, **kw):
+        sent_payloads.append({"url": url, "body": json})
+        return _FakeResp()
+
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    client = seeded_user_with_telegram
+    r = client.post("/preferences/test")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["receipts"] == [{"channel": "telegram", "status": "ok", "error": None}]
+    assert body["reason"] is None
+    # Sent payload uses the USER's bot token + chat_id from notify_channels overlay
+    assert len(sent_payloads) == 1
+    assert "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12" in sent_payloads[0]["url"]
+    assert sent_payloads[0]["body"]["chat_id"] == "987654321"
+
+
+def test_test_endpoint_two_calls_within_window_both_succeed(seeded_user_with_telegram, monkeypatch):
+    """Defense against future dedup window changes: 2 calls in quick succession
+    BOTH return ok=true. Bypass of notify() guarantees this regardless of any
+    future tightening of signal-type dedup defaults."""
+    class _FakeResp:
+        ok = True
+        status_code = 200
+        text = "ok"
+    def _fake_post(url, **kw):
+        return _FakeResp()
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    client = seeded_user_with_telegram
+    r1 = client.post("/preferences/test")
+    r2 = client.post("/preferences/test")
+    assert r1.json()["ok"] is True
+    assert r2.json()["ok"] is True
+
+
+def test_test_endpoint_does_not_write_to_notifications_sent(seeded_user_with_telegram, monkeypatch):
+    """Bypass of notify() means no row written to notifications_sent
+    (avoids polluting NotificationBell with test pings)."""
+    class _FakeResp:
+        ok = True
+        status_code = 200
+        text = "ok"
+    def _fake_post(url, **kw):
+        return _FakeResp()
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    from db.connection import get_db
+    con = get_db()
+    before = con.execute("SELECT COUNT(*) FROM notifications_sent").fetchone()[0]
+    con.close()
+
+    client = seeded_user_with_telegram
+    client.post("/preferences/test")
+
+    con = get_db()
+    after = con.execute("SELECT COUNT(*) FROM notifications_sent").fetchone()[0]
+    con.close()
+    assert before == after, "POST /test should NOT write to notifications_sent"
+```
+
+- [ ] **Step 3.2: Run tests — verify FAIL**
+
+```bash
+python -m pytest tests/test_api_user_preferences.py -v -k "test_test_endpoint"
+```
+
+Expected: 5 tests FAIL — endpoint no existe, devuelve 404.
+
+- [ ] **Step 3.3: Implementar `POST /preferences/test` en `api/user_preferences.py`**
+
+Agregar después de `put_preferences`:
+
+```python
+@router.post(
+    "/test",
+    summary="Send a test message to current tenant's Telegram",
+    dependencies=[Depends(verify_api_key)],
+)
+def post_preferences_test(tenant_id: int = Depends(get_current_tenant_id)):
+    """Verifica end-to-end que las credenciales de Telegram del usuario
+    funcionan, mandando un mensaje 'ping' a su bot.
+
+    Bypassa notify() y dispatch_signal_to_users a propósito (spec §Backend
+    Option 2):
+      - Evita dedup edge-cases (signal event_type tiene dedup_window=0 hoy,
+        pero el bypass blinda contra cambios futuros del default).
+      - Evita side-effect en NotificationBell: cada test press NO crea una
+        row en notifications_sent.
+      - No aplica filtros del usuario (symbol_filter / min_score) — esos
+        aplican a signals reales, no a "verificá tu config".
+
+    Trade-off: NO ejercita el dispatcher per-user. Aceptable porque el
+    dispatcher tiene cobertura propia (tests/test_multi_tenant_b4_signal_
+    routing.py).
+    """
+    from api.config import load_config
+    from db.user_preferences import db_get_user_preferences as _db_get
+    from notifier.channels.telegram import TelegramChannel
+
+    prefs = _db_get(tenant_id) or {}
+    notify_channels = prefs.get("notify_channels") or {}
+    base_cfg = load_config()
+    user_cfg = {**base_cfg, **notify_channels}
+
+    token = (user_cfg.get("telegram_bot_token") or "").strip()
+    chat_id = (user_cfg.get("telegram_chat_id") or "").strip()
+    if not token or not chat_id:
+        return {"ok": False, "receipts": [], "reason": "no_telegram_configured"}
+
+    channel = TelegramChannel(user_cfg)
+    receipt = channel.send(
+        "*Crypto Scanner — prueba de conexión*\n"
+        "Si ves este mensaje, tu bot y chat están bien configurados. ✅"
+    )
+    return {
+        "ok": receipt.status == "ok",
+        "receipts": [{
+            "channel": receipt.channel,
+            "status": receipt.status,
+            "error": receipt.error,
+        }],
+        "reason": None,
+    }
+```
+
+- [ ] **Step 3.4: Run tests — verify PASS**
+
+```bash
+python -m pytest tests/test_api_user_preferences.py -v
+```
+
+Expected: 12/12 PASS (3 mask + 4 GET/PUT + 5 endpoint).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add api/user_preferences.py tests/test_api_user_preferences.py
+git commit -m "feat(prefs): POST /preferences/test verifies user telegram config
+
+Bypasses notify() and dispatch_signal_to_users to avoid:
+- Dedup collisions on rapid presses (defensive against future changes
+  to signal event_type dedup window default, currently 0).
+- Side-effect in NotificationBell (test pings would otherwise appear
+  as 'TEST' rows in notifications_sent).
+- Filter false-negatives (user's symbol_filter / min_score should not
+  block 'verify my config' flow).
+
+Returns {ok, receipts, reason} where reason is 'no_telegram_configured'
+when token or chat_id missing.
+
+Pre-reg: docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md §Backend"
+```
+
+---
+
+### Task 4: Frontend — types + api wrapper
+
+**Files:**
+- Modify: `frontend/src/types.ts` (agregar 2 interfaces).
+- Modify: `frontend/src/api.ts` (agregar 1 wrapper).
+
+- [ ] **Step 4.1: Agregar tipo `TestDeliveryResponse` + `NotifyChannels` a `frontend/src/types.ts`**
+
+Append:
+
+```typescript
+// ---- Telegram per-user config (spec 2026-05-21) ----
+
+export interface NotifyChannels {
+  telegram_bot_token?: string;   // masked from server: '<10chars>****<4chars>'
+  telegram_chat_id?:   string;
+}
+
+export interface TestDeliveryReceipt {
+  channel: string;
+  status:  'ok' | 'failed' | 'rate_limited';
+  error:   string | null;
+}
+
+export type TestDeliveryReason = 'no_telegram_configured' | null;
+
+export interface TestDeliveryResponse {
+  ok:       boolean;
+  receipts: TestDeliveryReceipt[];
+  reason:   TestDeliveryReason;
+}
+```
+
+- [ ] **Step 4.2: Agregar wrapper `testPreferencesDelivery` a `frontend/src/api.ts`**
+
+Encontrar las funciones existentes de preferences (alrededor línea 413-419). Después de `updateUserPreferences`, agregar:
+
+```typescript
+export async function testPreferencesDelivery(): Promise<TestDeliveryResponse> {
+  return request<TestDeliveryResponse>('/preferences/test', { method: 'POST' });
+}
+```
+
+Y al import del archivo, agregar `TestDeliveryResponse` a la lista importada de `types.ts`.
+
+- [ ] **Step 4.3: Verificar typecheck**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | tail -5
+```
+
+Expected: cero errors.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add frontend/src/types.ts frontend/src/api.ts
+git commit -m "feat(prefs/frontend): types + wrapper for testPreferencesDelivery"
+```
+
+---
+
+### Task 5: Frontend — `ConnectionsPanel.tsx` skeleton + load prefs
+
+**Files:**
+- Create: `frontend/src/components/ConnectionsPanel.tsx`.
+- Create: `frontend/src/components/ConnectionsPanel.module.css`.
+- Create: `frontend/src/components/ConnectionsPanel.test.tsx`.
+
+- [ ] **Step 5.1: Crear failing test — renders form with masked token from GET**
+
+Create `frontend/src/components/ConnectionsPanel.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConnectionsPanel from './ConnectionsPanel';
+import * as api from '../api';
+
+describe('ConnectionsPanel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders form with masked token from current preferences', async () => {
+    vi.spyOn(api, 'getUserPreferences').mockResolvedValue({
+      tenant_id:       1,
+      symbol_filter:   null,
+      min_score:       4,
+      notify_channels: {
+        telegram_bot_token: '123456789:****gH12',
+        telegram_chat_id:   '987654321',
+      },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+
+    await waitFor(() => {
+      const tokenInput = screen.getByLabelText(/bot token/i) as HTMLInputElement;
+      expect(tokenInput.value).toBe('123456789:****gH12');
+    });
+    const chatInput = screen.getByLabelText(/chat id/i) as HTMLInputElement;
+    expect(chatInput.value).toBe('987654321');
+    expect(screen.getByText(/token guardado/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 5.2: Run test — verify FAIL**
+
+```bash
+cd frontend && npm test -- --run ConnectionsPanel 2>&1 | tail -10
+```
+
+Expected: FAIL with "Cannot find module './ConnectionsPanel'".
+
+- [ ] **Step 5.3: Crear `ConnectionsPanel.module.css`**
+
+```css
+/* ConnectionsPanel — slide-out from right, mirrors ConfigPanel.module.css. */
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+}
+
+.panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(480px, 100vw);
+  background: var(--bg-elevated, #0f1410);
+  z-index: 101;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+}
+
+.header {
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title { font-size: 18px; font-weight: 500; }
+
+.body { flex: 1; overflow-y: auto; padding: 24px; }
+
+.section { margin-bottom: 32px; }
+
+.sectionTitle {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+  margin-bottom: 12px;
+}
+
+.field { margin-bottom: 16px; }
+
+.label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+  margin-bottom: 6px;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg, #0a0d0b);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+  color: var(--text, white);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px;
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--text-dim, rgba(255, 255, 255, 0.4));
+  margin-top: 4px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.btn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  background: var(--bg-input, rgba(255, 255, 255, 0.08));
+  color: var(--text, white);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.btnPrimary {
+  background: var(--accent, #4a9eff);
+  color: white;
+  border-color: var(--accent, #4a9eff);
+}
+
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.testResult { margin-top: 12px; font-size: 12px; }
+.testOk { color: var(--success, #4ade80); }
+.testErr { color: var(--danger, #f87171); }
+
+.closeBtn {
+  background: none;
+  border: none;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+  font-size: 24px;
+  cursor: pointer;
+}
+```
+
+- [ ] **Step 5.4: Crear `ConnectionsPanel.tsx` con shape mínima para passing test**
+
+```typescript
+// ============================================================
+// ConnectionsPanel.tsx — per-user Telegram bot config slide-out.
+// Anchored to UserMenu → 'Conexiones' item.
+// Spec: docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md
+// ============================================================
+
+import React, { useEffect, useState } from 'react';
+import styles from './ConnectionsPanel.module.css';
+import type { NotifyChannels } from '../types';
+import { getUserPreferences } from '../api';
+
+interface ConnectionsPanelProps {
+  open:    boolean;
+  onClose: () => void;
+}
+
+const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) => {
+  const [botToken, setBotToken]   = useState('');
+  const [chatId,   setChatId]     = useState('');
+  const [tokenIsMasked, setTokenIsMasked] = useState(false);
+  const [loading,  setLoading]    = useState(true);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    getUserPreferences()
+      .then((prefs) => {
+        const nc = (prefs.notify_channels ?? {}) as NotifyChannels;
+        setBotToken(nc.telegram_bot_token ?? '');
+        setChatId(nc.telegram_chat_id ?? '');
+        setTokenIsMasked((nc.telegram_bot_token ?? '').includes('****'));
+      })
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className={styles.backdrop} onClick={onClose} aria-hidden="true" />
+      <aside className={styles.panel} role="dialog" aria-labelledby="connections-title">
+        <header className={styles.header}>
+          <h2 id="connections-title" className={styles.title}>Conexiones</h2>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Cerrar">×</button>
+        </header>
+        <div className={styles.body}>
+          <section className={styles.section}>
+            <h3 className={styles.sectionTitle}>Telegram</h3>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="bot-token">Bot Token</label>
+              <input
+                id="bot-token"
+                className={styles.input}
+                type="password"
+                value={botToken}
+                onChange={(e) => { setBotToken(e.target.value); setTokenIsMasked(false); }}
+                placeholder="123456789:ABCdef..."
+                disabled={loading}
+              />
+              {tokenIsMasked && (
+                <div className={styles.hint}>
+                  Token guardado · pegá uno nuevo para reemplazar
+                </div>
+              )}
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="chat-id">Chat ID</label>
+              <input
+                id="chat-id"
+                className={styles.input}
+                type="text"
+                value={chatId}
+                onChange={(e) => setChatId(e.target.value)}
+                placeholder="123456789"
+                disabled={loading}
+              />
+            </div>
+          </section>
+        </div>
+      </aside>
+    </>
+  );
+};
+
+export default ConnectionsPanel;
+```
+
+- [ ] **Step 5.5: Run test — verify PASS**
+
+```bash
+cd frontend && npm test -- --run ConnectionsPanel 2>&1 | tail -10
+```
+
+Expected: 1/1 PASS.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add frontend/src/components/ConnectionsPanel.tsx \
+        frontend/src/components/ConnectionsPanel.module.css \
+        frontend/src/components/ConnectionsPanel.test.tsx
+git commit -m "feat(prefs/frontend): ConnectionsPanel skeleton — loads + renders prefs"
+```
+
+---
+
+### Task 6: Frontend — Save handler (preserve / replace)
+
+**Files:**
+- Modify: `frontend/src/components/ConnectionsPanel.tsx` (agregar save handler + button).
+- Modify: `frontend/src/components/ConnectionsPanel.test.tsx` (agregar 2 tests).
+
+- [ ] **Step 6.1: Agregar failing tests para save**
+
+Append to `ConnectionsPanel.test.tsx`:
+
+```typescript
+  it('save sends notify_channels body when user changed chat_id, masked token preserved server-side', async () => {
+    vi.spyOn(api, 'getUserPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: '123456789:****gH12', telegram_chat_id: '987' },
+    });
+    const updateSpy = vi.spyOn(api, 'updateUserPreferences').mockResolvedValue({
+      ok: true, preferences: { tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    const chatInput = await screen.findByLabelText(/chat id/i);
+    await userEvent.clear(chatInput);
+    await userEvent.type(chatInput, '111');
+    await userEvent.click(screen.getByRole('button', { name: /guardar/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith({
+        notify_channels: {
+          telegram_bot_token: '123456789:****gH12',  // unchanged, server-side preserve
+          telegram_chat_id:   '111',
+        },
+      });
+    });
+  });
+
+  it('save sends plain token when user pastes a new one', async () => {
+    vi.spyOn(api, 'getUserPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: '123456789:****gH12', telegram_chat_id: '987' },
+    });
+    const updateSpy = vi.spyOn(api, 'updateUserPreferences').mockResolvedValue({
+      ok: true, preferences: { tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    const tokenInput = await screen.findByLabelText(/bot token/i);
+    await userEvent.clear(tokenInput);
+    await userEvent.type(tokenInput, '999:NEW_PLAIN_TOKEN_VALUE');
+    await userEvent.click(screen.getByRole('button', { name: /guardar/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith({
+        notify_channels: {
+          telegram_bot_token: '999:NEW_PLAIN_TOKEN_VALUE',
+          telegram_chat_id:   '987',
+        },
+      });
+    });
+  });
+```
+
+- [ ] **Step 6.2: Run tests — verify FAIL**
+
+```bash
+cd frontend && npm test -- --run ConnectionsPanel 2>&1 | tail -10
+```
+
+Expected: 2 nuevos FAIL — no hay save button todavía.
+
+- [ ] **Step 6.3: Agregar save logic a `ConnectionsPanel.tsx`**
+
+Importar `updateUserPreferences` y agregar dentro del componente:
+
+```typescript
+import { getUserPreferences, updateUserPreferences } from '../api';
+// ... within component:
+
+const [saving, setSaving] = useState(false);
+
+const handleSave = async () => {
+  setSaving(true);
+  try {
+    await updateUserPreferences({
+      notify_channels: {
+        telegram_bot_token: botToken,
+        telegram_chat_id:   chatId,
+      },
+    });
+  } finally {
+    setSaving(false);
+  }
+};
+```
+
+Y dentro del JSX, después del field de chat_id (antes de cerrar la section), agregar:
+
+```typescript
+<div className={styles.actions}>
+  <button
+    className={`${styles.btn} ${styles.btnPrimary}`}
+    onClick={handleSave}
+    disabled={saving || loading}
+  >
+    {saving ? 'Guardando...' : 'Guardar'}
+  </button>
+</div>
+```
+
+- [ ] **Step 6.4: Run tests — verify PASS**
+
+```bash
+cd frontend && npm test -- --run ConnectionsPanel 2>&1 | tail -10
+```
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add frontend/src/components/ConnectionsPanel.tsx \
+        frontend/src/components/ConnectionsPanel.test.tsx
+git commit -m "feat(prefs/frontend): ConnectionsPanel save handler"
+```
+
+---
+
+### Task 7: Frontend — "Probar envío" + "Eliminar credenciales" buttons
+
+**Files:**
+- Modify: `frontend/src/components/ConnectionsPanel.tsx`.
+- Modify: `frontend/src/components/ConnectionsPanel.test.tsx`.
+
+- [ ] **Step 7.1: Agregar failing tests para probar + eliminar**
+
+Append to `ConnectionsPanel.test.tsx`:
+
+```typescript
+  it('"Probar envío" disabled when there are unsaved changes', async () => {
+    vi.spyOn(api, 'getUserPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: '123:****abcd', telegram_chat_id: '987' },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+
+    const probarBtn = screen.getByRole('button', { name: /probar env/i });
+    expect(probarBtn).not.toBeDisabled();  // initially clean
+
+    await userEvent.type(screen.getByLabelText(/chat id/i), '5');
+    expect(probarBtn).toBeDisabled();  // dirty
+  });
+
+  it('"Probar envío" shows ok on success', async () => {
+    vi.spyOn(api, 'getUserPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: 'x:y', telegram_chat_id: 'z' },
+    });
+    vi.spyOn(api, 'testPreferencesDelivery').mockResolvedValue({
+      ok: true,
+      receipts: [{ channel: 'telegram', status: 'ok', error: null }],
+      reason: null,
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+    await userEvent.click(screen.getByRole('button', { name: /probar env/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/enviado/i)).toBeInTheDocument();
+    });
+  });
+
+  it('"Probar envío" shows error on failure', async () => {
+    vi.spyOn(api, 'getUserPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: 'x:y', telegram_chat_id: 'z' },
+    });
+    vi.spyOn(api, 'testPreferencesDelivery').mockResolvedValue({
+      ok: false,
+      receipts: [{ channel: 'telegram', status: 'failed', error: 'HTTP 401: Unauthorized' }],
+      reason: null,
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+    await userEvent.click(screen.getByRole('button', { name: /probar env/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unauthorized/)).toBeInTheDocument();
+    });
+  });
+
+  it('"Probar envío" shows no_telegram_configured hint', async () => {
+    vi.spyOn(api, 'getUserPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null,
+    });
+    vi.spyOn(api, 'testPreferencesDelivery').mockResolvedValue({
+      ok: false, receipts: [], reason: 'no_telegram_configured',
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+    await userEvent.click(screen.getByRole('button', { name: /probar env/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/configur.*token.*chat/i)).toBeInTheDocument();
+    });
+  });
+
+  it('"Eliminar credenciales" sends notify_channels: null', async () => {
+    vi.spyOn(api, 'getUserPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: 'x:y', telegram_chat_id: 'z' },
+    });
+    const updateSpy = vi.spyOn(api, 'updateUserPreferences').mockResolvedValue({
+      ok: true, preferences: { tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+    await userEvent.click(screen.getByRole('button', { name: /eliminar credenciales/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith({ notify_channels: null });
+    });
+  });
+```
+
+- [ ] **Step 7.2: Run tests — verify FAIL**
+
+```bash
+cd frontend && npm test -- --run ConnectionsPanel 2>&1 | tail -10
+```
+
+Expected: 5 nuevos FAIL.
+
+- [ ] **Step 7.3: Agregar handlers + UI a `ConnectionsPanel.tsx`**
+
+Importar `testPreferencesDelivery`:
+
+```typescript
+import { getUserPreferences, updateUserPreferences, testPreferencesDelivery } from '../api';
+import type { NotifyChannels, TestDeliveryResponse } from '../types';
+```
+
+Agregar state + handlers dentro del component:
+
+```typescript
+const [dirty, setDirty] = useState(false);
+const [testResult, setTestResult] = useState<TestDeliveryResponse | null>(null);
+const [testing, setTesting] = useState(false);
+
+// Update existing handleSave to clear dirty
+const handleSave = async () => {
+  setSaving(true);
+  try {
+    await updateUserPreferences({
+      notify_channels: { telegram_bot_token: botToken, telegram_chat_id: chatId },
+    });
+    setDirty(false);
+    setTestResult(null);
+  } finally {
+    setSaving(false);
+  }
+};
+
+const handleTest = async () => {
+  setTesting(true);
+  setTestResult(null);
+  try {
+    const res = await testPreferencesDelivery();
+    setTestResult(res);
+  } finally {
+    setTesting(false);
+  }
+};
+
+const handleDelete = async () => {
+  setSaving(true);
+  try {
+    await updateUserPreferences({ notify_channels: null });
+    setBotToken('');
+    setChatId('');
+    setTokenIsMasked(false);
+    setTestResult(null);
+  } finally {
+    setSaving(false);
+  }
+};
+```
+
+Y los input onChange deben marcar dirty:
+
+```typescript
+onChange={(e) => { setBotToken(e.target.value); setTokenIsMasked(false); setDirty(true); }}
+// ...
+onChange={(e) => { setChatId(e.target.value); setDirty(true); }}
+```
+
+Reemplazar el bloque `.actions` con:
+
+```typescript
+<div className={styles.actions}>
+  <button
+    className={`${styles.btn} ${styles.btnPrimary}`}
+    onClick={handleSave}
+    disabled={saving || loading || !dirty}
+  >
+    {saving ? 'Guardando...' : 'Guardar'}
+  </button>
+  <button
+    className={styles.btn}
+    onClick={handleTest}
+    disabled={testing || saving || dirty}
+  >
+    {testing ? 'Enviando...' : 'Probar envío'}
+  </button>
+  <button
+    className={styles.btn}
+    onClick={handleDelete}
+    disabled={saving}
+  >
+    Eliminar credenciales
+  </button>
+</div>
+{testResult && (
+  <div className={styles.testResult}>
+    {testResult.ok && <span className={styles.testOk}>✓ Mensaje enviado a tu Telegram.</span>}
+    {!testResult.ok && testResult.reason === 'no_telegram_configured' && (
+      <span className={styles.testErr}>Configurá tu token y chat ID primero, después Guardar y volvé a probar.</span>
+    )}
+    {!testResult.ok && testResult.reason === null && testResult.receipts[0] && (
+      <span className={styles.testErr}>✗ {testResult.receipts[0].error}</span>
+    )}
+  </div>
+)}
+```
+
+Nota: el "Guardar" disabled-when-not-dirty + "Probar" disabled-when-dirty resuelve juntos el "type without save" → probar disabled.
+
+- [ ] **Step 7.4: Run tests — verify PASS**
+
+```bash
+cd frontend && npm test -- --run ConnectionsPanel 2>&1 | tail -10
+```
+
+Expected: 8/8 PASS.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add frontend/src/components/ConnectionsPanel.tsx \
+        frontend/src/components/ConnectionsPanel.test.tsx
+git commit -m "feat(prefs/frontend): ConnectionsPanel test + delete handlers"
+```
+
+---
+
+### Task 8: Frontend — UserMenu wire-up (onClick + conditional badge)
+
+**Files:**
+- Modify: `frontend/src/components/UserMenu.tsx`.
+- Create: `frontend/src/components/UserMenu.test.tsx`.
+
+- [ ] **Step 8.1: Crear failing tests para UserMenu badge**
+
+Create `frontend/src/components/UserMenu.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import UserMenu from './UserMenu';
+import type { AuthUser } from '../auth/api';
+
+const _fakeUser: AuthUser = { id: 1, email: 'a@example.com', role: 'admin' };
+
+describe('UserMenu', () => {
+  it('shows badge "1" on Conexiones when telegram is unconfigured', () => {
+    render(
+      <UserMenu
+        open={true}
+        user={_fakeUser}
+        onClose={() => {}}
+        onLogout={() => {}}
+        onConnectionsOpen={() => {}}
+        telegramConfigured={false}
+      />
+    );
+    const conexionesBtn = screen.getByText('Conexiones').closest('button')!;
+    expect(conexionesBtn.textContent).toContain('1');
+  });
+
+  it('hides badge on Conexiones when telegram is configured', () => {
+    render(
+      <UserMenu
+        open={true}
+        user={_fakeUser}
+        onClose={() => {}}
+        onLogout={() => {}}
+        onConnectionsOpen={() => {}}
+        telegramConfigured={true}
+      />
+    );
+    const conexionesBtn = screen.getByText('Conexiones').closest('button')!;
+    expect(conexionesBtn.textContent).not.toContain('1');
+  });
+
+  it('calls onConnectionsOpen when Conexiones is clicked', async () => {
+    const onOpen = vi.fn();
+    const { default: userEvent } = await import('@testing-library/user-event');
+    render(
+      <UserMenu
+        open={true}
+        user={_fakeUser}
+        onClose={() => {}}
+        onLogout={() => {}}
+        onConnectionsOpen={onOpen}
+        telegramConfigured={false}
+      />
+    );
+    await userEvent.default.click(screen.getByText('Conexiones'));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 8.2: Run tests — verify FAIL**
+
+```bash
+cd frontend && npm test -- --run UserMenu 2>&1 | tail -10
+```
+
+Expected: 3 FAIL (props no aceptados, badge hardcoded).
+
+- [ ] **Step 8.3: Modificar `UserMenu.tsx` para aceptar props + wire conditional**
+
+Encontrar:
+
+```typescript
+interface UserMenuProps {
+  open:    boolean;
+  user:    AuthUser;
+  onClose: () => void;
+  onLogout: () => void;
+}
+```
+
+Reemplazar con:
+
+```typescript
+interface UserMenuProps {
+  open:    boolean;
+  user:    AuthUser;
+  onClose: () => void;
+  onLogout: () => void;
+  onConnectionsOpen?: () => void;
+  telegramConfigured?: boolean;
+}
+
+const UserMenu: React.FC<UserMenuProps> = ({
+  open, user, onClose, onLogout,
+  onConnectionsOpen, telegramConfigured = false,
+}) => {
+```
+
+Encontrar el array `items` (línea ~28) y reemplazar la entry de Conexiones:
+
+```typescript
+  const items: MenuItem[] = [
+    { icon: '◧', label: 'Mi cuenta', hint: 'email · contraseña · 2FA' },
+    { icon: '✦', label: 'Capital y riesgo', hint: 'gestión de balance' },
+    {
+      icon: '◐',
+      label: 'Conexiones',
+      hint: 'Telegram · Webhook',
+      badge: telegramConfigured ? undefined : '1',
+      onClick: () => { onConnectionsOpen?.(); onClose(); },
+    },
+    { icon: '⌨', label: 'Atajos de teclado', kbd: '?' },
+    { icon: '❑', label: 'Documentación' },
+  ];
+```
+
+- [ ] **Step 8.4: Run tests — verify PASS**
+
+```bash
+cd frontend && npm test -- --run UserMenu 2>&1 | tail -10
+```
+
+Expected: 3/3 PASS.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add frontend/src/components/UserMenu.tsx \
+        frontend/src/components/UserMenu.test.tsx
+git commit -m "feat(prefs/frontend): UserMenu wire onClick + conditional badge
+
+Item 'Conexiones' now opens ConnectionsPanel via onConnectionsOpen prop.
+Badge '1' shows when notify_channels.telegram_bot_token is unconfigured;
+hides once user has saved credentials."
+```
+
+---
+
+### Task 9: Frontend — App.tsx wire-up (OverlayKind + render)
+
+**Files:**
+- Modify: `frontend/src/App.tsx`.
+
+- [ ] **Step 9.1: Extender `OverlayKind` en App.tsx**
+
+Encontrar línea 92:
+
+```typescript
+type OverlayKind = 'notifs' | 'settings' | 'user' | null;
+```
+
+Reemplazar con:
+
+```typescript
+type OverlayKind = 'notifs' | 'settings' | 'user' | 'connections' | null;
+```
+
+- [ ] **Step 9.2: Importar `ConnectionsPanel` + agregar state para telegramConfigured**
+
+Después del import de `ConfigPanel` (línea ~67):
+
+```typescript
+import ConnectionsPanel from './components/ConnectionsPanel';
+```
+
+Dentro del componente, agregar state que se hidrata desde GET /preferences:
+
+```typescript
+const [telegramConfigured, setTelegramConfigured] = useState(false);
+
+useEffect(() => {
+  // Initial load + refresh after panel closes
+  if (openOverlay !== 'connections') {
+    getUserPreferences().then((p) => {
+      const tok = (p.notify_channels as { telegram_bot_token?: string } | null)?.telegram_bot_token;
+      setTelegramConfigured(Boolean(tok));
+    }).catch(() => {});  // silent: badge stays in default state on error
+  }
+}, [openOverlay]);
+```
+
+(Asegurar que `getUserPreferences` está importado desde `./api`.)
+
+- [ ] **Step 9.3: Pasar props al `<UserMenu>` (encontrar la invocation alrededor de línea 724)**
+
+Encontrar:
+
+```typescript
+<UserMenu
+  open={openOverlay === 'user'}
+  // ...
+/>
+```
+
+Agregar props:
+
+```typescript
+<UserMenu
+  open={openOverlay === 'user'}
+  user={...}
+  onClose={() => setOpenOverlay(null)}
+  onLogout={...}
+  onConnectionsOpen={() => setOpenOverlay('connections')}
+  telegramConfigured={telegramConfigured}
+/>
+```
+
+- [ ] **Step 9.4: Renderizar `<ConnectionsPanel>` cerca del `<ConfigPanel>` existente**
+
+Después del `<ConfigPanel>` (alrededor de línea 719-722):
+
+```typescript
+<ConnectionsPanel
+  open={openOverlay === 'connections'}
+  onClose={() => setOpenOverlay(null)}
+/>
+```
+
+- [ ] **Step 9.5: Verificar typecheck + suite frontend completa**
+
+```bash
+cd frontend && npx tsc --noEmit && npm test -- --run 2>&1 | tail -15
+```
+
+Expected: cero tsc errors, toda la suite vitest passes.
+
+- [ ] **Step 9.6: Commit**
+
+```bash
+git add frontend/src/App.tsx
+git commit -m "feat(prefs/frontend): wire ConnectionsPanel into App + hydrate badge state"
+```
+
+---
+
+### Task 10: Backend regression check + frontend build verify
+
+**Files:** none modified.
+
+- [ ] **Step 10.1: Backend regression — toda la suite agent + prefs**
+
+```bash
+python -m pytest tests/test_api_user_preferences.py tests/test_provider_registry.py tests/test_multi_tenant_b4_signal_routing.py tests/test_multi_tenant_b7_idor.py -k "not trio" 2>&1 | tail -5
+```
+
+Expected: all pass. Si rojo, abort + fix antes de seguir.
+
+- [ ] **Step 10.2: Frontend build verify**
+
+```bash
+cd frontend && npm run build 2>&1 | tail -10
+```
+
+Expected: build exitoso sin errors. Bundle size sigue razonable (<5% growth).
+
+---
+
+### Task 11: Playwright e2e (Claude vía Playwright MCP)
+
+**Owner:** Claude using `mcp__plugin_playwright_playwright__*` tools. Samuel watches.
+
+- [ ] **Step 11.1: Restart dev server / verificar prod accesible**
+
+Usar el browser de Playwright que ya está logueado en `https://trading.sdar.dev/` (sesión activa). Si el feature está merged a main + deploy completado, el panel ya está disponible en prod.
+
+Alternativa local (si querés testear antes del deploy): start frontend dev server y backend local, login. **No recomendado** para esta iteración — preferible deploy + test en prod.
+
+- [ ] **Step 11.2: E2E happy path con creds fake (DB write check)**
+
+Browser_evaluate sequence:
+
+```js
+// 1. Click avatar dropdown
+async () => {
+  document.querySelector('button[aria-label*="operador" i], button[class*="userBtn" i]')?.click();
+  // wait for menu to render
+  await new Promise(r => setTimeout(r, 200));
+  return { menu_visible: !!document.querySelector('[role="menu"]') };
+}
+```
+
+Después:
+
+```js
+// 2. Click "Conexiones"
+async () => {
+  const btn = [...document.querySelectorAll('button')].find(b => b.textContent?.includes('Conexiones'));
+  btn?.click();
+  await new Promise(r => setTimeout(r, 200));
+  return { panel_visible: !!document.querySelector('[role="dialog"][aria-labelledby="connections-title"]') };
+}
+```
+
+Después:
+
+```js
+// 3. Llenar creds FAKE + save (los reales son Task 12)
+async () => {
+  const csrf = document.cookie.split('; ').find(c => c.startsWith('csrf_token='))?.split('=')[1];
+  const tokenInput = document.querySelector('#bot-token');
+  const chatInput  = document.querySelector('#chat-id');
+  tokenInput.value = 'FAKE_TOKEN_FOR_E2E:abcdefghi';
+  tokenInput.dispatchEvent(new Event('input', { bubbles: true }));
+  chatInput.value = 'FAKE_CHAT_ID_E2E';
+  chatInput.dispatchEvent(new Event('input', { bubbles: true }));
+  await new Promise(r => setTimeout(r, 100));
+  document.querySelector('button.btnPrimary')?.click();
+  await new Promise(r => setTimeout(r, 500));
+  // Verify saved by re-fetching prefs
+  const r = await fetch('/api/preferences', { credentials: 'include' });
+  return await r.json();
+}
+```
+
+Expected: response shows masked token con `****` y chat_id `FAKE_CHAT_ID_E2E`.
+
+- [ ] **Step 11.3: Click "Eliminar credenciales"**
+
+```js
+async () => {
+  const btn = [...document.querySelectorAll('button')].find(b => b.textContent?.includes('Eliminar credenciales'));
+  btn?.click();
+  await new Promise(r => setTimeout(r, 500));
+  const r = await fetch('/api/preferences', { credentials: 'include' });
+  return await r.json();
+}
+```
+
+Expected: `notify_channels: null`.
+
+- [ ] **Step 11.4: Cleanup — limpiar la fila de prefs**
+
+```js
+async () => {
+  const csrf = document.cookie.split('; ').find(c => c.startsWith('csrf_token='))?.split('=')[1];
+  await fetch('/api/preferences', {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+    body: JSON.stringify({ notify_channels: null }),
+  });
+}
+```
+
+E2E completo. **No commit necesario** (no hay code change).
+
+---
+
+### Task 12: Manual gate — Samuel hace el BotFather flow real
+
+**Owner:** Samuel.
+
+- [ ] **Step 12.1: Crear bot en BotFather**
+
+En Telegram, abrir [@BotFather](https://t.me/BotFather):
+1. `/newbot`
+2. Nombre amigable (ej "Crypto Scanner - Samuel").
+3. Username terminado en `bot`.
+4. Guardar el token devuelto (formato `123456789:ABC...`).
+
+- [ ] **Step 12.2: Iniciar conversación con el bot**
+
+Buscar el username en Telegram, mandar `/start`.
+
+- [ ] **Step 12.3: Conseguir chat_id**
+
+Browser: `https://api.telegram.org/bot<TOKEN>/getUpdates` → copy `result[0].message.chat.id` (entero positivo).
+
+- [ ] **Step 12.4: Configurar via dashboard**
+
+1. Abrir https://trading.sdar.dev → avatar ▾ → Conexiones.
+2. Pegar token + chat_id en los inputs.
+3. Click Guardar.
+4. Click Probar envío.
+5. Confirmar que llega mensaje "*Crypto Scanner — prueba de conexión*..." en Telegram.
+
+- [ ] **Step 12.5: Sub-gate — NotificationBell no se llena con TEST entries**
+
+Click en el bell del header. Expected: 0 entries nuevas a pesar del "Probar envío" reciente. Confirma que el bypass de `notify()` funciona.
+
+- [ ] **Step 12.6: Sub-gate — rapid-fire 5 presses**
+
+Click "Probar envío" 5 veces seguidas. Todos deben mostrar ✓ enviado. Confirma que no hay dedup collision.
+
+- [ ] **Step 12.7: Acceptance gate principal — recibir signal real**
+
+Esperar (o forzar con POST /api/scan) un signal real con score ≥ 4. Verificar:
+- journalctl muestra `dispatch: user_id=1 symbol=X score=Y receipts=1`.
+- Telegram recibe mensaje con shape de signal real (símbolo + dirección + SL/TP).
+
+- [ ] **Step 12.8: Decisión final + cierre**
+
+Si todos los gates verdes:
+- Mergear el PR.
+- Actualizar memoria con [[telegram-per-user-config-done]] en MEMORY.md.
+- Cerrar tasks #21 + #22.
+
+Si algún gate rojo: abort, investigar, fix, retry.
+
+---
+
+## Acceptance gates (resumen)
+
+Phase A v2 completo cuando los **3 son verdaderos**:
+
+| Gate | Verificación | Owner |
+|---|---|---|
+| Tests | Backend + frontend suites verdes (Task 10) | Claude |
+| E2E DB write | Playwright verifica save + masked GET + delete (Task 11) | Claude |
+| Manual real-world | Samuel recibe signal real en su bot post-config (Task 12.7) | Samuel |
+
+---
+
+## Rollback
+
+Si el feature rompe algo grave en prod:
+
+```bash
+# Local revert
+git checkout main
+git revert <merge_sha>
+git push origin main
+```
+
+CI redeploy con código pre-feature. Schema sin cambios → no migration rollback necesaria. Si hay rows con notify_channels populadas, ignored gracefully por el código pre-feature (no rompe, simplemente no rutea).

--- a/docs/superpowers/specs/es/2026-05-21-telegram-multitenant-phase-a-pre-reg.md
+++ b/docs/superpowers/specs/es/2026-05-21-telegram-multitenant-phase-a-pre-reg.md
@@ -1,0 +1,134 @@
+# Telegram multi-tenant — Phase A (backend wiring) — pre-reg
+
+**Fecha:** 2026-05-21
+**Operator:** Samuel (en nombre de Simon)
+**Estado:** pre-reg pre-ejecución
+**Estimación:** ~30 min wall-clock
+
+## Contexto
+
+El operator reportó que la app no está enviando señales a Telegram. Investigación con `superpowers:systematic-debugging` (este turno, transcript inline) descartó la hipótesis inicial "deploy borró credentials" — el operator nunca configuró Telegram. La app nunca ha mandado señales porque `config.json` jamás tuvo `telegram_bot_token` ni equivalente por env (`TRADING_TELEGRAM_BOT_TOKEN`).
+
+El operator quiere configurar Telegram en modo **multi-tenant**, no como canal único de broadcast. Cada usuario del sistema (hoy solo Simon; en el futuro post-Epic B #253) recibirá sus señales en su **propio chat** de Telegram, gestionado vía `user_preferences.notify_channels.telegram_chat_id`.
+
+Phase A es el primer sub-proyecto de un epic más amplio (ver §10). Cubre **solo el wiring de backend** que pone a Simon recibiendo señales hoy. UI y bot webhook quedan para Phases B/C.
+
+## Goal
+
+Después de Phase A:
+
+- Simon recibe en su chat de Telegram cada signal con `score ≥ 4` (default `signal_filters.min_score`) que no esté dentro del dedup window de 30 min.
+- El dispatch ocurre por la **ruta per-user** (`notifier/dispatch_per_user.py:dispatch_signal_to_users`), no por el fallback global broadcast.
+- `journalctl -u trading-spacial` muestra explícitamente `dispatch: user_id=1 symbol=<X> score=<Y> receipts=1` para cada signal entregado.
+
+## Out of scope para Phase A
+
+- Frontend UI para que un usuario gestione sus propias preferences (Phase B).
+- `/webhook/test` compatibilidad con per-user dispatch — hoy usa `cfg["telegram_chat_id"]` global (Phase B incluirá un endpoint `/preferences/test` que sí ejercita el path per-user).
+- Bot webhook (`POST /telegram/webhook`) que reciba `/start` y capture chat_ids automáticamente — Phase C, deferido hasta que Epic B abra usuarios.
+- Cualquier cambio de código. Phase A es **pure config + DB row update**.
+
+## Arquitectura — qué existe vs qué cambia
+
+### Ya implementado (no se toca)
+
+- `notifier/dispatch_per_user.py` (B.4 #257): fan-out por usuario activo con filtro `symbol_filter` + `min_score` + overlay `notify_channels` sobre la base cfg.
+- `notifier/channels/telegram.py`: `TelegramChannel` lee `cfg["telegram_bot_token"]` y `cfg["telegram_chat_id"]`, hace POST a la Bot API con retries (3 attempts + backoff exponencial, 429-aware).
+- `db/user_preferences.py` + `api/user_preferences.py`: schema `user_preferences.notify_channels_json` (JSON column), endpoints `GET /api/preferences` y `PUT /api/preferences`. Hoy `verify_api_key` es open (no hay `api_key` en config), así que `PUT` acepta JWT solo.
+- `api/config.py:_env_map`: mapea `TRADING_TELEGRAM_BOT_TOKEN` → `cfg["telegram_bot_token"]`. `load_config()` re-lee per-request (validado por el flip del agent earlier today).
+- Scanner loop (`scanner/runtime.py:execute_scan_for_symbol`) ya llama `push_telegram_direct(rep, cfg)` que internamente delega a `dispatch_signal_to_users` cuando hay usuarios activos.
+
+### Qué se cambia (estado)
+
+1. `/var/www/trading/.env`: se agrega línea `TRADING_TELEGRAM_BOT_TOKEN=<token>`.
+2. Process env de `trading-spacial`: tras restart, contiene la nueva var.
+3. Fila de `user_preferences` con `tenant_id=1`: `notify_channels_json={"telegram_chat_id": "<chat_id>"}` (upsert).
+
+## Pasos de ejecución
+
+### Owner: Samuel (operator, en Telegram + en server)
+
+1. **Crear bot** vía [@BotFather](https://t.me/BotFather):
+   - `/newbot` → nombre → username → recibe token `123456789:ABC...`
+2. **Conseguir chat_id**:
+   - Mandar `/start` (o cualquier mensaje) al bot recién creado.
+   - Abrir en browser: `https://api.telegram.org/bot<TOKEN>/getUpdates`
+   - Copiar `result[0].message.chat.id` (entero positivo para chats 1-a-1). **Importante**: el chat_id se persiste como **string** en `notify_channels_json` — `TelegramChannel.send` (`notifier/channels/telegram.py:26`) llama `.strip()` y crashearía sobre un int. JSON.stringify del paso 5 ya lo serializa correcto si el valor JS es string.
+3. **Agregar token al `.env`** (SSH al server):
+   ```bash
+   ssh aws-server "echo 'TRADING_TELEGRAM_BOT_TOKEN=<token>' | sudo tee -a /var/www/trading/.env >/dev/null"
+   ```
+   Verificar (key-only, sin valor): `ssh aws-server "sudo grep -c '^TRADING_TELEGRAM_BOT_TOKEN=' /var/www/trading/.env"` → esperado `1`.
+4. **Restart del service**:
+   ```bash
+   ssh aws-server "sudo systemctl restart trading-spacial"
+   ```
+   2-3s downtime. Verificar: `systemctl is-active trading-spacial` → `active` y `curl localhost:8100/health` → `healthy: true`.
+
+### Owner: Claude (vía browser Playwright, sesión JWT activa)
+
+5. **PUT chat_id a preferences** — vía `browser_evaluate` con la cookie de Samuel ya cargada:
+   ```js
+   fetch('/api/preferences', {
+     method: 'PUT',
+     credentials: 'include',
+     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+     body: JSON.stringify({ notify_channels: { telegram_chat_id: '<chat_id>' } })
+   })
+   ```
+   Verificar response 200 + `body.preferences.notify_channels.telegram_chat_id === '<chat_id>'`.
+
+6. **Force scan + verify dispatch**:
+   - `POST /api/scan` (force) o esperar 5 min al próximo ciclo.
+   - `ssh aws-server "sudo journalctl -u trading-spacial -f --since '30 seconds ago'"` — esperar línea `dispatch: user_id=1 symbol=<X> score=<Y> receipts=1`.
+   - Samuel confirma recepción en Telegram del bot.
+
+## Failure modes + recovery
+
+| # | Síntoma observable | Causa probable | Recovery |
+|---|---|---|---|
+| F1 | journalctl: `dispatch_signal_to_users: no active users — broadcast skipped` | `users.is_active=0` para Samuel (no debería pasar — está logueado) | Query DB: `SELECT id, email, is_active FROM users` |
+| F2 | `dispatch: ... receipts=0` o receipts con `status=failed` | Per-user `notify_channels` no aplicó o token vacío en process env | Re-verificar PUT response + `sudo systemctl restart` para releer .env |
+| F3 | TelegramChannel log: `telegram not configured (missing token or chat_id)` | Token no llegó al proceso (restart no leyó .env) o chat_id no en prefs | `systemctl restart trading-spacial` + verificar PUT row en DB |
+| F4 | TelegramChannel log: `HTTP 400: Bad Request: chat not found` | chat_id mal escrito o el bot nunca recibió `/start` (Telegram requiere "permiso") | Re-DM al bot + re-fetch getUpdates + re-PUT chat_id |
+| F5 | TelegramChannel log: `HTTP 401: Unauthorized` | Token mal copiado o bot deleted en BotFather | Re-issue token vía `/token` en BotFather + re-set .env + restart |
+| F6 | Service no levanta post-restart | `.env` con syntax error (typo en línea agregada) | `journalctl -u trading-spacial -n 50 --no-pager`, editar .env manualmente, retry |
+
+## Rollback
+
+Reversible 100%:
+- Para deshacer **token**: `sudo sed -i '/^TRADING_TELEGRAM_BOT_TOKEN=/d' /var/www/trading/.env && sudo systemctl restart trading-spacial`.
+- Para deshacer **chat_id en prefs**: `PUT /api/preferences` con `{"notify_channels": null}`.
+
+Estado pre-Phase-A queda exactamente como antes (sin telegram, sin prefs).
+
+## Test plan / criterios de aceptación
+
+Se considera Phase A completo cuando **los 3 son verdaderos**:
+
+- [ ] (Backend) `journalctl -u trading-spacial --since '5 minutes ago' | grep 'dispatch: user_id=1'` muestra **al menos 1 línea** con `receipts=1` para un signal real (no /webhook/test).
+- [ ] (User) Samuel confirma haber recibido **al menos 1 mensaje** del bot en su chat de Telegram, con el formato esperado de signal (símbolo + score + precio + dirección + SL/TP).
+- [ ] (Database) Query verifica que la fila persistió:
+  ```python
+  json.loads(con.execute("SELECT notify_channels_json FROM user_preferences WHERE tenant_id=1").fetchone()[0])
+  # → {"telegram_chat_id": "<chat_id>"}
+  ```
+
+## Estimación + responsibilities
+
+| Owner | Paso | Tiempo |
+|---|---|---|
+| Samuel | 1 — Bot creation en BotFather | 2 min |
+| Samuel | 2 — Chat ID discovery vía getUpdates | 2 min |
+| Samuel | 3 — Token al `.env` | 1 min |
+| Samuel | 4 — `systemctl restart` | 30 sec |
+| Claude | 5 — PUT preferences | 30 sec |
+| Claude | 6a — POST /api/scan | 10 sec |
+| Both | 6b — Verify journalctl + Telegram receipt | 1-5 min (wait for signal) |
+
+Total wall-clock: **~10-15 min de trabajo activo + hasta ~5 min de espera** del próximo signal con score ≥ 4.
+
+## Next phases (pointers, no scope acá)
+
+- **Phase B — Frontend UI self-service**: nuevo componente `NotificationSettings` en el dropdown del usuario, con form para gestionar `chat_id` + `min_score` + `symbol_filter` y botón "send test" que ejercita el path per-user (necesita nuevo endpoint `POST /api/preferences/test` o extender `/webhook/test`). Prereq: Phase A. Spec separado cuando Phase A esté en prod.
+- **Phase C — Bot webhook + deep-link invites**: `POST /telegram/webhook` recibe updates de Telegram, captura `/start <invite_token>` y auto-popula `notify_channels.telegram_chat_id` del usuario invitado. Tabla nueva `telegram_invite_tokens(token, tenant_id, expires_at, used_at)`. Prereq: Phase B (UI para "invite user" admin action). Spec separado, deferido hasta que Epic B (#253) habilite onboarding.

--- a/docs/superpowers/specs/es/2026-05-21-telegram-multitenant-phase-a-pre-reg.md
+++ b/docs/superpowers/specs/es/2026-05-21-telegram-multitenant-phase-a-pre-reg.md
@@ -21,6 +21,8 @@ Después de Phase A:
 - El dispatch ocurre por la **ruta per-user** (`notifier/dispatch_per_user.py:dispatch_signal_to_users`), no por el fallback global broadcast.
 - `journalctl -u trading-spacial` muestra explícitamente `dispatch: user_id=1 symbol=<X> score=<Y> receipts=1` para cada signal entregado.
 
+**Nota sobre dedup multi-tenant** (relevante para revisar Phase B sin confusiones): cuando `notify()` recibe `tenant_id` (lo cual hace `dispatch_signal_to_users` per `notifier/__init__.py:88-91`), el dedup key se prefija con `tenant:{tenant_id}:`. O sea, el stream de Samuel no comparte ventana de dedup con eventuales broadcasts legacy previos del mismo símbolo. Clean-slate garantizada por diseño, pero hay también un dedup **anterior** en el scanner (`api/signals.py:_is_duplicate_signal`, in-memory global) que NO es tenant-aware — bloquea el símbolo a nivel pre-fan-out (ver F7).
+
 ## Out of scope para Phase A
 
 - Frontend UI para que un usuario gestione sus propias preferences (Phase B).
@@ -54,29 +56,41 @@ Después de Phase A:
    - Mandar `/start` (o cualquier mensaje) al bot recién creado.
    - Abrir en browser: `https://api.telegram.org/bot<TOKEN>/getUpdates`
    - Copiar `result[0].message.chat.id` (entero positivo para chats 1-a-1). **Importante**: el chat_id se persiste como **string** en `notify_channels_json` — `TelegramChannel.send` (`notifier/channels/telegram.py:26`) llama `.strip()` y crashearía sobre un int. JSON.stringify del paso 5 ya lo serializa correcto si el valor JS es string.
-3. **Agregar token al `.env`** (SSH al server):
+3. **Agregar token al `.env`** (SSH al server). Robusto contra `.env` sin trailing newline (causa más probable de F6):
    ```bash
-   ssh aws-server "echo 'TRADING_TELEGRAM_BOT_TOKEN=<token>' | sudo tee -a /var/www/trading/.env >/dev/null"
+   ssh aws-server "sudo sh -c 'printf \"\\nTRADING_TELEGRAM_BOT_TOKEN=%s\\n\" \"<token>\" >> /var/www/trading/.env'"
    ```
-   Verificar (key-only, sin valor): `ssh aws-server "sudo grep -c '^TRADING_TELEGRAM_BOT_TOKEN=' /var/www/trading/.env"` → esperado `1`.
+   El `\\n` líder garantiza que aunque el último byte previo no fuera newline, la línea agregada queda bien delimitada. Verificar (key-only, sin valor): `ssh aws-server "sudo grep -c '^TRADING_TELEGRAM_BOT_TOKEN=' /var/www/trading/.env"` → esperado `1`.
 4. **Restart del service**:
    ```bash
    ssh aws-server "sudo systemctl restart trading-spacial"
    ```
-   2-3s downtime. Verificar: `systemctl is-active trading-spacial` → `active` y `curl localhost:8100/health` → `healthy: true`.
+   2-3s downtime nominal, pero cold start con DB warmup puede tardar ~10s. Verificar con espera tolerante:
+   ```bash
+   sleep 15 && ssh aws-server "systemctl is-active trading-spacial && curl -fsS http://localhost:8100/health"
+   ```
+   Si `is-active` ≠ `active` tras 15s, ir directamente a F6.
 
 ### Owner: Claude (vía browser Playwright, sesión JWT activa)
 
-5. **PUT chat_id a preferences** — vía `browser_evaluate` con la cookie de Samuel ya cargada:
+5. **PUT chat_id a preferences** — vía `browser_evaluate` con la cookie de Samuel ya cargada. **Precondición**: hacer `GET /api/preferences` primero para chequear si hay row existente con `min_score` residual (e.g. valor de pruebas anteriores ≠ 4 que bloquearía signals válidos). El PUT siguiente debe incluir `min_score: 4` **explícitamente** para forzar el reset, no confiar en el default:
    ```js
-   fetch('/api/preferences', {
+   // 1) Pre-check
+   const cur = await fetch('/api/preferences', { credentials: 'include' }).then(r => r.json())
+   console.log('current min_score:', cur.min_score, 'channels:', cur.notify_channels)
+
+   // 2) Upsert con min_score explícito (defensivo contra residual)
+   await fetch('/api/preferences', {
      method: 'PUT',
      credentials: 'include',
      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
-     body: JSON.stringify({ notify_channels: { telegram_chat_id: '<chat_id>' } })
+     body: JSON.stringify({
+       min_score: 4,
+       notify_channels: { telegram_chat_id: '<chat_id>' }
+     })
    })
    ```
-   Verificar response 200 + `body.preferences.notify_channels.telegram_chat_id === '<chat_id>'`.
+   Verificar response 200 + `body.preferences.notify_channels.telegram_chat_id === '<chat_id>'` + `body.preferences.min_score === 4`.
 
 6. **Force scan + verify dispatch**:
    - `POST /api/scan` (force) o esperar 5 min al próximo ciclo.
@@ -92,7 +106,9 @@ Después de Phase A:
 | F3 | TelegramChannel log: `telegram not configured (missing token or chat_id)` | Token no llegó al proceso (restart no leyó .env) o chat_id no en prefs | `systemctl restart trading-spacial` + verificar PUT row en DB |
 | F4 | TelegramChannel log: `HTTP 400: Bad Request: chat not found` | chat_id mal escrito o el bot nunca recibió `/start` (Telegram requiere "permiso") | Re-DM al bot + re-fetch getUpdates + re-PUT chat_id |
 | F5 | TelegramChannel log: `HTTP 401: Unauthorized` | Token mal copiado o bot deleted en BotFather | Re-issue token vía `/token` en BotFather + re-set .env + restart |
-| F6 | Service no levanta post-restart | `.env` con syntax error (typo en línea agregada) | `journalctl -u trading-spacial -n 50 --no-pager`, editar .env manualmente, retry |
+| F6 | Service no levanta post-restart | `.env` con syntax error (typo en línea agregada o ausencia de trailing newline antes — mitigado en paso 3) | `journalctl -u trading-spacial -n 50 --no-pager`, editar .env manualmente, retry |
+| F7 | Verify (paso 6) no muestra `dispatch: ...receipts=1` aunque hay signals fresh en `/signals` | Dedup en 2 capas — (a) scanner global cache: log `{sym}: senal duplicada, notificacion omitida` en `scanner/runtime.py:271`. (b) notifier tenant-prefixed dedup: window post-fan-out, silencioso (return [] sin log). Ambas duran 30 min por símbolo. | Esperar que la ventana expire, O probar con otro símbolo, O reiniciar el service (limpia el cache in-memory de `_is_duplicate_signal`) |
+| F8 | journalctl: `dispatch: user_id=1 skipped — symbol=X score=4 filter=None min=8` | Fila previa en `user_preferences` con `min_score > 4` (testing residual). Filtro per-user rechaza signals válidos antes de llamar al canal. | PUT `/api/preferences` con `min_score: 4` explícito (mitigado preventivamente en paso 5) |
 
 ## Rollback
 
@@ -106,7 +122,7 @@ Estado pre-Phase-A queda exactamente como antes (sin telegram, sin prefs).
 
 Se considera Phase A completo cuando **los 3 son verdaderos**:
 
-- [ ] (Backend) `journalctl -u trading-spacial --since '5 minutes ago' | grep 'dispatch: user_id=1'` muestra **al menos 1 línea** con `receipts=1` para un signal real (no /webhook/test).
+- [ ] (Backend) `journalctl -u trading-spacial --since '5 minutes ago' | grep -E 'dispatch: user_id=1.*receipts=[1-9]'` muestra **al menos 1 línea** para un signal real (no /webhook/test). El pattern `receipts=[1-9]` excluye tanto las skip lines (que también arrancan con `dispatch: user_id=1`) como las `receipts=0` que indicarían canal mal configurado.
 - [ ] (User) Samuel confirma haber recibido **al menos 1 mensaje** del bot en su chat de Telegram, con el formato esperado de signal (símbolo + score + precio + dirección + SL/TP).
 - [ ] (Database) Query verifica que la fila persistió:
   ```python
@@ -130,5 +146,5 @@ Total wall-clock: **~10-15 min de trabajo activo + hasta ~5 min de espera** del 
 
 ## Next phases (pointers, no scope acá)
 
-- **Phase B — Frontend UI self-service**: nuevo componente `NotificationSettings` en el dropdown del usuario, con form para gestionar `chat_id` + `min_score` + `symbol_filter` y botón "send test" que ejercita el path per-user (necesita nuevo endpoint `POST /api/preferences/test` o extender `/webhook/test`). Prereq: Phase A. Spec separado cuando Phase A esté en prod.
+- **Phase B — Frontend UI self-service**: nuevo componente `NotificationSettings` en el dropdown del usuario, con form para gestionar `chat_id` + `min_score` + `symbol_filter` y botón "send test" que ejercita el path per-user. Hoy `/webhook/test` (`btc_api.py:547-586`) usa **solo** el `cfg["telegram_chat_id"]` global, no el per-user — por eso Phase B necesita o un endpoint nuevo `POST /api/preferences/test` (no existe hoy) o extender `/webhook/test` para aceptar `tenant_id` y resolver vía `dispatch_signal_to_users`. Prereq: Phase A. Spec separado cuando Phase A esté en prod.
 - **Phase C — Bot webhook + deep-link invites**: `POST /telegram/webhook` recibe updates de Telegram, captura `/start <invite_token>` y auto-popula `notify_channels.telegram_chat_id` del usuario invitado. Tabla nueva `telegram_invite_tokens(token, tenant_id, expires_at, used_at)`. Prereq: Phase B (UI para "invite user" admin action). Spec separado, deferido hasta que Epic B (#253) habilite onboarding.

--- a/docs/superpowers/specs/es/2026-05-21-telegram-multitenant-phase-a-pre-reg.md
+++ b/docs/superpowers/specs/es/2026-05-21-telegram-multitenant-phase-a-pre-reg.md
@@ -1,8 +1,10 @@
 # Telegram multi-tenant — Phase A (backend wiring) — pre-reg
 
+> ⚠️ **SUPERSEDED 2026-05-21** by [`2026-05-21-telegram-per-user-config-pre-reg.md`](2026-05-21-telegram-per-user-config-pre-reg.md). Durante la ejecución de este spec, el operator pidió "configurable como openclaw" — modelo where each user has their own bot, each manages own config, fully UI-driven (no admin SSH/.env work). Ese cambio fundamental invierte la arquitectura: token deja de ser global, pasa a per-user en `user_preferences.notify_channels`. Spec nuevo lo refleja. Este queda como artefacto histórico.
+
 **Fecha:** 2026-05-21
 **Operator:** Samuel (en nombre de Simon)
-**Estado:** pre-reg pre-ejecución
+**Estado:** SUPERSEDED — ver banner arriba
 **Estimación:** ~30 min wall-clock
 
 ## Contexto

--- a/docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md
+++ b/docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md
@@ -168,7 +168,7 @@ export async function testPreferencesDelivery(): Promise<TestDeliveryResponse> {
 8. Backend `db_upsert_user_preferences` persiste a `user_preferences.notify_channels_json`.
 9. Usuario click "Probar envío".
 10. `testPreferencesDelivery()` → `POST /api/preferences/test`.
-11. Backend: `dispatch_signal_to_users(SignalEvent("TEST", score=9, ...), base_cfg)` → para `tenant_id=current`, overlay carga `telegram_bot_token` + `telegram_chat_id` del JSON, `TelegramChannel.send()` postea a la Bot API.
+11. Backend: lookup `db_get_user_preferences(tenant_id) → prefs.notify_channels`, overlay sobre `load_config()` → if `token` + `chat_id` ambos presentes, `TelegramChannel(user_cfg).send("*Crypto Scanner — prueba de conexión*…")`; else return `{ok: false, receipts: [], reason: "no_telegram_configured"}`.
 12. Response: `{ok: true/false, receipts: [{channel, status, error}]}`.
 13. UI muestra resultado.
 
@@ -206,9 +206,18 @@ UI-side: el campo `telegram_bot_token` es `<input type="password">`, no se logge
 
 ```python
 def _mask_token(token: str) -> str:
-    """123456789:ABCdef...wxyz → 123456789:****wxyz (preserva últimos 4 chars)"""
+    """123456789:ABCdef...wxyz → 123456789:****wxyz (preserva últimos 4 chars).
+
+    Nota defensiva: tokens reales de Telegram tienen ~46 chars
+    (<bot_id>:<35-char-secret>), así que `len < 10` solo se dispara
+    para inputs basura (vacío, corrupto). Devolver "" en ese caso
+    significa que el frontend va a pre-fillear vacío, indistinguible
+    de "sin configurar" — aceptable porque en prod este path no se
+    debería disparar. No agregar tests específicos para bordes
+    `len ∈ {1..9}`, no son escenarios reales.
+    """
     if not token or len(token) < 10:
-        return ""  # vacío o demasiado corto para enmascarar significativamente
+        return ""
     return f"{token[:10]}****{token[-4:]}"
 ```
 
@@ -233,8 +242,7 @@ Documentado para que el reviewer del próximo Phase no se sorprenda.
 
 | # | Síntoma observable | Causa probable | Recovery |
 |---|---|---|---|
-| F1 | "Probar envío" responde `{ok: false, receipts: []}` | Usuario no tiene `notify_channels` seteado (null) | Llenar campos + Guardar primero |
-| F2 | "Probar envío" responde con receipt status `failed`, error `"telegram not configured (missing token or chat_id)"` | Uno de los 2 campos vacío después del save | Re-verificar ambos campos, save again |
+| F1 | "Probar envío" responde `{ok: false, receipts: [], reason: "no_telegram_configured"}` | Uno o ambos campos vacíos en DB (notify_channels null, o token sin chat_id, o viceversa) | Llenar token + chat_id en el panel, Save, retry. Early-return del endpoint atrapa esto antes de llamar a TelegramChannel — el error "telegram not configured" del channel no llega a aparecer por este path. |
 | F3 | Receipt error `"HTTP 401: Unauthorized"` | Token mal copiado (typo, espacio extra) o bot deleted en BotFather | Re-issue token vía `/token` en BotFather, paste de nuevo |
 | F4 | Receipt error `"HTTP 400: Bad Request: chat not found"` | chat_id mal escrito O usuario nunca hizo `/start` del bot (Telegram requiere "permiso explícito") | Mandar `/start` en Telegram, re-verificar chat_id en getUpdates, paste de nuevo |
 | F5 | Receipt error `"HTTP 403: Forbidden: bot was blocked by the user"` | Usuario bloqueó el bot en Telegram | Desbloquear el bot, re-test |

--- a/docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md
+++ b/docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md
@@ -1,0 +1,224 @@
+# Telegram per-user config — pre-reg
+
+**Fecha:** 2026-05-21
+**Operator:** Samuel (en nombre de Simon)
+**Estado:** pre-reg pre-implementación
+**Estimación:** ~½ – 1 día
+**Supersedes:** [`2026-05-21-telegram-multitenant-phase-a-pre-reg.md`](2026-05-21-telegram-multitenant-phase-a-pre-reg.md) (modelo admin-side abandonado)
+
+## Contexto
+
+Sesión 2026-05-21: investigación con `systematic-debugging` descartó la hipótesis "deploy borró credenciales" — Telegram nunca había sido configurado en este deploy. Primera iteración de diseño asumía el modelo standard "un bot global compartido por todos los usuarios, admin lo configura via SSH + .env" (ver spec superseded). Durante la ejecución, el operator redirigió:
+
+> "yo quiero que sea un canal al que varios usuarios puedan subscribirse" → (después del intercambio sobre el modelo de canal) → "en openclaw el bot es personal de cada usuario pero la configuracion la hace cada usuario tambien pero es muy facil de integrar"
+
+El modelo correcto es **per-user end-to-end**: cada operador crea su propio bot en BotFather y administra su propio token + chat_id desde el dashboard. Zero admin work, zero SSH, zero global infra.
+
+La plomería del backend **ya soporta esto sin cambios**: `notifier/channels/telegram.py:24-26` lee `telegram_bot_token` y `telegram_chat_id` del `cfg`; `notifier/dispatch_per_user.py:107` hace `user_cfg = {**base_cfg, **notify_channels}` que aplica overlay per-user sobre el base. Si el usuario guarda **ambos** valores en su `notify_channels`, el TelegramChannel los recibe y postea a SU bot.
+
+Este spec cubre lo que falta:
+1. Frontend self-service para que el usuario gestione `telegram_bot_token` + `telegram_chat_id`.
+2. Un endpoint `POST /api/preferences/test` que dispare un signal sintético contra el path per-user del dispatcher, para que el usuario verifique su setup sin esperar al próximo signal real.
+
+## Goal
+
+Después de este spec implementado:
+
+- Cada usuario logueado puede abrir su panel "Mi configuración" desde el dropdown del avatar (top right del header).
+- En el panel ve una sección "Notificaciones por Telegram" con dos campos (`bot_token` masked + `chat_id` text), un botón "Guardar" y un botón "Probar envío".
+- Después de guardar y testear con éxito, el usuario recibe automáticamente cada signal con `score ≥ min_score` (default 4) en SU bot.
+- Cero pasos manuales del lado del admin/servidor.
+
+## Non-goals (Out of scope)
+
+- **Admin-side global bot token**: descartado por el operator. No habrá `TRADING_TELEGRAM_BOT_TOKEN` en .env, ni columna global en `config.json`, ni endpoint admin para setear el token de otros usuarios.
+- **Bot webhook + deep-link invites** (`POST /telegram/webhook` que captura `/start` automático): queda para una Phase B futura. Hoy el usuario discover-ea su chat_id manualmente via `getUpdates`.
+- **Per-user min_score / symbol_filter UI**: el schema lo soporta pero la UI queda fuera de este spec. Se agregan en una iteración futura cuando se justifique.
+- **Encryption-at-rest de bot tokens**: ver §7 (security note). Decisión actual: plain-text en JSON column es aceptable para el modelo de threat actual (single-server EC2, único operador con sudo). Documentado, no implementado.
+- **Multi-user testing real**: hoy hay un solo usuario (`tenant_id=1`, sssamuelll@gmail.com). El path per-user se ejercita con él. Multi-user real espera a Epic B (#253) onboarding.
+
+## Arquitectura
+
+### Lo que ya existe (sin cambios)
+
+- `notifier/channels/telegram.py:TelegramChannel.__init__` lee `cfg["telegram_bot_token"]` + `cfg["telegram_chat_id"]`. Per-call retries con backoff exponencial.
+- `notifier/dispatch_per_user.py:dispatch_signal_to_users` itera usuarios activos, hace `user_cfg = {**base_cfg, **notify_channels}` y llama `notify(event, user_cfg, tenant_id=user["id"])`. Tenant-prefixed dedup keys (`notifier/__init__.py:88-91`).
+- `api/user_preferences.py:get_preferences` (GET) + `put_preferences` (PUT, JWT-gated). `PreferencesPutBody.notify_channels: Optional[dict[str, Any]]` — acepta cualquier shape, no valida keys.
+- `db/user_preferences.py:db_upsert_user_preferences` persiste `notify_channels_json` como TEXT JSON.
+- `frontend/src/api.ts`: ya tiene `getUserPreferences()` + `updateUserPreferences()` wrappers (líneas ~398-419).
+- `frontend/src/types.ts`: `UserPreferences.notify_channels: Record<string, unknown> | null` — type-safe para cualquier shape.
+
+### Lo que cambia
+
+#### Backend (nuevo, ~1 file)
+
+**`api/user_preferences.py`** — agregar endpoint `POST /preferences/test`:
+
+```python
+@router.post("/test", summary="Send a synthetic SignalEvent to current tenant's channels")
+def post_preferences_test(tenant_id: int = Depends(get_current_tenant_id)):
+    """Dispara un SignalEvent placeholder por el path per-user del dispatcher
+    para que el usuario verifique end-to-end que sus credenciales funcionan.
+
+    Reuses dispatch_signal_to_users so la verificación cubre exactamente la
+    misma ruta que un signal real (notify_channels overlay → TelegramChannel
+    → Telegram API).
+    """
+    from api.config import load_config
+    from notifier.events import SignalEvent
+    from notifier.dispatch_per_user import dispatch_signal_to_users
+
+    event = SignalEvent(
+        symbol="TEST", score=9, direction="LONG",
+        entry=0.0, sl=0.0, tp=0.0,
+        lrc_pct=None, health_state="NORMAL",
+    )
+    base_cfg = load_config()
+    receipts = dispatch_signal_to_users(event, base_cfg)
+    user_receipts = receipts.get(tenant_id, [])
+    return {
+        "ok": any(r.status == "ok" for r in user_receipts),
+        "receipts": [
+            {"channel": r.channel, "status": r.status, "error": r.error}
+            for r in user_receipts
+        ],
+    }
+```
+
+Tres notas sobre este endpoint:
+- **Filtros aplican**: `dispatch_signal_to_users` aplica `symbol_filter` + `min_score` del usuario. Usamos `symbol="TEST"` + `score=9` para que pasen filtros razonables (score=9 ≥ cualquier min_score; symbol_filter=null acepta todo, lista explícita debería incluir "TEST" o el usuario verá receipts=[] aunque sus creds estén bien). Esto es un trade-off: forzar `score=9` bypassa el filtro real del usuario, pero verifica el path técnico. Documentado en el response para que el usuario sepa qué se ejercitó.
+- **Dedup**: usar `symbol="TEST"` evita colisionar con dedup keys de signals reales. Cada test es independiente.
+- **No-op si el usuario no tiene notify_channels**: receipts será `[]` (no canales configurados). Response: `{"ok": false, "receipts": []}`. UI muestra "Configurá token + chat_id antes de probar".
+
+#### Frontend (2 archivos nuevos + 4 modificaciones)
+
+**Discovery clave**: `UserMenu.tsx:31` ya tiene un item placeholder `{ icon: '◐', label: 'Conexiones', hint: 'Telegram · Webhook', badge: '1' }` con `onClick` sin wirear. La UI scaffold ya estaba diseñada para este feature. Solo hay que poner el click + crear el panel que abre.
+
+**Crear: `frontend/src/components/ConnectionsPanel.tsx`** — slide-out panel inspirado en `ConfigPanel.tsx` (mismo patrón: slide-out from right + backdrop blur). Una sola sección activa por ahora: "Telegram". Estructura preparada para futuras (Webhook, Discord, etc).
+
+Sección "Telegram":
+- Input `telegram_bot_token`: type=password, placeholder hint "123456789:ABCdef...", botón "ojo" para revelar/ocultar.
+- Input `telegram_chat_id`: type=text, placeholder "123456789".
+- Botón "Guardar" → llama `updateUserPreferences({notify_channels: {telegram_bot_token, telegram_chat_id}})`.
+- Botón "Probar envío" (deshabilitado mientras dirty unsaved): llama nuevo wrapper `testPreferencesDelivery()` → POST /preferences/test. Muestra resultado inline (✓ enviado / ✗ error con detail).
+- Instrucciones colapsables: "¿Cómo creo mi bot?" con steps de BotFather + getUpdates.
+
+**Crear: `frontend/src/components/ConnectionsPanel.module.css`** — estilos consistentes con `ConfigPanel.module.css`.
+
+**Modificar: `frontend/src/components/UserMenu.tsx`** — agregar `onClick` al item "Conexiones" existente. Aceptar nueva prop `onConnectionsOpen: () => void`.
+
+**Modificar: `frontend/src/App.tsx`** — extender `OverlayKind = 'notifs' | 'settings' | 'user' | 'connections' | null`. Pasar `onConnectionsOpen` al UserMenu. Render del `<ConnectionsPanel>` cuando `openOverlay === 'connections'`. El click en "Conexiones" cierra el UserMenu (`setOpenOverlay('connections')` reemplaza el `'user'` actual).
+
+**Modificar: `frontend/src/api.ts`** — agregar wrapper:
+```typescript
+export async function testPreferencesDelivery(): Promise<TestDeliveryResponse> {
+  return request<TestDeliveryResponse>('/preferences/test', { method: 'POST' });
+}
+```
++ type `TestDeliveryResponse` en `types.ts`.
+
+**Bonus opcional (no blocker)**: el badge "1" del menú item actualmente es hardcoded en `UserMenu.tsx`. Podría wire-arse a "número de conexiones no configuradas" (1 si telegram_bot_token vacío, 0 si seteado). Out of scope para esta iteración — leave hardcoded.
+
+### Data flow end-to-end
+
+1. Usuario click en avatar ▾ del header → UserMenu abre.
+2. Click en item "Conexiones".
+3. App.tsx: `setOpenOverlay('connections')` (cierra el UserMenu, abre el panel).
+4. `ConnectionsPanel` monta, llama `getUserPreferences()` → recibe `{notify_channels: {telegram_bot_token, telegram_chat_id} | null, ...}`.
+5. Form renderiza valores actuales (o vacíos si null).
+6. Usuario tipea credenciales → click Guardar.
+7. `updateUserPreferences({notify_channels: {...}})` → `PUT /api/preferences` con JWT cookie + CSRF.
+8. Backend `db_upsert_user_preferences` persiste a `user_preferences.notify_channels_json`.
+9. Usuario click "Probar envío".
+10. `testPreferencesDelivery()` → `POST /api/preferences/test`.
+11. Backend: `dispatch_signal_to_users(SignalEvent("TEST", score=9, ...), base_cfg)` → para `tenant_id=current`, overlay carga `telegram_bot_token` + `telegram_chat_id` del JSON, `TelegramChannel.send()` postea a la Bot API.
+12. Response: `{ok: true/false, receipts: [{channel, status, error}]}`.
+13. UI muestra resultado.
+
+### Storage — extensión del shape de notify_channels
+
+Antes:
+```json
+{ "telegram_chat_id": "123456789" }
+```
+
+Después:
+```json
+{
+  "telegram_bot_token": "123456789:ABCdef...",
+  "telegram_chat_id": "123456789"
+}
+```
+
+Ambos como **string** (TelegramChannel hace `.strip()` — int causaría crash, documented en spec superseded). `dict[str, Any]` del Pydantic acepta el shape sin schema change.
+
+## Security note
+
+**Bot tokens en plain text dentro de `notify_channels_json` (TEXT column de SQLite).** Threat model actual:
+- Single-server EC2 con UNICO operador admin (Samuel/Simon).
+- Acceso al servidor implica acceso a `.env` (donde viven JWT secrets, DEEPSEEK API key) y a `signals.db`.
+- Robar un bot token NO es más grave que cualquier otra credencial — todas viven al mismo nivel de protección.
+
+**Aceptable hoy. Futuro:**
+- Si se invitan operadores no-trusted (post-Epic B #253), revisitar: encrypt-at-rest con clave en .env, o stash en separate `secrets` table con column-level encryption.
+- Documentado como **deferred** en este spec. NO se implementa en esta iteración.
+
+UI-side: el campo `telegram_bot_token` es `<input type="password">`, no se loggea en el browser, ni se envía al `/agent/conversations` audit. El response del GET /preferences sí lo devuelve plain (necesario para pre-fill al editar). Acceptable por threat model.
+
+## Failure modes
+
+| # | Síntoma observable | Causa probable | Recovery |
+|---|---|---|---|
+| F1 | "Probar envío" responde `{ok: false, receipts: []}` | Usuario no tiene `notify_channels` seteado (null) | Llenar campos + Guardar primero |
+| F2 | "Probar envío" responde con receipt status `failed`, error `"telegram not configured (missing token or chat_id)"` | Uno de los 2 campos vacío después del save | Re-verificar ambos campos, save again |
+| F3 | Receipt error `"HTTP 401: Unauthorized"` | Token mal copiado (typo, espacio extra) o bot deleted en BotFather | Re-issue token vía `/token` en BotFather, paste de nuevo |
+| F4 | Receipt error `"HTTP 400: Bad Request: chat not found"` | chat_id mal escrito O usuario nunca hizo `/start` del bot (Telegram requiere "permiso explícito") | Mandar `/start` en Telegram, re-verificar chat_id en getUpdates, paste de nuevo |
+| F5 | Receipt error `"HTTP 403: Forbidden: bot was blocked by the user"` | Usuario bloqueó el bot en Telegram | Desbloquear el bot, re-test |
+| F6 | Signals reales (no el test) no llegan aunque "Probar envío" ✓ | min_score del usuario o symbol_filter excluyen los signals que aparecen | Verificar min_score vía GET /preferences; si demasiado alto, bajarlo |
+| F7 | Después de save, "Probar envío" sigue fallando con creds que parecen correctas | Race: el PUT response volvió 200 pero load_config cachea (en realidad no — re-lee cada request) | Recargar la página, GET /preferences debería mostrar valores correctos |
+
+## Rollback
+
+Reversible 100%:
+- Si el feature rompe algo en prod: revert los commits de backend + frontend. Schema sin cambios (sigue siendo `notify_channels: dict[str, Any]`), el shape extendido se ignora gracefully por TelegramChannel cuando ambos campos no están.
+- Si el operator decide volver al modelo admin-side global: descartar este spec y volver al [`2026-05-21-telegram-multitenant-phase-a-pre-reg.md`](2026-05-21-telegram-multitenant-phase-a-pre-reg.md) original.
+- Si solo se quiere desactivar feature flag (en caso de bug grave): no hay feature flag explícito porque el shape extendido es backward-compatible. Hard-rollback es revert.
+
+## Test plan / acceptance gates
+
+### Unit tests (backend)
+
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_no_channels_returns_empty_receipts` — usuario sin `notify_channels` → `{ok: false, receipts: []}`.
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_with_telegram_routes_correctly` — usuario con `{telegram_bot_token, telegram_chat_id}` → llama `dispatch_signal_to_users` con `SignalEvent("TEST", score=9, ...)`, receipts incluye un row con `channel="telegram"`. (Telegram API mockeada para evitar I/O real).
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_only_returns_current_tenant_receipts` — con 2 usuarios activos en DB, el response solo incluye receipts del JWT-actual tenant_id (no del otro).
+
+### Unit tests (frontend, vitest)
+
+- [ ] `ConnectionsPanel.test.tsx::renders_form_with_current_values` — mock GET /preferences con notify_channels populado, verifica que los inputs muestran los valores.
+- [ ] `ConnectionsPanel.test.tsx::save_calls_put_with_correct_body` — type en inputs + click Save, verifica que `updateUserPreferences` recibe el body esperado.
+- [ ] `ConnectionsPanel.test.tsx::test_button_disabled_when_dirty` — type sin save → "Probar envío" debe estar disabled.
+- [ ] `ConnectionsPanel.test.tsx::test_button_shows_ok_on_success` — mock POST /preferences/test con `{ok: true}`, verifica UI muestra "✓ enviado".
+- [ ] `ConnectionsPanel.test.tsx::test_button_shows_error_on_failure` — mock con `{ok: false, receipts: [{error: "HTTP 401..."}]}`, verifica error mostrado.
+
+### Integration (manual + Playwright e2e)
+
+- [ ] **Manual (Samuel)**: Crear bot en BotFather, conseguir chat_id, abrir avatar ▾ → Conexiones → pegar credenciales → Guardar → Probar envío, confirmar que llega mensaje "TEST" en Telegram. **Este es el gate principal del feature** — sin esto el spec no se considera shipped.
+- [ ] **Playwright e2e (yo)**: Abrir el dashboard, click avatar ▾, click "Conexiones", type creds fake, save, verificar DB tiene `notify_channels` con ambos campos, verificar que GET /preferences los devuelve.
+
+## Estimación
+
+| Componente | Effort |
+|---|---|
+| Backend endpoint + 3 tests | ~2h |
+| Frontend `ConnectionsPanel.tsx` + CSS + 5 tests | ~3h |
+| Wire-up: App.tsx OverlayKind, UserMenu.tsx onClick, api.ts wrapper, types.ts | ~30 min |
+| Manual + Playwright integration | ~1h |
+| PR review iteration | ~1h |
+| **Total** | **~½ – 1 día** |
+
+## Next phases (out of scope acá)
+
+- **Phase B — Bot webhook + deep-link invites** (deferido hasta Epic B #253 user-onboarding): `POST /telegram/webhook` recibe updates de Telegram, captura `/start <invite_token>` y auto-popula `notify_channels.telegram_chat_id` del usuario invitado. Tabla nueva `telegram_invite_tokens`. Removes the manual `getUpdates` step.
+- **Future — Encryption-at-rest** de tokens (deferred per §7). Disparado por el momento en que se invite a un operador no-trusted al sistema.
+- **Future — Per-user `min_score` UI**: el field ya existe en `user_preferences`, el GET/PUT lo soporta. Solo falta exponerlo en el panel (slider 0-9). Bajo nivel de prioridad mientras hay un solo usuario.
+- **Future — Per-user `symbol_filter` UI**: lista de checkboxes de los 10 símbolos curados. Same story.

--- a/docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md
+++ b/docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md
@@ -55,40 +55,76 @@ Después de este spec implementado:
 **`api/user_preferences.py`** — agregar endpoint `POST /preferences/test`:
 
 ```python
-@router.post("/test", summary="Send a synthetic SignalEvent to current tenant's channels")
+@router.post(
+    "/test",
+    summary="Send a test message to current tenant's Telegram",
+    dependencies=[Depends(verify_api_key)],
+)
 def post_preferences_test(tenant_id: int = Depends(get_current_tenant_id)):
-    """Dispara un SignalEvent placeholder por el path per-user del dispatcher
-    para que el usuario verifique end-to-end que sus credenciales funcionan.
+    """Verifica end-to-end que las credenciales de Telegram del usuario
+    funcionan, mandando un mensaje "ping" a su bot.
 
-    Reuses dispatch_signal_to_users so la verificación cubre exactamente la
-    misma ruta que un signal real (notify_channels overlay → TelegramChannel
-    → Telegram API).
+    Bypassa `notify()` y `dispatch_signal_to_users` a propósito (ver §Notas):
+    construye un `TelegramChannel` directamente con el cfg-con-overlay del
+    usuario y llama `.send()`. Eso evita:
+      - dedup collisions si en el futuro alguien cambia el default window
+        de event_type=signal (hoy es 0, pero defensive design).
+      - side-effect en NotificationBell: cada test press NO crea una row
+        en notifications_sent (no usa notify(), no llama record_delivery).
+      - filter false-negatives: el endpoint NO debería ser bloqueado por
+        symbol_filter / min_score del usuario — esos aplican a signals
+        reales, no a "verificá tu config".
+
+    Trade-off: NO ejercita el dispatcher per-user. Aceptable porque el
+    dispatcher está bien testeado (tests/test_notifier_dispatch_per_user.py)
+    y lo que el usuario quiere verificar es "¿llega un mensaje a mi bot
+    cuando lo configuro?", no "¿el dispatcher me rutea correcto?".
     """
     from api.config import load_config
-    from notifier.events import SignalEvent
-    from notifier.dispatch_per_user import dispatch_signal_to_users
+    from db.user_preferences import db_get_user_preferences
+    from notifier.channels.telegram import TelegramChannel
 
-    event = SignalEvent(
-        symbol="TEST", score=9, direction="LONG",
-        entry=0.0, sl=0.0, tp=0.0,
-        lrc_pct=None, health_state="NORMAL",
-    )
+    prefs = db_get_user_preferences(tenant_id) or {}
+    notify_channels = prefs.get("notify_channels") or {}
     base_cfg = load_config()
-    receipts = dispatch_signal_to_users(event, base_cfg)
-    user_receipts = receipts.get(tenant_id, [])
+    user_cfg = {**base_cfg, **notify_channels}
+
+    token = (user_cfg.get("telegram_bot_token") or "").strip()
+    chat_id = (user_cfg.get("telegram_chat_id") or "").strip()
+    if not token or not chat_id:
+        return {
+            "ok": False,
+            "receipts": [],
+            "reason": "no_telegram_configured",
+        }
+
+    channel = TelegramChannel(user_cfg)
+    receipt = channel.send(
+        "*Crypto Scanner — prueba de conexión*\n"
+        "Si ves este mensaje, tu bot y chat están bien configurados. ✅"
+    )
     return {
-        "ok": any(r.status == "ok" for r in user_receipts),
-        "receipts": [
-            {"channel": r.channel, "status": r.status, "error": r.error}
-            for r in user_receipts
-        ],
+        "ok": receipt.status == "ok",
+        "receipts": [{
+            "channel": receipt.channel,
+            "status": receipt.status,
+            "error": receipt.error,
+        }],
+        "reason": None,
     }
 ```
 
-Tres notas sobre este endpoint:
-- **Filtros aplican**: `dispatch_signal_to_users` aplica `symbol_filter` + `min_score` del usuario. Usamos `symbol="TEST"` + `score=9` para que pasen filtros razonables (score=9 ≥ cualquier min_score; symbol_filter=null acepta todo, lista explícita debería incluir "TEST" o el usuario verá receipts=[] aunque sus creds estén bien). Esto es un trade-off: forzar `score=9` bypassa el filtro real del usuario, pero verifica el path técnico. Documentado en el response para que el usuario sepa qué se ejercitó.
-- **Dedup**: usar `symbol="TEST"` evita colisionar con dedup keys de signals reales. Cada test es independiente.
-- **No-op si el usuario no tiene notify_channels**: receipts será `[]` (no canales configurados). Response: `{"ok": false, "receipts": []}`. UI muestra "Configurá token + chat_id antes de probar".
+**Decisión de diseño documentada** (Option 2 del review 2026-05-21): bypassar `notify()` y `dispatch_signal_to_users` es deliberado. Las alternativas consideradas:
+
+| Opción | Pros | Cons |
+|---|---|---|
+| 1. Nuevo `SignalTestEvent` con dedupe_key random | Ejercita dispatcher real | Requiere new dataclass + 2 entries en mappings + filtro en NotificationBell para no mostrar tests |
+| **2. Bypass notify, llamar TelegramChannel direct** ✅ | Simple, sin side-effects, sin dedup edge-cases | No ejercita dispatcher (aceptable — dispatcher cubierto por otros tests) |
+| 3. Override dedupe_key por-call | Invasivo, cambia API pública de notify() | Rechazada |
+
+**Auth**: `dependencies=[Depends(verify_api_key)]` por consistencia con el PUT existente (`api/user_preferences.py:60`). Hoy `api_key` está vacío en config → open access via JWT only (mismo behavior que PUT). Si en el futuro alguien setea el api_key, ambos endpoints se gatean.
+
+**No-op si el usuario no tiene credenciales seteadas**: response `{ok: false, receipts: [], reason: "no_telegram_configured"}`. La UI usa el `reason` field para mostrar un mensaje claro ("Configurá tu token y chat_id primero").
 
 #### Frontend (2 archivos nuevos + 4 modificaciones)
 
@@ -97,10 +133,11 @@ Tres notas sobre este endpoint:
 **Crear: `frontend/src/components/ConnectionsPanel.tsx`** — slide-out panel inspirado en `ConfigPanel.tsx` (mismo patrón: slide-out from right + backdrop blur). Una sola sección activa por ahora: "Telegram". Estructura preparada para futuras (Webhook, Discord, etc).
 
 Sección "Telegram":
-- Input `telegram_bot_token`: type=password, placeholder hint "123456789:ABCdef...", botón "ojo" para revelar/ocultar.
+- Input `telegram_bot_token`: type=password, placeholder hint "123456789:ABCdef...", botón "ojo" para revelar/ocultar. Pre-fill con masked value desde GET; al typear nuevo value reemplaza, sin tipear preserva (detection vía `****`).
 - Input `telegram_chat_id`: type=text, placeholder "123456789".
-- Botón "Guardar" → llama `updateUserPreferences({notify_channels: {telegram_bot_token, telegram_chat_id}})`.
+- Botón "Guardar" → llama `updateUserPreferences({notify_channels: {telegram_bot_token, telegram_chat_id}})`. Skip token en el body si el value sigue siendo masked (no se modificó).
 - Botón "Probar envío" (deshabilitado mientras dirty unsaved): llama nuevo wrapper `testPreferencesDelivery()` → POST /preferences/test. Muestra resultado inline (✓ enviado / ✗ error con detail).
+- Botón "Eliminar credenciales" (review fix): llama `updateUserPreferences({notify_channels: null})`. Limpia los inputs + muestra confirmación inline ("Credenciales eliminadas"). Use case principal: rotation de tokens, o usuario que quiere parar de recibir signals sin perder su user account.
 - Instrucciones colapsables: "¿Cómo creo mi bot?" con steps de BotFather + getUpdates.
 
 **Crear: `frontend/src/components/ConnectionsPanel.module.css`** — estilos consistentes con `ConfigPanel.module.css`.
@@ -117,7 +154,7 @@ export async function testPreferencesDelivery(): Promise<TestDeliveryResponse> {
 ```
 + type `TestDeliveryResponse` en `types.ts`.
 
-**Bonus opcional (no blocker)**: el badge "1" del menú item actualmente es hardcoded en `UserMenu.tsx`. Podría wire-arse a "número de conexiones no configuradas" (1 si telegram_bot_token vacío, 0 si seteado). Out of scope para esta iteración — leave hardcoded.
+**Badge "1" condicional** (review fix): el badge actual `'1'` está hardcoded en `UserMenu.tsx:31`. Wire-arlo a "número de conexiones no configuradas": si `notify_channels.telegram_bot_token` está seteado, badge desaparece (undefined); si no, badge='1'. Implementation: 3 líneas — leer prefs desde el contexto del UserMenu (props desde App.tsx) y pasar conditional al item.
 
 ### Data flow end-to-end
 
@@ -163,7 +200,34 @@ Ambos como **string** (TelegramChannel hace `.strip()` — int causaría crash, 
 - Si se invitan operadores no-trusted (post-Epic B #253), revisitar: encrypt-at-rest con clave en .env, o stash en separate `secrets` table con column-level encryption.
 - Documentado como **deferred** en este spec. NO se implementa en esta iteración.
 
-UI-side: el campo `telegram_bot_token` es `<input type="password">`, no se loggea en el browser, ni se envía al `/agent/conversations` audit. El response del GET /preferences sí lo devuelve plain (necesario para pre-fill al editar). Acceptable por threat model.
+UI-side: el campo `telegram_bot_token` es `<input type="password">`, no se loggea en el browser, ni se envía al `/agent/conversations` audit.
+
+**Token masking en el GET response** (review fix): el endpoint `GET /api/preferences` enmascara el `telegram_bot_token` antes de devolverlo. Shape:
+
+```python
+def _mask_token(token: str) -> str:
+    """123456789:ABCdef...wxyz → 123456789:****wxyz (preserva últimos 4 chars)"""
+    if not token or len(token) < 10:
+        return ""  # vacío o demasiado corto para enmascarar significativamente
+    return f"{token[:10]}****{token[-4:]}"
+```
+
+El frontend muestra el masked value como pre-fill con label "Token guardado · pegá uno nuevo para reemplazar". Si el usuario NO modifica el campo (value sigue conteniendo `****`), el PUT detecta esto y preserva el valor existente (no sobrescribe con el masked). Si el usuario pega un token nuevo (sin `****`), reemplaza.
+
+Esto reduce el blast radius de un XSS/script-injection ~90% sin tocar schema. Documentado como mitigación cheap. Encryption-at-rest sigue deferred per arriba.
+
+**Threat asymmetry** (matiz al framing inicial): un bot token comprometido permite postear como ese bot a todos los chats que lo añadieron (hoy solo Samuel). Un JWT secret comprometido controla toda la auth de la app. JWT es estrictamente peor, pero la asimetría no es perfecta — son riesgos del mismo orden de magnitud. La mitigación de masking arriba reduce uno de los dos.
+
+## Rate-limit decision (review note)
+
+Telegram Bot API tiene un rate limit de ~1 msg/sec por chat. El path real de signals tiene rate-limit via `notifier.ratelimit.bucket_for("telegram")` (token bucket por canal). Pero el endpoint POST /preferences/test bypassa `notify()` (ver Option 2 arriba) y por ende también el rate-limit del notifier.
+
+**Decisión**: NO agregar rate-limit explícito al /test en esta iteración. Justificación:
+- El usuario es operator-trust (sesión JWT autenticada, no usuario público).
+- Click loco de "Probar envío" en peor caso satura SU PROPIO chat de Telegram — Telegram devuelve 429, el receipt mostrará el error, no afecta a otros usuarios.
+- Si en algún momento esto se vuelve un problema operativo (logs llenos de 429s), agregar un in-memory cooldown trivial (~10s per tenant_id) es 5 líneas. Frame as deferred.
+
+Documentado para que el reviewer del próximo Phase no se sorprenda.
 
 ## Failure modes
 
@@ -182,28 +246,41 @@ UI-side: el campo `telegram_bot_token` es `<input type="password">`, no se logge
 Reversible 100%:
 - Si el feature rompe algo en prod: revert los commits de backend + frontend. Schema sin cambios (sigue siendo `notify_channels: dict[str, Any]`), el shape extendido se ignora gracefully por TelegramChannel cuando ambos campos no están.
 - Si el operator decide volver al modelo admin-side global: descartar este spec y volver al [`2026-05-21-telegram-multitenant-phase-a-pre-reg.md`](2026-05-21-telegram-multitenant-phase-a-pre-reg.md) original.
-- Si solo se quiere desactivar feature flag (en caso de bug grave): no hay feature flag explícito porque el shape extendido es backward-compatible. Hard-rollback es revert.
+- **Feature flag opcional** (review polish, no implementado por defecto): si se quisiera kill-switch sin redeploy, agregar `cfg.features.telegram_per_user` (read-time, default `true`) y gate el endpoint POST /preferences/test + esconder el menu item "Conexiones" cuando false. ~5 líneas de code. Decisión: no implementar porque el feature es backward-compatible y bajo riesgo; revert via PR es suficiente. Si después de shipping aparece un bug que no se puede contener con revert (ej: persistencia corrupta), agregar el flag entonces.
 
 ## Test plan / acceptance gates
 
 ### Unit tests (backend)
 
-- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_no_channels_returns_empty_receipts` — usuario sin `notify_channels` → `{ok: false, receipts: []}`.
-- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_with_telegram_routes_correctly` — usuario con `{telegram_bot_token, telegram_chat_id}` → llama `dispatch_signal_to_users` con `SignalEvent("TEST", score=9, ...)`, receipts incluye un row con `channel="telegram"`. (Telegram API mockeada para evitar I/O real).
-- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_only_returns_current_tenant_receipts` — con 2 usuarios activos en DB, el response solo incluye receipts del JWT-actual tenant_id (no del otro).
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_no_channels_returns_no_telegram_configured` — usuario sin `notify_channels` → `{ok: false, receipts: [], reason: "no_telegram_configured"}`.
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_token_only_returns_no_telegram_configured` — usuario con token pero sin chat_id → mismo `reason: "no_telegram_configured"`.
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_with_telegram_routes_correctly` — usuario con `{telegram_bot_token, telegram_chat_id}` → llama `TelegramChannel.send` con cfg-con-overlay, receipt status=ok. (Telegram API mockeada).
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_two_calls_within_window_both_succeed` — 2 calls consecutivos del mismo tenant retornan ambos ok: true. Verifica que el bypass de `notify()` evita la dedup collision potencial (defensive design — hoy `signal` event_type tiene dedup_window=0 pero el bypass blinda contra cambios futuros).
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_does_not_write_to_notifications_sent` — pre-condition: count rows en `notifications_sent`. Llamar /test. Post-condition: count idéntico. Confirma que el bypass de `notify()` evita el side-effect en NotificationBell.
+- [ ] `tests/test_api_user_preferences.py::test_test_endpoint_isolated_per_tenant` — con 2 usuarios en DB (cada uno con su token+chat_id distinto), tenant_A llamando /test solo recibe receipt del envío a SU bot, no del de tenant_B.
+- [ ] `tests/test_api_user_preferences.py::test_get_preferences_masks_token` — GET con token en DB → response.notify_channels.telegram_bot_token tiene shape `"<10chars>****<4chars>"`, no plain.
+- [ ] `tests/test_api_user_preferences.py::test_put_preferences_preserves_masked_token` — PUT con `notify_channels.telegram_bot_token` que contiene `****` → DB queda con el token original, no se sobrescribe.
+- [ ] `tests/test_api_user_preferences.py::test_put_preferences_replaces_when_token_unmasked` — PUT con token nuevo plain (sin `****`) → DB queda con el nuevo.
 
 ### Unit tests (frontend, vitest)
 
-- [ ] `ConnectionsPanel.test.tsx::renders_form_with_current_values` — mock GET /preferences con notify_channels populado, verifica que los inputs muestran los valores.
-- [ ] `ConnectionsPanel.test.tsx::save_calls_put_with_correct_body` — type en inputs + click Save, verifica que `updateUserPreferences` recibe el body esperado.
+- [ ] `ConnectionsPanel.test.tsx::renders_form_with_masked_token` — mock GET /preferences con notify_channels populado (token masked), verifica que el input muestra el masked value + label "Token guardado · ...".
+- [ ] `ConnectionsPanel.test.tsx::save_preserves_token_when_unchanged` — type chat_id pero NO token (queda masked), click Save → updateUserPreferences body solo incluye chat_id + masked token. Backend skip-detection se ejercita server-side, frontend solo manda lo que el usuario tipeó.
+- [ ] `ConnectionsPanel.test.tsx::save_replaces_token_when_user_pastes_new` — type token nuevo plain + save → body con token plain.
 - [ ] `ConnectionsPanel.test.tsx::test_button_disabled_when_dirty` — type sin save → "Probar envío" debe estar disabled.
 - [ ] `ConnectionsPanel.test.tsx::test_button_shows_ok_on_success` — mock POST /preferences/test con `{ok: true}`, verifica UI muestra "✓ enviado".
 - [ ] `ConnectionsPanel.test.tsx::test_button_shows_error_on_failure` — mock con `{ok: false, receipts: [{error: "HTTP 401..."}]}`, verifica error mostrado.
+- [ ] `ConnectionsPanel.test.tsx::test_button_shows_no_telegram_reason` — mock con `{ok: false, receipts: [], reason: "no_telegram_configured"}`, verifica UI muestra "Configurá tu token y chat_id primero".
+- [ ] `ConnectionsPanel.test.tsx::delete_clears_db_row` — click "Eliminar credenciales" → confirma `updateUserPreferences({notify_channels: null})` called.
+- [ ] `UserMenu.test.tsx::badge_visible_when_telegram_unconfigured` — render con prefs.notify_channels === null → badge '1' visible.
+- [ ] `UserMenu.test.tsx::badge_hidden_when_telegram_configured` — render con prefs.notify_channels.telegram_bot_token set → badge undefined/hidden.
 
 ### Integration (manual + Playwright e2e)
 
-- [ ] **Manual (Samuel)**: Crear bot en BotFather, conseguir chat_id, abrir avatar ▾ → Conexiones → pegar credenciales → Guardar → Probar envío, confirmar que llega mensaje "TEST" en Telegram. **Este es el gate principal del feature** — sin esto el spec no se considera shipped.
-- [ ] **Playwright e2e (yo)**: Abrir el dashboard, click avatar ▾, click "Conexiones", type creds fake, save, verificar DB tiene `notify_channels` con ambos campos, verificar que GET /preferences los devuelve.
+- [ ] **Manual (Samuel) — gate principal**: Crear bot en BotFather, conseguir chat_id, abrir avatar ▾ → Conexiones → pegar credenciales → Guardar → Probar envío, confirmar que llega mensaje "*Crypto Scanner — prueba de conexión*..." en Telegram. **Sin esto el spec no se considera shipped.**
+- [ ] **Manual (Samuel) — sub-gate NotificationBell**: después de 3 presses consecutivos de "Probar envío" (todos exitosos), el NotificationBell del header sigue mostrando 0 entries nuevas — verifica que el bypass de `notify()` evita el side-effect que llenaría el bell con "TEST" duplicates.
+- [ ] **Manual (Samuel) — sub-gate rapid-fire**: 5 presses rápidos de "Probar envío" — todos retornan ok=true. Verifica que no hay dedup collision aunque el dispatcher per-user lo tendría (defensive design del Option 2).
+- [ ] **Playwright e2e (yo)**: Abrir el dashboard, click avatar ▾, click "Conexiones", type creds fake, save, verificar DB tiene `notify_channels` con ambos campos, verificar que GET /preferences los devuelve masked, click "Eliminar credenciales", verificar DB `notify_channels=null`.
 
 ## Estimación
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.1",
@@ -1097,9 +1098,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1114,9 +1112,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,9 +1126,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1148,9 +1140,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,9 +1154,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,9 +1168,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1199,9 +1182,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,9 +1196,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1233,9 +1210,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1250,9 +1224,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1267,9 +1238,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1284,9 +1252,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1301,9 +1266,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1468,6 +1430,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import {
   closePosition,
   updatePosition,
   getHealthDashboard,
+  getPreferences,
 } from './api';
 import type {
   SymbolStatus,
@@ -65,6 +66,7 @@ import StatusBar from './components/StatusBar';
 import SymbolsGrid from './components/SymbolsGrid';
 import SignalsTable from './components/SignalsTable';
 import ConfigPanel from './components/ConfigPanel';
+import ConnectionsPanel from './components/ConnectionsPanel';
 import PositionsView, { type PortfolioSummary } from './components/PositionsView';
 import OpenPositionModal from './components/OpenPositionModal';
 import AutoTuneView from './components/AutoTuneView';
@@ -89,7 +91,7 @@ import appStyles from './App.module.css';
 
 const REFRESH_INTERVAL_MS = 30_000;
 
-type OverlayKind = 'notifs' | 'settings' | 'user' | null;
+type OverlayKind = 'notifs' | 'settings' | 'user' | 'connections' | null;
 
 const App: React.FC = () => {
   const { user, logout } = useAuth();
@@ -121,6 +123,7 @@ const App: React.FC = () => {
   const [selectedSymbol, setSelectedSymbol] = useState<SymbolStatus | null>(null);
   const [openOverlay,    setOpenOverlay]    = useState<OverlayKind>(null);
   const [unreadCount,    setUnreadCount]    = useState<number>(0);
+  const [telegramConfigured, setTelegramConfigured] = useState(false);
 
   // Signal to open as position (passed from SignalsTable)
   const [signalForPos, setSignalForPos] = useState<Signal | null>(null);
@@ -194,6 +197,16 @@ const App: React.FC = () => {
     const id = setInterval(fetchAll, REFRESH_INTERVAL_MS);
     return () => clearInterval(id);
   }, [fetchAll]);
+
+  // Hydrate telegramConfigured badge on initial load + after ConnectionsPanel closes.
+  useEffect(() => {
+    if (openOverlay !== 'connections') {
+      getPreferences().then((p) => {
+        const tok = (p.notify_channels as { telegram_bot_token?: string } | null)?.telegram_bot_token;
+        setTelegramConfigured(Boolean(tok));
+      }).catch(() => {});  // silent: badge stays in default state on error
+    }
+  }, [openOverlay]);
 
   // ── derived state ──────────────────────────────────────
   const lastRefreshTs = lastRefresh ? lastRefresh.getTime() : null;
@@ -720,6 +733,10 @@ const App: React.FC = () => {
         open={openOverlay === 'settings'}
         onClose={() => setOpenOverlay(null)}
       />
+      <ConnectionsPanel
+        open={openOverlay === 'connections'}
+        onClose={() => setOpenOverlay(null)}
+      />
       {user && (
         <UserMenu
           open={openOverlay === 'user'}
@@ -729,6 +746,8 @@ const App: React.FC = () => {
             setOpenOverlay(null);
             handleLogout();
           }}
+          onConnectionsOpen={() => setOpenOverlay('connections')}
+          telegramConfigured={telegramConfigured}
         />
       )}
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -30,6 +30,7 @@ import type {
   UserPreferences,
   PreferencesPutPayload,
   AgentStatus,
+  TestDeliveryResponse,
 } from './types';
 
 const BASE_URL = '/api';
@@ -420,4 +421,8 @@ export async function putPreferences(
     method: 'PUT',
     body: JSON.stringify(payload),
   });
+}
+
+export async function testPreferencesDelivery(): Promise<TestDeliveryResponse> {
+  return request<TestDeliveryResponse>('/preferences/test', { method: 'POST' });
 }

--- a/frontend/src/components/ConnectionsPanel.module.css
+++ b/frontend/src/components/ConnectionsPanel.module.css
@@ -1,0 +1,106 @@
+/* ConnectionsPanel — slide-out from right, mirrors ConfigPanel.module.css. */
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+}
+
+.panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(480px, 100vw);
+  background: var(--bg-elevated, #0f1410);
+  z-index: 101;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+}
+
+.header {
+  padding: 20px 24px;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title { font-size: 18px; font-weight: 500; }
+
+.body { flex: 1; overflow-y: auto; padding: 24px; }
+
+.section { margin-bottom: 32px; }
+
+.sectionTitle {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+  margin-bottom: 12px;
+}
+
+.field { margin-bottom: 16px; }
+
+.label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+  margin-bottom: 6px;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg, #0a0d0b);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  border-radius: 6px;
+  color: var(--text, white);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 13px;
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--text-dim, rgba(255, 255, 255, 0.4));
+  margin-top: 4px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.btn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  background: var(--bg-input, rgba(255, 255, 255, 0.08));
+  color: var(--text, white);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.btnPrimary {
+  background: var(--accent, #4a9eff);
+  color: white;
+  border-color: var(--accent, #4a9eff);
+}
+
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.testResult { margin-top: 12px; font-size: 12px; }
+.testOk { color: var(--success, #4ade80); }
+.testErr { color: var(--danger, #f87171); }
+
+.closeBtn {
+  background: none;
+  border: none;
+  color: var(--text-dim, rgba(255, 255, 255, 0.6));
+  font-size: 24px;
+  cursor: pointer;
+}

--- a/frontend/src/components/ConnectionsPanel.test.tsx
+++ b/frontend/src/components/ConnectionsPanel.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import ConnectionsPanel from './ConnectionsPanel';
 import * as api from '../api';
 

--- a/frontend/src/components/ConnectionsPanel.test.tsx
+++ b/frontend/src/components/ConnectionsPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ConnectionsPanel from './ConnectionsPanel';
 import * as api from '../api';
 
@@ -28,5 +29,57 @@ describe('ConnectionsPanel', () => {
     const chatInput = screen.getByLabelText(/chat id/i) as HTMLInputElement;
     expect(chatInput.value).toBe('987654321');
     expect(screen.getByText(/token guardado/i)).toBeInTheDocument();
+  });
+
+  it('save sends notify_channels body when user changed chat_id, masked token preserved server-side', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: '123456789:****gH12', telegram_chat_id: '987' },
+    });
+    const updateSpy = vi.spyOn(api, 'putPreferences').mockResolvedValue({
+      ok: true,
+      preferences: { tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    const chatInput = await screen.findByLabelText(/chat id/i);
+    await userEvent.clear(chatInput);
+    await userEvent.type(chatInput, '111');
+    await userEvent.click(screen.getByRole('button', { name: /guardar/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith({
+        notify_channels: {
+          telegram_bot_token: '123456789:****gH12',  // unchanged, server-side preserve
+          telegram_chat_id:   '111',
+        },
+      });
+    });
+  });
+
+  it('save sends plain token when user pastes a new one', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: '123456789:****gH12', telegram_chat_id: '987' },
+    });
+    const updateSpy = vi.spyOn(api, 'putPreferences').mockResolvedValue({
+      ok: true,
+      preferences: { tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    const tokenInput = await screen.findByLabelText(/bot token/i);
+    await userEvent.clear(tokenInput);
+    await userEvent.type(tokenInput, '999:NEW_PLAIN_TOKEN_VALUE');
+    await userEvent.click(screen.getByRole('button', { name: /guardar/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith({
+        notify_channels: {
+          telegram_bot_token: '999:NEW_PLAIN_TOKEN_VALUE',
+          telegram_chat_id:   '987',
+        },
+      });
+    });
   });
 });

--- a/frontend/src/components/ConnectionsPanel.test.tsx
+++ b/frontend/src/components/ConnectionsPanel.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConnectionsPanel from './ConnectionsPanel';
+import * as api from '../api';
+
+describe('ConnectionsPanel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders form with masked token from current preferences', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id:       1,
+      symbol_filter:   null,
+      min_score:       4,
+      notify_channels: {
+        telegram_bot_token: '123456789:****gH12',
+        telegram_chat_id:   '987654321',
+      },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+
+    await waitFor(() => {
+      const tokenInput = screen.getByLabelText(/bot token/i) as HTMLInputElement;
+      expect(tokenInput.value).toBe('123456789:****gH12');
+    });
+    const chatInput = screen.getByLabelText(/chat id/i) as HTMLInputElement;
+    expect(chatInput.value).toBe('987654321');
+    expect(screen.getByText(/token guardado/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ConnectionsPanel.test.tsx
+++ b/frontend/src/components/ConnectionsPanel.test.tsx
@@ -82,4 +82,95 @@ describe('ConnectionsPanel', () => {
       });
     });
   });
+
+  it('"Probar envío" disabled when there are unsaved changes', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: '123:****abcd', telegram_chat_id: '987' },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+
+    const probarBtn = screen.getByRole('button', { name: /probar env/i });
+    expect(probarBtn).not.toBeDisabled();  // initially clean
+
+    await userEvent.type(screen.getByLabelText(/chat id/i), '5');
+    expect(probarBtn).toBeDisabled();  // dirty
+  });
+
+  it('"Probar envío" shows ok on success', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: 'x:y', telegram_chat_id: 'z' },
+    });
+    vi.spyOn(api, 'testPreferencesDelivery').mockResolvedValue({
+      ok: true,
+      receipts: [{ channel: 'telegram', status: 'ok', error: null }],
+      reason: null,
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+    await userEvent.click(screen.getByRole('button', { name: /probar env/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/enviado/i)).toBeInTheDocument();
+    });
+  });
+
+  it('"Probar envío" shows error on failure', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: 'x:y', telegram_chat_id: 'z' },
+    });
+    vi.spyOn(api, 'testPreferencesDelivery').mockResolvedValue({
+      ok: false,
+      receipts: [{ channel: 'telegram', status: 'failed', error: 'HTTP 401: Unauthorized' }],
+      reason: null,
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+    await userEvent.click(screen.getByRole('button', { name: /probar env/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unauthorized/)).toBeInTheDocument();
+    });
+  });
+
+  it('"Probar envío" shows no_telegram_configured hint', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null,
+    });
+    vi.spyOn(api, 'testPreferencesDelivery').mockResolvedValue({
+      ok: false, receipts: [], reason: 'no_telegram_configured',
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+    await userEvent.click(screen.getByRole('button', { name: /probar env/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/configur.*token.*chat/i)).toBeInTheDocument();
+    });
+  });
+
+  it('"Eliminar credenciales" sends notify_channels: null', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4,
+      notify_channels: { telegram_bot_token: 'x:y', telegram_chat_id: 'z' },
+    });
+    const updateSpy = vi.spyOn(api, 'putPreferences').mockResolvedValue({
+      ok: true, preferences: { tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null },
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    await screen.findByLabelText(/bot token/i);
+    await userEvent.click(screen.getByRole('button', { name: /eliminar credenciales/i }));
+
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith({ notify_channels: null });
+    });
+  });
 });

--- a/frontend/src/components/ConnectionsPanel.tsx
+++ b/frontend/src/components/ConnectionsPanel.tsx
@@ -6,8 +6,8 @@
 
 import React, { useEffect, useState } from 'react';
 import styles from './ConnectionsPanel.module.css';
-import type { NotifyChannels } from '../types';
-import { getPreferences, putPreferences } from '../api';
+import type { NotifyChannels, TestDeliveryResponse } from '../types';
+import { getPreferences, putPreferences, testPreferencesDelivery } from '../api';
 
 interface ConnectionsPanelProps {
   open:    boolean;
@@ -29,11 +29,16 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
         setBotToken(nc.telegram_bot_token ?? '');
         setChatId(nc.telegram_chat_id ?? '');
         setTokenIsMasked((nc.telegram_bot_token ?? '').includes('****'));
+        setDirty(false);
+        setTestResult(null);
       })
       .finally(() => setLoading(false));
   }, [open]);
 
-  const [saving, setSaving] = useState(false);
+  const [saving,     setSaving]     = useState(false);
+  const [dirty,      setDirty]      = useState(false);
+  const [testResult, setTestResult] = useState<TestDeliveryResponse | null>(null);
+  const [testing,    setTesting]    = useState(false);
 
   const handleSave = async () => {
     setSaving(true);
@@ -44,6 +49,33 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
           telegram_chat_id:   chatId,
         },
       });
+      setDirty(false);
+      setTestResult(null);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const res = await testPreferencesDelivery();
+      setTestResult(res);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setSaving(true);
+    try {
+      await putPreferences({ notify_channels: null });
+      setBotToken('');
+      setChatId('');
+      setTokenIsMasked(false);
+      setTestResult(null);
+      setDirty(false);
     } finally {
       setSaving(false);
     }
@@ -69,7 +101,7 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
                 className={styles.input}
                 type="password"
                 value={botToken}
-                onChange={(e) => { setBotToken(e.target.value); setTokenIsMasked(false); }}
+                onChange={(e) => { setBotToken(e.target.value); setTokenIsMasked(false); setDirty(true); }}
                 placeholder="123456789:ABCdef..."
                 disabled={loading}
               />
@@ -86,7 +118,7 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
                 className={styles.input}
                 type="text"
                 value={chatId}
-                onChange={(e) => setChatId(e.target.value)}
+                onChange={(e) => { setChatId(e.target.value); setDirty(true); }}
                 placeholder="123456789"
                 disabled={loading}
               />
@@ -95,11 +127,38 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
               <button
                 className={`${styles.btn} ${styles.btnPrimary}`}
                 onClick={handleSave}
-                disabled={saving || loading}
+                disabled={saving || loading || !dirty}
               >
                 {saving ? 'Guardando...' : 'Guardar'}
               </button>
+              <button
+                className={styles.btn}
+                onClick={handleTest}
+                disabled={testing || saving || dirty}
+              >
+                {testing ? 'Enviando...' : 'Probar envío'}
+              </button>
+              <button
+                className={styles.btn}
+                onClick={handleDelete}
+                disabled={saving}
+              >
+                Eliminar credenciales
+              </button>
             </div>
+            {testResult && (
+              <div className={styles.testResult}>
+                {testResult.ok && (
+                  <span className={styles.testOk}>✓ Mensaje enviado a tu Telegram.</span>
+                )}
+                {!testResult.ok && testResult.reason === 'no_telegram_configured' && (
+                  <span className={styles.testErr}>Configurá tu token y chat ID primero, después Guardar y volvé a probar.</span>
+                )}
+                {!testResult.ok && testResult.reason === null && testResult.receipts[0] && (
+                  <span className={styles.testErr}>✗ {testResult.receipts[0].error}</span>
+                )}
+              </div>
+            )}
           </section>
         </div>
       </aside>

--- a/frontend/src/components/ConnectionsPanel.tsx
+++ b/frontend/src/components/ConnectionsPanel.tsx
@@ -1,0 +1,85 @@
+// ============================================================
+// ConnectionsPanel.tsx — per-user Telegram bot config slide-out.
+// Anchored to UserMenu → 'Conexiones' item.
+// Spec: docs/superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md
+// ============================================================
+
+import React, { useEffect, useState } from 'react';
+import styles from './ConnectionsPanel.module.css';
+import type { NotifyChannels } from '../types';
+import { getPreferences } from '../api';
+
+interface ConnectionsPanelProps {
+  open:    boolean;
+  onClose: () => void;
+}
+
+const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) => {
+  const [botToken, setBotToken]   = useState('');
+  const [chatId,   setChatId]     = useState('');
+  const [tokenIsMasked, setTokenIsMasked] = useState(false);
+  const [loading,  setLoading]    = useState(true);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    getPreferences()
+      .then((prefs) => {
+        const nc = (prefs.notify_channels ?? {}) as NotifyChannels;
+        setBotToken(nc.telegram_bot_token ?? '');
+        setChatId(nc.telegram_chat_id ?? '');
+        setTokenIsMasked((nc.telegram_bot_token ?? '').includes('****'));
+      })
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className={styles.backdrop} onClick={onClose} aria-hidden="true" />
+      <aside className={styles.panel} role="dialog" aria-labelledby="connections-title">
+        <header className={styles.header}>
+          <h2 id="connections-title" className={styles.title}>Conexiones</h2>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Cerrar">×</button>
+        </header>
+        <div className={styles.body}>
+          <section className={styles.section}>
+            <h3 className={styles.sectionTitle}>Telegram</h3>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="bot-token">Bot Token</label>
+              <input
+                id="bot-token"
+                className={styles.input}
+                type="password"
+                value={botToken}
+                onChange={(e) => { setBotToken(e.target.value); setTokenIsMasked(false); }}
+                placeholder="123456789:ABCdef..."
+                disabled={loading}
+              />
+              {tokenIsMasked && (
+                <div className={styles.hint}>
+                  Token guardado · pegá uno nuevo para reemplazar
+                </div>
+              )}
+            </div>
+            <div className={styles.field}>
+              <label className={styles.label} htmlFor="chat-id">Chat ID</label>
+              <input
+                id="chat-id"
+                className={styles.input}
+                type="text"
+                value={chatId}
+                onChange={(e) => setChatId(e.target.value)}
+                placeholder="123456789"
+                disabled={loading}
+              />
+            </div>
+          </section>
+        </div>
+      </aside>
+    </>
+  );
+};
+
+export default ConnectionsPanel;

--- a/frontend/src/components/ConnectionsPanel.tsx
+++ b/frontend/src/components/ConnectionsPanel.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect, useState } from 'react';
 import styles from './ConnectionsPanel.module.css';
 import type { NotifyChannels } from '../types';
-import { getPreferences } from '../api';
+import { getPreferences, putPreferences } from '../api';
 
 interface ConnectionsPanelProps {
   open:    boolean;
@@ -32,6 +32,22 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
       })
       .finally(() => setLoading(false));
   }, [open]);
+
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await putPreferences({
+        notify_channels: {
+          telegram_bot_token: botToken,
+          telegram_chat_id:   chatId,
+        },
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
 
   if (!open) return null;
 
@@ -74,6 +90,15 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
                 placeholder="123456789"
                 disabled={loading}
               />
+            </div>
+            <div className={styles.actions}>
+              <button
+                className={`${styles.btn} ${styles.btnPrimary}`}
+                onClick={handleSave}
+                disabled={saving || loading}
+              >
+                {saving ? 'Guardando...' : 'Guardar'}
+              </button>
             </div>
           </section>
         </div>

--- a/frontend/src/components/UserMenu.test.tsx
+++ b/frontend/src/components/UserMenu.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserMenu from './UserMenu';
+import type { AuthUser } from '../auth/api';
+
+const _fakeUser: AuthUser = {
+  id: 1,
+  email: 'a@example.com',
+  role: 'admin',
+  is_active: true,
+  last_login_at: null,
+};
+
+describe('UserMenu', () => {
+  it('shows badge "1" on Conexiones when telegram is unconfigured', () => {
+    render(
+      <UserMenu
+        open={true}
+        user={_fakeUser}
+        onClose={() => {}}
+        onLogout={() => {}}
+        onConnectionsOpen={() => {}}
+        telegramConfigured={false}
+      />
+    );
+    const conexionesBtn = screen.getByText('Conexiones').closest('button')!;
+    expect(conexionesBtn.textContent).toContain('1');
+  });
+
+  it('hides badge on Conexiones when telegram is configured', () => {
+    render(
+      <UserMenu
+        open={true}
+        user={_fakeUser}
+        onClose={() => {}}
+        onLogout={() => {}}
+        onConnectionsOpen={() => {}}
+        telegramConfigured={true}
+      />
+    );
+    const conexionesBtn = screen.getByText('Conexiones').closest('button')!;
+    expect(conexionesBtn.textContent).not.toContain('1');
+  });
+
+  it('calls onConnectionsOpen when Conexiones is clicked', async () => {
+    const onOpen = vi.fn();
+    render(
+      <UserMenu
+        open={true}
+        user={_fakeUser}
+        onClose={() => {}}
+        onLogout={() => {}}
+        onConnectionsOpen={onOpen}
+        telegramConfigured={false}
+      />
+    );
+    await userEvent.click(screen.getByText('Conexiones'));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -11,6 +11,8 @@ interface UserMenuProps {
   user:    AuthUser;
   onClose: () => void;
   onLogout: () => void;
+  onConnectionsOpen?: () => void;
+  telegramConfigured?: boolean;
 }
 
 interface MenuItem {
@@ -22,13 +24,22 @@ interface MenuItem {
   onClick?: () => void;
 }
 
-const UserMenu: React.FC<UserMenuProps> = ({ open, user, onClose, onLogout }) => {
+const UserMenu: React.FC<UserMenuProps> = ({
+  open, user, onClose, onLogout,
+  onConnectionsOpen, telegramConfigured = false,
+}) => {
   if (!open) return null;
 
   const items: MenuItem[] = [
     { icon: '◧', label: 'Mi cuenta', hint: 'email · contraseña · 2FA' },
     { icon: '✦', label: 'Capital y riesgo', hint: 'gestión de balance' },
-    { icon: '◐', label: 'Conexiones', hint: 'Telegram · Webhook', badge: '1' },
+    {
+      icon: '◐',
+      label: 'Conexiones',
+      hint: 'Telegram · Webhook',
+      badge: telegramConfigured ? undefined : '1',
+      onClick: () => { onConnectionsOpen?.(); onClose(); },
+    },
     { icon: '⌨', label: 'Atajos de teclado', kbd: '?' },
     { icon: '❑', label: 'Documentación' },
   ];

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -38,7 +38,12 @@ const UserMenu: React.FC<UserMenuProps> = ({
       label: 'Conexiones',
       hint: 'Telegram · Webhook',
       badge: telegramConfigured ? undefined : '1',
-      onClick: () => { onConnectionsOpen?.(); onClose(); },
+      // Only call onConnectionsOpen — the parent's setOpenOverlay('connections')
+      // is the same setter as onClose's setOpenOverlay(null), so calling both
+      // would race (last call wins → null → panel never opens). The menu closes
+      // naturally because UserMenu's `open={openOverlay === 'user'}` flips false
+      // once the overlay is 'connections'.
+      onClick: () => { onConnectionsOpen?.(); },
     },
     { icon: '⌨', label: 'Atajos de teclado', kbd: '?' },
     { icon: '❑', label: 'Documentación' },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -456,3 +456,24 @@ export interface PreferencesPutPayload {
   min_score?: number;
   notify_channels?: Record<string, unknown> | null;
 }
+
+// ---- Telegram per-user config (spec 2026-05-21) ----
+
+export interface NotifyChannels {
+  telegram_bot_token?: string;   // masked from server: '<10chars>****<4chars>'
+  telegram_chat_id?:   string;
+}
+
+export interface TestDeliveryReceipt {
+  channel: string;
+  status:  'ok' | 'failed' | 'rate_limited';
+  error:   string | null;
+}
+
+export type TestDeliveryReason = 'no_telegram_configured' | null;
+
+export interface TestDeliveryResponse {
+  ok:       boolean;
+  receipts: TestDeliveryReceipt[];
+  reason:   TestDeliveryReason;
+}

--- a/tests/test_api_user_preferences.py
+++ b/tests/test_api_user_preferences.py
@@ -140,3 +140,112 @@ def test_put_replaces_token_when_value_unmasked(seeded_user_with_telegram):
     resp_token = r.json()["preferences"]["notify_channels"]["telegram_bot_token"]
     assert _MASK_MARKER in resp_token
     assert "NEWXYZabcDEF" not in resp_token
+
+
+# ── POST /api/preferences/test ──────────────────────────────────────
+
+
+def test_test_endpoint_no_channels_returns_no_telegram_configured(tmp_path, monkeypatch):
+    """User without notify_channels → {ok: false, reason: 'no_telegram_configured'}."""
+    import btc_api
+    from fastapi.testclient import TestClient
+    from db.auth_schema import init_auth_db
+    from db.schema import init_db
+    from db.connection import get_db
+
+    db_path = str(tmp_path / "test_prefs_no_channels.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    init_db()
+    init_auth_db()
+    # No user row needed: conftest auth bypass uses synthetic User(id=0).
+
+    client = TestClient(btc_api.app)
+    r = client.post("/preferences/test")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"ok": False, "receipts": [], "reason": "no_telegram_configured"}
+
+
+def test_test_endpoint_only_token_returns_no_telegram_configured(seeded_user_with_telegram, monkeypatch):
+    """Token set but chat_id missing → still no_telegram_configured."""
+    from db.user_preferences import db_upsert_user_preferences
+    # Overwrite the fixture's prefs to remove chat_id
+    db_upsert_user_preferences(0, notify_channels={"telegram_bot_token": "xxx:yyy"})
+
+    client = seeded_user_with_telegram
+    r = client.post("/preferences/test")
+    assert r.json()["reason"] == "no_telegram_configured"
+
+
+def test_test_endpoint_with_telegram_routes_correctly(seeded_user_with_telegram, monkeypatch):
+    """Happy path: token + chat_id set → TelegramChannel.send called with user_cfg.
+    Mock requests.post to avoid hitting real Telegram API."""
+    sent_payloads = []
+    class _FakeResp:
+        ok = True
+        status_code = 200
+        text = "ok"
+    def _fake_post(url, json=None, **kw):
+        sent_payloads.append({"url": url, "body": json})
+        return _FakeResp()
+
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    client = seeded_user_with_telegram
+    r = client.post("/preferences/test")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["receipts"] == [{"channel": "telegram", "status": "ok", "error": None}]
+    assert body["reason"] is None
+    # Sent payload uses the USER's bot token + chat_id from notify_channels overlay
+    assert len(sent_payloads) == 1
+    assert "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12" in sent_payloads[0]["url"]
+    assert sent_payloads[0]["body"]["chat_id"] == "987654321"
+
+
+def test_test_endpoint_two_calls_within_window_both_succeed(seeded_user_with_telegram, monkeypatch):
+    """Defense against future dedup window changes: 2 calls in quick succession
+    BOTH return ok=true. Bypass of notify() guarantees this regardless of any
+    future tightening of signal-type dedup defaults."""
+    class _FakeResp:
+        ok = True
+        status_code = 200
+        text = "ok"
+    def _fake_post(url, **kw):
+        return _FakeResp()
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    client = seeded_user_with_telegram
+    r1 = client.post("/preferences/test")
+    r2 = client.post("/preferences/test")
+    assert r1.json()["ok"] is True
+    assert r2.json()["ok"] is True
+
+
+def test_test_endpoint_does_not_write_to_notifications_sent(seeded_user_with_telegram, monkeypatch):
+    """Bypass of notify() means no row written to notifications_sent
+    (avoids polluting NotificationBell with test pings)."""
+    class _FakeResp:
+        ok = True
+        status_code = 200
+        text = "ok"
+    def _fake_post(url, **kw):
+        return _FakeResp()
+    import requests
+    monkeypatch.setattr(requests, "post", _fake_post)
+
+    from db.connection import get_db
+    con = get_db()
+    before = con.execute("SELECT COUNT(*) FROM notifications_sent").fetchone()[0]
+    con.close()
+
+    client = seeded_user_with_telegram
+    client.post("/preferences/test")
+
+    con = get_db()
+    after = con.execute("SELECT COUNT(*) FROM notifications_sent").fetchone()[0]
+    con.close()
+    assert before == after, "POST /test should NOT write to notifications_sent"

--- a/tests/test_api_user_preferences.py
+++ b/tests/test_api_user_preferences.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import pytest
 
+from api.user_preferences import _MASK_MARKER
+
 
 # ── _mask_token helper ──────────────────────────────────────────────
 
@@ -113,6 +115,11 @@ def test_put_preserves_token_when_value_contains_mask_marker(seeded_user_with_te
     assert nc["telegram_bot_token"] == "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12"
     assert nc["telegram_chat_id"] == "111222333"
 
+    # Response body should also have masked token (consistency with GET).
+    resp_token = r.json()["preferences"]["notify_channels"]["telegram_bot_token"]
+    assert _MASK_MARKER in resp_token
+    assert "ABCdefGHI" not in resp_token  # secret portion must not leak in response
+
 
 def test_put_replaces_token_when_value_unmasked(seeded_user_with_telegram):
     """If user submits a plain token (no ****), DB updates to the new value."""
@@ -128,3 +135,8 @@ def test_put_replaces_token_when_value_unmasked(seeded_user_with_telegram):
     from db.user_preferences import db_get_user_preferences
     row = db_get_user_preferences(0)
     assert row["notify_channels"]["telegram_bot_token"] == "111111111:NEWXYZabcDEFghiJKLmnoPQRstuVWXyzABCDE"
+
+    # Response body should reflect the new token, masked.
+    resp_token = r.json()["preferences"]["notify_channels"]["telegram_bot_token"]
+    assert _MASK_MARKER in resp_token
+    assert "NEWXYZabcDEF" not in resp_token

--- a/tests/test_api_user_preferences.py
+++ b/tests/test_api_user_preferences.py
@@ -36,3 +36,95 @@ def test_mask_token_short_input_returns_empty():
     from api.user_preferences import _mask_token
     assert _mask_token("123") == ""
     assert _mask_token("123456789") == ""  # exactly 9, still under threshold
+
+
+# ── GET /api/preferences masking ────────────────────────────────────
+
+
+@pytest.fixture
+def seeded_user_with_telegram(tmp_path, monkeypatch):
+    """Fresh DB with notify_channels seeded for the test-bypass tenant (id=0).
+
+    The autouse _auth_bypass_default fixture (conftest.py) activates
+    AUTH_TEST_BYPASS_ROLE=admin, which makes AuthMiddleware inject a
+    synthetic User(id=0). We therefore seed preferences for tenant_id=0 so
+    GET /preferences returns the row we expect.
+
+    No real users table row is needed — the bypass user is never DB-hydrated.
+    """
+    import btc_api
+    from fastapi.testclient import TestClient
+    from db.schema import init_db
+    from db.user_preferences import db_upsert_user_preferences
+
+    db_path = str(tmp_path / "test_prefs.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    init_db()
+
+    db_upsert_user_preferences(
+        0,
+        notify_channels={
+            "telegram_bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12",
+            "telegram_chat_id":   "987654321",
+        },
+    )
+
+    return TestClient(btc_api.app)
+
+
+def test_get_preferences_masks_telegram_bot_token(seeded_user_with_telegram):
+    """GET response should return masked token, not plain — defense against
+    XSS exfiltration of credentials."""
+    client = seeded_user_with_telegram
+    r = client.get("/preferences")
+    assert r.status_code == 200
+    data = r.json()
+    masked = data["notify_channels"]["telegram_bot_token"]
+    assert masked == "123456789:****gH12"
+    assert "ABCdefGHI" not in masked, "secret portion should not leak"
+
+
+def test_get_preferences_chat_id_not_masked(seeded_user_with_telegram):
+    """chat_id is not secret (visible in any getUpdates response); pass through."""
+    client = seeded_user_with_telegram
+    r = client.get("/preferences")
+    assert r.json()["notify_channels"]["telegram_chat_id"] == "987654321"
+
+
+# ── PUT /api/preferences preserves masked token ──────────────────────
+
+
+def test_put_preserves_token_when_value_contains_mask_marker(seeded_user_with_telegram):
+    """If user submits the masked value (didn't retype), DB token stays unchanged."""
+    client = seeded_user_with_telegram
+    masked = "123456789:****gH12"
+    r = client.put("/preferences", json={
+        "notify_channels": {
+            "telegram_bot_token": masked,
+            "telegram_chat_id":   "111222333",  # changed
+        },
+    })
+    assert r.status_code == 200
+
+    # Re-fetch raw from DB (bypass masking) to verify token preserved
+    from db.user_preferences import db_get_user_preferences
+    row = db_get_user_preferences(0)
+    nc = row["notify_channels"]
+    assert nc["telegram_bot_token"] == "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12"
+    assert nc["telegram_chat_id"] == "111222333"
+
+
+def test_put_replaces_token_when_value_unmasked(seeded_user_with_telegram):
+    """If user submits a plain token (no ****), DB updates to the new value."""
+    client = seeded_user_with_telegram
+    r = client.put("/preferences", json={
+        "notify_channels": {
+            "telegram_bot_token": "111111111:NEWXYZabcDEFghiJKLmnoPQRstuVWXyzABCDE",
+            "telegram_chat_id":   "987654321",
+        },
+    })
+    assert r.status_code == 200
+
+    from db.user_preferences import db_get_user_preferences
+    row = db_get_user_preferences(0)
+    assert row["notify_channels"]["telegram_bot_token"] == "111111111:NEWXYZabcDEFghiJKLmnoPQRstuVWXyzABCDE"

--- a/tests/test_api_user_preferences.py
+++ b/tests/test_api_user_preferences.py
@@ -243,7 +243,8 @@ def test_test_endpoint_does_not_write_to_notifications_sent(seeded_user_with_tel
     con.close()
 
     client = seeded_user_with_telegram
-    client.post("/preferences/test")
+    r = client.post("/preferences/test")
+    assert r.status_code == 200  # ensures the endpoint actually ran (regression guard)
 
     con = get_db()
     after = con.execute("SELECT COUNT(*) FROM notifications_sent").fetchone()[0]

--- a/tests/test_api_user_preferences.py
+++ b/tests/test_api_user_preferences.py
@@ -1,0 +1,38 @@
+"""Tests for api/user_preferences.py — masking + /preferences/test endpoint.
+
+Covers:
+- _mask_token helper invariants.
+- GET /api/preferences masks telegram_bot_token in response.
+- PUT /api/preferences preserves masked token, replaces unmasked.
+- POST /api/preferences/test: no-creds early-return, happy path, dedup-bypass,
+  no-write-to-notifications_sent, isolated per tenant.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ── _mask_token helper ──────────────────────────────────────────────
+
+
+def test_mask_token_real_telegram_token():
+    """Real Telegram tokens are ~46 chars (<bot_id>:<35-char-secret>).
+    Mask should preserve first 10 + last 4 chars with **** between."""
+    from api.user_preferences import _mask_token
+    token = "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12"
+    assert _mask_token(token) == "123456789:****gH12"
+
+
+def test_mask_token_empty_returns_empty():
+    """Empty input → empty output (no masking artifacts on empty)."""
+    from api.user_preferences import _mask_token
+    assert _mask_token("") == ""
+
+
+def test_mask_token_short_input_returns_empty():
+    """Inputs shorter than 10 chars are treated as garbage and return ""
+    (defensive: real tokens are always ≥10 chars; this guard prevents
+    leaking partial credentials via mask='****X' for X<10 chars)."""
+    from api.user_preferences import _mask_token
+    assert _mask_token("123") == ""
+    assert _mask_token("123456789") == ""  # exactly 9, still under threshold


### PR DESCRIPTION
## Summary
- Discovered during Playwright e2e against prod after PR #421 deploy: the panel never opened when clicking the avatar dropdown's "Conexiones" item.
- Root cause: UserMenu's onClick called both `onConnectionsOpen()` AND `onClose()`. Both reach App.tsx as `setOpenOverlay(...)` calls. The second one (`setOpenOverlay(null)` from `onClose`) wins, so the overlay never reaches `'connections'`.

## Fix
One-line change in `UserMenu.tsx`: call only `onConnectionsOpen?.()`. The menu still closes naturally because its `open={openOverlay === 'user'}` flips false once the overlay becomes `'connections'`.

## Test plan
- [x] `npm test -- --run UserMenu ConnectionsPanel` → 11/11 pass (3 UserMenu + 8 ConnectionsPanel). Existing UserMenu click test still passes because it only asserts `onConnectionsOpen` was called.
- [ ] After deploy: re-run Playwright e2e — clicking Conexiones should now open the ConnectionsPanel slide-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)