### PR TITLE
fix(prefs/frontend): UserMenu Conexiones click no longer races onClose

### DIFF
--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -38,7 +38,12 @@ const UserMenu: React.FC<UserMenuProps> = ({
       label: 'Conexiones',
       hint: 'Telegram · Webhook',
       badge: telegramConfigured ? undefined : '1',
-      onClick: () => { onConnectionsOpen?.(); onClose(); },
+      // Only call onConnectionsOpen — the parent's setOpenOverlay('connections')
+      // is the same setter as onClose's setOpenOverlay(null), so calling both
+      // would race (last call wins → null → panel never opens). The menu closes
+      // naturally because UserMenu's `open={openOverlay === 'user'}` flips false
+      // once the overlay is 'connections'.
+      onClick: () => { onConnectionsOpen?.(); },
     },
     { icon: '⌨', label: 'Atajos de teclado', kbd: '?' },
     { icon: '❑', label: 'Documentación' },


### PR DESCRIPTION
## Summary
Follow-up to #421. Discovered during Playwright e2e against prod after deploy: panel never opened when clicking the avatar dropdown's "Conexiones" item.

## Root cause
UserMenu's onClick called both `onConnectionsOpen()` AND `onClose()`. Both reach App.tsx as `setOpenOverlay(...)` calls. The last one wins (`setOpenOverlay(null)` from `onClose`), so the overlay never reached `'connections'`.

## Fix
One-line change in `UserMenu.tsx`: call only `onConnectionsOpen?.()`. The menu still closes naturally because its `open={openOverlay === 'user'}` flips false once the overlay becomes `'connections'`.

## Test plan
- [x] `npm test -- --run UserMenu ConnectionsPanel` → 11/11 pass. Existing UserMenu click test still passes (it only asserts `onConnectionsOpen` was called, doesn't check `onClose`).
- [ ] After deploy: re-run Playwright e2e — clicking Conexiones should open the ConnectionsPanel slide-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)