### PR TITLE
fix(prefs/frontend): Eliminar credenciales sends {} not null to actually clear

### DIFF
--- a/frontend/src/components/ConnectionsPanel.test.tsx
+++ b/frontend/src/components/ConnectionsPanel.test.tsx
@@ -170,7 +170,8 @@ describe('ConnectionsPanel', () => {
     await userEvent.click(screen.getByRole('button', { name: /eliminar credenciales/i }));
 
     await waitFor(() => {
-      expect(updateSpy).toHaveBeenCalledWith({ notify_channels: null });
+      // Backend PATCH semantics: null means "preserve". Must send {} to clear.
+      expect(updateSpy).toHaveBeenCalledWith({ notify_channels: {} });
     });
   });
 });

--- a/frontend/src/components/ConnectionsPanel.tsx
+++ b/frontend/src/components/ConnectionsPanel.tsx
@@ -70,7 +70,13 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
   const handleDelete = async () => {
     setSaving(true);
     try {
-      await putPreferences({ notify_channels: null });
+      // Backend PUT /preferences treats notify_channels=null as "preserve
+      // existing" (PATCH-like semantics, see db/user_preferences.py:67-69).
+      // To CLEAR the credentials we must send an empty object — DB updates
+      // the JSON column to "{}", which dispatch_per_user reads as no
+      // overlay (notify_channels or {} → {}). Safe with global telegram_*
+      // values absent from config.json.
+      await putPreferences({ notify_channels: {} });
       setBotToken('');
       setChatId('');
       setTokenIsMasked(false);


### PR DESCRIPTION
## Summary
Second follow-up to #421 (after #423 fix for the click race). Playwright e2e revealed: clicking "Eliminar credenciales" cleared the UI inputs but left the DB row unchanged.

## Root cause
Backend `PUT /preferences` has PATCH-like semantics (see `db/user_preferences.py:67-69`): `notify_channels=null` means "preserve existing", not "clear".

## Fix
Frontend's `handleDelete` now sends `notify_channels: {}` (empty dict). Backend writes `{}` to the JSON column. `dispatch_per_user` reads `notify_channels or {}` → `{}` either way, so dispatch behavior is identical to the null/cleared case.

## Why not change backend semantics
The PATCH-like null=preserve semantics is documented and used by other callers. Changing it would be a wider-scope behavioral change requiring its own ticket. The frontend workaround is surgical and safe under the current threat model (prod's `config.json` has no global `telegram_*` keys, so the `{**base_cfg, **{}}` overlay falls through to no creds → no leak).

## Test plan
- [x] `npm test -- --run ConnectionsPanel` → 8/8 pass.
- [ ] After deploy: re-run Playwright e2e — clicking Eliminar should actually clear the DB row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)