### PR TITLE
fix(copilot): keep chat input focused across turns + refreshes

### DIFF
--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -47,6 +47,7 @@ const AgentDock: React.FC<AgentDockProps> = ({
 }) => {
   const [input, setInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const { msgs, loading, sendTurn, confirmProposal } = useAgentStream({ surface: SURFACE_DOCK });
   // Synthetic welcome bubble before the first real turn so the dock
@@ -82,6 +83,14 @@ const AgentDock: React.FC<AgentDockProps> = ({
   useEffect(() => {
     if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [msgs, loading]);
+
+  // Keep the input focused while the dock is open and idle. Without this,
+  // ending a turn (loading: true → false) leaves the user without focus
+  // because the browser blurred the input when it became disabled and
+  // doesn't restore focus when it's re-enabled.
+  useEffect(() => {
+    if (open && !loading) inputRef.current?.focus();
+  }, [open, loading]);
 
   const submit = async (text: string) => {
     const t = text.trim();
@@ -154,11 +163,11 @@ const AgentDock: React.FC<AgentDockProps> = ({
           <form className={styles.inputRow} onSubmit={(e) => { e.preventDefault(); void submit(input); }}>
             <span className={styles.prompt}>&gt;</span>
             <input
+              ref={inputRef}
               className={styles.input}
               placeholder={loading ? 'pensando…' : 'pregúntame algo sobre el mercado, tus posiciones, un par…'}
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              disabled={loading}
               autoFocus
             />
             <button className={styles.send} type="submit" disabled={loading || !input.trim()}>↵</button>

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -389,6 +389,7 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, agentEnabled }) => {
   const AGENT_ENABLED = agentEnabled;
   const [input, setInput] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Phase 3 rewire: replace the legacy one-shot chatAgent + frontend
   // system prompt with the streaming hook. The server owns the prompt
@@ -424,6 +425,13 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, agentEnabled }) => {
   useEffect(() => {
     if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [msgs, loading]);
+
+  // Keep the input focused once a turn finishes (loading: true → false).
+  // Without this, the user had to click back into the input after every
+  // assistant response because the browser blurred the disabled field.
+  useEffect(() => {
+    if (!loading) inputRef.current?.focus();
+  }, [loading]);
 
   const send = async (text: string) => {
     const t = text.trim();
@@ -498,11 +506,11 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, agentEnabled }) => {
           <form className={styles.cpInputRow} onSubmit={submitInput}>
             <span className={styles.cpInputPrompt}>&gt;</span>
             <input
+              ref={inputRef}
               className={styles.cpInput}
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder={loading ? 'pensando…' : 'pregunta lo que quieras sobre este par'}
-              disabled={loading}
               autoFocus
             />
             <button


### PR DESCRIPTION
## Summary
- The chat input in **AgentDock** (floating copilot) and **SymbolDetail's Copilot** (per-symbol drawer) had `disabled={loading}`. When `loading` flipped to true during a turn, the browser blurred the field; when it flipped back to false, focus was **not** restored.
- Net effect: every assistant response forced the user to click back into the input before typing the next message. With the dashboard's 30s scanner refresh + 3s live-ticker polling re-rendering frequently, papá / María perceive this as constant focus loss while chatting.

## Fix
- Remove `disabled={loading}` from the input itself. The `submit()` / `sendTurn()` early-returns on `loading`, so a double-send was never possible — the prop was purely cosmetic and caused the blur.
- Keep `disabled={loading || !input.trim()}` on the send button (visual feedback intact).
- Add a `useEffect` that refocuses the input via ref whenever a turn finishes (`loading: true → false`). In AgentDock the effect also fires on `open` so the dock takes focus when slid up.

## Test plan
- [ ] Open copilot dock, type and send a message → response streams in → focus stays in the input, can type next message without clicking
- [ ] Watch a 30s scanner tick land during a conversation → focus stays
- [ ] Open symbol drawer, use embedded Copilot → same behavior
- [ ] Send button still disabled visually while loading
- [ ] Press Enter while loading=true → no submit (early-return path still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)