### PR TITLE
docs: public methodology translation — METHODOLOGY.md + docs/README.md + README rewrite

### DIFF
--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -79,7 +79,7 @@ Any number in this repo — backtest P&L, Sharpe ratio, win rate, drawdown — n
 |---|---|---|---|---|
 | [#223](https://github.com/sssimon/trading-spacial/pull/223) / #224 | 2026-04-25 | **Bug fix** | Sign error in `_close_position` that double-counted PnL on certain exit paths | Pre-fix numbers were inflated; not a "calibration improvement" |
 | [#296](https://github.com/sssimon/trading-spacial/pull/296)+#297+#298+#299 | 2026-05-03 | **Triple Barrier structural fix** | Time-limit barrier, participation cap, per-symbol overrides honored in live + backtest paths | Closed the legacy `atr_*` kwargs bypass for the live path |
-| [#309](https://github.com/sssimon/trading-spacial/pull/309) | 2026-05-11 | **Modeling decision** | Symmetric K=10 per-trade overshoot cap. Bounds `\|pnl_usd\| ≤ K × risk_amount` | Realistic; bounds the catastrophic-bar mechanism without enforcing pooled-portfolio capital management |
+| [#309](https://github.com/sssimon/trading-spacial/pull/309) | 2026-05-11 | **Modeling decision** | Symmetric K=10 per-trade overshoot cap. Bounds `&#124;pnl_usd&#124; ≤ K × risk_amount` | Realistic; bounds the catastrophic-bar mechanism without enforcing pooled-portfolio capital management |
 | [#313](https://github.com/sssimon/trading-spacial/pull/313) | 2026-05-11 | **Bug fix** | Post-bankruptcy ghost trades. Symbol halts at `0.1 × INITIAL_CAPITAL` floor | Closed the silent-continued-fictional-trading sub-gap; metrics dict now carries `bankruptcy_count` |
 | [#329](https://github.com/sssimon/trading-spacial/pull/329) | 2026-05-12 | **Phase 2 R1 outcome** | SIGNAL_EXIT branch kept flag-gated False on live — mechanism engaged in backtest, profitability absent | Honest closure of a hypothesis that failed its pre-registered gate |
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -119,25 +119,21 @@ Full classification of the backtest-vs-live distinction: [`2026-05-01-operationa
 
 ## Where the research is going
 
-The LRC strategy class (4H macro → 1H signal → 5M entry, ATR-based SL/TP) is mature but produced `EDGE_WEAK` in the post-#223 re-baselining. The active research direction is:
+The honest state, as of 2026-05-22: no validated systematic strategy. Three iterations have been closed with documented failure modes, and the project's center of gravity has shifted to **operator-tooling + multi-tenant production**.
 
-**Regime-allocation strategy class** (epic [#338](https://github.com/sssimon/trading-spacial/issues/338), pre-reg [`2026-05-13-epic-regime-allocation-strategy-pivot.md`](docs/superpowers/specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md))
+**Closed strategy research:**
 
-Structurally distinct alternative: equal-weight Donchian ensemble (9 lookbacks: 5/10/20/30/60/90/150/250/360 days), daily updates at 23:00 UTC close, vol-targeting sizing (30% annualized portfolio vol target replaces R-multiple), bidirectional rotational SHORT, 2× leverage cap, signal-based exits (no SL/TP/TL).
+1. **LRC strategy class** (4H macro → 1H signal → 5M entry, ATR-based SL/TP) — mature codepath, but produced `EDGE_WEAK` in the post-#223 re-baselining (Direction A, PR [#357](https://github.com/sssimon/trading-spacial/pull/357)). Only confirmed edge: Q2 operator-discretion exit timing.
+2. **Regime-allocation strategy class** (epic [#338](https://github.com/sssimon/trading-spacial/issues/338), pre-reg [`2026-05-13-epic-regime-allocation-strategy-pivot.md`](docs/superpowers/specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md)) — equal-weight Donchian ensemble (9 lookbacks: 5/10/20/30/60/90/150/250/360 days), daily updates at 23:00 UTC, vol-targeting sizing replacing R-multiple, bidirectional rotational SHORT, 2× leverage cap, signal-based exits. **Epic closed 2026-05-15 with verdict `PHASE_3_INSUFFICIENT_DATA`** — not enough independent observations in the post-2017 universe to discriminate. Phase 1 (architecture + flag-gated implementation) shipped; Phases 2-6 deferred behind the insufficient-data verdict.
+3. **Direction A re-baselining** (PR [#357](https://github.com/sssimon/trading-spacial/pull/357)) — multi-direction test of post-#223 mechanisms. Verdict `EDGE_WEAK`. Only Q2 (operator-discretion exit timing) survived.
 
-Status as of 2026-05-22:
-- **Phase 1** (architecture + flag-gated implementation): shipped 2026-05-13
-- **Phase 2** (pre-Phase 3 sanity checks on synthetic data): pre-reg complete
-- **Phase 3** (real-data evaluation): returned `PHASE_3_INSUFFICIENT_DATA` — not enough independent observations in the post-2017 universe to discriminate
-- **Phase 4-6**: pending Phase 3 resolution
+**Active work (operator-tooling, not strategy research):**
 
-**Multi-tenant production** (epic [#253](https://github.com/sssimon/trading-spacial/issues/253), closed 2026-05-16)
+- **Multi-tenant production** — Epic [#253](https://github.com/sssimon/trading-spacial/issues/253). All B.1–B.8 sub-tasks shipped in `080a74e`; B.8 production migration completed 2026-05-16 (3,306 signal_outcomes + 410 notifications stamped `tenant_id=1`, zero downtime). The umbrella ticket stays open as a tracking anchor for follow-up isolation work. Per-user data isolation (`tenant_id` foreign keys), IDOR-safe API, per-user Telegram dispatcher, per-user dashboard state.
+- **Per-user copilot history** — Epic [#428](https://github.com/sssimon/trading-spacial/issues/428), open. Persist + retrieve past LLM-copilot chats per tenant. Research lens: capture the operator-LLM dialogue at the moment of a discretionary decision, so we can later evaluate which operator decisions correlated with positive outcomes.
+- **First-login onboarding wizard** — Epic [#427](https://github.com/sssimon/trading-spacial/issues/427), open. Guided multi-step (capital, preferences, Telegram) for invitees (papá Simón id=2, María id=3).
 
-Per-user data isolation (`tenant_id` foreign keys), IDOR-safe API, per-user Telegram dispatcher, per-user dashboard state. The methodology question now extends to: *whose operator-discretion edge are we measuring?* Each invitee (papá Simón id=2, María id=3) becomes their own operator-discretion data point.
-
-**Per-user copilot history** (epic [#428](https://github.com/sssimon/trading-spacial/issues/428), open)
-
-Persist + retrieve past LLM-copilot chats per tenant. Research lens: capture the operator-LLM dialogue at the moment of a discretionary decision, so we can later evaluate which operator decisions correlated with positive outcomes.
+**The methodology question now**: *whose operator-discretion edge are we measuring?* Each invitee becomes their own data point. The system's value proposition has shifted from "find the alpha" to "instrument operator decisions and study them over time".
 
 ## How to evaluate any claim in this repo
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -89,15 +89,55 @@ Full reasoning: PR #316 inflection-point spec §A.2 + [`2026-05-02-structural-fi
 
 ## Cost model v2 — why naive `slippage = participation × spread` is wrong
 
-(TBD — Task 4)
+The original backtest cost model was `slippage_bps = base + linear × participation`. PR #341 replaced it with a sqrt-participation formulation grounded in market-microstructure literature:
+
+```
+slippage_bps = base_bps + size_factor × sqrt(notional / liquidity_per_min)
+```
+
+Capped at `EXTREME_PARTICIPATION_CAP_BPS = 500` (5%) per fill.
+
+**Anchor parity preserved**: at 0.1% participation, v2 and v1 produce identical total slippage per tier — calibration invariant tested in `test_backtest_costs_v2.py::TestAnchorParity`.
+
+**Funding-rate accounting** (new in v2): per-tier conservative bps per 8h funding interval (`major=1.0`, `mid=2.0`, `small=5.0` in `costs_calibration.json`). Floor semantics: 7h pays 0, 8h pays 1, 24h pays 3. Conservative mode = always positive cost regardless of direction (worst-case for the strategy).
+
+**Forensic motivation**: the DOGE `-$30K` single-trade case from audit H8 (#323) is mitigated >1000× under v2. v1 produced an unbounded ~$19.8M per-fill cost on the catastrophically thin bar; v2 caps at $1,050. The new vol-targeting strategy class (regime-allocation epic) prevents the catastrophic $21K notional from being placed in the first place.
+
+**Calibration sources** are cited inline in `costs_calibration.json`: Almgren-Chriss (2001), Donier-Bonart (2015), Tóth et al (2011).
 
 ## Operational model — signals are not trades
 
-(TBD — Task 4)
+This repo generates signals automatically; it does not place trades automatically.
+
+The scanner emits a scored signal (0–9) on the curated 10-symbol basket every 300 seconds. The dashboard shows the signal. Telegram (per-user, since [#421](https://github.com/sssimon/trading-spacial/pull/421)) pushes a notification. **A human decides whether to enter, and at what size**.
+
+Exclusions E2–E5 in `btc_scanner.py:305-335` are *manual-check by design* — the scanner does not gate on them because in backtest there is no operator to ask. In live, the operator decides whether to override.
+
+This is not a defect waiting to be automated. The only confirmed edge from the post-inflection re-baselining (Direction A, PR [#357](https://github.com/sssimon/trading-spacial/pull/357)) was **Q2: operator-discretion exit timing**. Removing the human and full-automating would *destroy* the edge that the project has actually validated.
+
+Full classification of the backtest-vs-live distinction: [`2026-05-01-operational-model-manual-gating.md`](docs/superpowers/specs/es/2026-05-01-operational-model-manual-gating.md).
 
 ## Where the research is going
 
-(TBD — Task 4)
+The LRC strategy class (4H macro → 1H signal → 5M entry, ATR-based SL/TP) is mature but produced `EDGE_WEAK` in the post-#223 re-baselining. The active research direction is:
+
+**Regime-allocation strategy class** (epic [#338](https://github.com/sssimon/trading-spacial/issues/338), pre-reg [`2026-05-13-epic-regime-allocation-strategy-pivot.md`](docs/superpowers/specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md))
+
+Structurally distinct alternative: equal-weight Donchian ensemble (9 lookbacks: 5/10/20/30/60/90/150/250/360 days), daily updates at 23:00 UTC close, vol-targeting sizing (30% annualized portfolio vol target replaces R-multiple), bidirectional rotational SHORT, 2× leverage cap, signal-based exits (no SL/TP/TL).
+
+Status as of 2026-05-22:
+- **Phase 1** (architecture + flag-gated implementation): shipped 2026-05-13
+- **Phase 2** (pre-Phase 3 sanity checks on synthetic data): pre-reg complete
+- **Phase 3** (real-data evaluation): returned `PHASE_3_INSUFFICIENT_DATA` — not enough independent observations in the post-2017 universe to discriminate
+- **Phase 4-6**: pending Phase 3 resolution
+
+**Multi-tenant production** (epic [#253](https://github.com/sssimon/trading-spacial/issues/253), closed 2026-05-16)
+
+Per-user data isolation (`tenant_id` foreign keys), IDOR-safe API, per-user Telegram dispatcher, per-user dashboard state. The methodology question now extends to: *whose operator-discretion edge are we measuring?* Each invitee (papá Simón id=2, María id=3) becomes their own operator-discretion data point.
+
+**Per-user copilot history** (epic [#428](https://github.com/sssimon/trading-spacial/issues/428), open)
+
+Persist + retrieve past LLM-copilot chats per tenant. Research lens: capture the operator-LLM dialogue at the moment of a discretionary decision, so we can later evaluate which operator decisions correlated with positive outcomes.
 
 ## How to evaluate any claim in this repo
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -4,15 +4,62 @@
 
 ## What this project actually is
 
-(TBD — Task 2)
+On the surface this is a Bitcoin / altcoin signal scanner with a React dashboard. Underneath, it's something rarer in retail trading: **a working laboratory for evaluating systematic strategies with research-grade discipline**.
+
+Concretely, this repo enforces:
+
+- A **locked holdout dataset** (12 months of OHLCV + Fear & Greed + funding rate, SHA-256 + commit hashed in `data/holdout/MANIFEST.json`, filesystem `chmod -R 444/555`) that strategy code and parameter tuning paths cannot read. Two independent guards prevent leakage: a runtime guard (`data/holdout_access.py` is the only legitimate read entry point) and a structural CI guard (`tests/test_holdout_isolation.py` AST-scans every `.py` for any reference to the holdout path).
+- **Pre-registration** of every methodology change: hypothesis, decision rule, gates, and abort conditions written down *before* running the experiment. See `docs/superpowers/specs/es/` for ~40 such pre-regs going back to April 2026.
+- **Bugs vs. modeling** framing on every result: if a backtest improves, was it because the strategy got better or because a simulator bug got fixed? PRs #223, #224, #309, #313 are all documented inflection points where prior results were known to be inflated by simulator behavior, not strategy edge. See *Structural fixes shipped* below.
+
+If you are evaluating this project as a strategy to trade live: **don't, yet.** Phase 3 of the regime-allocation pivot returned `PHASE_3_INSUFFICIENT_DATA` in May 2026; Direction A of the post-inflection re-baselining returned `EDGE_WEAK`. The only confirmed edge to date is **operator-discretion exit timing** (Q2). The dashboard exists to surface signals for a human to evaluate, not to execute them automatically.
+
+If you are evaluating this project as a methodology artifact: read on.
 
 ## Pre-registration discipline
 
-(TBD — Task 2)
+Every non-trivial decision that touches the simulator, parameter grid, or evaluation rule goes through a pre-registration document in `docs/superpowers/specs/es/<date>-<topic>-pre-reg.md`. The pre-reg locks:
+
+1. **Hypothesis** — what we expect to find
+2. **Decision rule** — exact numerical gates and what each outcome means
+3. **Methodology** — data window, train/test split, metrics, statistical treatment
+4. **Abort conditions** — what would make us stop and revisit
+
+The pre-reg is committed *before* any code that consumes the data runs. After execution, a separate `-result.md` or follow-up PR records the outcome against the pre-registered gates. If the result contradicts the hypothesis or a gate fails, we don't move the goalposts — we document the failure and either pivot or abort.
+
+Examples:
+- [`2026-05-11-a4-hallazgo-inflexion-metodologica.md`](docs/superpowers/specs/es/2026-05-11-a4-hallazgo-inflexion-metodologica.md) — discovered during A.4 re-tune that the entire historical edge was simulator-bug-inflated. Did not paper over; documented and pivoted.
+- [`2026-05-13-r3-fail-closure-path-a-honoring.md`](docs/superpowers/specs/es/2026-05-13-r3-fail-closure-path-a-honoring.md) — R3 trend-pullback hypothesis pre-registered with a hard gate. Failed the gate. Closed honestly.
+- [`2026-05-13-epic-regime-allocation-strategy-pivot.md`](docs/superpowers/specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md) — when the LRC strategy class hit `EDGE_WEAK`, pre-registered a structurally distinct alternative (regime-allocation) with locked parameters, mutual-exclusion gating, and Phase 2-6 plan.
+
+This discipline exists because retail trading literature is saturated with results that fail out-of-sample. The defense is institutional, not technical: write down the rule before you see the data.
 
 ## Holdout dataset isolation
 
-(TBD — Task 2)
+The holdout dataset at `data/holdout/` is the project's single most valuable artifact and is governed accordingly.
+
+**Lock parameters:**
+- 12-month fixed window (not rolling): `2025-04-30T00:00:00 UTC` → `2026-04-30`
+- 10 curated symbols × 4 timeframes of OHLCV + Fear & Greed daily + BTC funding rate
+- SHA-256 + commit hash recorded in `data/holdout/MANIFEST.json`
+- Filesystem state `chmod -R 444/555` (read-only)
+
+**Two-layer access guard:**
+
+1. **Runtime guard (Guard A)** — `data/holdout_access.py` exposes a single function `open_holdout(rel_path, *, evaluation_mode=True)` that returns the resolved Path. Anything else raises `HoldoutAccessError`. There is no monkey-patch escape hatch, no env var override.
+
+2. **Structural guard (Guard B)** — `tests/test_holdout_isolation.py` AST-scans every `.py` file in the repo on CI. Any non-whitelisted module that references the holdout path via string literal, `os.path.join(..., 'holdout', ...)`, `Path / 'holdout'`, or f-string with `'holdout'` fails the build. Docstrings are skipped. The whitelist (`HOLDOUT_LEGITIMATE_MODULES`) is small and reviewed in PR.
+
+To use the holdout from a new module: either call `open_holdout(..., evaluation_mode=True)` and never reference the path directly, or add the module to the whitelist with explicit justification.
+
+**The reason for two layers:** Guard A is opt-in ergonomics. Guard B is the structural net that catches mistakes — including AI-assisted refactors that might naively grep for paths. Belt and suspenders.
+
+**Leakage caveats inherited (must be honored by future evaluation passes):**
+- ATR multipliers (10 × {sl, tp, be} = 30 values) were tuned over full history *including* the holdout range. A re-tune over `[earliest, holdout_start - 1 bar]` is required before evaluating against the holdout. Tracked in issue [#322](https://github.com/sssimon/trading-spacial/issues/322).
+- Regime thresholds `>60/<40` were also data-derived during the 4-config optimization in commit `bf581f1` (2026-04-18); window undocumented in commit/changelog. Treated as leaked-pending-re-tune. Tracked in issue A.4-1.5.
+- Other constants (RISK_PER_TRADE=0.01, score thresholds, K=10 overshoot cap) were verified rule/principle-derived (not data-derived-then-frozen) via `git log -p` depth-2 archaeology.
+
+Full provenance: [`2026-04-30-a1-holdout-dataset-provenance.md`](docs/superpowers/specs/es/2026-04-30-a1-holdout-dataset-provenance.md).
 
 ## How to read the backtest numbers
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -63,11 +63,29 @@ Full provenance: [`2026-04-30-a1-holdout-dataset-provenance.md`](docs/superpower
 
 ## How to read the backtest numbers
 
-(TBD — Task 3)
+Any number in this repo — backtest P&L, Sharpe ratio, win rate, drawdown — needs to be read against three questions:
+
+1. **Pre or post #223/#224?** PR #223 fixed a sign error in `_close_position` that inflated historical results. Numbers from specs dated before 2026-04-25 (notably [`2026-04-17-formula-ganadora-resultados-finales.md`](docs/superpowers/specs/es/2026-04-17-formula-ganadora-resultados-finales.md) and [`2026-04-18-documento-completo-sistema-trading.md`](docs/superpowers/specs/es/2026-04-18-documento-completo-sistema-trading.md)) are **pre-fix and known-inflated**. Do not cite them as baseline.
+
+2. **K-cap binding?** PR #309 added a symmetric `K=10` per-trade overshoot cap. Without it, single trades on thin bars could amplify into `170× initial_capital` losses (the PENDLE case during A.4-1.5 sweep). With it, any trade where `clamped_trade_count > 0` reflects cap-bounded behavior on those bars, not strategy edge. The metrics dict surfaces `clamped_trade_count` per symbol — if it accounts for `>5%` of trades, the headline number is measuring the cap, not the strategy.
+
+3. **Bankruptcy halt fired?** PR #313 added per-symbol bankruptcy halt: when simulated equity drops below `0.1 × INITIAL_CAPITAL`, the symbol emits a `BANKRUPT` exit and stops opening new positions for the simulation. Pre-#313, the simulator continued issuing fictional zero-risk trades after bankruptcy, which silently inflated `sum(net_pnl)` for any config that drove a symbol broke. The A.4-1.5 sweep had to operator-override the regime config because `no_detector` "won" only via post-bankruptcy ghost trades on JUPUSDT. Always check `bankruptcy_count` in the metrics dict.
+
+**Recommended framing in narrative**: previous backtests reflected simulator bugs (#223, #313) and modeling decisions (#309), not pure strategy behavior. The bug fixes recovered real numbers; the modeling cap (K=10) is a calibration with its own uncertainty band — don't conflate the two.
 
 ## Structural fixes shipped (and what they say about prior numbers)
 
-(TBD — Task 3)
+| PR | Date | Type | What it fixed | Effect on prior numbers |
+|---|---|---|---|---|
+| [#223](https://github.com/sssimon/trading-spacial/pull/223) / #224 | 2026-04-25 | **Bug fix** | Sign error in `_close_position` that double-counted PnL on certain exit paths | Pre-fix numbers were inflated; not a "calibration improvement" |
+| [#296](https://github.com/sssimon/trading-spacial/pull/296)+#297+#298+#299 | 2026-05-03 | **Triple Barrier structural fix** | Time-limit barrier, participation cap, per-symbol overrides honored in live + backtest paths | Closed the legacy `atr_*` kwargs bypass for the live path |
+| [#309](https://github.com/sssimon/trading-spacial/pull/309) | 2026-05-11 | **Modeling decision** | Symmetric K=10 per-trade overshoot cap. Bounds `\|pnl_usd\| ≤ K × risk_amount` | Realistic; bounds the catastrophic-bar mechanism without enforcing pooled-portfolio capital management |
+| [#313](https://github.com/sssimon/trading-spacial/pull/313) | 2026-05-11 | **Bug fix** | Post-bankruptcy ghost trades. Symbol halts at `0.1 × INITIAL_CAPITAL` floor | Closed the silent-continued-fictional-trading sub-gap; metrics dict now carries `bankruptcy_count` |
+| [#329](https://github.com/sssimon/trading-spacial/pull/329) | 2026-05-12 | **Phase 2 R1 outcome** | SIGNAL_EXIT branch kept flag-gated False on live — mechanism engaged in backtest, profitability absent | Honest closure of a hypothesis that failed its pre-registered gate |
+
+**The framing matters**: #223, #224, #313 are bugs. The simulator was wrong; fixing it recovers real numbers. #309 is a modeling decision with its own uncertainty band (`K=10` chosen as conservative threshold, not empirically tuned). Don't conflate "we fixed bugs" with "we made the simulator more realistic" — the former is methodologically stronger.
+
+Full reasoning: PR #316 inflection-point spec §A.2 + [`2026-05-02-structural-fix-parameter-study.md`](docs/superpowers/research/2026-05-02-structural-fix-parameter-study.md).
 
 ## Cost model v2 — why naive `slippage = participation × spread` is wrong
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -1,0 +1,43 @@
+# Methodology
+
+> Why this project looks like a trading scanner but behaves like a research artifact.
+
+## What this project actually is
+
+(TBD — Task 2)
+
+## Pre-registration discipline
+
+(TBD — Task 2)
+
+## Holdout dataset isolation
+
+(TBD — Task 2)
+
+## How to read the backtest numbers
+
+(TBD — Task 3)
+
+## Structural fixes shipped (and what they say about prior numbers)
+
+(TBD — Task 3)
+
+## Cost model v2 — why naive `slippage = participation × spread` is wrong
+
+(TBD — Task 4)
+
+## Operational model — signals are not trades
+
+(TBD — Task 4)
+
+## Where the research is going
+
+(TBD — Task 4)
+
+## How to evaluate any claim in this repo
+
+(TBD — Task 5)
+
+## References
+
+(TBD — Task 5)

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -137,8 +137,42 @@ The honest state, as of 2026-05-22: no validated systematic strategy. Three iter
 
 ## How to evaluate any claim in this repo
 
-(TBD — Task 5)
+Default skepticism stance for any number, chart, or claim you find in this repo:
+
+1. **Find the pre-reg.** If a result has no pre-registration document under `docs/superpowers/specs/es/`, treat it as exploratory analysis, not as evidence. Exploratory analysis informs hypothesis generation; it does not test hypotheses.
+
+2. **Check the date against #223/#224/#309/#313.** Pre-2026-04-25 numbers are pre-PnL-sign-fix. Pre-2026-05-11 numbers are pre-K-cap and pre-bankruptcy-halt. Each of these inflected results materially. The structural-fixes table above is the canonical reference.
+
+3. **Read the `pending_steps` or open issues.** Active gates that bar further claims are tracked as open GitHub issues labeled `methodology/*`. If `#322` (A.4-3 holdout execution) is open, no claim about holdout performance is valid yet.
+
+4. **Look for the `clamped_trade_count` and `bankruptcy_count`.** Any backtest report should surface both. If a result is good but `bankruptcy_count > 0` or `clamped_trade_count > 5%` of trades on any symbol, the result is reporting cap-bounded behavior, not strategy edge.
+
+5. **Sister variables.** When a finding is reported, ask: what parallel paths or related parameters might exhibit the same pattern? An honest analysis acknowledges them in the same writeup.
+
+6. **Operator discretion is real.** Numbers from the live system include operator-discretion exit timing. Numbers from backtest do not. The two are not comparable without explicit translation.
 
 ## References
 
-(TBD — Task 5)
+**Canonical specs** (all under `docs/superpowers/specs/es/`):
+- [`2026-04-30-a1-holdout-dataset-provenance.md`](docs/superpowers/specs/es/2026-04-30-a1-holdout-dataset-provenance.md) — holdout provenance + lock parameters
+- [`2026-05-11-a4-hallazgo-inflexion-metodologica.md`](docs/superpowers/specs/es/2026-05-11-a4-hallazgo-inflexion-metodologica.md) — inflection point that triggered the regime-allocation pivot
+- [`2026-05-13-epic-regime-allocation-strategy-pivot.md`](docs/superpowers/specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md) — regime-allocation strategy pivot (closed 2026-05-15 with PHASE_3_INSUFFICIENT_DATA verdict)
+- [`2026-05-01-operational-model-manual-gating.md`](docs/superpowers/specs/es/2026-05-01-operational-model-manual-gating.md) — why exclusions E2–E5 are manual-check by design
+- [`2026-05-11-strategy-structural-audit.md`](docs/superpowers/specs/es/2026-05-11-strategy-structural-audit.md) — comprehensive audit of strategy components
+- [`2026-05-16-multi-tenant-threat-model.md`](docs/superpowers/specs/es/2026-05-16-multi-tenant-threat-model.md) — per-tenant isolation guarantees
+- [`2026-05-03-asunciones-tecnicas-pre-holdout.md`](docs/superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md) — assumptions audit pre-holdout-evaluation
+
+**Research notes** (`docs/superpowers/research/`):
+- [`2026-05-02-structural-fix-parameter-study.md`](docs/superpowers/research/2026-05-02-structural-fix-parameter-study.md) — K-cap parameter study
+- [`2026-04-30-exit-logic-benchmark-crypto.md`](docs/superpowers/research/2026-04-30-exit-logic-benchmark-crypto.md) — exit logic benchmark
+
+**Academic anchors cited in `costs_calibration.json`:**
+- Almgren-Chriss (2001), "Optimal execution of portfolio transactions"
+- Donier-Bonart (2015), "A Million Metaorder Analysis of Market Impact on the Bitcoin"
+- Tóth et al (2011), "Anomalous price impact and the critical nature of liquidity in financial markets"
+
+**External method references:**
+- Pre-registration practice from clinical trials methodology (e.g. ClinicalTrials.gov)
+- Holdout-set discipline from machine-learning competition norms (Kaggle private leaderboards)
+
+**Navigation:** the full index of specs, plans, and research is at [`docs/README.md`](docs/README.md).

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -79,7 +79,7 @@ Any number in this repo — backtest P&L, Sharpe ratio, win rate, drawdown — n
 |---|---|---|---|---|
 | [#223](https://github.com/sssimon/trading-spacial/pull/223) / #224 | 2026-04-25 | **Bug fix** | Sign error in `_close_position` that double-counted PnL on certain exit paths | Pre-fix numbers were inflated; not a "calibration improvement" |
 | [#296](https://github.com/sssimon/trading-spacial/pull/296)+#297+#298+#299 | 2026-05-03 | **Triple Barrier structural fix** | Time-limit barrier, participation cap, per-symbol overrides honored in live + backtest paths | Closed the legacy `atr_*` kwargs bypass for the live path |
-| [#309](https://github.com/sssimon/trading-spacial/pull/309) | 2026-05-11 | **Modeling decision** | Symmetric K=10 per-trade overshoot cap. Bounds `&#124;pnl_usd&#124; ≤ K × risk_amount` | Realistic; bounds the catastrophic-bar mechanism without enforcing pooled-portfolio capital management |
+| [#309](https://github.com/sssimon/trading-spacial/pull/309) | 2026-05-11 | **Modeling decision** | Symmetric K=10 per-trade overshoot cap. Bounds `abs(pnl_usd) ≤ K × risk_amount` | Realistic; bounds the catastrophic-bar mechanism without enforcing pooled-portfolio capital management |
 | [#313](https://github.com/sssimon/trading-spacial/pull/313) | 2026-05-11 | **Bug fix** | Post-bankruptcy ghost trades. Symbol halts at `0.1 × INITIAL_CAPITAL` floor | Closed the silent-continued-fictional-trading sub-gap; metrics dict now carries `bankruptcy_count` |
 | [#329](https://github.com/sssimon/trading-spacial/pull/329) | 2026-05-12 | **Phase 2 R1 outcome** | SIGNAL_EXIT branch kept flag-gated False on live — mechanism engaged in backtest, profitability absent | Honest closure of a hypothesis that failed its pre-registered gate |
 
@@ -101,7 +101,7 @@ Capped at `EXTREME_PARTICIPATION_CAP_BPS = 500` (5%) per fill.
 
 **Funding-rate accounting** (new in v2): per-tier conservative bps per 8h funding interval (`major=1.0`, `mid=2.0`, `small=5.0` in `costs_calibration.json`). Floor semantics: 7h pays 0, 8h pays 1, 24h pays 3. Conservative mode = always positive cost regardless of direction (worst-case for the strategy).
 
-**Forensic motivation**: the DOGE `-$30K` single-trade case from audit H8 (#323) is mitigated >1000× under v2. v1 produced an unbounded ~$19.8M per-fill cost on the catastrophically thin bar; v2 caps at $1,050. The new vol-targeting strategy class (regime-allocation epic) prevents the catastrophic $21K notional from being placed in the first place.
+**Forensic motivation**: the DOGE `-$30K` single-trade case from audit H8 ([#323](https://github.com/sssimon/trading-spacial/issues/323)) is mitigated >1000× under v2. v1 produced an unbounded ~$19.8M per-fill cost on the catastrophically thin bar; v2 caps at $1,050. The new vol-targeting strategy class (regime-allocation epic) prevents the catastrophic $21K notional from being placed in the first place.
 
 **Calibration sources** are cited inline in `costs_calibration.json`: Almgren-Chriss (2001), Donier-Bonart (2015), Tóth et al (2011).
 

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -131,7 +131,7 @@ The honest state, as of 2026-05-22: no validated systematic strategy. Three iter
 
 - **Multi-tenant production** — Epic [#253](https://github.com/sssimon/trading-spacial/issues/253). All B.1–B.8 sub-tasks shipped in `080a74e`; B.8 production migration completed 2026-05-16 (3,306 signal_outcomes + 410 notifications stamped `tenant_id=1`, zero downtime). The umbrella ticket stays open as a tracking anchor for follow-up isolation work. Per-user data isolation (`tenant_id` foreign keys), IDOR-safe API, per-user Telegram dispatcher, per-user dashboard state.
 - **Per-user copilot history** — Epic [#428](https://github.com/sssimon/trading-spacial/issues/428), open. Persist + retrieve past LLM-copilot chats per tenant. Research lens: capture the operator-LLM dialogue at the moment of a discretionary decision, so we can later evaluate which operator decisions correlated with positive outcomes.
-- **First-login onboarding wizard** — Epic [#427](https://github.com/sssimon/trading-spacial/issues/427), open. Guided multi-step (capital, preferences, Telegram) for invitees (papá Simón id=2, María id=3).
+- **First-login onboarding wizard** — Epic [#427](https://github.com/sssimon/trading-spacial/issues/427), open. Guided multi-step (capital, preferences, Telegram) for invited operators.
 
 **The methodology question now**: *whose operator-discretion edge are we measuring?* Each invitee becomes their own data point. The system's value proposition has shifted from "find the alpha" to "instrument operator decisions and study them over time".
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,12 @@ For the why behind these bounds, see [`METHODOLOGY.md`](METHODOLOGY.md) § Struc
 |-------|------|
 | Backend | Python 3.12, FastAPI, SQLite |
 | Frontend | React 18, TypeScript, Vite, lightweight-charts |
-| Alerts | Telegram (per-user bot, via notifier/dispatch_per_user.py) |
-| Infrastructure | Docker, Windows Task Scheduler |
+| LLM copilot | Anthropic Claude + DeepSeek (multi-provider, epic #400) |
+| Alerts | Telegram (per-user, configured by each operator via dashboard) |
+| Auth | JWT, per-user setup, password reset by shell only |
+| Data sources | Binance Futures (primary), Bybit (fallback), CoinGecko (symbol metadata), Alternative.me (Fear & Greed) |
+| Production | Linux EC2 (`trading.sdar.dev`), Caddy reverse proxy, GitHub Actions deploy |
+| Local dev | Windows or Linux/macOS, Docker for frontend + n8n |
 
 ---
 
@@ -290,25 +294,58 @@ python -m pytest tests/test_api.py -v
 
 ## Project Structure
 
-```
-├── btc_api.py              # FastAPI server (port 8000)
-├── btc_scanner.py          # Signal engine (indicators + scoring)
-├── btc_report.py           # Standalone HTML market report generator
-├── trading_webhook.py      # Webhook receiver → Telegram (port 9000)
-├── watchdog.py             # Process supervisor (Windows)
-├── docker-compose.yml      # Frontend + n8n containers
-├── requirements_scanner.txt
-├── frontend/               # React 18 dashboard
-│   └── src/
-│       ├── components/     # SymbolsGrid, SignalsTable, PositionsPanel, ...
-│       ├── api.ts          # Typed fetch wrapper
-│       └── types.ts        # TypeScript interfaces
-├── tests/
-│   ├── test_scanner.py
-│   └── test_api.py
-├── scripts/                # Windows automation (PS1 + BAT)
-├── Backtesting_BTCUSDT/    # Backtesting results and charts (V6)
-└── data/                   # Position sizing calculator, trade tracker
+```text
+├── README.md                  # You are here
+├── METHODOLOGY.md             # The moat: pre-registration, holdout guards, structural fixes
+├── CLAUDE.md                  # Current-state truth (architecture, configs, known limitations)
+├── docs/                      # Specs, plans, research notes — see docs/README.md
+│   ├── README.md              # Documentation index
+│   └── superpowers/
+│       ├── specs/es/          # ~40 pre-registration documents
+│       ├── plans/             # ~35 implementation plans (active + archive/)
+│       └── research/          # Research notes (K-cap study, exit benchmarks)
+│
+│  # — Entry points —
+├── btc_api.py                 # FastAPI server (port 8000), scanner thread
+├── btc_scanner.py             # Signal engine: indicators, scoring, regime detection
+├── btc_report.py              # Standalone HTML market report generator
+├── trading_webhook.py         # Webhook receiver → Telegram (legacy path, port 9000)
+├── watchdog.py                # Process supervisor — ⚠️ Windows-only; Linux prod
+│                              #   supervises via systemd (not yet in repo, tracked
+│                              #   in audit follow-ups)
+│
+│  # — Modular code —
+├── api/                       # REST endpoints split by domain
+├── auth/                      # JWT auth + setup paths
+├── db/                        # SQLite schema + migrations + capital
+├── notifier/                  # Per-user signal dispatch (multi-tenant)
+├── strategy/                  # Indicators, regime, sizing, kill-switch, vol-targeting
+├── strategies/                # ⚠️ Legacy ADX router — being consolidated (tracked)
+├── scanner/                   # HTTP helpers
+├── cli/                       # CLI commands
+├── tools/                     # Operator scripts
+│
+│  # — Backtest + tuning —
+├── backtest.py                # Simulator (post-#309 K-cap + #313 bankruptcy halt)
+├── backtest_costs.py          # Cost model v2 (sqrt-participation + funding)
+├── auto_tune.py               # Parameter sweep harness
+├── grid_search_tf.py          # Timeframe grid search
+├── optimize_new_tokens.py     # New-token evaluation
+│
+│  # — Frontend + infra —
+├── frontend/                  # React 18 + Vite + TypeScript dashboard
+│   └── src/                   # Components, hooks, types, copilot dock
+├── infra/                     # Deploy configs (Caddy, GitHub Actions)
+├── scripts/                   # Windows automation (PS1 + BAT) + Linux setup
+│
+│  # — Tests + data —
+├── tests/                     # pytest (api, scanner, backtest, multi-tenant, holdout)
+├── data/                      # Operational data
+│   ├── holdout/               # 🔒 Locked holdout dataset — data/holdout/ (read-only, guard-protected)
+│   ├── regime_cache.json
+│   ├── symbols_status.json
+│   └── signals_history.csv
+└── logs/                      # Runtime logs (signals, webhook, watchdog)
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -364,58 +364,70 @@ python -m pytest tests/test_api.py -v
 
 ## Troubleshooting
 
-### El scanner no genera señales
-1. Verificar conexion a Binance: `curl -s https://api.binance.com/api/v3/ping`
-2. Revisar logs: `tail -f logs/btc_api.log`
-3. Verificar que `config.json` existe y tiene formato valido
-4. Forzar scan manual: `curl -X POST http://localhost:8000/scan`
-5. Revisar el endpoint de salud: `curl http://localhost:8000/health`
+### Scanner generates no signals
+1. Verify Binance connectivity: `curl -s https://api.binance.com/api/v3/ping`
+2. Check the API log: `tail -f logs/btc_api.log`
+3. Confirm `config.json` exists and is valid JSON
+4. Force a manual scan: `curl -X POST http://localhost:8000/scan`
+5. Hit the health endpoint: `curl http://localhost:8000/health`
 
-### Telegram no envia mensajes
-1. Verificar `telegram_bot_token` y `telegram_chat_id` en `config.json`
-2. Probar envio: `curl http://localhost:8000/webhook/test`
-3. Verificar que `signal_filters.min_score` no es demasiado alto (default: 4)
-4. Revisar logs para errores de Telegram: `grep -i telegram logs/btc_api.log`
-5. Si usa proxy: verificar formato `socks5://127.0.0.1:1080`
+### Telegram is silent
+1. Confirm `telegram_bot_token` and `telegram_chat_id` are set — note: since [#421](https://github.com/sssimon/trading-spacial/pull/421) these are **per-user** in `user_preferences`, not in `config.json`. Configure via the dashboard → avatar → Conexiones.
+2. Test delivery: dashboard → Conexiones → "Probar envío" button, or `curl http://localhost:8000/webhook/test`
+3. Check `signal_filters.min_score` isn't too restrictive (default: 4)
+4. Search the API log for Telegram errors: `grep -i telegram logs/btc_api.log`
+5. If using a proxy: confirm format `socks5://127.0.0.1:1080`
 
-### El dashboard no carga datos
-1. Verificar que `btc_api.py` esta corriendo: `curl http://localhost:8000/status`
-2. Si usa Docker: verificar que el container esta activo: `docker ps`
-3. Verificar proxy en nginx: `curl http://localhost:3000/api/status`
-4. Revisar la consola del navegador para errores CORS
+### Dashboard shows no data
+1. Confirm `btc_api.py` is running: `curl http://localhost:8000/status`
+2. If running under Docker: `docker ps`
+3. Verify the nginx / Caddy proxy: `curl http://localhost:3000/api/status`
+4. Check the browser console for CORS errors
 
-### Errores de base de datos
-1. Verificar que `signals.db` existe y no esta corrupto
-2. Si esta corrupto, restaurar desde backup: `cp backups/signals_YYYYMMDD.db signals.db`
-3. Para recrear la DB: eliminar `signals.db` y reiniciar `btc_api.py`
+### Database errors
+1. Confirm `signals.db` exists and isn't corrupt
+2. To restore from backup: `cp backups/signals_YYYYMMDD.db signals.db`
+3. To recreate from scratch: delete `signals.db` and restart `btc_api.py`
 
-### El watchdog no inicia (Windows)
-1. Verificar que Python esta en PATH: `python --version`
-2. Ejecutar como administrador: `powershell -ExecutionPolicy Bypass -File scripts/INSTALAR_AUTOSTART.ps1`
-3. Verificar tarea en Task Scheduler: buscar "BTCScannerWatchdog"
-4. Revisar logs: `type logs\watchdog.log`
+### Watchdog won't start (Windows local dev only)
+1. Check Python is on PATH: `python --version`
+2. Run the installer as administrator: `powershell -ExecutionPolicy Bypass -File scripts/INSTALAR_AUTOSTART.ps1`
+3. Verify the scheduled task exists: open Task Scheduler, look for `BTCScannerWatchdog`
+4. Check the log: `type logs\watchdog.log`
+
+> **Production note:** `watchdog.py` is Windows-only and is *not* what supervises production. Production runs on Linux EC2 (`trading.sdar.dev`) where supervision is via systemd. The systemd unit files are not yet checked into the repo — tracked in the audit punch list. If you're deploying to a Linux server, do not rely on `watchdog.py`.
 
 ## Deployment Checklist
 
-- [ ] Crear `config.json` con credenciales (copiar template del README)
-- [ ] Configurar `telegram_bot_token` y `telegram_chat_id`
-- [ ] Opcional: configurar `api_key` para proteger endpoints sensibles
-- [ ] Verificar conectividad a Binance: `curl https://api.binance.com/api/v3/ping`
-- [ ] Instalar dependencias: `pip install -r requirements.txt`
-- [ ] Iniciar API: `python btc_api.py`
-- [ ] Verificar salud: `curl http://localhost:8000/health`
-- [ ] Probar Telegram: `curl http://localhost:8000/webhook/test`
-- [ ] Iniciar frontend: `cd frontend && npm install && npm run dev`
-- [ ] Verificar dashboard en `http://localhost:5173`
-- [ ] Para produccion: `docker compose up --build`
-- [ ] Configurar autostart (Windows): ejecutar `scripts/INSTALAR_AUTOSTART.ps1`
-- [ ] Verificar logs se generan en `logs/`
+- [ ] Create `config.json` with credentials (copy template from this README)
+- [ ] Configure system-level Telegram only if you want a fallback channel — otherwise each user configures their own via the dashboard (since #421)
+- [ ] Optional: set `api_key` to protect sensitive endpoints
+- [ ] Verify Binance connectivity: `curl https://api.binance.com/api/v3/ping`
+- [ ] Install dependencies: `pip install -r requirements.txt`
+- [ ] Start the API: `python btc_api.py`
+- [ ] Health check: `curl http://localhost:8000/health`
+- [ ] Test legacy Telegram (if configured): `curl http://localhost:8000/webhook/test`
+- [ ] Start the frontend: `cd frontend && npm install && npm run dev`
+- [ ] Open the dashboard: `http://localhost:5173`
+- [ ] For production: see `infra/` + GitHub Actions deploy workflow (`.github/workflows/deploy.yml`)
+- [ ] Configure autostart:
+  - **Windows local dev:** `scripts/INSTALAR_AUTOSTART.ps1`
+  - **Linux production:** systemd unit (see ops docs — not yet in repo)
+- [ ] Confirm logs are landing in `logs/`
+- [ ] Confirm `data/regime_cache.json` populates after the first daily-bar fetch
 
 ---
 
 ## Notes
 
-- `config.json` is git-ignored — contains sensitive credentials
-- `watchdog.py` is Windows-only (uses `tasklist`, `taskkill`, `wmic`)
-- Symbols list is dynamically fetched from CoinGecko every hour with fallback to a hardcoded top-20 list
-- Binance Futures API is the primary data source; Bybit is the fallback
+- `config.json` is git-ignored — contains credentials. Use the template in this README to bootstrap.
+- `watchdog.py` is Windows-only (uses `tasklist`, `taskkill`, `wmic`). Linux production is supervised by systemd; the unit files are not yet in the repo (tracked).
+- The curated symbol list is **static** (10 coins) since epic #135 — see Signal Logic section above.
+- Binance Futures is the primary data source; Bybit is the fallback.
+- The locked holdout dataset at `data/holdout/` is read-only and guard-protected. See [`METHODOLOGY.md`](METHODOLOGY.md) § Holdout dataset isolation before writing any new code that touches it.
+
+## Research methodology
+
+This isn't just a trading scanner. The methodology underneath — pre-registration, holdout isolation, structural-fix ledger, honest closure of failed hypotheses — is what makes this repo different from the generic crypto-bot landscape.
+
+→ **Read [`METHODOLOGY.md`](METHODOLOGY.md)**, then [`docs/README.md`](docs/README.md) for the full spec index.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# Crypto Trading Scanner — Ultimate Macro & Order Flow V6.0
+# trading-spacial
 
 [![CI](https://github.com/sssimon/trading-spacial/actions/workflows/ci.yml/badge.svg)](https://github.com/sssimon/trading-spacial/actions/workflows/ci.yml)
 
-Automated signal system for the top 20 crypto pairs by market cap. Uses multi-timeframe technical analysis (4H macro context → 1H signal → 5M entry trigger) to generate scored entry alerts delivered to Telegram.
+> A research-grade laboratory for evaluating systematic crypto-trading strategies, with a working signal scanner + dashboard on top.
+
+The surface is a Bitcoin / altcoin signal scanner: multi-timeframe technical analysis (4H macro → 1H signal → 5M entry), scored signals delivered to Telegram per-user, React dashboard with position tracking and an in-app LLM copilot.
+
+The substance is the methodology underneath: pre-registered hypotheses, a locked holdout dataset with two-layer access guards, explicit structural-fix ledger (bug fixes vs. modeling decisions), and honest closure of failed hypotheses. **See [`METHODOLOGY.md`](METHODOLOGY.md)** for what makes this different from the 50,000 other crypto bots on GitHub.
+
+**Status (2026-05-22):** the LRC strategy class has been re-baselined post-PR #223 and returned `EDGE_WEAK`. The only confirmed edge is operator-discretion exit timing (Direction A Q2). Two structurally distinct strategy directions have been explored and closed: (1) regime-allocation pivot (epic [#338](https://github.com/sssimon/trading-spacial/issues/338)) closed 2026-05-15 with verdict `PHASE_3_INSUFFICIENT_DATA`, and (2) trend-pullback (R3) closed earlier with FAIL verdict. Current active work is operator-tooling (multi-tenant production [#253](https://github.com/sssimon/trading-spacial/issues/253), per-user copilot history [#428](https://github.com/sssimon/trading-spacial/issues/428), onboarding wizard [#427](https://github.com/sssimon/trading-spacial/issues/427)). Do not trade this system live.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,33 +14,55 @@ The substance is the methodology underneath: pre-registered hypotheses, a locked
 
 ## Architecture
 
-```
+```text
 Binance API (Bybit fallback)
-  └─ btc_scanner.py     — fetch OHLCV, calculate indicators, score signals
-       └─ btc_api.py    — FastAPI server, SQLite storage, notification filters
-            └─ trading_webhook.py  →  Telegram (via OpenClaw CLI)
-               n8n workflow        →  Telegram (alternative)
+  └─ btc_scanner.py      — fetch OHLCV, compute indicators (LRC, RSI, BB, SMA, ATR, ADX),
+     |                     score signals (0–9), gate by regime detector
+     ├─ strategy/         — modular indicators, regime detection, sizing, vol-targeting
+     ├─ strategies/       — ⚠️ legacy ADX-based router (kept for back-compat; see CLAUDE.md)
+     └─ backtest.py       — simulator with K-cap overshoot bound + bankruptcy halt
+            ↓
+  └─ btc_api.py            — FastAPI server (port 8000), SQLite storage, scanner thread
+     ├─ api/                 — REST endpoints (signals, positions, prefs, agent)
+     ├─ auth/                — JWT auth, per-user setup, password reset by shell only
+     ├─ db/                  — SQLite schema + migrations + capital tracker
+     └─ notifier/            — per-user signal dispatch (multi-tenant since epic #253)
+            ↓
+  └─ Telegram (per-user)   — each operator configures their own bot + chat_id
+                              via dashboard → UserMenu → Conexiones (since #421)
 
-frontend/               — React 18 dashboard (Vite + TypeScript)
-watchdog.py             — Windows process supervisor (keeps API alive)
+frontend/                    — React 18 dashboard (Vite + TypeScript)
+                              symbols grid, signals table, positions, copilot dock
+infra/                       — deploy configs (Caddy, GitHub Actions)
 ```
 
 ### Signal Logic
 
 | Timeframe | Role | Indicators |
-|-----------|------|-----------|
+|-----------|------|------------|
 | 4H | Macro context | SMA100, trend direction |
 | 1H | Main signal | LRC (100-bar), RSI, Bollinger Bands |
 | 5M | Entry trigger | Reversal candle confirmation |
 
-**Entry zone:** price within 25% of the lower Linear Regression Channel band (`LRC% ≤ 25`)
+**Entry zone:** `LRC_LONG_MAX = 25%` (long), `LRC_SHORT_MIN = 75%` (short, gated by `regime=BEAR`).
 
-**Score tiers:**
+**Score tiers (operator-chosen partition, stable from inception):**
 - `0–1` → 50% position size
 - `2–3` → standard size
 - `≥ 4` → premium signal (+50% size)
 
-**Default TP/SL:** 4% take profit / 2% stop loss
+**Risk per trade:** fixed 1% of capital. Per-symbol volatility adaptation is handled by tuned `atr_sl_mult / tp / be` values in `config.json["symbol_overrides"]` (epic #121). Do not add multiplicative scalers on top.
+
+**Regime detection** (`detect_regime`, once daily, cached in `data/regime_cache.json`):
+Composite score = 40% price (SMA50/200, 30d momentum) + 30% Fear & Greed + 30% Binance Futures funding rate. Score >60 = BULL/LONG, <40 = BEAR/SHORT-enabled, 40–60 = NEUTRAL/LONG-only.
+
+**Structural bounds (post-#223 simulator):**
+- **K-cap (#309)**: `abs(pnl_usd) ≤ 10 × risk_amount` per trade. Bounds the catastrophic-bar mechanism.
+- **Bankruptcy halt (#313)**: symbol stops new entries when equity drops below `0.1 × INITIAL_CAPITAL`. Existing positions close naturally.
+
+For the why behind these bounds, see [`METHODOLOGY.md`](METHODOLOGY.md) § Structural fixes shipped.
+
+**Curated symbols (static, 10):** BTC, ETH, ADA, AVAX, DOGE, UNI, XLM, PENDLE, JUP, RUNE. Static since epic #135 confirmed via 768+ backtest combinations that the 13 removed tokens (BNB, SOL, XRP, DOT, MATIC, LINK, LTC, ATOM, NEAR, FIL, APT, OP, ARB) are not profitable with this strategy regardless of parameters.
 
 ---
 
@@ -50,7 +72,7 @@ watchdog.py             — Windows process supervisor (keeps API alive)
 |-------|------|
 | Backend | Python 3.12, FastAPI, SQLite |
 | Frontend | React 18, TypeScript, Vite, lightweight-charts |
-| Alerts | Telegram (via n8n or OpenClaw CLI) |
+| Alerts | Telegram (per-user bot, via notifier/dispatch_per_user.py) |
 | Infrastructure | Docker, Windows Task Scheduler |
 
 ---

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Binance API (Bybit fallback)
   └─ btc_scanner.py      — fetch OHLCV, compute indicators (LRC, RSI, BB, SMA, ATR, ADX),
      |                     score signals (0–9), gate by regime detector
      ├─ strategy/         — modular indicators, regime detection, sizing, vol-targeting
-     ├─ strategies/       — ⚠️ legacy ADX-based router (kept for back-compat; see CLAUDE.md)
+     ├─ strategies/       — ⚠️ legacy ADX-based router (kept until consolidation; see strategies/router.py)
      └─ backtest.py       — simulator with K-cap overshoot bound + bankruptcy halt
             ↓
   └─ btc_api.py            — FastAPI server (port 8000), SQLite storage, scanner thread

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ If you're new to the project and want to understand what it's actually about:
 
 ## Canonical specs by topic
 
+> Specs are written in Spanish (language of operator thinking) — see "Convention notes" below. The dates in filenames are the pre-registration commit dates.
+
 ### Project framing + methodology
 - [`specs/es/2026-04-30-a1-holdout-dataset-provenance.md`](superpowers/specs/es/2026-04-30-a1-holdout-dataset-provenance.md) — holdout dataset provenance
 - [`specs/es/2026-05-01-operational-model-manual-gating.md`](superpowers/specs/es/2026-05-01-operational-model-manual-gating.md) — why this isn't auto-trading

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,65 @@
+# Documentation Index
+
+> Navigation surface over the research artifacts in this repo. Start here.
+
+## Start here
+
+If you're new to the project and want to understand what it's actually about:
+1. Read [`/METHODOLOGY.md`](../METHODOLOGY.md) — the moat, in 10 sections
+2. Read [`/CLAUDE.md`](../CLAUDE.md) — current-state truth (architecture, configs, known limitations)
+3. Skim the canonical specs below by topic
+
+## Canonical specs by topic
+
+### Project framing + methodology
+- [`specs/es/2026-04-30-a1-holdout-dataset-provenance.md`](superpowers/specs/es/2026-04-30-a1-holdout-dataset-provenance.md) — holdout dataset provenance
+- [`specs/es/2026-05-01-operational-model-manual-gating.md`](superpowers/specs/es/2026-05-01-operational-model-manual-gating.md) — why this isn't auto-trading
+- [`specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md`](superpowers/specs/es/2026-05-03-asunciones-tecnicas-pre-holdout.md) — assumptions audit
+- [`specs/es/2026-05-11-strategy-structural-audit.md`](superpowers/specs/es/2026-05-11-strategy-structural-audit.md) — strategy components audit
+
+### Inflection points (where prior numbers were re-baselined)
+- [`specs/es/2026-05-11-a4-hallazgo-inflexion-metodologica.md`](superpowers/specs/es/2026-05-11-a4-hallazgo-inflexion-metodologica.md) — the inflection itself
+- [`research/2026-05-02-structural-fix-parameter-study.md`](superpowers/research/2026-05-02-structural-fix-parameter-study.md) — K-cap parameter study
+- [`specs/es/2026-04-18-documento-completo-sistema-trading.md`](superpowers/specs/es/2026-04-18-documento-completo-sistema-trading.md) — full system doc (⚠️ numbers are pre-#223, see METHODOLOGY § Structural fixes)
+
+### Strategy research
+- [`specs/es/2026-04-15-analisis-estrategia-spot-v6.md`](superpowers/specs/es/2026-04-15-analisis-estrategia-spot-v6.md) — initial V6 analysis
+- [`specs/es/2026-04-16-detector-regimen-multi-signal.md`](superpowers/specs/es/2026-04-16-detector-regimen-multi-signal.md) — regime detector design
+- [`specs/es/2026-04-17-formula-ganadora-resultados-finales.md`](superpowers/specs/es/2026-04-17-formula-ganadora-resultados-finales.md) — winning formula (⚠️ pre-#223)
+- [`specs/es/2026-04-18-vol-normalized-resultados.md`](superpowers/specs/es/2026-04-18-vol-normalized-resultados.md) — vol normalization
+- [`specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md`](superpowers/specs/es/2026-05-13-epic-regime-allocation-strategy-pivot.md) — closed 2026-05-15 with PHASE_3_INSUFFICIENT_DATA verdict
+
+### Kill-switch + risk
+- [`specs/es/2026-04-21-kill-switch-design.md`](superpowers/specs/es/2026-04-21-kill-switch-design.md) — kill-switch v1
+- [`specs/es/2026-04-23-kill-switch-v2-design.md`](superpowers/specs/es/2026-04-23-kill-switch-v2-design.md) — kill-switch v2
+
+### Production + multi-tenant
+- [`specs/es/2026-04-29-trading-sdar-dev-deploy-design.md`](superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md) — deploy design
+- [`specs/es/2026-05-16-multi-tenant-threat-model.md`](superpowers/specs/es/2026-05-16-multi-tenant-threat-model.md) — multi-tenant threat model
+- [`specs/es/2026-05-21-telegram-per-user-config-pre-reg.md`](superpowers/specs/es/2026-05-21-telegram-per-user-config-pre-reg.md) — per-user Telegram
+
+### LLM copilot
+- [`specs/es/2026-05-19-trading-copilot-production-grade-pre-reg.md`](superpowers/specs/es/2026-05-19-trading-copilot-production-grade-pre-reg.md) — copilot prod-grade
+- [`specs/es/2026-05-20-multi-provider-copilot-pre-reg.md`](superpowers/specs/es/2026-05-20-multi-provider-copilot-pre-reg.md) — multi-provider (DeepSeek)
+
+## Active implementation plans
+
+Plans for current work are in `superpowers/plans/`. Recent (2026-05-*):
+- `2026-05-21-telegram-per-user-config.md` (shipped #421)
+- `2026-05-21-telegram-multitenant-phase-a.md` (shipped epic #253)
+- `2026-05-22-readme-methodology-public-translation.md` (this plan)
+
+Archived plans: `superpowers/plans/archive/`
+
+## Other documentation
+
+- [`CHANGELOG-2026-04-17-18.md`](CHANGELOG-2026-04-17-18.md) — historical changelog snippet (April inflection week)
+- [`atomic-deploy-migration.md`](atomic-deploy-migration.md) — deploy migration notes
+- [`strategy-backtest-report.md`](strategy-backtest-report.md) — historical backtest report (⚠️ check dates against #223)
+- `rollouts/` — operational rollout playbooks
+
+## Convention notes
+
+**Why are most specs in Spanish (`specs/es/`)?** The operator works primarily in Spanish; pre-regs are written in the language of thinking. Public-facing docs (`README.md`, `METHODOLOGY.md`, this file) are in English so the moat is legible to a broader audience. The double-surface is intentional: research depth in the native language, public framing in English.
+
+**Pre-#223 caveat marker**: docs that contain backtest numbers from before the PR #223 sign-error fix are marked ⚠️ above. Read them for methodology and reasoning; do not cite their numbers.


### PR DESCRIPTION
## Summary
- Adds **`METHODOLOGY.md`** (new, repo root) — 10-section moat doc covering pre-registration, holdout guards, backtest-reading checklist, structural-fix ledger (bug vs modeling), cost model v2, operational model, current research direction
- Adds **`docs/README.md`** (new) — navigation index over the 37 specs + 35 plans + research notes already in `docs/superpowers/`
- Rewrites **`README.md`** — drops `Ultimate Macro V6.0` branding, unifies to English, updates Architecture / Signal Logic / Project Structure to reflect current code (per-user Telegram dispatcher, K-cap, BANKRUPT halt, regime detector, multi-tenant), adds a "Research methodology" closing section

## Motivation
External-evaluator audit identified the project's hidden moat (research discipline) as invisible from the repo surface. README was outdated (showed pre-#223 score-tier model, single-tenant Telegram via OpenClaw, Windows-only watchdog as if it ran prod) and mixed English+Spanish. This PR translates the discipline that lives in `CLAUDE.md` + `docs/superpowers/specs/es/` into public-facing artifacts.

## Honest framing of state
- LRC strategy class: `EDGE_WEAK` post-#223 re-baselining
- Regime-allocation strategy class (#338): closed 2026-05-15 with `PHASE_3_INSUFFICIENT_DATA`
- R3 trend-pullback: closed earlier with FAIL verdict
- Current active work: operator-tooling (multi-tenant #253, copilot history #428, onboarding wizard #427), not strategy research
- Only confirmed edge: Q2 operator-discretion exit timing (Direction A)

The methodology moat doc surfaces all of this; the README status block doesn't oversell.

## Out of scope (deferred to separate tickets)
- `strategy/` vs `strategies/` consolidation (audit #2) — disclosed in tree with ⚠️ legacy marker
- Linux production systemd unit files (audit #7) — disclosed in tree + production note in Troubleshooting
- `mempalace.yaml` relocation (audit #9 — verified benign during audit)
- Retroactive tagging of gate-closure commits (audit #8)

## Operator action required (cannot be done from Claude's session)
GitHub repo metadata (description, homepage, topics) needs admin permission on `sssimon/trading-spacial`. Samuel has `write`, not `admin`. Papá Simón (or grant Samuel admin first) must run:

\`\`\`bash
gh repo edit sssimon/trading-spacial \\
  --description "Research-grade laboratory for evaluating systematic crypto-trading strategies. Locked holdout, pre-registered hypotheses, explicit structural-fix ledger. Working signal scanner + dashboard on top." \\
  --homepage "https://trading.sdar.dev" \\
  --add-topic algorithmic-trading --add-topic quantitative-finance --add-topic backtesting \\
  --add-topic cryptocurrency --add-topic research-methodology --add-topic pre-registration \\
  --add-topic holdout-validation --add-topic fastapi --add-topic react
\`\`\`

## Test plan
- [x] All 27 internal \`.md\` links resolve (verified during final review pass)
- [x] No remaining \`(TBD)\` placeholders, \`Ultimate Macro\`, \`V6.0\`, \`OpenClaw\`, or \`Windows Task Scheduler\` strings
- [x] METHODOLOGY.md sections cross-reference real specs (spot-checked against \`gh issue/pr view\`)
- [x] README+METHODOLOGY+docs/README internally consistent re: regime-allocation closure verdict, multi-tenant production status, current active work classification
- [x] Outsider-perspective cold-read pass: moat lands by end of first README paragraph
- [ ] After merge: papá Simón runs the \`gh repo edit\` command above (or grants Samuel admin)
- [ ] After merge: optional outsider read by papá or María to confirm the README isn't intimidating

## Commit history
14 focused commits — METHODOLOGY built section-by-section (skeleton → 4 content commits + 2 corrective commits from review feedback), then docs/README.md, then README rewrite in 4 commits (header, architecture, structure, troubleshooting), closed by polish pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)