### PR TITLE
fix(prefs/frontend): disable browser autofill on ConnectionsPanel inputs (#425)

### DIFF
--- a/frontend/src/components/ConnectionsPanel.test.tsx
+++ b/frontend/src/components/ConnectionsPanel.test.tsx
@@ -156,6 +156,19 @@ describe('ConnectionsPanel', () => {
     });
   });
 
+  it('disables browser autofill on credential inputs (#425)', async () => {
+    vi.spyOn(api, 'getPreferences').mockResolvedValue({
+      tenant_id: 1, symbol_filter: null, min_score: 4, notify_channels: null,
+    });
+
+    render(<ConnectionsPanel open={true} onClose={() => {}} />);
+    const tokenInput = await screen.findByLabelText(/bot token/i);
+    const chatInput  = screen.getByLabelText(/chat id/i);
+
+    expect(tokenInput).toHaveAttribute('autocomplete', 'new-password');
+    expect(chatInput).toHaveAttribute('autocomplete', 'off');
+  });
+
   it('"Eliminar credenciales" sends notify_channels: null', async () => {
     vi.spyOn(api, 'getPreferences').mockResolvedValue({
       tenant_id: 1, symbol_filter: null, min_score: 4,

--- a/frontend/src/components/ConnectionsPanel.tsx
+++ b/frontend/src/components/ConnectionsPanel.tsx
@@ -106,6 +106,7 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
                 id="bot-token"
                 className={styles.input}
                 type="password"
+                autoComplete="new-password"
                 value={botToken}
                 onChange={(e) => { setBotToken(e.target.value); setTokenIsMasked(false); setDirty(true); }}
                 placeholder="123456789:ABCdef..."
@@ -123,6 +124,7 @@ const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({ open, onClose }) =>
                 id="chat-id"
                 className={styles.input}
                 type="text"
+                autoComplete="off"
                 value={chatId}
                 onChange={(e) => { setChatId(e.target.value); setDirty(true); }}
                 placeholder="123456789"


### PR DESCRIPTION
Closes #425.

## Summary
- `bot-token` input gets `autoComplete="new-password"` — Chromium ignores `off` on `type=password`; `new-password` is the documented escape hatch that suppresses password-manager offers without claiming the field is for *creating* credentials in a save-prompt sense.
- `chat-id` input gets `autoComplete="off"` — honored on text inputs.
- New vitest assertion verifies both attributes.

Pure UX papercut. The form is JWT-gated; no auth/security impact.

## Test plan
- [x] `npx vitest run src/components/ConnectionsPanel.test.tsx` — 9/9 (8 existing + 1 new).
- [x] Full frontend suite — 109 passed / 7 skipped / 0 failed, no regressions.
- [ ] After merge: open UserMenu → Conexiones in browser with a password manager active; confirm no suggestion popup on focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)