### PR TITLE
feat(agent): H.2 conversation history write path (#428)

### DIFF
--- a/api/agent/audit.py
+++ b/api/agent/audit.py
@@ -6,18 +6,37 @@ write is best-effort and fail-tolerant: a DB hiccup must NOT kill the
 streaming response that's already on the wire to the user.
 
 Pre-reg §9. Shape of the row mirrors the schema in db/schema.py.
+
+Epic #428 H.2 extends this module: in addition to the audit row, every
+terminal event also persists the raw user/assistant content into
+`agent_messages` + upserts `agent_conversation_meta`. That tier feeds
+the per-tenant history sidebar (H.3..H.5). Pre-reg
+docs/superpowers/specs/es/2026-05-22-conversation-history-pre-reg.md.
 """
 from __future__ import annotations
 
 import json
 import logging
 import time
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
 
 from db.connection import get_db
 
 log = logging.getLogger("api.agent.audit")
+
+
+# ── Epic #428 history constants ────────────────────────────────────────
+#
+# RETENTION_DAYS controls how long a turn's content remains visible in
+# the sidebar / re-hydration endpoint. The audit table (agent_conversations)
+# has its OWN lifecycle and is NOT subject to this — operator-facing
+# /agent/metrics needs the full audit history regardless.
+#
+# TITLE_MAX_CHARS — pre-reg D.3 sets the first 80 chars of the first
+# user message as the sidebar title (no LLM-summary in v1).
+RETENTION_DAYS = 90
+TITLE_MAX_CHARS = 80
 
 
 def record_turn(
@@ -90,6 +109,143 @@ def record_turn(
         )
 
 
+def _retention_expiry_iso(now: Optional[datetime] = None) -> str:
+    """ISO timestamp RETENTION_DAYS in the future (computed-on-write).
+
+    Pre-reg D.2: cleanup-on-read filters `expires_at <= NOW` so a row
+    written today expires on day 91. Computing at write time keeps the
+    WHERE clause cheap (no per-row arithmetic).
+    """
+    base = now or datetime.now(timezone.utc)
+    return (base + timedelta(days=RETENTION_DAYS)).isoformat()
+
+
+def _derive_title(user_message: Optional[str]) -> Optional[str]:
+    """First TITLE_MAX_CHARS of the user message, ellipsis-suffixed if
+    truncated. Returns None if the message is empty/None — meta row goes
+    in with NULL title and the sidebar shows a fallback placeholder."""
+    if not user_message:
+        return None
+    s = user_message.strip()
+    if not s:
+        return None
+    if len(s) <= TITLE_MAX_CHARS:
+        return s
+    return s[: TITLE_MAX_CHARS - 1] + "…"
+
+
+def _terminalize_chips(chips: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Coerce any 'pending' chip to 'error' before persisting.
+
+    Without this, a turn that ended via ErrorEvent or client-cancel would
+    persist a chip with status='pending' that the rehydrated UI would
+    render as a perpetual spinner. The tool didn't return a result, so
+    treat it as error for display purposes — the audit table has the
+    actual closed-enum reason if an operator needs to investigate.
+    """
+    out: list[dict[str, Any]] = []
+    for c in chips:
+        if c.get("status") == "pending":
+            c = {**c, "status": "error"}
+        out.append(c)
+    return out
+
+
+def record_history(
+    *,
+    tenant_id: int,
+    surface: str,
+    conversation_id: str,
+    user_message: Optional[str],
+    assistant_text: str,
+    assistant_reasoning: Optional[str],
+    tool_chips: list[dict[str, Any]],
+    proposals: list[dict[str, Any]],
+) -> None:
+    """Persist one turn's content to agent_messages + upsert the meta row.
+
+    Writes:
+      - 1 row in `agent_messages` with role='user' if user_message is set.
+      - 1 row in `agent_messages` with role='assistant' (always — even if
+        the turn errored, the assistant content is the friendly error
+        text so the rehydrated transcript stays coherent).
+      - 1 UPSERT into `agent_conversation_meta` keyed by conversation_id:
+        INSERT on first turn (carrying the title derived from the user
+        message); UPDATE on subsequent turns (refresh last_ts +
+        message_count, preserve title).
+
+    Fail-tolerant: any DB error swallows + logs warning. The streaming
+    response is already on the wire when this is called; raising here
+    would surface as a 500 on a request whose body has already been
+    flushed. Mirror of the discipline in record_turn.
+
+    Note on signed_payload omission: the proposal envelopes stored here
+    deliberately drop the `signed_payload` field. The HMAC has a short
+    TTL (minutes); persisting the token across 90 days would be storing
+    an expired credential. H.3 reconstructs the proposal state by joining
+    against agent_side_effects on confirm.
+    """
+    try:
+        now_iso = datetime.now(timezone.utc).isoformat()
+        expires_at = _retention_expiry_iso()
+        chips_persisted = _terminalize_chips(tool_chips)
+        proposals_persisted = [
+            {k: v for k, v in p.items() if k != "signed_payload"}
+            for p in proposals
+        ]
+        rows_inserted = 0
+
+        con = get_db()
+        try:
+            if user_message:
+                con.execute(
+                    """INSERT INTO agent_messages
+                       (tenant_id, conversation_id, ts, role, content,
+                        reasoning, tool_chips_json, proposals_json, expires_at)
+                       VALUES (?, ?, ?, 'user', ?, NULL, NULL, NULL, ?)""",
+                    (tenant_id, conversation_id, now_iso, user_message, expires_at),
+                )
+                rows_inserted += 1
+
+            con.execute(
+                """INSERT INTO agent_messages
+                   (tenant_id, conversation_id, ts, role, content,
+                    reasoning, tool_chips_json, proposals_json, expires_at)
+                   VALUES (?, ?, ?, 'assistant', ?, ?, ?, ?, ?)""",
+                (
+                    tenant_id, conversation_id, now_iso, assistant_text,
+                    assistant_reasoning,
+                    json.dumps(chips_persisted) if chips_persisted else None,
+                    json.dumps(proposals_persisted) if proposals_persisted else None,
+                    expires_at,
+                ),
+            )
+            rows_inserted += 1
+
+            con.execute(
+                """INSERT INTO agent_conversation_meta
+                   (conversation_id, tenant_id, title, surface,
+                    first_ts, last_ts, message_count, pinned, expires_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)
+                   ON CONFLICT(conversation_id) DO UPDATE SET
+                       last_ts = excluded.last_ts,
+                       message_count = message_count + excluded.message_count,
+                       expires_at = excluded.expires_at""",
+                (
+                    conversation_id, tenant_id, _derive_title(user_message),
+                    surface, now_iso, now_iso, rows_inserted, expires_at,
+                ),
+            )
+            con.commit()
+        finally:
+            con.close()
+    except Exception:  # noqa: BLE001
+        log.warning(
+            "record_history failed for tenant=%s conv=%s — history rows dropped",
+            tenant_id, conversation_id, exc_info=True,
+        )
+
+
 class TurnAuditWrapper:
     """Wrap a loop-events async iterator to persist a row on
     MessageEnd / ErrorEvent. Yields events unchanged.
@@ -112,6 +268,7 @@ class TurnAuditWrapper:
         surface: str,
         conversation_id: str,
         model: str,
+        user_message_text: Optional[str] = None,
     ):
         self._events = events
         self._tenant_id = tenant_id
@@ -131,6 +288,18 @@ class TurnAuditWrapper:
         # in the audit table — bad for operator debugging.
         self._terminal_recorded = False
 
+        # Epic #428 H.2: accumulate per-turn content so a single
+        # record_history() call at the terminal event can persist the
+        # full assistant message + reasoning + tool chips + proposals.
+        # The user message arrives via constructor (router pulls it
+        # from body.messages[-1]); the assistant side is built up from
+        # the streamed events. Pre-reg §write path.
+        self._user_message_text = user_message_text
+        self._assistant_text: str = ""
+        self._assistant_reasoning: Optional[str] = None
+        self._tool_chips: list[dict[str, Any]] = []
+        self._proposals: list[dict[str, Any]] = []
+
     def __aiter__(self):
         return self
 
@@ -138,7 +307,15 @@ class TurnAuditWrapper:
         # Import here to avoid circular import: loop.py imports prompts,
         # prompts depend on registry; this module is imported from
         # router.py which sees them all.
-        from api.agent.loop import ErrorEvent, MessageEnd
+        from api.agent.loop import (
+            ErrorEvent,
+            MessageEnd,
+            ProposalEvent,
+            ReasoningDelta,
+            TextDelta,
+            ToolUseResult,
+            ToolUseStart,
+        )
 
         try:
             ev = await self._events.__anext__()
@@ -151,6 +328,37 @@ class TurnAuditWrapper:
             if not self._terminal_recorded:
                 self._record_cancelled()
             raise
+
+        # Epic #428 H.2: accumulate streamed content into per-turn state
+        # so the terminal event can persist everything atomically. These
+        # branches mirror useAgentStream.applyEvent on the frontend so
+        # the rehydrated DOM is byte-equivalent to what the user saw
+        # live (modulo terminalized chip states).
+        if isinstance(ev, TextDelta):
+            self._assistant_text += ev.text
+        elif isinstance(ev, ReasoningDelta):
+            self._assistant_reasoning = (self._assistant_reasoning or "") + ev.text
+        elif isinstance(ev, ToolUseStart):
+            self._tool_chips.append({"tool": ev.tool, "status": "pending"})
+        elif isinstance(ev, ToolUseResult):
+            # Match the first pending chip with the same tool name and
+            # close it out — mirror of the frontend logic in
+            # useAgentStream.ts case 'tool_use_result'.
+            for chip in self._tool_chips:
+                if chip["tool"] == ev.tool and chip["status"] == "pending":
+                    chip["status"] = ev.status
+                    break
+        elif isinstance(ev, ProposalEvent):
+            self._proposals.append({
+                "proposal_id": ev.proposal_id,
+                "action":      ev.action,
+                "args":        ev.args,
+                "expires_at":  ev.expires_at,
+                "summary":     ev.summary,
+                # signed_payload deliberately omitted from history persist
+                # (TTL minutes; useless on rehydrate). See record_history
+                # docstring.
+            })
 
         if isinstance(ev, MessageEnd):
             latency_ms = int((time.monotonic() - self._t_start) * 1000)
@@ -173,6 +381,10 @@ class TurnAuditWrapper:
                 cost_usd=ev.cost_usd,
                 refused=False,
             )
+            # Epic #428 H.2: persist the user-visible history alongside
+            # the audit row. Same fail-quiet discipline; the streaming
+            # response is already on the wire.
+            self._record_history(self._assistant_text)
             # Charge the tenant's daily/monthly quota AFTER the turn
             # completed successfully — best-effort, swallows exceptions
             # (see api/agent/quotas.py:record_spend docstring).
@@ -195,6 +407,11 @@ class TurnAuditWrapper:
                 content_summary=ev.reason,
                 refused=(ev.reason == "too_many_tool_hops"),
             )
+            # Epic #428 H.2: persist the user-visible history even on
+            # error. The assistant content is the friendly error message
+            # so the rehydrated transcript shows what the user saw on
+            # their screen (not the raw closed-enum reason).
+            self._record_history(ev.user_message)
             self._terminal_recorded = True
         return ev
 
@@ -216,12 +433,33 @@ class TurnAuditWrapper:
                 content_summary="cancelled",
                 refused=False,
             )
+            # Epic #428 H.2: persist whatever assistant content
+            # accumulated before cancel + the user message. The
+            # rehydrated transcript shows the partial answer the user
+            # saw before disconnecting.
+            self._record_history(self._assistant_text)
             self._terminal_recorded = True
         except Exception:  # noqa: BLE001
             log.warning(
                 "TurnAuditWrapper._record_cancelled failed for tenant=%s conv=%s",
                 self._tenant_id, self._conversation_id, exc_info=True,
             )
+
+    def _record_history(self, assistant_text_final: str) -> None:
+        """Delegate to the module-level record_history with the wrapper's
+        accumulated state. Centralizes the call so MessageEnd / ErrorEvent
+        / cancelled all share the same fail-quiet semantics + payload
+        shape."""
+        record_history(
+            tenant_id=self._tenant_id,
+            surface=self._surface,
+            conversation_id=self._conversation_id,
+            user_message=self._user_message_text,
+            assistant_text=assistant_text_final,
+            assistant_reasoning=self._assistant_reasoning,
+            tool_chips=self._tool_chips,
+            proposals=self._proposals,
+        )
 
     @staticmethod
     def _resolve_provider_static(model: str) -> Optional[str]:

--- a/api/agent/audit.py
+++ b/api/agent/audit.py
@@ -197,6 +197,39 @@ def record_history(
 
         con = get_db()
         try:
+            # Cross-tenant guard (PR #433 review fix). The H.1 schema
+            # makes conversation_id the sole PK on agent_conversation_meta,
+            # so two tenants writing the same conversation_id collide.
+            # Without this check, an attacker who learned a victim's
+            # UUID could mutate the victim's meta row via the UPSERT
+            # (bumping last_ts / message_count / expires_at) and
+            # leave orphan agent_messages rows tagged with their own
+            # tenant_id. UUID guessability is low, but UUIDs leak
+            # through logs / screenshots / sharing — defense in depth.
+            #
+            # Two layers:
+            #   1. This SELECT short-circuits the common case (sequential
+            #      writes). Abort fail-quiet — same discipline as the
+            #      outer try/except — and log so an operator can spot
+            #      attempts in webhook.log.
+            #   2. The DO UPDATE below carries an additional WHERE clause
+            #      that makes it a silent no-op if the meta row ends up
+            #      owned by a different tenant (covers the race where
+            #      the SELECT saw nothing because the victim's INSERT
+            #      hadn't committed yet under WAL).
+            existing = con.execute(
+                "SELECT tenant_id FROM agent_conversation_meta "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if existing is not None and existing[0] != tenant_id:
+                log.warning(
+                    "record_history: refusing cross-tenant write — "
+                    "conversation_id=%s owned by tenant=%s, attempted by "
+                    "tenant=%s", conversation_id, existing[0], tenant_id,
+                )
+                return
+
             if user_message:
                 con.execute(
                     """INSERT INTO agent_messages
@@ -230,7 +263,8 @@ def record_history(
                    ON CONFLICT(conversation_id) DO UPDATE SET
                        last_ts = excluded.last_ts,
                        message_count = message_count + excluded.message_count,
-                       expires_at = excluded.expires_at""",
+                       expires_at = excluded.expires_at
+                   WHERE agent_conversation_meta.tenant_id = excluded.tenant_id""",
                 (
                     conversation_id, tenant_id, _derive_title(user_message),
                     surface, now_iso, now_iso, rows_inserted, expires_at,

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -195,6 +195,16 @@ async def post_agent_turn(
         {"role": m.role, "content": m.content} for m in body.messages
     ]
 
+    # Epic #428 H.2: extract the latest user message for history persist.
+    # Frontend always sends `messages[-1]` as the new user turn, but we
+    # scan from the end defensively — a malformed transcript without a
+    # trailing user message produces None and the wrapper skips the
+    # user-side row insert (assistant row + meta upsert still go).
+    user_message_text: Optional[str] = next(
+        (m.content for m in reversed(body.messages) if m.role == "user"),
+        None,
+    )
+
     loop_events = run_turn(
         client=client,
         model=model,
@@ -209,6 +219,7 @@ async def post_agent_turn(
         surface=body.surface,
         conversation_id=conversation_id,
         model=model,
+        user_message_text=user_message_text,
     )
     sse_bytes = sse_serialize(audited)
 

--- a/tests/test_agent_history_writes.py
+++ b/tests/test_agent_history_writes.py
@@ -1,0 +1,663 @@
+"""Tests for the H.2 history write path (#428).
+
+Two layers:
+  - record_history() called directly with synthetic payloads → verifies
+    schema-side behavior (UPSERT semantics, title derivation, terminalize
+    pending chips, signed_payload omission, expires_at horizon).
+  - TurnAuditWrapper driven over an async iterator of LoopEvents →
+    verifies the integration: streamed text/reasoning/chips/proposals
+    accumulate correctly and the terminal event triggers exactly one
+    record_history call per turn with the right shape.
+
+Pre-reg: docs/superpowers/specs/es/2026-05-22-conversation-history-pre-reg.md
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh DB with the H.1 schema applied via init_db()."""
+    import btc_api
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def _fetch_messages(db_path: str, conversation_id: str) -> list[dict]:
+    """Return ordered message rows for a conversation as dicts."""
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "SELECT tenant_id, conversation_id, ts, role, content, reasoning, "
+        "tool_chips_json, proposals_json, expires_at FROM agent_messages "
+        "WHERE conversation_id = ? ORDER BY id ASC",
+        (conversation_id,),
+    ).fetchall()
+    con.close()
+    return [dict(r) for r in rows]
+
+
+def _fetch_meta(db_path: str, conversation_id: str) -> dict | None:
+    con = sqlite3.connect(db_path)
+    con.row_factory = sqlite3.Row
+    row = con.execute(
+        "SELECT * FROM agent_conversation_meta WHERE conversation_id = ?",
+        (conversation_id,),
+    ).fetchone()
+    con.close()
+    return dict(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# record_history — direct calls
+# ---------------------------------------------------------------------------
+
+
+class TestRecordHistoryFirstTurn:
+    def test_inserts_user_and_assistant_rows(self, tmp_db):
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-A",
+            user_message="que opinas de PENDLE?",
+            assistant_text="PENDLE está en zona LRC baja...",
+            assistant_reasoning=None,
+            tool_chips=[], proposals=[],
+        )
+        rows = _fetch_messages(tmp_db, "conv-A")
+        assert len(rows) == 2
+        assert rows[0]["role"] == "user"
+        assert rows[0]["content"] == "que opinas de PENDLE?"
+        assert rows[1]["role"] == "assistant"
+        assert rows[1]["content"] == "PENDLE está en zona LRC baja..."
+        # Same conversation_id, same tenant_id on both rows
+        assert all(r["tenant_id"] == 1 for r in rows)
+
+    def test_inserts_meta_row_with_title(self, tmp_db):
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-A",
+            user_message="que opinas de PENDLE?",
+            assistant_text="PENDLE...",
+            assistant_reasoning=None,
+            tool_chips=[], proposals=[],
+        )
+        meta = _fetch_meta(tmp_db, "conv-A")
+        assert meta is not None
+        assert meta["title"] == "que opinas de PENDLE?"
+        assert meta["surface"] == "dock"
+        assert meta["message_count"] == 2  # user + assistant
+        assert meta["pinned"] == 0
+        assert meta["first_ts"] == meta["last_ts"]  # same turn
+
+    def test_skips_user_row_when_user_message_is_none(self, tmp_db):
+        """A malformed transcript without a trailing user message produces
+        None — only the assistant row is written; message_count = 1."""
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-B",
+            user_message=None,
+            assistant_text="response without preceding user msg",
+            assistant_reasoning=None,
+            tool_chips=[], proposals=[],
+        )
+        rows = _fetch_messages(tmp_db, "conv-B")
+        assert len(rows) == 1
+        assert rows[0]["role"] == "assistant"
+        meta = _fetch_meta(tmp_db, "conv-B")
+        assert meta["message_count"] == 1
+        assert meta["title"] is None  # no user message → no title yet
+
+
+class TestRecordHistorySecondTurn:
+    def test_upsert_preserves_title_and_first_ts(self, tmp_db):
+        """A second call with the same conversation_id keeps the original
+        title + first_ts, updates last_ts, and increments message_count."""
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-C",
+            user_message="primer mensaje",
+            assistant_text="primera respuesta",
+            assistant_reasoning=None,
+            tool_chips=[], proposals=[],
+        )
+        first_meta = _fetch_meta(tmp_db, "conv-C")
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-C",
+            user_message="segundo mensaje",
+            assistant_text="segunda respuesta",
+            assistant_reasoning=None,
+            tool_chips=[], proposals=[],
+        )
+        second_meta = _fetch_meta(tmp_db, "conv-C")
+
+        assert second_meta["title"] == first_meta["title"]  # title preserved
+        assert second_meta["title"] == "primer mensaje"
+        assert second_meta["first_ts"] == first_meta["first_ts"]
+        assert second_meta["last_ts"] >= first_meta["last_ts"]
+        assert second_meta["message_count"] == 4  # 2 user + 2 assistant
+
+    def test_upsert_handles_user_skip_on_second_turn(self, tmp_db):
+        """If the second turn has no user_message (defensive None), the
+        upsert increments by 1, not 2."""
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-D",
+            user_message="primer mensaje",
+            assistant_text="primera respuesta",
+            assistant_reasoning=None,
+            tool_chips=[], proposals=[],
+        )
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-D",
+            user_message=None,  # malformed second turn
+            assistant_text="segunda respuesta",
+            assistant_reasoning=None,
+            tool_chips=[], proposals=[],
+        )
+        meta = _fetch_meta(tmp_db, "conv-D")
+        assert meta["message_count"] == 3  # 2 from first + 1 from second
+
+
+class TestTitleDerivation:
+    def test_short_message_used_verbatim(self):
+        from api.agent.audit import _derive_title
+        assert _derive_title("hola") == "hola"
+
+    def test_message_exactly_at_limit_not_truncated(self):
+        from api.agent.audit import TITLE_MAX_CHARS, _derive_title
+        msg = "x" * TITLE_MAX_CHARS
+        assert _derive_title(msg) == msg
+
+    def test_long_message_truncated_with_ellipsis(self):
+        from api.agent.audit import TITLE_MAX_CHARS, _derive_title
+        msg = "x" * (TITLE_MAX_CHARS + 50)
+        title = _derive_title(msg)
+        assert len(title) == TITLE_MAX_CHARS
+        assert title.endswith("…")
+        assert title.startswith("x")
+
+    def test_whitespace_stripped(self):
+        from api.agent.audit import _derive_title
+        assert _derive_title("  hola  ") == "hola"
+
+    def test_empty_or_none_returns_none(self):
+        from api.agent.audit import _derive_title
+        assert _derive_title("") is None
+        assert _derive_title(None) is None
+        assert _derive_title("   ") is None
+
+
+class TestTerminalizeChips:
+    def test_pending_chip_becomes_error(self):
+        from api.agent.audit import _terminalize_chips
+        chips = [{"tool": "get_symbol_state", "status": "pending"}]
+        out = _terminalize_chips(chips)
+        assert out[0]["status"] == "error"
+
+    def test_ok_and_error_unchanged(self):
+        from api.agent.audit import _terminalize_chips
+        chips = [
+            {"tool": "a", "status": "ok"},
+            {"tool": "b", "status": "error"},
+        ]
+        out = _terminalize_chips(chips)
+        assert out == chips
+
+    def test_does_not_mutate_input(self):
+        from api.agent.audit import _terminalize_chips
+        chips = [{"tool": "x", "status": "pending"}]
+        _terminalize_chips(chips)
+        # Caller's list is untouched (defensive copy)
+        assert chips[0]["status"] == "pending"
+
+
+class TestChipsAndProposalsPersisted:
+    def test_chips_terminalized_on_persist(self, tmp_db):
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-E",
+            user_message="usa get_positions",
+            assistant_text="aca van",
+            assistant_reasoning=None,
+            tool_chips=[
+                {"tool": "get_positions", "status": "ok"},
+                {"tool": "get_symbol_state", "status": "pending"},  # never completed
+            ],
+            proposals=[],
+        )
+        rows = _fetch_messages(tmp_db, "conv-E")
+        assistant_row = next(r for r in rows if r["role"] == "assistant")
+        chips = json.loads(assistant_row["tool_chips_json"])
+        statuses = {c["tool"]: c["status"] for c in chips}
+        assert statuses == {"get_positions": "ok", "get_symbol_state": "error"}
+
+    def test_proposals_strip_signed_payload(self, tmp_db):
+        """signed_payload is short-TTL HMAC — useless on rehydration 90d
+        later. record_history MUST drop it before persist."""
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-F",
+            user_message="cerra BTC",
+            assistant_text="propongo cerrar",
+            assistant_reasoning=None,
+            tool_chips=[],
+            proposals=[{
+                "proposal_id":    "prop_abc",
+                "signed_payload": "this_should_NOT_be_persisted",
+                "action":         "close_position",
+                "args":           {"position_id": 42},
+                "expires_at":     "2026-05-22T08:30:00Z",
+                "summary":        "Cerrar BTCUSDT #42",
+            }],
+        )
+        rows = _fetch_messages(tmp_db, "conv-F")
+        assistant_row = next(r for r in rows if r["role"] == "assistant")
+        proposals = json.loads(assistant_row["proposals_json"])
+        assert len(proposals) == 1
+        assert proposals[0]["proposal_id"] == "prop_abc"
+        assert "signed_payload" not in proposals[0]
+        assert proposals[0]["action"] == "close_position"
+
+    def test_reasoning_persisted_when_present(self, tmp_db):
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-G",
+            user_message="analiza",
+            assistant_text="respuesta",
+            assistant_reasoning="<think>chain of thought</think>",
+            tool_chips=[], proposals=[],
+        )
+        rows = _fetch_messages(tmp_db, "conv-G")
+        assistant_row = next(r for r in rows if r["role"] == "assistant")
+        assert assistant_row["reasoning"] == "<think>chain of thought</think>"
+        # User row has NULL reasoning (only assistant turns reason)
+        user_row = next(r for r in rows if r["role"] == "user")
+        assert user_row["reasoning"] is None
+
+
+class TestExpiresAt:
+    def test_expires_at_is_90_days_from_now(self, tmp_db):
+        from api.agent.audit import RETENTION_DAYS, record_history
+
+        before = datetime.now(timezone.utc)
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-H",
+            user_message="hola",
+            assistant_text="ok",
+            assistant_reasoning=None,
+            tool_chips=[], proposals=[],
+        )
+        after = datetime.now(timezone.utc)
+
+        rows = _fetch_messages(tmp_db, "conv-H")
+        meta = _fetch_meta(tmp_db, "conv-H")
+        # All rows + meta share the same horizon (computed once per call)
+        expires_set = {r["expires_at"] for r in rows} | {meta["expires_at"]}
+        assert len(expires_set) == 1
+        expires_at = datetime.fromisoformat(expires_set.pop())
+        # Should be RETENTION_DAYS away (with some clock jitter)
+        delta = expires_at - before
+        assert delta >= timedelta(days=RETENTION_DAYS, seconds=-1)
+        assert (expires_at - after) <= timedelta(days=RETENTION_DAYS, seconds=1)
+
+    def test_second_turn_refreshes_meta_expires_at(self, tmp_db):
+        """Meta expires_at follows last_ts (per pre-reg note: active
+        conversations stay alive while the user keeps engaging)."""
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-I",
+            user_message="t1", assistant_text="a1",
+            assistant_reasoning=None, tool_chips=[], proposals=[],
+        )
+        first_expires = _fetch_meta(tmp_db, "conv-I")["expires_at"]
+
+        # Real call — but we control time only via wall clock; sleep a hair
+        # then ensure the second meta expires_at moved forward.
+        import time
+        time.sleep(0.01)
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-I",
+            user_message="t2", assistant_text="a2",
+            assistant_reasoning=None, tool_chips=[], proposals=[],
+        )
+        second_expires = _fetch_meta(tmp_db, "conv-I")["expires_at"]
+        assert second_expires > first_expires
+
+
+class TestFailQuiet:
+    def test_db_error_swallowed(self, tmp_db, monkeypatch, caplog):
+        """A DB hiccup must NOT raise — the streaming response is already
+        on the wire."""
+        from api.agent import audit
+
+        def _explode(*_a, **_kw):
+            raise sqlite3.OperationalError("disk full")
+
+        monkeypatch.setattr(audit, "get_db", _explode)
+
+        # Should not raise
+        audit.record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-J",
+            user_message="hola", assistant_text="ok",
+            assistant_reasoning=None, tool_chips=[], proposals=[],
+        )
+        # Warning was emitted
+        assert any(
+            "record_history failed" in r.message for r in caplog.records
+        )
+
+
+class TestTenantIsolation:
+    def test_two_tenants_dont_see_each_other(self, tmp_db):
+        """Both tenants write to the same conversation_id (worst-case
+        malicious): the rows segregate by tenant_id. Meta is a single
+        row (PK on conversation_id) but the test verifies the read
+        path's WHERE clause can isolate by tenant_id."""
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-T1",
+            user_message="tenant 1 message", assistant_text="reply",
+            assistant_reasoning=None, tool_chips=[], proposals=[],
+        )
+        record_history(
+            tenant_id=2, surface="dock", conversation_id="conv-T2",
+            user_message="tenant 2 message", assistant_text="reply",
+            assistant_reasoning=None, tool_chips=[], proposals=[],
+        )
+
+        con = sqlite3.connect(tmp_db)
+        t1_count = con.execute(
+            "SELECT COUNT(*) FROM agent_messages WHERE tenant_id = 1"
+        ).fetchone()[0]
+        t2_count = con.execute(
+            "SELECT COUNT(*) FROM agent_messages WHERE tenant_id = 2"
+        ).fetchone()[0]
+        con.close()
+        assert t1_count == 2
+        assert t2_count == 2
+
+
+# ---------------------------------------------------------------------------
+# TurnAuditWrapper — async integration over a synthetic event stream
+# ---------------------------------------------------------------------------
+
+
+async def _events_async_gen(events):
+    """Wrap a list as an async iterator for the wrapper."""
+    for e in events:
+        yield e
+
+
+async def _drain(wrapped):
+    out = []
+    async for ev in wrapped:
+        out.append(ev)
+    return out
+
+
+@pytest.mark.anyio
+async def test_wrapper_message_end_writes_history(tmp_db):
+    """Full happy path: TextDelta + MessageEnd → user row + assistant row
+    + meta row, plus the existing audit row."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import MessageEnd, TextDelta
+
+    events = [
+        TextDelta(text="Hola, "),
+        TextDelta(text="tu BTC está en zona LRC baja."),
+        MessageEnd(
+            usage={"input_tokens": 100, "output_tokens": 20,
+                   "cache_read_input_tokens": 0,
+                   "cache_creation_input_tokens": 0},
+            stop_reason="end_turn",
+            cost_usd=0.001,
+        ),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock",
+        conversation_id="conv-W1", model="claude-sonnet-4-6",
+        user_message_text="¿cómo va mi portafolio?",
+    )
+    out = await _drain(wrapped)
+    # Wrapper passes events through unchanged
+    assert len(out) == 3
+    rows = _fetch_messages(tmp_db, "conv-W1")
+    assert [r["role"] for r in rows] == ["user", "assistant"]
+    assert rows[1]["content"] == "Hola, tu BTC está en zona LRC baja."
+    meta = _fetch_meta(tmp_db, "conv-W1")
+    assert meta["title"] == "¿cómo va mi portafolio?"
+    assert meta["surface"] == "dock"
+    assert meta["message_count"] == 2
+
+
+@pytest.mark.anyio
+async def test_wrapper_reasoning_accumulates(tmp_db):
+    """ReasoningDelta chunks land in the `reasoning` column on the
+    assistant row, distinct from `content`."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import MessageEnd, ReasoningDelta, TextDelta
+
+    events = [
+        ReasoningDelta(text="<think>step1 "),
+        ReasoningDelta(text="step2</think>"),
+        TextDelta(text="respuesta final"),
+        MessageEnd(usage={}, stop_reason="end_turn", cost_usd=0.001),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W2",
+        model="deepseek-reasoner",
+        user_message_text="que opinas",
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W2")
+    assistant = next(r for r in rows if r["role"] == "assistant")
+    assert assistant["content"] == "respuesta final"
+    assert assistant["reasoning"] == "<think>step1 step2</think>"
+
+
+@pytest.mark.anyio
+async def test_wrapper_tool_chips_persisted_and_terminalized(tmp_db):
+    """Chips that close out as ok/error are persisted as-is; any chip
+    still pending at MessageEnd is terminalized to error to avoid stuck
+    spinners on rehydrate."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import (
+        MessageEnd, TextDelta, ToolUseResult, ToolUseStart,
+    )
+
+    events = [
+        ToolUseStart(tool="get_positions"),
+        ToolUseResult(tool="get_positions", status="ok"),
+        ToolUseStart(tool="get_symbol_state"),
+        # No ToolUseResult for get_symbol_state — simulates a result
+        # that never came back (or arrived after MessageEnd in a buggy
+        # provider). Should terminalize to error.
+        TextDelta(text="resumen"),
+        MessageEnd(usage={}, stop_reason="end_turn", cost_usd=0.0),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W3",
+        model="claude-sonnet-4-6",
+        user_message_text="usá tools",
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W3")
+    assistant = next(r for r in rows if r["role"] == "assistant")
+    chips = json.loads(assistant["tool_chips_json"])
+    statuses = {c["tool"]: c["status"] for c in chips}
+    assert statuses == {"get_positions": "ok", "get_symbol_state": "error"}
+
+
+@pytest.mark.anyio
+async def test_wrapper_proposals_persisted_without_signed_payload(tmp_db):
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import MessageEnd, ProposalEvent, TextDelta
+
+    events = [
+        TextDelta(text="propongo cerrar"),
+        ProposalEvent(
+            proposal_id="prop_xyz",
+            signed_payload="DO_NOT_PERSIST_THIS",
+            action="close_position",
+            args={"position_id": 7},
+            expires_at="2026-05-22T08:30:00Z",
+            summary="Cerrar #7",
+        ),
+        MessageEnd(usage={}, stop_reason="tool_use", cost_usd=0.0),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W4",
+        model="claude-sonnet-4-6",
+        user_message_text="cerra esa posición",
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W4")
+    assistant = next(r for r in rows if r["role"] == "assistant")
+    proposals = json.loads(assistant["proposals_json"])
+    assert len(proposals) == 1
+    assert proposals[0]["proposal_id"] == "prop_xyz"
+    assert "signed_payload" not in proposals[0]
+
+
+@pytest.mark.anyio
+async def test_wrapper_error_event_writes_history_with_friendly_text(tmp_db):
+    """On ErrorEvent the assistant row's content is the user-facing
+    friendly message (not the closed-enum reason)."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import ErrorEvent
+
+    events = [
+        ErrorEvent(
+            reason="too_many_tool_hops",
+            user_message="El copiloto se quedó pensando demasiado.",
+        ),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W5",
+        model="claude-sonnet-4-6",
+        user_message_text="hazlo todo",
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W5")
+    assert [r["role"] for r in rows] == ["user", "assistant"]
+    assert rows[1]["content"] == "El copiloto se quedó pensando demasiado."
+    # Audit row got the closed-enum reason (different from history)
+    con = sqlite3.connect(tmp_db)
+    audit_row = con.execute(
+        "SELECT role, content_json FROM agent_conversations "
+        "WHERE conversation_id = ?", ("conv-W5",),
+    ).fetchone()
+    con.close()
+    assert audit_row[0] == "error"
+    assert "too_many_tool_hops" in audit_row[1]
+
+
+@pytest.mark.anyio
+async def test_wrapper_cancellation_writes_partial_history(tmp_db):
+    """Iterator ends without MessageEnd / ErrorEvent → _record_cancelled
+    fires and persists whatever partial text accumulated. Mirrors a
+    client mid-stream disconnect."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import TextDelta
+
+    events = [
+        TextDelta(text="parcial..."),
+        # No terminal event — iterator just ends.
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W6",
+        model="claude-sonnet-4-6",
+        user_message_text="explica",
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W6")
+    assert len(rows) == 2
+    assistant = next(r for r in rows if r["role"] == "assistant")
+    assert assistant["content"] == "parcial..."
+
+
+@pytest.mark.anyio
+async def test_wrapper_no_user_message_still_persists_assistant(tmp_db):
+    """user_message_text=None is the defensive path — the wrapper still
+    writes the assistant row + meta; user row is skipped."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import MessageEnd, TextDelta
+
+    events = [
+        TextDelta(text="resp"),
+        MessageEnd(usage={}, stop_reason="end_turn", cost_usd=0.0),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W7",
+        model="claude-sonnet-4-6",
+        user_message_text=None,
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W7")
+    assert len(rows) == 1
+    assert rows[0]["role"] == "assistant"
+    meta = _fetch_meta(tmp_db, "conv-W7")
+    assert meta["message_count"] == 1
+    assert meta["title"] is None
+
+
+@pytest.mark.anyio
+async def test_wrapper_does_not_double_record_history_on_message_end(tmp_db):
+    """One terminal event → exactly one history persist. Verify by
+    counting rows after a single MessageEnd-terminated stream."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import MessageEnd, TextDelta
+
+    events = [
+        TextDelta(text="ok"),
+        MessageEnd(usage={}, stop_reason="end_turn", cost_usd=0.0),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W8",
+        model="claude-sonnet-4-6",
+        user_message_text="hola",
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W8")
+    assert len(rows) == 2  # user + assistant — no duplicates

--- a/tests/test_agent_history_writes.py
+++ b/tests/test_agent_history_writes.py
@@ -373,11 +373,15 @@ class TestFailQuiet:
 
 
 class TestTenantIsolation:
-    def test_two_tenants_dont_see_each_other(self, tmp_db):
-        """Both tenants write to the same conversation_id (worst-case
-        malicious): the rows segregate by tenant_id. Meta is a single
-        row (PK on conversation_id) but the test verifies the read
-        path's WHERE clause can isolate by tenant_id."""
+    """Cross-tenant write protection. agent_conversation_meta has the
+    conversation_id as sole PK, so a malicious tenant with a leaked UUID
+    could collide on INSERT. record_history MUST refuse the write rather
+    than mutate the victim's meta row or persist orphan agent_messages
+    rows. PR #433 review issue #1."""
+
+    def test_distinct_conversation_ids_segregate_by_tenant(self, tmp_db):
+        """Sanity baseline: two tenants writing different conversation_ids
+        each end up with their own meta row + messages."""
         from api.agent.audit import record_history
 
         record_history(
@@ -401,6 +405,82 @@ class TestTenantIsolation:
         con.close()
         assert t1_count == 2
         assert t2_count == 2
+
+    def test_cross_tenant_write_attempt_is_refused(self, tmp_db, caplog):
+        """Attacker scenario: tenant B writes to a conversation_id that
+        already belongs to tenant A.
+
+        Expected outcome:
+          - Victim's (A's) meta row is BYTE-IDENTICAL after the attack
+            (same last_ts, same message_count, same expires_at).
+          - Zero orphan agent_messages rows tagged with B's tenant_id
+            on A's conversation.
+          - Operator-facing warning logged so the attempt is visible
+            in webhook.log / cloudwatch.
+        """
+        import logging
+
+        from api.agent.audit import record_history
+
+        # Tenant 1 (victim) creates the conversation
+        record_history(
+            tenant_id=1, surface="dock", conversation_id="conv-shared",
+            user_message="mensaje de la victima",
+            assistant_text="respuesta original",
+            assistant_reasoning=None, tool_chips=[], proposals=[],
+        )
+        victim_meta_before = _fetch_meta(tmp_db, "conv-shared")
+        victim_msg_count_before = len(_fetch_messages(tmp_db, "conv-shared"))
+
+        # Tenant 2 (attacker) hits the same conversation_id
+        with caplog.at_level(logging.WARNING, logger="api.agent.audit"):
+            record_history(
+                tenant_id=2, surface="dock", conversation_id="conv-shared",
+                user_message="intento del atacante",
+                assistant_text="respuesta del atacante",
+                assistant_reasoning=None, tool_chips=[], proposals=[],
+            )
+
+        # 1) Victim's meta row untouched
+        victim_meta_after = _fetch_meta(tmp_db, "conv-shared")
+        assert victim_meta_after == victim_meta_before, (
+            "victim's meta row was mutated by cross-tenant write"
+        )
+
+        # 2) Zero orphan agent_messages rows under conv-shared with
+        #    attacker's tenant_id
+        con = sqlite3.connect(tmp_db)
+        orphan_count = con.execute(
+            "SELECT COUNT(*) FROM agent_messages "
+            "WHERE conversation_id = 'conv-shared' AND tenant_id = 2"
+        ).fetchone()[0]
+        con.close()
+        assert orphan_count == 0, "orphan messages persisted under victim's conversation"
+
+        # 3) Victim's message rows still there, untouched
+        assert len(_fetch_messages(tmp_db, "conv-shared")) == victim_msg_count_before
+
+        # 4) Operator-facing log warning emitted
+        assert any(
+            "refusing cross-tenant write" in r.message
+            for r in caplog.records
+        ), "no warning logged for the cross-tenant attempt"
+
+    def test_first_write_to_a_new_conversation_id_succeeds(self, tmp_db):
+        """Negative control: the cross-tenant guard must NOT block the
+        first-ever write to a new conversation_id (no prior meta row =
+        no ownership conflict)."""
+        from api.agent.audit import record_history
+
+        record_history(
+            tenant_id=5, surface="dock", conversation_id="conv-fresh",
+            user_message="primera vez", assistant_text="ok",
+            assistant_reasoning=None, tool_chips=[], proposals=[],
+        )
+        meta = _fetch_meta(tmp_db, "conv-fresh")
+        assert meta is not None
+        assert meta["tenant_id"] == 5
+        assert len(_fetch_messages(tmp_db, "conv-fresh")) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -638,6 +718,72 @@ async def test_wrapper_no_user_message_still_persists_assistant(tmp_db):
     meta = _fetch_meta(tmp_db, "conv-W7")
     assert meta["message_count"] == 1
     assert meta["title"] is None
+
+
+@pytest.mark.anyio
+async def test_wrapper_tool_only_turn_persists_empty_content(tmp_db):
+    """A turn that does no text generation (model only emits tool_use,
+    waiting for the tool result before answering) still gets a row in
+    agent_messages with content=''. Schema allows it; rehydrated UI
+    will show the chips + empty bubble — accurate to what the user saw.
+    PR #433 review issue #5a."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import (
+        MessageEnd, ToolUseResult, ToolUseStart,
+    )
+
+    events = [
+        ToolUseStart(tool="get_positions"),
+        ToolUseResult(tool="get_positions", status="ok"),
+        # No TextDelta — the model only did a tool use, the loop ended
+        # without a follow-up text generation.
+        MessageEnd(usage={}, stop_reason="tool_use", cost_usd=0.0),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W9",
+        model="claude-sonnet-4-6",
+        user_message_text="mostra posiciones",
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W9")
+    assert len(rows) == 2
+    assistant = next(r for r in rows if r["role"] == "assistant")
+    assert assistant["content"] == ""  # empty, not NULL
+    # Chips still persisted
+    chips = json.loads(assistant["tool_chips_json"])
+    assert chips == [{"tool": "get_positions", "status": "ok"}]
+
+
+@pytest.mark.anyio
+async def test_wrapper_error_event_without_user_message(tmp_db):
+    """Defensive path: ErrorEvent fires before any user message text was
+    extractable (e.g. router constructed wrapper with user_message_text
+    =None on a turn that errored upstream of normal flow). Assistant
+    row + meta still persist; user row is skipped; message_count = 1.
+    PR #433 review issue #5b."""
+    from api.agent.audit import TurnAuditWrapper
+    from api.agent.loop import ErrorEvent
+
+    events = [
+        ErrorEvent(reason="upstream", user_message="Hubo un problema."),
+    ]
+    wrapped = TurnAuditWrapper(
+        _events_async_gen(events),
+        tenant_id=1, surface="dock", conversation_id="conv-W10",
+        model="claude-sonnet-4-6",
+        user_message_text=None,
+    )
+    await _drain(wrapped)
+
+    rows = _fetch_messages(tmp_db, "conv-W10")
+    assert len(rows) == 1
+    assert rows[0]["role"] == "assistant"
+    assert rows[0]["content"] == "Hubo un problema."
+    meta = _fetch_meta(tmp_db, "conv-W10")
+    assert meta["message_count"] == 1
+    assert meta["title"] is None  # no user message → no title derived
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Refs epic #428. Implements H.2 (backend write path).

Depends on #432 (H.1 schema) — already merged to main.

## Summary
`TurnAuditWrapper` now persists user/assistant content into the H.1 tables alongside the existing `agent_conversations` audit row. New module-level `record_history()` is fail-quiet (DB hiccup → `log.warning`, never raise — the SSE response is already on the wire). The wrapper accumulates `_assistant_text`, `_assistant_reasoning`, `_tool_chips`, `_proposals` from streamed events; calls `record_history()` once per terminal event (`MessageEnd` / `ErrorEvent` / cancellation).

## Pre-reg decisions exercised
| # | Decision | Where |
|---|---|---|
| D.2 | Retention 90d | `RETENTION_DAYS` constant; `_retention_expiry_iso()` computed at write time |
| D.3 | Title from first 80 chars of first user msg | `_derive_title()`; ellipsis-suffixed on truncation; whitespace stripped |
| D.4 | Reasoning persisted | `reasoning` column populated from `ReasoningDelta` chunks (DS-R1 only) |
| D.6 | No branching | Flat ordered list per `conversation_id` |
| D.7 | Multi-tenant | `tenant_id` from constructor (router pulls from JWT); never from event payload |

## Subtle behaviors that are easy to miss in review
- **UPSERT on meta:** `ON CONFLICT(conversation_id) DO UPDATE` preserves `title` + `first_ts`; updates `last_ts`, `message_count`, `expires_at`. Active conversations don't expire while the user keeps engaging.
- **Pending tool chips terminalized to 'error':** rehydrated UI would otherwise show stuck spinners on rows where the tool never reported a result (turn errored / cancelled mid-call).
- **`signed_payload` dropped from proposals on persist:** HMAC TTL is minutes; persisting across 90d would be storing an expired credential.
- **Audit vs history split, deliberate:** `agent_conversations` rows with `role='error'` carry the closed-enum reason as `content_summary` (operator-facing). `agent_messages` rows with `role='assistant'` on errors carry the user-facing friendly text (UX-facing). Same turn, different audiences, different fields.

## Test plan
- [x] `pytest tests/test_agent_history_writes.py -v` — 28/28 (direct calls + async wrapper drives).
- [x] Regression: `pytest tests/test_agent_*.py` — 233 passed / 1 skipped, no drift.
- [ ] CI green (backend pytest + frontend tsc/vitest/build).
- [ ] After merge: papá triggers a turn from `trading.sdar.dev`; check `agent_messages` + `agent_conversation_meta` rows materialize with his `tenant_id`.

## Files
- `api/agent/audit.py` — module-level `record_history()`, `_derive_title()`, `_terminalize_chips()`, `_retention_expiry_iso()`; `TurnAuditWrapper` gains `user_message_text` kwarg + 4 accumulators + `_record_history()` private method.
- `api/agent/router.py` — extracts `user_message_text` from `body.messages` defensively (scan from end for last `role='user'`) and threads it through.
- `tests/test_agent_history_writes.py` — 28 tests covering direct calls, title derivation edge cases, chip terminalization, proposals, expires_at horizon, tenant isolation, fail-quiet, and 8 async wrapper integration tests.

## Next
H.3 (backend read endpoints): `GET /agent/conversations`, `GET /agent/conversations/{id}/messages`, `DELETE`, `POST /pin` — all JWT-gated with IDOR matrix in `tests/test_agent_history_idor.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)