### PR TITLE
feat(agent): H.3 conversation history read endpoints + IDOR suite (#428)

### DIFF
--- a/api/agent/history.py
+++ b/api/agent/history.py
@@ -58,13 +58,22 @@ class ProposalRecord(BaseModel):
     """Rehydrated proposal shape. `signed_payload` is intentionally
     absent — the HMAC TTL is minutes and the token is never persisted.
     `state` is derived at read time from agent_side_effects (where the
-    confirm lives) or from expires_at (if never confirmed)."""
+    confirm lives) or from expires_at (if never confirmed).
+
+    Why no 'pending' value here even though the live SSE wire emits it
+    (see frontend/src/agent/types.ts ProposalChip.state): a REST
+    rehydration NEVER has a valid signed_payload — by the time the
+    user re-opens a conversation, the HMAC's minute-scale TTL has
+    long passed. A chip that was 'pending' at write-time but never
+    confirmed lands here as 'stale': the frontend renders it without
+    a confirm button. PR #434 review issue #6.
+    """
     proposal_id: str
     action:      str
     args:        dict[str, Any]
     expires_at:  str
     summary:     str
-    state:       Literal["pending", "ok", "expired", "error", "conflict"]
+    state:       Literal["stale", "ok", "expired", "error", "conflict"]
 
 
 class MessageRecord(BaseModel):
@@ -97,25 +106,75 @@ def _escape_like(s: str) -> str:
     return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def _safe_load_chips(blob: Optional[str], conversation_id: str,
+                      ts: str) -> list[ToolChipRecord]:
+    """Decode `tool_chips_json` into validated chip records.
+
+    Fail-graceful (PR #434 review issue #2): on JSONDecodeError or a
+    pydantic ValidationError, log a warning and return an empty list.
+    The user sees a message bubble without chips rather than a 500
+    blanking the whole transcript.
+    """
+    if not blob:
+        return []
+    try:
+        raw = json.loads(blob)
+        return [ToolChipRecord(**c) for c in raw]
+    except Exception:  # noqa: BLE001
+        log.warning(
+            "history: malformed tool_chips_json for conversation=%s ts=%s — "
+            "skipping chips for this message",
+            conversation_id, ts,
+        )
+        return []
+
+
+def _safe_load_proposals(blob: Optional[str], conversation_id: str,
+                          ts: str) -> list[dict[str, Any]]:
+    """Decode `proposals_json` into raw dicts (state derivation happens
+    in the caller). Same fail-graceful contract as _safe_load_chips."""
+    if not blob:
+        return []
+    try:
+        return json.loads(blob)
+    except Exception:  # noqa: BLE001
+        log.warning(
+            "history: malformed proposals_json for conversation=%s ts=%s — "
+            "skipping proposals for this message",
+            conversation_id, ts,
+        )
+        return []
+
+
 def _derive_proposal_state(con: sqlite3.Connection, proposal_id: str,
-                            original_expires_at: str) -> str:
+                            original_expires_at: str, tenant_id: int) -> str:
     """Reconstruct the proposal's terminal state at read time.
 
     Three cases:
       1. A row exists in `agent_side_effects` keyed by `idempotency_key`
-         = proposal_id → the user confirmed it at some point. Return
-         the recorded `result` (ok / expired / conflict / error).
-      2. No side-effect row, original `expires_at` is in the past →
-         the proposal expired naturally without confirmation. Return
-         'expired'.
-      3. No side-effect row, expires_at still in the future → still
-         actionable in principle, but the rehydrated UI WON'T have a
-         valid `signed_payload` (we never persist it). Return 'pending'
-         and let the frontend render it as a non-actionable chip.
+         = proposal_id AND tenant_id = the caller → the user confirmed
+         it at some point. Return the recorded `result` (ok / expired
+         / conflict / error).
+      2. No matching side-effect row, original `expires_at` is in the
+         past → the proposal expired naturally without confirmation.
+         Return 'expired'.
+      3. No matching side-effect row, expires_at still in the future
+         → the proposal was emitted in a prior turn but never
+         confirmed. Return 'stale' — the rehydrated UI WON'T have a
+         valid `signed_payload` (we never persist it), so the chip
+         shows as non-actionable.
+
+    PR #434 review issue #1: tenant_id scopes the side-effects lookup
+    even though idempotency_key is globally UNIQUE. Defense in depth
+    against any future path where a tenant could influence what goes
+    into their own proposals_json (today the propose_handlers
+    server-generate the ids, so this can't be exploited, but cheap to
+    close the theoretical vector).
     """
     row = con.execute(
-        "SELECT result FROM agent_side_effects WHERE idempotency_key = ?",
-        (proposal_id,),
+        "SELECT result FROM agent_side_effects "
+        "WHERE idempotency_key = ? AND tenant_id = ?",
+        (proposal_id, tenant_id),
     ).fetchone()
     if row is not None:
         result = row[0] or "error"
@@ -127,7 +186,7 @@ def _derive_proposal_state(con: sqlite3.Connection, proposal_id: str,
             return "expired"
     except (TypeError, ValueError):
         pass
-    return "pending"
+    return "stale"
 
 
 # ── GET /agent/conversations ───────────────────────────────────────────
@@ -142,7 +201,12 @@ def list_conversations(
     tenant_id: int = Depends(get_current_tenant_id),
     limit:  int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
-    surface: Optional[Literal["dock", "symbol_detail", "brief", "kill_switch", "autotune", "historial"]] = Query(default=None),
+    # Surface enum mirrors api/agent/router.py::_AgentTurnRequest.surface
+    # (the writer's contract). Dropping 'brief' from the filter — the
+    # pre-reg listed it but it was never wired in the writer, so a
+    # ?surface=brief filter would always return zero rows. PR #434
+    # review issue #3.
+    surface: Optional[Literal["dock", "symbol_detail", "kill_switch", "autotune", "historial"]] = Query(default=None),
     q:       Optional[str] = Query(default=None, max_length=200),
 ):
     """Sidebar list. Pinned first, then last_ts DESC. Hides expired
@@ -283,13 +347,23 @@ def get_messages(
 
         messages: list[MessageRecord] = []
         for r in rows:
-            chips_raw = json.loads(r["tool_chips_json"]) if r["tool_chips_json"] else []
-            chips = [ToolChipRecord(**c) for c in chips_raw]
-
-            proposals_raw = json.loads(r["proposals_json"]) if r["proposals_json"] else []
+            # Fail-graceful on corrupted JSON blobs (DB bit-rot, a buggy
+            # past writer, or future schema drift). PR #434 review
+            # issue #2: a JSONDecodeError on one row should not kill
+            # the entire transcript. Log + degrade to empty chips/
+            # proposals; the user sees the messages with missing chips
+            # rather than a 500.
+            chips = _safe_load_chips(
+                r["tool_chips_json"], conversation_id, r["ts"],
+            )
+            proposals_raw = _safe_load_proposals(
+                r["proposals_json"], conversation_id, r["ts"],
+            )
             proposals: list[ProposalRecord] = []
             for p in proposals_raw:
-                state = _derive_proposal_state(con, p["proposal_id"], p["expires_at"])
+                state = _derive_proposal_state(
+                    con, p["proposal_id"], p["expires_at"], tenant_id,
+                )
                 proposals.append(ProposalRecord(
                     proposal_id=p["proposal_id"],
                     action=p["action"],
@@ -401,9 +475,14 @@ def toggle_pin(
         if cursor.rowcount == 0:
             raise HTTPException(status_code=404, detail="conversation_not_found")
         con.commit()
+        # SELECT scoped by tenant_id for consistency with the rest of
+        # the file's tenant-scoped reads (PR #434 review issue #5).
+        # The preceding UPDATE already confirmed ownership; this is
+        # belt-and-suspenders style only.
         new_state = con.execute(
-            "SELECT pinned FROM agent_conversation_meta WHERE conversation_id = ?",
-            (conversation_id,),
+            "SELECT pinned FROM agent_conversation_meta "
+            "WHERE conversation_id = ? AND tenant_id = ?",
+            (conversation_id, tenant_id),
         ).fetchone()
         return PinResponse(ok=True, pinned=bool(new_state["pinned"]))
     finally:

--- a/api/agent/history.py
+++ b/api/agent/history.py
@@ -1,0 +1,410 @@
+"""Per-tenant conversation history read endpoints (#428 H.3).
+
+Reads from the H.1 tables (agent_messages + agent_conversation_meta) for
+the sidebar + transcript rehydration on the frontend. Soft delete + pin
+toggle round out the CRUD surface. All endpoints are JWT-gated, derive
+tenant_id from `get_current_tenant_id` (never from request body / query /
+header / path), and gate reads through the retention TTL.
+
+Pre-reg: docs/superpowers/specs/es/2026-05-22-conversation-history-pre-reg.md
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from pydantic import BaseModel, Field
+
+from api.agent.audit import RETENTION_DAYS
+from auth.dependencies import get_current_tenant_id
+from db.connection import get_db
+
+log = logging.getLogger("api.agent.history")
+
+router = APIRouter(tags=["agent-history"])
+
+
+# ── Response models ────────────────────────────────────────────────────
+
+
+class ConversationSummary(BaseModel):
+    """One row in the sidebar list."""
+    conversation_id: str
+    title:           Optional[str]
+    surface:         str
+    last_ts:         str
+    first_ts:        str
+    message_count:   int
+    pinned:          bool
+
+
+class ConversationListResponse(BaseModel):
+    conversations: list[ConversationSummary]
+    total:         int
+    limit:         int
+    offset:        int
+
+
+class ToolChipRecord(BaseModel):
+    tool:   str
+    status: Literal["pending", "ok", "error"]
+
+
+class ProposalRecord(BaseModel):
+    """Rehydrated proposal shape. `signed_payload` is intentionally
+    absent — the HMAC TTL is minutes and the token is never persisted.
+    `state` is derived at read time from agent_side_effects (where the
+    confirm lives) or from expires_at (if never confirmed)."""
+    proposal_id: str
+    action:      str
+    args:        dict[str, Any]
+    expires_at:  str
+    summary:     str
+    state:       Literal["pending", "ok", "expired", "error", "conflict"]
+
+
+class MessageRecord(BaseModel):
+    role:       Literal["user", "assistant"]
+    ts:         str
+    content:    str
+    reasoning:  Optional[str] = None
+    tool_chips: list[ToolChipRecord] = Field(default_factory=list)
+    proposals:  list[ProposalRecord] = Field(default_factory=list)
+
+
+class ConversationDetailResponse(BaseModel):
+    conversation_id: str
+    title:           Optional[str]
+    surface:         str
+    pinned:          bool
+    messages:        list[MessageRecord]
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _escape_like(s: str) -> str:
+    """Escape LIKE wildcards (% and _) so user input is treated as
+    literal text. Pairs with `ESCAPE '\\'` in the SQL clause."""
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _derive_proposal_state(con: sqlite3.Connection, proposal_id: str,
+                            original_expires_at: str) -> str:
+    """Reconstruct the proposal's terminal state at read time.
+
+    Three cases:
+      1. A row exists in `agent_side_effects` keyed by `idempotency_key`
+         = proposal_id → the user confirmed it at some point. Return
+         the recorded `result` (ok / expired / conflict / error).
+      2. No side-effect row, original `expires_at` is in the past →
+         the proposal expired naturally without confirmation. Return
+         'expired'.
+      3. No side-effect row, expires_at still in the future → still
+         actionable in principle, but the rehydrated UI WON'T have a
+         valid `signed_payload` (we never persist it). Return 'pending'
+         and let the frontend render it as a non-actionable chip.
+    """
+    row = con.execute(
+        "SELECT result FROM agent_side_effects WHERE idempotency_key = ?",
+        (proposal_id,),
+    ).fetchone()
+    if row is not None:
+        result = row[0] or "error"
+        if result in ("ok", "expired", "conflict", "error"):
+            return result
+        return "error"
+    try:
+        if datetime.fromisoformat(original_expires_at) < datetime.now(timezone.utc):
+            return "expired"
+    except (TypeError, ValueError):
+        pass
+    return "pending"
+
+
+# ── GET /agent/conversations ───────────────────────────────────────────
+
+
+@router.get(
+    "/agent/conversations",
+    response_model=ConversationListResponse,
+    summary="List recent conversations for the current tenant",
+)
+def list_conversations(
+    tenant_id: int = Depends(get_current_tenant_id),
+    limit:  int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    surface: Optional[Literal["dock", "symbol_detail", "brief", "kill_switch", "autotune", "historial"]] = Query(default=None),
+    q:       Optional[str] = Query(default=None, max_length=200),
+):
+    """Sidebar list. Pinned first, then last_ts DESC. Hides expired
+    conversations via the retention filter.
+
+    Query params:
+      - limit / offset: standard pagination, default 20, cap 100.
+      - surface: optional filter ('dock' / 'symbol_detail' / 'brief').
+      - q: substring search across title + message content; LIKE-escaped
+        so % and _ are literals. Empty / whitespace-only q is ignored.
+
+    Pre-reg D.7: tenant_id from JWT, never from query/body.
+    """
+    now = _now_iso()
+    con = get_db()
+    try:
+        # Parameters live in two buckets so the order in execute() lines
+        # up with the placeholder order in the final SQL: JOIN clause
+        # comes BEFORE WHERE, so any `?` in the JOIN must be earlier in
+        # the param tuple than the WHERE params. Easy to get wrong if
+        # you append-as-you-go to one list.
+        join_params: list[Any] = []
+        where_params: list[Any] = [tenant_id, now]
+        where_parts = [
+            "m.tenant_id = ?",
+            "m.expires_at > ?",
+        ]
+
+        if surface:
+            where_parts.append("m.surface = ?")
+            where_params.append(surface)
+
+        join_clause = ""
+        if q and q.strip():
+            pattern = f"%{_escape_like(q.strip())}%"
+            join_clause = (
+                " LEFT JOIN agent_messages msg "
+                "ON msg.conversation_id = m.conversation_id "
+                "AND msg.tenant_id = m.tenant_id "
+                "AND msg.expires_at > ? "
+            )
+            join_params.append(now)
+            where_parts.append(
+                "(m.title LIKE ? ESCAPE '\\' OR msg.content LIKE ? ESCAPE '\\')"
+            )
+            where_params.append(pattern)
+            where_params.append(pattern)
+
+        where_sql = " AND ".join(where_parts)
+        all_filter_params = (*join_params, *where_params)
+
+        rows = con.execute(
+            f"""SELECT DISTINCT m.conversation_id, m.title, m.surface,
+                       m.first_ts, m.last_ts, m.message_count, m.pinned
+                FROM agent_conversation_meta m
+                {join_clause}
+                WHERE {where_sql}
+                ORDER BY m.pinned DESC, m.last_ts DESC
+                LIMIT ? OFFSET ?""",
+            (*all_filter_params, limit, offset),
+        ).fetchall()
+
+        total = con.execute(
+            f"""SELECT COUNT(DISTINCT m.conversation_id)
+                FROM agent_conversation_meta m
+                {join_clause}
+                WHERE {where_sql}""",
+            all_filter_params,
+        ).fetchone()[0]
+
+        conversations = [
+            ConversationSummary(
+                conversation_id=r["conversation_id"],
+                title=r["title"],
+                surface=r["surface"],
+                first_ts=r["first_ts"],
+                last_ts=r["last_ts"],
+                message_count=r["message_count"],
+                pinned=bool(r["pinned"]),
+            )
+            for r in rows
+        ]
+        return ConversationListResponse(
+            conversations=conversations,
+            total=int(total),
+            limit=limit,
+            offset=offset,
+        )
+    finally:
+        con.close()
+
+
+# ── GET /agent/conversations/{id}/messages ─────────────────────────────
+
+
+_CONVERSATION_ID_PATTERN = r"^[A-Za-z0-9_\-]+$"
+
+
+@router.get(
+    "/agent/conversations/{conversation_id}/messages",
+    response_model=ConversationDetailResponse,
+    summary="Fetch the full transcript for one conversation",
+)
+def get_messages(
+    conversation_id: str = Path(
+        ..., min_length=1, max_length=128, pattern=_CONVERSATION_ID_PATTERN,
+    ),
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    """Hydrate a conversation's full transcript. 404 if the conversation
+    doesn't exist OR belongs to a different tenant — same response shape
+    either way so existence isn't leaked across tenants.
+
+    `proposals[].state` is reconstructed from agent_side_effects; the
+    signed_payload is never persisted and therefore never returned.
+    """
+    now = _now_iso()
+    con = get_db()
+    try:
+        meta = con.execute(
+            "SELECT conversation_id, tenant_id, title, surface, pinned, expires_at "
+            "FROM agent_conversation_meta WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+
+        if meta is None or meta["tenant_id"] != tenant_id or meta["expires_at"] <= now:
+            # Same 404 for "doesn't exist" and "exists but not yours / expired".
+            # No information leak across tenants.
+            raise HTTPException(status_code=404, detail="conversation_not_found")
+
+        rows = con.execute(
+            "SELECT role, ts, content, reasoning, tool_chips_json, proposals_json "
+            "FROM agent_messages "
+            "WHERE conversation_id = ? AND tenant_id = ? AND expires_at > ? "
+            "ORDER BY ts ASC, id ASC",
+            (conversation_id, tenant_id, now),
+        ).fetchall()
+
+        messages: list[MessageRecord] = []
+        for r in rows:
+            chips_raw = json.loads(r["tool_chips_json"]) if r["tool_chips_json"] else []
+            chips = [ToolChipRecord(**c) for c in chips_raw]
+
+            proposals_raw = json.loads(r["proposals_json"]) if r["proposals_json"] else []
+            proposals: list[ProposalRecord] = []
+            for p in proposals_raw:
+                state = _derive_proposal_state(con, p["proposal_id"], p["expires_at"])
+                proposals.append(ProposalRecord(
+                    proposal_id=p["proposal_id"],
+                    action=p["action"],
+                    args=p["args"],
+                    expires_at=p["expires_at"],
+                    summary=p["summary"],
+                    state=state,
+                ))
+
+            messages.append(MessageRecord(
+                role=r["role"],
+                ts=r["ts"],
+                content=r["content"],
+                reasoning=r["reasoning"],
+                tool_chips=chips,
+                proposals=proposals,
+            ))
+
+        return ConversationDetailResponse(
+            conversation_id=meta["conversation_id"],
+            title=meta["title"],
+            surface=meta["surface"],
+            pinned=bool(meta["pinned"]),
+            messages=messages,
+        )
+    finally:
+        con.close()
+
+
+# ── DELETE /agent/conversations/{id} — soft delete ─────────────────────
+
+
+class DeleteResponse(BaseModel):
+    ok: bool
+
+
+@router.delete(
+    "/agent/conversations/{conversation_id}",
+    response_model=DeleteResponse,
+    summary="Soft-delete a conversation (sets expires_at=now)",
+)
+def delete_conversation(
+    conversation_id: str = Path(
+        ..., min_length=1, max_length=128, pattern=_CONVERSATION_ID_PATTERN,
+    ),
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    """Soft delete via `expires_at = NOW`. Cleanup-on-read filters hide
+    the rows from subsequent GETs. Pre-reg D.5.
+
+    IDOR: the UPDATE WHERE clause carries `tenant_id = ?`, so attacker's
+    DELETE on another tenant's conversation_id affects zero rows and
+    returns 404 — no observable difference from "doesn't exist".
+    """
+    now = _now_iso()
+    con = get_db()
+    try:
+        cursor = con.execute(
+            "UPDATE agent_conversation_meta SET expires_at = ? "
+            "WHERE conversation_id = ? AND tenant_id = ? AND expires_at > ?",
+            (now, conversation_id, tenant_id, now),
+        )
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="conversation_not_found")
+
+        # Also soft-delete the message rows so the GET endpoints don't
+        # return them under any future surface (e.g. cross-conversation
+        # search). Two-step UPDATE; both run inside the same transaction.
+        con.execute(
+            "UPDATE agent_messages SET expires_at = ? "
+            "WHERE conversation_id = ? AND tenant_id = ?",
+            (now, conversation_id, tenant_id),
+        )
+        con.commit()
+        return DeleteResponse(ok=True)
+    finally:
+        con.close()
+
+
+# ── POST /agent/conversations/{id}/pin — toggle ────────────────────────
+
+
+class PinResponse(BaseModel):
+    ok:     bool
+    pinned: bool
+
+
+@router.post(
+    "/agent/conversations/{conversation_id}/pin",
+    response_model=PinResponse,
+    summary="Toggle the pinned flag on a conversation",
+)
+def toggle_pin(
+    conversation_id: str = Path(
+        ..., min_length=1, max_length=128, pattern=_CONVERSATION_ID_PATTERN,
+    ),
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    """Toggle pinned (0 → 1, 1 → 0). IDOR-safe: UPDATE WHERE tenant_id;
+    rowcount = 0 → 404 with the same body as 'doesn't exist'."""
+    now = _now_iso()
+    con = get_db()
+    try:
+        cursor = con.execute(
+            "UPDATE agent_conversation_meta SET pinned = 1 - pinned "
+            "WHERE conversation_id = ? AND tenant_id = ? AND expires_at > ?",
+            (conversation_id, tenant_id, now),
+        )
+        if cursor.rowcount == 0:
+            raise HTTPException(status_code=404, detail="conversation_not_found")
+        con.commit()
+        new_state = con.execute(
+            "SELECT pinned FROM agent_conversation_meta WHERE conversation_id = ?",
+            (conversation_id,),
+        ).fetchone()
+        return PinResponse(ok=True, pinned=bool(new_state["pinned"]))
+    finally:
+        con.close()

--- a/btc_api.py
+++ b/btc_api.py
@@ -85,6 +85,7 @@ from api.signals import router as signals_router
 from api.telegram import build_telegram_message, push_telegram_direct, push_webhook  # noqa: F401
 from api.tune import router as tune_router
 from api.agent.router import router as agent_router
+from api.agent.history import router as agent_history_router
 from btc_scanner import scan  # noqa: F401 — patch("btc_api.scan", ...) in test_api.py line 421
 from data import market_data as md  # used directly at line 145; patch.object(btc_api.md) in test_api.py
 # DB_FILE: monkeypatched as btc_api.DB_FILE by ~25 test files to redirect SQLite path
@@ -277,6 +278,7 @@ app.include_router(notifications_router)
 app.include_router(capital_router)
 app.include_router(user_preferences_router)
 app.include_router(agent_router)
+app.include_router(agent_history_router)
 
 
 @app.get("/", summary="Bienvenida y estado general")

--- a/tests/test_agent_history_api.py
+++ b/tests/test_agent_history_api.py
@@ -206,9 +206,11 @@ class TestGetMessages:
         assert assistant["reasoning"] == "<think>razonamiento</think>"
         assert assistant["tool_chips"] == [{"tool": "get_positions", "status": "ok"}]
 
-    def test_proposal_state_pending_when_never_confirmed(self, client):
+    def test_proposal_state_stale_when_never_confirmed(self, client):
         """No matching row in agent_side_effects + future expires_at →
-        state is 'pending'."""
+        state is 'stale' (REST rehydration never has a valid
+        signed_payload, so the chip can't be confirmed). PR #434
+        review issue #6."""
         future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
         _seed(
             0, "conv-P1", "cerra mi BTC",
@@ -223,7 +225,7 @@ class TestGetMessages:
         )
         resp = client.get("/agent/conversations/conv-P1/messages")
         assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
-        assert assistant["proposals"][0]["state"] == "pending"
+        assert assistant["proposals"][0]["state"] == "stale"
         # signed_payload never present in the response
         assert "signed_payload" not in assistant["proposals"][0]
 
@@ -242,6 +244,164 @@ class TestGetMessages:
         resp = client.get("/agent/conversations/conv-P2/messages")
         assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
         assert assistant["proposals"][0]["state"] == "expired"
+
+    def test_proposal_state_error_from_agent_side_effects(self, client):
+        """Verify error result from agent_side_effects propagates."""
+        from db.connection import get_db
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        _seed(
+            0, "conv-Perr", "cerra",
+            proposals=[{
+                "proposal_id": "prop-perr",
+                "action":      "close_position",
+                "args":        {"position_id": 10},
+                "expires_at":  future,
+                "summary":     "Cerrar #10",
+            }],
+        )
+        con = get_db()
+        con.execute(
+            """INSERT INTO agent_side_effects
+               (tenant_id, conversation_id, ts, action, args_json,
+                idempotency_key, result, http_status, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (0, "conv-Perr", "2026-05-22T10:00:00Z", "close_position",
+             "{}", "prop-perr", "error", 500, future),
+        )
+        con.commit()
+        con.close()
+
+        resp = client.get("/agent/conversations/conv-Perr/messages")
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        assert assistant["proposals"][0]["state"] == "error"
+
+    def test_proposal_state_conflict_from_agent_side_effects(self, client):
+        """conflict result (proposal_id collision) propagates."""
+        from db.connection import get_db
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        _seed(
+            0, "conv-Pconf", "cerra",
+            proposals=[{
+                "proposal_id": "prop-pconf",
+                "action":      "close_position",
+                "args":        {"position_id": 11},
+                "expires_at":  future,
+                "summary":     "Cerrar #11",
+            }],
+        )
+        con = get_db()
+        con.execute(
+            """INSERT INTO agent_side_effects
+               (tenant_id, conversation_id, ts, action, args_json,
+                idempotency_key, result, http_status, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (0, "conv-Pconf", "2026-05-22T10:00:00Z", "close_position",
+             "{}", "prop-pconf", "conflict", 409, future),
+        )
+        con.commit()
+        con.close()
+
+        resp = client.get("/agent/conversations/conv-Pconf/messages")
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        assert assistant["proposals"][0]["state"] == "conflict"
+
+    def test_proposal_state_lookup_is_tenant_scoped(self, client):
+        """PR #434 review issue #1: even though idempotency_key is
+        globally UNIQUE on agent_side_effects, the state derivation
+        joins on tenant_id too. If another tenant's confirm shares a
+        proposal_id by accident, the current tenant doesn't see that
+        result — defense in depth.
+
+        Simulate: tenant 999 has a side_effect row for 'prop-shared'
+        marked 'ok'. Tenant 0 (TestClient) has a message with the
+        same proposal_id but no side_effect of their own. The state
+        derivation MUST return 'stale' (no row found for this tenant)
+        — NOT 'ok' (which would leak the other tenant's outcome).
+        """
+        from db.connection import get_db
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        _seed(
+            0, "conv-Pscope", "x",
+            proposals=[{
+                "proposal_id": "prop-shared",
+                "action":      "close_position",
+                "args":        {"position_id": 999},
+                "expires_at":  future,
+                "summary":     "Cerrar #999",
+            }],
+        )
+        # Other tenant confirmed something with the same key — IRL
+        # this won't happen because the UNIQUE constraint blocks it,
+        # but the test verifies our SELECT wouldn't return it anyway.
+        con = get_db()
+        con.execute(
+            "DELETE FROM agent_side_effects WHERE idempotency_key = ?",
+            ("prop-shared",),
+        )
+        con.execute(
+            """INSERT INTO agent_side_effects
+               (tenant_id, conversation_id, ts, action, args_json,
+                idempotency_key, result, http_status, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (999, "other-conv", "2026-05-22T10:00:00Z", "close_position",
+             "{}", "prop-shared", "ok", 200, future),
+        )
+        con.commit()
+        con.close()
+
+        resp = client.get("/agent/conversations/conv-Pscope/messages")
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        # Must be 'stale' (this tenant never confirmed), NOT 'ok'
+        # (which would have leaked the other tenant's outcome).
+        assert assistant["proposals"][0]["state"] == "stale"
+
+    def test_malformed_tool_chips_json_falls_back_gracefully(self, client, caplog):
+        """A corrupted blob (DB bit-rot, schema drift, future bug)
+        must not 500 the whole transcript. Log warning + degrade to
+        empty chips. PR #434 review issue #2."""
+        import logging
+        from db.connection import get_db
+        _seed(0, "conv-Mal", "hola", assistant_text="ok")
+        # Corrupt the assistant row's tool_chips_json directly
+        con = get_db()
+        con.execute(
+            "UPDATE agent_messages SET tool_chips_json = ? "
+            "WHERE conversation_id = ? AND role = 'assistant'",
+            ("{NOT VALID JSON", "conv-Mal"),
+        )
+        con.commit()
+        con.close()
+
+        with caplog.at_level(logging.WARNING, logger="api.agent.history"):
+            resp = client.get("/agent/conversations/conv-Mal/messages")
+        assert resp.status_code == 200
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        assert assistant["tool_chips"] == []  # graceful empty list
+        assert any(
+            "malformed tool_chips_json" in r.message for r in caplog.records
+        )
+
+    def test_malformed_proposals_json_falls_back_gracefully(self, client, caplog):
+        import logging
+        from db.connection import get_db
+        _seed(0, "conv-MalP", "hola", assistant_text="ok")
+        con = get_db()
+        con.execute(
+            "UPDATE agent_messages SET proposals_json = ? "
+            "WHERE conversation_id = ? AND role = 'assistant'",
+            ("not json at all", "conv-MalP"),
+        )
+        con.commit()
+        con.close()
+
+        with caplog.at_level(logging.WARNING, logger="api.agent.history"):
+            resp = client.get("/agent/conversations/conv-MalP/messages")
+        assert resp.status_code == 200
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        assert assistant["proposals"] == []
+        assert any(
+            "malformed proposals_json" in r.message for r in caplog.records
+        )
 
     def test_proposal_state_ok_from_agent_side_effects(self, client):
         """If the user confirmed the proposal, agent_side_effects has the
@@ -285,8 +445,9 @@ class TestGetMessages:
         resp = client.get("/agent/conversations/conv-expired/messages")
         assert resp.status_code == 404
 
-    def test_404_for_invalid_conversation_id_chars(self, client):
-        """Path pattern blocks special chars."""
+    def test_422_for_invalid_conversation_id_chars(self, client):
+        """Path pattern blocks special chars (FastAPI validation
+        returns 422, not 404, when the Path regex doesn't match)."""
         resp = client.get("/agent/conversations/has space/messages")
         assert resp.status_code == 422
 

--- a/tests/test_agent_history_api.py
+++ b/tests/test_agent_history_api.py
@@ -1,0 +1,377 @@
+"""Tests for #428 H.3 — conversation-history read endpoints.
+
+Happy-path coverage: list / messages / delete / pin against a TestClient
+seeded via record_history(). IDOR / cross-tenant tests live in
+test_agent_history_idor.py (mirror B.7 #260 pattern).
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path as _Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """TestClient with fresh DB + bypass-auth. Mirror of the B.7 fixture
+    so the TestClient operates as the synthetic test user (id=0)."""
+    import btc_api
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"api_key": "test-key"}))
+    monkeypatch.setattr(btc_api, "CONFIG_FILE", str(cfg_path), raising=False)
+    import api.config as _ac
+    monkeypatch.setattr(_ac, "CONFIG_FILE", str(cfg_path), raising=False)
+    monkeypatch.setattr(btc_api, "DEFAULTS_FILE", str(tmp_path / "no_def.json"), raising=False)
+    monkeypatch.setattr(_ac, "DEFAULTS_FILE", str(tmp_path / "no_def.json"), raising=False)
+    monkeypatch.setattr(btc_api, "SECRETS_FILE", str(tmp_path / "no_sec.json"), raising=False)
+    monkeypatch.setattr(_ac, "SECRETS_FILE", str(tmp_path / "no_sec.json"), raising=False)
+    return TestClient(btc_api.app)
+
+
+def _seed(tenant_id: int, conversation_id: str, user_msg: str,
+          assistant_text: str = "ok", surface: str = "dock",
+          reasoning: str | None = None,
+          tool_chips: list[dict] | None = None,
+          proposals: list[dict] | None = None) -> None:
+    """Seed one turn via the production write path."""
+    from api.agent.audit import record_history
+    record_history(
+        tenant_id=tenant_id, surface=surface, conversation_id=conversation_id,
+        user_message=user_msg, assistant_text=assistant_text,
+        assistant_reasoning=reasoning,
+        tool_chips=tool_chips or [], proposals=proposals or [],
+    )
+
+
+def _expire_meta(conversation_id: str, when_iso: str | None = None) -> None:
+    """Set expires_at on a conversation to a past timestamp (test-only
+    helper — simulates the retention horizon having elapsed)."""
+    from db.connection import get_db
+    past = when_iso or "2000-01-01T00:00:00+00:00"
+    con = get_db()
+    con.execute(
+        "UPDATE agent_conversation_meta SET expires_at = ? WHERE conversation_id = ?",
+        (past, conversation_id),
+    )
+    con.execute(
+        "UPDATE agent_messages SET expires_at = ? WHERE conversation_id = ?",
+        (past, conversation_id),
+    )
+    con.commit()
+    con.close()
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/conversations
+# ---------------------------------------------------------------------------
+
+
+class TestListConversations:
+    def test_returns_empty_when_no_data(self, client):
+        resp = client.get("/agent/conversations")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"conversations": [], "total": 0, "limit": 20, "offset": 0}
+
+    def test_returns_own_conversations_only(self, client):
+        _seed(0, "conv-mine", "mi pregunta")
+        resp = client.get("/agent/conversations")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["conversations"][0]["conversation_id"] == "conv-mine"
+        assert body["conversations"][0]["title"] == "mi pregunta"
+        assert body["conversations"][0]["pinned"] is False
+        assert body["conversations"][0]["message_count"] == 2
+
+    def test_pinned_floats_to_top(self, client):
+        _seed(0, "old", "viejo", surface="dock")
+        time.sleep(0.01)
+        _seed(0, "new", "nuevo", surface="dock")
+        # Pin the OLD one
+        from db.connection import get_db
+        con = get_db()
+        con.execute(
+            "UPDATE agent_conversation_meta SET pinned = 1 WHERE conversation_id = 'old'"
+        )
+        con.commit()
+        con.close()
+
+        resp = client.get("/agent/conversations")
+        ids = [c["conversation_id"] for c in resp.json()["conversations"]]
+        # Pinned 'old' floats above 'new' even though new has later last_ts
+        assert ids == ["old", "new"]
+
+    def test_excludes_expired_conversations(self, client):
+        _seed(0, "expired", "expirado")
+        _seed(0, "fresh", "vigente")
+        _expire_meta("expired")
+
+        resp = client.get("/agent/conversations")
+        ids = [c["conversation_id"] for c in resp.json()["conversations"]]
+        assert ids == ["fresh"]
+        assert resp.json()["total"] == 1
+
+    def test_filter_by_surface(self, client):
+        _seed(0, "from-dock", "del dock", surface="dock")
+        _seed(0, "from-detail", "del symbol detail", surface="symbol_detail")
+
+        resp = client.get("/agent/conversations?surface=symbol_detail")
+        ids = [c["conversation_id"] for c in resp.json()["conversations"]]
+        assert ids == ["from-detail"]
+
+    def test_search_q_matches_title(self, client):
+        _seed(0, "a", "que opinas de PENDLE?")
+        _seed(0, "b", "que tal BTC?")
+
+        resp = client.get("/agent/conversations?q=PENDLE")
+        ids = [c["conversation_id"] for c in resp.json()["conversations"]]
+        assert ids == ["a"]
+
+    def test_search_q_matches_message_content(self, client):
+        """The user message includes 'BTC' in its title (and content), but
+        the SEARCH key 'ZONA LRC' lives only in the assistant body."""
+        _seed(0, "a", "que opinas?", assistant_text="BTC está en ZONA LRC baja")
+        _seed(0, "b", "otra cosa", assistant_text="respuesta cualquiera")
+
+        resp = client.get("/agent/conversations?q=ZONA LRC")
+        ids = [c["conversation_id"] for c in resp.json()["conversations"]]
+        assert ids == ["a"]
+
+    def test_search_escapes_like_wildcards(self, client):
+        """A user searching for '%' must match literal '%', not 'anything'."""
+        _seed(0, "a", "100% rentable")
+        _seed(0, "b", "perdida total")
+
+        resp = client.get("/agent/conversations?q=%25")  # URL-encoded %
+        ids = [c["conversation_id"] for c in resp.json()["conversations"]]
+        assert ids == ["a"]
+
+    def test_pagination_limit_offset(self, client):
+        for i in range(5):
+            _seed(0, f"c{i}", f"msg {i}")
+            time.sleep(0.005)
+        resp = client.get("/agent/conversations?limit=2&offset=1")
+        body = resp.json()
+        assert body["limit"] == 2
+        assert body["offset"] == 1
+        assert len(body["conversations"]) == 2
+        assert body["total"] == 5  # total of full set, not page size
+
+    def test_limit_cap_max_100(self, client):
+        resp = client.get("/agent/conversations?limit=101")
+        assert resp.status_code == 422  # FastAPI validation error
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/conversations/{id}/messages
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessages:
+    def test_returns_ordered_transcript(self, client):
+        _seed(0, "conv-X", "primera", assistant_text="A1")
+        time.sleep(0.01)
+        _seed(0, "conv-X", "segunda", assistant_text="A2")
+
+        resp = client.get("/agent/conversations/conv-X/messages")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["conversation_id"] == "conv-X"
+        assert body["title"] == "primera"
+        roles = [m["role"] for m in body["messages"]]
+        contents = [m["content"] for m in body["messages"]]
+        assert roles == ["user", "assistant", "user", "assistant"]
+        assert contents == ["primera", "A1", "segunda", "A2"]
+
+    def test_includes_reasoning_and_chips(self, client):
+        _seed(
+            0, "conv-Y", "usa tools",
+            assistant_text="respuesta",
+            reasoning="<think>razonamiento</think>",
+            tool_chips=[{"tool": "get_positions", "status": "ok"}],
+        )
+        resp = client.get("/agent/conversations/conv-Y/messages")
+        body = resp.json()
+        assistant = next(m for m in body["messages"] if m["role"] == "assistant")
+        assert assistant["reasoning"] == "<think>razonamiento</think>"
+        assert assistant["tool_chips"] == [{"tool": "get_positions", "status": "ok"}]
+
+    def test_proposal_state_pending_when_never_confirmed(self, client):
+        """No matching row in agent_side_effects + future expires_at →
+        state is 'pending'."""
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        _seed(
+            0, "conv-P1", "cerra mi BTC",
+            assistant_text="propongo cerrar",
+            proposals=[{
+                "proposal_id": "prop-p1",
+                "action":      "close_position",
+                "args":        {"position_id": 7},
+                "expires_at":  future,
+                "summary":     "Cerrar #7",
+            }],
+        )
+        resp = client.get("/agent/conversations/conv-P1/messages")
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        assert assistant["proposals"][0]["state"] == "pending"
+        # signed_payload never present in the response
+        assert "signed_payload" not in assistant["proposals"][0]
+
+    def test_proposal_state_expired_when_ttl_passed(self, client):
+        past = "2020-01-01T00:00:00+00:00"
+        _seed(
+            0, "conv-P2", "cerra ya",
+            proposals=[{
+                "proposal_id": "prop-p2",
+                "action":      "close_position",
+                "args":        {"position_id": 8},
+                "expires_at":  past,
+                "summary":     "Cerrar #8",
+            }],
+        )
+        resp = client.get("/agent/conversations/conv-P2/messages")
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        assert assistant["proposals"][0]["state"] == "expired"
+
+    def test_proposal_state_ok_from_agent_side_effects(self, client):
+        """If the user confirmed the proposal, agent_side_effects has the
+        terminal result. State derives from there, not from expires_at."""
+        from db.connection import get_db
+        future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+        _seed(
+            0, "conv-P3", "cerra",
+            proposals=[{
+                "proposal_id": "prop-p3",
+                "action":      "close_position",
+                "args":        {"position_id": 9},
+                "expires_at":  future,
+                "summary":     "Cerrar #9",
+            }],
+        )
+        # Pretend the confirm fired and recorded an 'ok'
+        con = get_db()
+        con.execute(
+            """INSERT INTO agent_side_effects
+               (tenant_id, conversation_id, ts, action, args_json,
+                idempotency_key, result, http_status, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (0, "conv-P3", "2026-05-22T10:00:00Z", "close_position",
+             "{}", "prop-p3", "ok", 200, future),
+        )
+        con.commit()
+        con.close()
+
+        resp = client.get("/agent/conversations/conv-P3/messages")
+        assistant = next(m for m in resp.json()["messages"] if m["role"] == "assistant")
+        assert assistant["proposals"][0]["state"] == "ok"
+
+    def test_404_for_nonexistent_conversation(self, client):
+        resp = client.get("/agent/conversations/does-not-exist/messages")
+        assert resp.status_code == 404
+
+    def test_404_for_expired_conversation(self, client):
+        _seed(0, "conv-expired", "viejo")
+        _expire_meta("conv-expired")
+        resp = client.get("/agent/conversations/conv-expired/messages")
+        assert resp.status_code == 404
+
+    def test_404_for_invalid_conversation_id_chars(self, client):
+        """Path pattern blocks special chars."""
+        resp = client.get("/agent/conversations/has space/messages")
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /agent/conversations/{id} — soft delete
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteConversation:
+    def test_soft_delete_removes_from_list_and_messages(self, client):
+        _seed(0, "conv-D1", "borrame")
+        # Sanity: visible before delete
+        assert len(client.get("/agent/conversations").json()["conversations"]) == 1
+
+        resp = client.delete(
+            "/agent/conversations/conv-D1",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        # Hidden after
+        assert client.get("/agent/conversations").json()["conversations"] == []
+        # GET messages now 404s
+        assert client.get("/agent/conversations/conv-D1/messages").status_code == 404
+
+    def test_404_for_nonexistent_conversation(self, client):
+        resp = client.delete(
+            "/agent/conversations/does-not-exist",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert resp.status_code == 404
+
+    def test_404_for_already_deleted_conversation(self, client):
+        _seed(0, "conv-D2", "hola")
+        client.delete("/agent/conversations/conv-D2",
+                      headers={"X-API-Key": "test-key"})
+        # Second delete on the same conversation
+        resp = client.delete("/agent/conversations/conv-D2",
+                             headers={"X-API-Key": "test-key"})
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /agent/conversations/{id}/pin — toggle
+# ---------------------------------------------------------------------------
+
+
+class TestTogglePin:
+    def test_pin_then_unpin(self, client):
+        _seed(0, "conv-PN1", "fijame")
+
+        # Pin
+        resp1 = client.post(
+            "/agent/conversations/conv-PN1/pin",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert resp1.status_code == 200
+        assert resp1.json() == {"ok": True, "pinned": True}
+
+        # Verify list shows pinned=True
+        body = client.get("/agent/conversations").json()
+        assert body["conversations"][0]["pinned"] is True
+
+        # Unpin
+        resp2 = client.post(
+            "/agent/conversations/conv-PN1/pin",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert resp2.status_code == 200
+        assert resp2.json() == {"ok": True, "pinned": False}
+
+    def test_404_on_nonexistent(self, client):
+        resp = client.post(
+            "/agent/conversations/nope/pin",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert resp.status_code == 404
+
+    def test_404_on_expired(self, client):
+        _seed(0, "conv-PN2", "viejo")
+        _expire_meta("conv-PN2")
+        resp = client.post(
+            "/agent/conversations/conv-PN2/pin",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert resp.status_code == 404

--- a/tests/test_agent_history_idor.py
+++ b/tests/test_agent_history_idor.py
@@ -1,0 +1,291 @@
+"""IDOR suite for #428 H.3 conversation-history endpoints.
+
+Mirrors the B.7 #260 pattern. TestClient operates as synthetic user
+(id=0). Cross-tenant data is seeded for OTHER_USER_ID via the
+production write path. Every endpoint must:
+
+- Hide other users' conversations from the list.
+- Return 404 (not 403) when probing other users' conversation_ids —
+  no existence leak across tenants.
+- Refuse to mutate other users' state (delete / pin).
+- Drop query/header tenant tampering.
+
+Threat model: docs/superpowers/specs/es/2026-05-22-conversation-history-pre-reg.md §7
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+OTHER_USER_ID = 999  # synthetic "other tenant" — distinct from TestClient (id=0)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import btc_api
+    db_path = str(tmp_path / "test.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"api_key": "test-key"}))
+    monkeypatch.setattr(btc_api, "CONFIG_FILE", str(cfg_path), raising=False)
+    import api.config as _ac
+    monkeypatch.setattr(_ac, "CONFIG_FILE", str(cfg_path), raising=False)
+    monkeypatch.setattr(btc_api, "DEFAULTS_FILE", str(tmp_path / "no_def.json"), raising=False)
+    monkeypatch.setattr(_ac, "DEFAULTS_FILE", str(tmp_path / "no_def.json"), raising=False)
+    monkeypatch.setattr(btc_api, "SECRETS_FILE", str(tmp_path / "no_sec.json"), raising=False)
+    monkeypatch.setattr(_ac, "SECRETS_FILE", str(tmp_path / "no_sec.json"), raising=False)
+    return TestClient(btc_api.app)
+
+
+def _seed(tenant_id: int, conversation_id: str, user_msg: str = "msg",
+          assistant_text: str = "ok", surface: str = "dock") -> None:
+    from api.agent.audit import record_history
+    record_history(
+        tenant_id=tenant_id, surface=surface,
+        conversation_id=conversation_id,
+        user_message=user_msg, assistant_text=assistant_text,
+        assistant_reasoning=None, tool_chips=[], proposals=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/conversations — list
+# ---------------------------------------------------------------------------
+
+
+class TestListIDOR:
+    def test_list_excludes_other_tenants(self, client):
+        _seed(OTHER_USER_ID, "victim-conv", "secreto de la victima")
+        _seed(0, "my-conv", "mi pregunta")
+
+        body = client.get("/agent/conversations").json()
+        ids = [c["conversation_id"] for c in body["conversations"]]
+        assert ids == ["my-conv"]
+        assert body["total"] == 1
+
+    def test_list_empty_when_only_other_tenant_has_conversations(self, client):
+        _seed(OTHER_USER_ID, "v1", "..")
+        _seed(OTHER_USER_ID, "v2", "..")
+
+        body = client.get("/agent/conversations").json()
+        assert body["conversations"] == []
+        assert body["total"] == 0
+
+    def test_search_q_does_not_leak_other_tenant_content(self, client):
+        """An attacker can't fish for content via q-search across tenants.
+        Even if the victim's messages contain the search keyword, the
+        attacker's list must not surface them."""
+        _seed(OTHER_USER_ID, "v-conv",
+              user_msg="contraseña super secreta xyz",
+              assistant_text="otro secreto")
+        _seed(0, "my-conv", user_msg="hola", assistant_text="qué tal")
+
+        body = client.get("/agent/conversations?q=secreta").json()
+        ids = [c["conversation_id"] for c in body["conversations"]]
+        assert ids == []  # no leak even though the keyword exists across tenant boundary
+        assert body["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /agent/conversations/{id}/messages — transcript read
+# ---------------------------------------------------------------------------
+
+
+class TestGetMessagesIDOR:
+    def test_404_when_probing_other_tenants_conversation(self, client):
+        _seed(OTHER_USER_ID, "victim-id", "secret")
+        resp = client.get("/agent/conversations/victim-id/messages")
+        assert resp.status_code == 404
+        # Same response as nonexistent (no existence leak)
+        nonexistent = client.get("/agent/conversations/never-existed/messages")
+        assert resp.json() == nonexistent.json()
+
+    def test_own_conversation_visible_other_invisible(self, client):
+        _seed(OTHER_USER_ID, "victim-id", "secret")
+        _seed(0, "mine", "hola")
+
+        ok = client.get("/agent/conversations/mine/messages")
+        assert ok.status_code == 200
+        assert ok.json()["conversation_id"] == "mine"
+
+        forbidden = client.get("/agent/conversations/victim-id/messages")
+        assert forbidden.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /agent/conversations/{id} — soft delete
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteIDOR:
+    def test_404_when_deleting_other_tenants_conversation(self, client):
+        from db.connection import get_db
+        _seed(OTHER_USER_ID, "victim-id", "secret")
+
+        resp = client.delete(
+            "/agent/conversations/victim-id",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert resp.status_code == 404
+
+        # Victim's row untouched (expires_at still in the future)
+        con = get_db()
+        row = con.execute(
+            "SELECT expires_at, tenant_id FROM agent_conversation_meta "
+            "WHERE conversation_id = 'victim-id'"
+        ).fetchone()
+        con.close()
+        from datetime import datetime, timezone
+        assert datetime.fromisoformat(row[0]) > datetime.now(timezone.utc)
+        assert row[1] == OTHER_USER_ID
+
+    def test_delete_does_not_affect_other_tenants_messages(self, client):
+        """Even with the IDOR-blocked DELETE returning 404, the attacker
+        could in theory have soft-deleted the victim's agent_messages
+        rows. Verify they're untouched."""
+        from db.connection import get_db
+        _seed(OTHER_USER_ID, "victim-id", "secret")
+
+        client.delete(
+            "/agent/conversations/victim-id",
+            headers={"X-API-Key": "test-key"},
+        )
+
+        con = get_db()
+        rows = con.execute(
+            "SELECT COUNT(*) FROM agent_messages "
+            "WHERE conversation_id = 'victim-id' AND tenant_id = ?",
+            (OTHER_USER_ID,),
+        ).fetchone()
+        con.close()
+        assert rows[0] == 2  # user + assistant both still present
+
+
+# ---------------------------------------------------------------------------
+# POST /agent/conversations/{id}/pin — toggle
+# ---------------------------------------------------------------------------
+
+
+class TestPinIDOR:
+    def test_404_when_pinning_other_tenants_conversation(self, client):
+        _seed(OTHER_USER_ID, "victim-id", "secret")
+        resp = client.post(
+            "/agent/conversations/victim-id/pin",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert resp.status_code == 404
+
+    def test_pin_does_not_mutate_other_tenants_row(self, client):
+        from db.connection import get_db
+        _seed(OTHER_USER_ID, "victim-id", "secret")
+
+        client.post(
+            "/agent/conversations/victim-id/pin",
+            headers={"X-API-Key": "test-key"},
+        )
+
+        con = get_db()
+        row = con.execute(
+            "SELECT pinned FROM agent_conversation_meta "
+            "WHERE conversation_id = 'victim-id'"
+        ).fetchone()
+        con.close()
+        assert row[0] == 0  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Tampering — query / body / header
+# ---------------------------------------------------------------------------
+
+
+class TestTamperingIgnored:
+    def test_query_tenant_id_ignored_in_list(self, client):
+        """`?tenant_id=999` must NOT override JWT-derived id."""
+        _seed(OTHER_USER_ID, "v1", "..")
+
+        body = client.get(f"/agent/conversations?tenant_id={OTHER_USER_ID}").json()
+        assert body["conversations"] == []
+        assert body["total"] == 0
+
+    def test_header_x_tenant_id_ignored_in_list(self, client):
+        _seed(OTHER_USER_ID, "v1", "..")
+        body = client.get(
+            "/agent/conversations",
+            headers={"X-Tenant-Id": str(OTHER_USER_ID)},
+        ).json()
+        assert body["conversations"] == []
+
+    def test_query_tenant_id_ignored_in_messages_get(self, client):
+        _seed(OTHER_USER_ID, "v-id", "..")
+        resp = client.get(
+            f"/agent/conversations/v-id/messages?tenant_id={OTHER_USER_ID}"
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Same conversation_id across tenants (write-side collision was fixed in
+# PR #433 review pickup; H.3 reads MUST also segregate)
+# ---------------------------------------------------------------------------
+
+
+class TestSameConversationIdAcrossTenants:
+    """The H.2 write path refuses cross-tenant writes via record_history's
+    pre-check. But what if pre-existing data (from before the security
+    fix) had orphan agent_messages rows under a victim's conversation_id
+    with a different tenant_id? The H.3 read path MUST still filter
+    those out so the attacker can't see victim's transcript even if
+    they know the conversation_id.
+    """
+
+    def test_messages_get_filters_by_tenant_id_even_with_orphans(self, client):
+        from db.connection import get_db
+        # Victim creates the conversation legitimately
+        _seed(OTHER_USER_ID, "shared-id", "secreto de la victima")
+
+        # Simulate pre-fix orphan rows: attacker's tenant_id=0 rows
+        # exist under the same conversation_id.
+        con = get_db()
+        con.execute(
+            """INSERT INTO agent_messages
+               (tenant_id, conversation_id, ts, role, content, expires_at)
+               VALUES (?, ?, ?, 'user', ?, ?)""",
+            (0, "shared-id", "2026-05-22T08:00:00Z",
+             "attacker injected", "2099-01-01T00:00:00Z"),
+        )
+        con.commit()
+        con.close()
+
+        # Attacker (id=0) probing the conversation: meta row is owned by
+        # OTHER_USER_ID, so the 404 fires before any message read can
+        # happen.
+        resp = client.get("/agent/conversations/shared-id/messages")
+        assert resp.status_code == 404
+
+    def test_list_does_not_surface_orphan_meta_for_other_tenant(self, client):
+        """Victim's meta row + attacker's orphan agent_messages rows
+        under the same conversation_id. Attacker's GET /conversations
+        must NOT return the conversation even if their orphan messages
+        match a q-filter."""
+        from db.connection import get_db
+        _seed(OTHER_USER_ID, "shared-id", "asunto victima")
+        con = get_db()
+        con.execute(
+            """INSERT INTO agent_messages
+               (tenant_id, conversation_id, ts, role, content, expires_at)
+               VALUES (?, ?, ?, 'user', ?, ?)""",
+            (0, "shared-id", "2026-05-22T08:00:00Z",
+             "match-this-keyword", "2099-01-01T00:00:00Z"),
+        )
+        con.commit()
+        con.close()
+
+        body = client.get("/agent/conversations?q=match-this-keyword").json()
+        ids = [c["conversation_id"] for c in body["conversations"]]
+        assert ids == []  # No row, even though attacker has a matching message
+        assert body["total"] == 0


### PR DESCRIPTION
Refs epic #428. Implements H.3 (backend read endpoints).
Depends on #432 (H.1 schema) + #433 (H.2 write path) — both merged to main.

## Summary
Four JWT-gated endpoints powering the sidebar UX:

| Endpoint | Purpose |
|---|---|
| `GET /agent/conversations` | Sidebar list. Pinned first → last_ts DESC. Supports `limit`/`offset` pagination, `surface` filter, `q` substring search across title + message content. |
| `GET /agent/conversations/{id}/messages` | Full transcript ordered by ts ASC. Reconstructs proposal `state` from `agent_side_effects`. |
| `DELETE /agent/conversations/{id}` | Soft delete (`expires_at = NOW`) on both meta + messages. |
| `POST /agent/conversations/{id}/pin` | Toggle pinned flag. |

All four derive `tenant_id` from `get_current_tenant_id` (JWT). Never from path/query/header/body. 404 is the only error code for cross-tenant probes — same response body as nonexistent (no existence leak).

## Subtle bug caught + fixed in the same iteration
First test run had 3 q-search failures. Root cause: parameter ordering. The JOIN clause's `?` lands **before** the WHERE's in the final SQL, but I was appending all params to one list as I built the WHERE — so the JOIN's `expires_at` ended up consuming the `tenant_id` slot and vice versa. Every q-search silently returned zero rows.

Fix: split into `join_params` + `where_params` buckets, concat in the right order at `con.execute`. Documented inline.

## Proposal state reconstruction
On `GET /messages`, every persisted proposal needs a derived `state` (`pending` / `ok` / `expired` / `error` / `conflict`). The H.2 write path never persists `signed_payload` (TTL minutes, useless on rehydrate). Reconstruction logic:

```
SELECT result FROM agent_side_effects WHERE idempotency_key = proposal_id
  → if found: return result
  → if not found, original expires_at in the past: 'expired'
  → otherwise: 'pending' (frontend renders chip without confirm button)
```

Three explicit tests for each branch.

## Test plan
- [x] `pytest tests/test_agent_history_api.py -v` — 24/24 (happy paths + pagination + q-search + retention + proposal states).
- [x] `pytest tests/test_agent_history_idor.py -v` — 14/14 (cross-tenant 404, no content leak via q-search, no mutation via DELETE/pin, query/header tampering ignored, orphan-rows-from-pre-#433-data filtered).
- [x] Regression: `pytest tests/test_agent_*.py tests/test_multi_tenant_b7_idor.py` — 292 passed / 1 skipped.
- [ ] CI green.
- [ ] After merge: H.4 (frontend sidebar) can consume the API.

## Files
- `api/agent/history.py` — new router, response models, helpers (`_escape_like`, `_derive_proposal_state`).
- `btc_api.py` — `app.include_router(agent_history_router)`.
- `tests/test_agent_history_api.py` — 24 happy-path tests.
- `tests/test_agent_history_idor.py` — 14 cross-tenant security tests (mirror B.7 #260 pattern).

## Next
H.4 (frontend sidebar) — slide-in `AgentHistorySidebar.tsx` from the dock header. List + load + delete + pin via vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)