### PR TITLE
feat(agent): H.4 conversation history sidebar UI (#428)

### DIFF
--- a/frontend/src/agent/client.ts
+++ b/frontend/src/agent/client.ts
@@ -13,6 +13,8 @@
 import type {
   AgentStreamEvent,
   AgentTurnRequest,
+  ConversationDetailResponse,
+  ConversationListResponse,
 } from './types';
 
 const BASE_URL = '/api';
@@ -189,4 +191,71 @@ export async function confirmAgentProposal(args: {
   if (resp.status === 409 || detail === 'state_drift') bucket = 'state_drift';
   else if (resp.status === 410 || detail === 'expired') bucket = 'expired';
   return { ok: false, result: bucket, http_status: resp.status };
+}
+
+// ── Epic #428 H.3 — conversation history client ─────────────────────
+
+async function _historyFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/json',
+    ...((init?.headers as Record<string, string>) ?? {}),
+  };
+  const method = (init?.method ?? 'GET').toUpperCase();
+  if (method !== 'GET' && method !== 'HEAD') {
+    headers['X-CSRF-Token'] = readCsrfCookie();
+    if (init?.body && !headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+  }
+  const resp = await fetch(`${BASE_URL}${path}`, {
+    method,
+    credentials: 'include',
+    headers,
+    ...init,
+  });
+  if (!resp.ok) {
+    throw new AgentStreamError(resp.status, `http_${resp.status}`);
+  }
+  return (await resp.json()) as T;
+}
+
+export interface ListConversationsArgs {
+  limit?:   number;
+  offset?:  number;
+  surface?: string;
+  q?:       string;
+}
+
+export async function listConversations(
+  args: ListConversationsArgs = {},
+): Promise<ConversationListResponse> {
+  const params = new URLSearchParams();
+  if (args.limit  !== undefined) params.set('limit',  String(args.limit));
+  if (args.offset !== undefined) params.set('offset', String(args.offset));
+  if (args.surface) params.set('surface', args.surface);
+  if (args.q && args.q.trim()) params.set('q', args.q.trim());
+  const qs = params.toString();
+  const path = `/agent/conversations${qs ? `?${qs}` : ''}`;
+  return _historyFetch<ConversationListResponse>(path);
+}
+
+export async function getConversationMessages(
+  conversation_id: string,
+): Promise<ConversationDetailResponse> {
+  const path = `/agent/conversations/${encodeURIComponent(conversation_id)}/messages`;
+  return _historyFetch<ConversationDetailResponse>(path);
+}
+
+export async function deleteConversation(
+  conversation_id: string,
+): Promise<{ ok: boolean }> {
+  const path = `/agent/conversations/${encodeURIComponent(conversation_id)}`;
+  return _historyFetch<{ ok: boolean }>(path, { method: 'DELETE' });
+}
+
+export async function togglePinConversation(
+  conversation_id: string,
+): Promise<{ ok: boolean; pinned: boolean }> {
+  const path = `/agent/conversations/${encodeURIComponent(conversation_id)}/pin`;
+  return _historyFetch<{ ok: boolean; pinned: boolean }>(path, { method: 'POST' });
 }

--- a/frontend/src/agent/types.ts
+++ b/frontend/src/agent/types.ts
@@ -19,6 +19,64 @@ export interface ToolChip {
   status: 'pending' | 'ok' | 'error';
 }
 
+// ── Epic #428 history rehydration types ───────────────────────────────
+//
+// These mirror the pydantic models in api/agent/history.py. The H.3
+// REST endpoints return them; the sidebar (H.4) lists them; the
+// rehydration hook (H.5) replays them into the dock transcript.
+
+export interface ConversationSummary {
+  conversation_id: string;
+  title:           string | null;
+  surface:         string;
+  first_ts:        string;
+  last_ts:         string;
+  message_count:   number;
+  pinned:          boolean;
+}
+
+export interface ConversationListResponse {
+  conversations: ConversationSummary[];
+  total:         number;
+  limit:         number;
+  offset:        number;
+}
+
+/**
+ * Proposal record on the REST rehydration response. Distinct from
+ * ProposalChip below: this shape has NO `signed_payload` (the HMAC
+ * was never persisted past minutes) and the `state` enum uses
+ * 'stale' for "rehydrated, never confirmed, TTL not yet passed" —
+ * see api/agent/history.py::ProposalRecord docstring + PR #434
+ * review issue #6. The rehydration hook converts this to ProposalChip
+ * before pushing into the transcript.
+ */
+export interface ProposalRecord {
+  proposal_id: string;
+  action:      string;
+  args:        Record<string, unknown>;
+  expires_at:  string;
+  summary:     string;
+  state:       'stale' | 'ok' | 'expired' | 'error' | 'conflict';
+}
+
+export interface MessageRecord {
+  role:       'user' | 'assistant';
+  ts:         string;
+  content:    string;
+  reasoning?: string | null;
+  tool_chips: ToolChip[];
+  proposals:  ProposalRecord[];
+}
+
+export interface ConversationDetailResponse {
+  conversation_id: string;
+  title:           string | null;
+  surface:         string;
+  pinned:          boolean;
+  messages:        MessageRecord[];
+}
+
 export interface AgentTextDelta {
   type: 'text_delta';
   text: string;
@@ -115,12 +173,13 @@ export type AgentStreamEvent =
  * sees the outcome without a toast.
  */
 export type ProposalState =
-  | 'pending'
-  | 'in_flight'
-  | 'ok'
-  | 'expired'
-  | 'drift'
-  | 'error';
+  | 'pending'    // live SSE: actionable, signed_payload is hot
+  | 'in_flight'  // confirm POST in progress
+  | 'ok'         // confirmed
+  | 'expired'    // TTL passed without confirm
+  | 'drift'      // confirmed but server state had changed
+  | 'error'      // confirm failed
+  | 'stale';     // #428 H.3 REST rehydration: never-confirmed, TTL not yet up, but signed_payload is gone — not actionable
 
 export interface ProposalChip {
   proposal_id:    string;

--- a/frontend/src/components/AgentDock.module.css
+++ b/frontend/src/components/AgentDock.module.css
@@ -442,3 +442,19 @@
   }
   .fabGlyph { font-size: 18px; }
 }
+
+/* H.4 history sidebar trigger — lives in the dock header. */
+.historyOpen {
+  background: none;
+  border: 1px solid rgba(106, 215, 255, 0.25);
+  color: rgba(232, 237, 243, 0.85);
+  cursor: pointer;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 4px 10px;
+  font-family: inherit;
+}
+.historyOpen:hover {
+  border-color: var(--bull, #6ad7ff);
+  color: var(--bull, #6ad7ff);
+}

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -14,7 +14,6 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AgentDock.module.css';
-import historyStyles from './AgentHistorySidebar.module.css';
 import type { SymbolStatus, Position, MacroState } from '../types';
 import { useAgentStream } from '../agent/useAgentStream';
 import { SURFACE_DOCK } from '../agent/surfaces';
@@ -132,7 +131,7 @@ const AgentDock: React.FC<AgentDockProps> = ({
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <button
                 type="button"
-                className={historyStyles.openButton}
+                className={styles.historyOpen}
                 onClick={() => setHistoryOpen(true)}
                 aria-label="Abrir historial"
               >Historial</button>

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -14,10 +14,12 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AgentDock.module.css';
+import historyStyles from './AgentHistorySidebar.module.css';
 import type { SymbolStatus, Position, MacroState } from '../types';
 import { useAgentStream } from '../agent/useAgentStream';
 import { SURFACE_DOCK } from '../agent/surfaces';
 import type { ProposalChip, ToolChip } from '../agent/types';
+import AgentHistorySidebar from './AgentHistorySidebar';
 
 interface AgentDockProps {
   open:           boolean;
@@ -46,6 +48,7 @@ const AgentDock: React.FC<AgentDockProps> = ({
   initialPrompt, unreadHint,
 }) => {
   const [input, setInput] = useState('');
+  const [historyOpen, setHistoryOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -126,7 +129,15 @@ const AgentDock: React.FC<AgentDockProps> = ({
                 </div>
               </div>
             </div>
-            <button className={styles.close} onClick={onClose} aria-label="Cerrar">×</button>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <button
+                type="button"
+                className={historyStyles.openButton}
+                onClick={() => setHistoryOpen(true)}
+                aria-label="Abrir historial"
+              >Historial</button>
+              <button className={styles.close} onClick={onClose} aria-label="Cerrar">×</button>
+            </div>
           </header>
 
           <div className={styles.scroll} ref={scrollRef}>
@@ -174,6 +185,14 @@ const AgentDock: React.FC<AgentDockProps> = ({
           </form>
         </aside>
       )}
+
+      {/* H.4 sidebar — slides in on top of the dock. H.5 will wire
+          onSelectConversation through useAgentStream to rehydrate the
+          transcript; for H.4 it just closes the sidebar (no-op load). */}
+      <AgentHistorySidebar
+        open={open && historyOpen}
+        onClose={() => setHistoryOpen(false)}
+      />
     </>
   );
 };
@@ -278,11 +297,17 @@ const ProposalConfirm: React.FC<ProposalConfirmProps> = ({ proposal, onConfirm }
     expired:   'Expirado',
     drift:     'Estado cambió — re-pregunta',
     error:     'Falló — re-pregunta',
+    // #428 H.3: rehydrated chip without a valid signed_payload. UX is
+    // identical to expired — not actionable, button disabled — but the
+    // copy distinguishes "TTL passed" from "you saw this in a previous
+    // session and the signed_payload wasn't persisted".
+    stale:     'Propuesta ya no activa',
   };
   const stateClass =
     proposal.state === 'in_flight' ? styles.toolConfirmInFlight :
     proposal.state === 'ok'        ? styles.toolConfirmOk :
-    (proposal.state === 'expired' || proposal.state === 'drift' || proposal.state === 'error')
+    (proposal.state === 'expired' || proposal.state === 'drift' ||
+     proposal.state === 'error' || proposal.state === 'stale')
                                    ? styles.toolConfirmError :
     '';
   const isInteractive = proposal.state === 'pending';

--- a/frontend/src/components/AgentHistorySidebar.module.css
+++ b/frontend/src/components/AgentHistorySidebar.module.css
@@ -1,0 +1,192 @@
+/* ============================================================
+   AgentHistorySidebar — slide-in panel for past copilot chats.
+   Anchored to the right edge of the AgentDock.
+   ============================================================ */
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 95;
+  animation: ahsFade 140ms ease-out;
+}
+
+.panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 360px;
+  max-width: 90vw;
+  background: var(--nbc-surface-solid, #0a0d15);
+  border-left: 1px solid var(--bull, #6ad7ff);
+  color: var(--nbc-primary-fg, #e8edf3);
+  z-index: 96;
+  display: flex;
+  flex-direction: column;
+  font-family: inherit;
+  animation: ahsSlide 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  box-shadow: -8px 0 24px -8px rgba(0, 0, 0, 0.6);
+}
+
+@keyframes ahsFade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes ahsSlide {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(106, 215, 255, 0.15);
+}
+.title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.closeBtn {
+  background: none;
+  border: none;
+  color: var(--nbc-primary-fg, #e8edf3);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.closeBtn:hover { color: var(--bull, #6ad7ff); }
+
+.searchBar {
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(106, 215, 255, 0.10);
+}
+.searchInput {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(106, 215, 255, 0.20);
+  color: inherit;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 13px;
+}
+.searchInput:focus {
+  outline: none;
+  border-color: var(--bull, #6ad7ff);
+}
+
+.list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.empty,
+.loading,
+.errorState {
+  padding: 24px 16px;
+  font-size: 13px;
+  color: rgba(232, 237, 243, 0.55);
+  text-align: center;
+}
+.errorState { color: var(--bear, #ff5b6e); }
+
+.item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(106, 215, 255, 0.08);
+  cursor: pointer;
+  transition: background 100ms ease;
+}
+.item:hover { background: rgba(106, 215, 255, 0.06); }
+.itemPinned { background: rgba(106, 215, 255, 0.04); }
+
+.itemBody {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.itemTitle {
+  font-size: 13px;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.itemTitleEmpty {
+  font-style: italic;
+  color: rgba(232, 237, 243, 0.45);
+}
+.itemMeta {
+  font-size: 11px;
+  color: rgba(232, 237, 243, 0.55);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.surfaceChip {
+  font-size: 10px;
+  padding: 1px 6px;
+  background: rgba(106, 215, 255, 0.10);
+  color: var(--bull, #6ad7ff);
+  border: 1px solid rgba(106, 215, 255, 0.20);
+  letter-spacing: 0.04em;
+}
+
+.itemActions {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+.item:hover .itemActions,
+.itemPinned .itemActions { opacity: 1; }
+
+.actionBtn {
+  background: none;
+  border: 1px solid rgba(106, 215, 255, 0.18);
+  color: rgba(232, 237, 243, 0.65);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 6px;
+  line-height: 1;
+}
+.actionBtn:hover {
+  border-color: var(--bull, #6ad7ff);
+  color: var(--bull, #6ad7ff);
+}
+.actionBtnPinned {
+  color: var(--bull, #6ad7ff);
+  border-color: var(--bull, #6ad7ff);
+}
+
+/* Trigger button (lives in AgentDock header). Re-exported style. */
+.openButton {
+  background: none;
+  border: 1px solid rgba(106, 215, 255, 0.25);
+  color: rgba(232, 237, 243, 0.85);
+  cursor: pointer;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 4px 10px;
+  font-family: inherit;
+}
+.openButton:hover {
+  border-color: var(--bull, #6ad7ff);
+  color: var(--bull, #6ad7ff);
+}

--- a/frontend/src/components/AgentHistorySidebar.module.css
+++ b/frontend/src/components/AgentHistorySidebar.module.css
@@ -174,19 +174,3 @@
   color: var(--bull, #6ad7ff);
   border-color: var(--bull, #6ad7ff);
 }
-
-/* Trigger button (lives in AgentDock header). Re-exported style. */
-.openButton {
-  background: none;
-  border: 1px solid rgba(106, 215, 255, 0.25);
-  color: rgba(232, 237, 243, 0.85);
-  cursor: pointer;
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  padding: 4px 10px;
-  font-family: inherit;
-}
-.openButton:hover {
-  border-color: var(--bull, #6ad7ff);
-  color: var(--bull, #6ad7ff);
-}

--- a/frontend/src/components/AgentHistorySidebar.test.tsx
+++ b/frontend/src/components/AgentHistorySidebar.test.tsx
@@ -99,6 +99,26 @@ describe('AgentHistorySidebar', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('item body is non-clickable when onSelectConversation is undefined', async () => {
+    // PR #435 review issue #6: until H.5 wires rehydration, the parent
+    // (AgentDock) does NOT pass onSelectConversation. The item body
+    // should render as a plain div so the user doesn't get the
+    // "I clicked but nothing happened" experience.
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv({ conversation_id: 'nope', title: 'sin handler' })],
+      total: 1, limit: 20, offset: 0,
+    });
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    await screen.findByText('sin handler');
+    // Should NOT find a button with the "Abrir conversación" label.
+    expect(
+      screen.queryByRole('button', { name: /abrir conversaci.n/i }),
+    ).toBeNull();
+    // Pin + delete buttons still present
+    expect(screen.getByRole('button', { name: /^fijar$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^borrar$/i })).toBeInTheDocument();
+  });
+
   it('clicking pin toggles + calls API', async () => {
     vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
       conversations: [_conv({ conversation_id: 'pin-c', pinned: false })],
@@ -150,6 +170,101 @@ describe('AgentHistorySidebar', () => {
     await waitFor(() => {
       expect(screen.getByText('survivor')).toBeInTheDocument();
     });
+  });
+
+  it('pin failure reverts the optimistic toggle (#435 issue #1)', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv({ conversation_id: 'pin-fail', pinned: false })],
+      total: 1, limit: 20, offset: 0,
+    });
+    vi.spyOn(agentClient, 'togglePinConversation').mockRejectedValue(
+      new Error('network'),
+    );
+
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    const pinBtn = await screen.findByRole('button', { name: /^fijar$/i });
+    await userEvent.click(pinBtn);
+    // After the rejection settles, the chip should be back to "Fijar"
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^fijar$/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /desfijar/i })).toBeNull();
+  });
+
+  it('pressing Escape closes the sidebar', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [], total: 0, limit: 20, offset: 0,
+    });
+    const onClose = vi.fn();
+    render(<AgentHistorySidebar open={true} onClose={onClose} />);
+    await screen.findByLabelText(/buscar/i);
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('clicking the backdrop closes the sidebar', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [], total: 0, limit: 20, offset: 0,
+    });
+    const onClose = vi.fn();
+    const { container } = render(
+      <AgentHistorySidebar open={true} onClose={onClose} />,
+    );
+    await screen.findByLabelText(/buscar/i);
+    // backdrop is the aria-hidden div with the backdrop class
+    const backdrop = container.querySelector('[aria-hidden="true"]');
+    expect(backdrop).not.toBeNull();
+    await userEvent.click(backdrop!);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('preserves the API ordering (pinned first then last_ts DESC)', async () => {
+    // The H.3 endpoint guarantees this ordering; the component must
+    // render rows in the order the API returned.
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [
+        _conv({ conversation_id: 'pin-old', title: 'fijada antigua',
+                pinned: true, last_ts: '2026-05-20T08:00:00Z' }),
+        _conv({ conversation_id: 'fresh', title: 'reciente sin fijar',
+                pinned: false, last_ts: '2026-05-22T09:00:00Z' }),
+        _conv({ conversation_id: 'older', title: 'vieja sin fijar',
+                pinned: false, last_ts: '2026-05-21T09:00:00Z' }),
+      ],
+      total: 3, limit: 20, offset: 0,
+    });
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    await screen.findByText('fijada antigua');
+    const titles = ['fijada antigua', 'reciente sin fijar', 'vieja sin fijar']
+      .map((t) => screen.getByText(t));
+    // Render order matches API order: pin first, then by last_ts DESC
+    expect(titles[0].compareDocumentPosition(titles[1])
+           & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(titles[1].compareDocumentPosition(titles[2])
+           & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('clearing the search input re-fires the list call without q', async () => {
+    const listSpy = vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [], total: 0, limit: 20, offset: 0,
+    });
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    const searchInput = await screen.findByLabelText(/buscar/i);
+
+    await userEvent.type(searchInput, 'X');
+    await waitFor(
+      () => expect(listSpy.mock.calls.some(([a]) => a?.q === 'X')).toBe(true),
+      { timeout: 1000 },
+    );
+
+    await userEvent.clear(searchInput);
+    // After clearing, the most recent call should NOT carry q
+    await waitFor(
+      () => {
+        const last = listSpy.mock.calls[listSpy.mock.calls.length - 1];
+        expect(last?.[0]?.q).toBeUndefined();
+      },
+      { timeout: 1000 },
+    );
   });
 
   it('search input passes q to listConversations (debounced)', async () => {

--- a/frontend/src/components/AgentHistorySidebar.test.tsx
+++ b/frontend/src/components/AgentHistorySidebar.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import AgentHistorySidebar from './AgentHistorySidebar';
+import * as agentClient from '../agent/client';
+import type { ConversationSummary } from '../agent/types';
+
+function _conv(overrides: Partial<ConversationSummary> = {}): ConversationSummary {
+  return {
+    conversation_id: 'conv-1',
+    title:           'que opinas de PENDLE?',
+    surface:         'dock',
+    first_ts:        '2026-05-22T08:00:00Z',
+    last_ts:         '2026-05-22T09:00:00Z',
+    message_count:   4,
+    pinned:          false,
+    ...overrides,
+  };
+}
+
+describe('AgentHistorySidebar', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when closed', () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv()], total: 1, limit: 20, offset: 0,
+    });
+    const { container } = render(
+      <AgentHistorySidebar open={false} onClose={() => {}} />,
+    );
+    expect(container.querySelector('aside')).toBeNull();
+  });
+
+  it('fetches and renders conversations on open', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv({ conversation_id: 'c1', title: 'primera' }),
+                      _conv({ conversation_id: 'c2', title: 'segunda' })],
+      total: 2, limit: 20, offset: 0,
+    });
+
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('primera')).toBeInTheDocument();
+    });
+    expect(screen.getByText('segunda')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no conversations', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [], total: 0, limit: 20, offset: 0,
+    });
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText(/no tienes conversaciones todav/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state on API failure', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockRejectedValue(
+      new Error('500 server error'),
+    );
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText(/no se pudo cargar/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders fallback title for null-title conversations', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv({ title: null })], total: 1, limit: 20, offset: 0,
+    });
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    await waitFor(() => {
+      expect(screen.getByText(/sin t.tulo/i)).toBeInTheDocument();
+    });
+  });
+
+  it('clicking an item invokes onSelectConversation + closes', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv({ conversation_id: 'pick-me', title: 'elígeme' })],
+      total: 1, limit: 20, offset: 0,
+    });
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <AgentHistorySidebar
+        open={true}
+        onClose={onClose}
+        onSelectConversation={onSelect}
+      />,
+    );
+    const button = await screen.findByRole('button', { name: /abrir conversaci.n el.geme/i });
+    await userEvent.click(button);
+    expect(onSelect).toHaveBeenCalledWith('pick-me');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('clicking pin toggles + calls API', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv({ conversation_id: 'pin-c', pinned: false })],
+      total: 1, limit: 20, offset: 0,
+    });
+    const togglePinSpy = vi.spyOn(agentClient, 'togglePinConversation').mockResolvedValue({
+      ok: true, pinned: true,
+    });
+
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    const pinBtn = await screen.findByRole('button', { name: /^fijar$/i });
+    await userEvent.click(pinBtn);
+    expect(togglePinSpy).toHaveBeenCalledWith('pin-c');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /desfijar/i })).toBeInTheDocument();
+    });
+  });
+
+  it('clicking delete removes item optimistically + calls API', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv({ conversation_id: 'kill-me', title: 'mátame' })],
+      total: 1, limit: 20, offset: 0,
+    });
+    const delSpy = vi.spyOn(agentClient, 'deleteConversation').mockResolvedValue({
+      ok: true,
+    });
+
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    await screen.findByText('mátame');
+    const delBtn = screen.getByRole('button', { name: /^borrar$/i });
+    await userEvent.click(delBtn);
+    expect(delSpy).toHaveBeenCalledWith('kill-me');
+    await waitFor(() => {
+      expect(screen.queryByText('mátame')).not.toBeInTheDocument();
+    });
+  });
+
+  it('delete failure reverts the optimistic removal', async () => {
+    vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [_conv({ conversation_id: 'oops', title: 'survivor' })],
+      total: 1, limit: 20, offset: 0,
+    });
+    vi.spyOn(agentClient, 'deleteConversation').mockRejectedValue(new Error('network'));
+
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    await screen.findByText('survivor');
+    await userEvent.click(screen.getByRole('button', { name: /^borrar$/i }));
+    // After the rejection settles, the item should reappear
+    await waitFor(() => {
+      expect(screen.getByText('survivor')).toBeInTheDocument();
+    });
+  });
+
+  it('search input passes q to listConversations (debounced)', async () => {
+    const listSpy = vi.spyOn(agentClient, 'listConversations').mockResolvedValue({
+      conversations: [], total: 0, limit: 20, offset: 0,
+    });
+    render(<AgentHistorySidebar open={true} onClose={() => {}} />);
+    // First call on open: no q
+    await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(1));
+    expect(listSpy.mock.calls[0][0]).toMatchObject({ limit: 20 });
+    expect(listSpy.mock.calls[0][0]?.q).toBeUndefined();
+
+    const searchInput = screen.getByLabelText(/buscar/i);
+    await userEvent.type(searchInput, 'PENDLE');
+    // Debounce 200ms — wait for the search-triggered call
+    await waitFor(
+      () => expect(listSpy.mock.calls.some(([a]) => a?.q === 'PENDLE')).toBe(true),
+      { timeout: 1000 },
+    );
+  });
+});

--- a/frontend/src/components/AgentHistorySidebar.tsx
+++ b/frontend/src/components/AgentHistorySidebar.tsx
@@ -1,0 +1,242 @@
+// ============================================================
+// AgentHistorySidebar — past conversation list anchored to AgentDock.
+//
+// Reads from H.3 endpoints (GET /agent/conversations, DELETE, POST /pin).
+// Per-item click bubbles up via onSelectConversation — the H.5 wiring
+// in AgentDock will hand that off to useAgentStream.loadConversation().
+// For H.4 the click is a no-op stub; the sidebar just closes itself.
+//
+// Pre-reg: docs/superpowers/specs/es/2026-05-22-conversation-history-pre-reg.md
+// ============================================================
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  deleteConversation,
+  listConversations,
+  togglePinConversation,
+} from '../agent/client';
+import type { ConversationSummary } from '../agent/types';
+import styles from './AgentHistorySidebar.module.css';
+
+interface AgentHistorySidebarProps {
+  open:                   boolean;
+  onClose:                () => void;
+  /** H.5 will wire this to useAgentStream.loadConversation. For H.4
+   *  the sidebar just closes itself after invoking. */
+  onSelectConversation?:  (id: string) => void;
+}
+
+const PAGE_SIZE = 20;
+
+const AgentHistorySidebar: React.FC<AgentHistorySidebarProps> = ({
+  open, onClose, onSelectConversation,
+}) => {
+  const [items,   setItems]   = useState<ConversationSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState<string | null>(null);
+  const [q,       setQ]       = useState('');
+
+  const refresh = useCallback(async (query: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await listConversations({
+        limit: PAGE_SIZE,
+        ...(query.trim() ? { q: query.trim() } : {}),
+      });
+      setItems(resp.conversations);
+    } catch (e) {
+      setError('No se pudo cargar el historial.');
+      if (typeof console !== 'undefined') console.warn('history list failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Refresh on open + when search query changes (debounced 200ms so a
+  // typing user doesn't fire one request per keystroke).
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setTimeout(() => { void refresh(q); }, q ? 200 : 0);
+    return () => window.clearTimeout(id);
+  }, [open, q, refresh]);
+
+  // Close on Escape — convention of the dock + ConnectionsPanel
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const handleSelect = (id: string) => {
+    onSelectConversation?.(id);
+    onClose();
+  };
+
+  const handlePin = async (id: string) => {
+    // Optimistic toggle so the row reorders before the request
+    // returns. Revert on error.
+    const before = items;
+    setItems((cur) => cur.map((c) =>
+      c.conversation_id === id ? { ...c, pinned: !c.pinned } : c,
+    ));
+    try {
+      const res = await togglePinConversation(id);
+      setItems((cur) => cur.map((c) =>
+        c.conversation_id === id ? { ...c, pinned: res.pinned } : c,
+      ));
+    } catch {
+      setItems(before);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    const before = items;
+    setItems((cur) => cur.filter((c) => c.conversation_id !== id));
+    try {
+      await deleteConversation(id);
+    } catch {
+      setItems(before);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className={styles.backdrop} onClick={onClose} aria-hidden="true" />
+      <aside
+        className={styles.panel}
+        role="dialog"
+        aria-labelledby="agent-history-title"
+      >
+        <header className={styles.header}>
+          <h2 id="agent-history-title" className={styles.title}>Historial</h2>
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={onClose}
+            aria-label="Cerrar historial"
+          >×</button>
+        </header>
+
+        <div className={styles.searchBar}>
+          <input
+            type="text"
+            className={styles.searchInput}
+            placeholder="Buscar conversaciones…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            aria-label="Buscar conversaciones"
+          />
+        </div>
+
+        <div className={styles.list} role="list">
+          {loading && items.length === 0 && (
+            <div className={styles.loading}>Cargando…</div>
+          )}
+          {!loading && error && (
+            <div className={styles.errorState}>{error}</div>
+          )}
+          {!loading && !error && items.length === 0 && (
+            <div className={styles.empty}>
+              {q ? 'No hay conversaciones que coincidan.' : 'No tienes conversaciones todavía.'}
+            </div>
+          )}
+          {items.map((c) => (
+            <ConversationItem
+              key={c.conversation_id}
+              item={c}
+              onSelect={() => handleSelect(c.conversation_id)}
+              onPin={() => handlePin(c.conversation_id)}
+              onDelete={() => handleDelete(c.conversation_id)}
+            />
+          ))}
+        </div>
+      </aside>
+    </>
+  );
+};
+
+interface ConversationItemProps {
+  item:    ConversationSummary;
+  onSelect: () => void;
+  onPin:    () => void;
+  onDelete: () => void;
+}
+
+const ConversationItem: React.FC<ConversationItemProps> = ({
+  item, onSelect, onPin, onDelete,
+}) => {
+  const timeAgo = useMemo(() => _relativeTime(item.last_ts), [item.last_ts]);
+  const klass = item.pinned
+    ? `${styles.item} ${styles.itemPinned}`
+    : styles.item;
+
+  return (
+    <div role="listitem" className={klass}>
+      <button
+        type="button"
+        className={styles.itemBody}
+        onClick={onSelect}
+        aria-label={`Abrir conversación ${item.title ?? item.conversation_id}`}
+        style={{ background: 'none', border: 'none', color: 'inherit',
+                 textAlign: 'left', font: 'inherit', cursor: 'pointer' }}
+      >
+        <div
+          className={item.title ? styles.itemTitle : `${styles.itemTitle} ${styles.itemTitleEmpty}`}
+          title={item.title ?? item.conversation_id}
+        >
+          {item.title ?? 'Sin título'}
+        </div>
+        <div className={styles.itemMeta}>
+          <span className={styles.surfaceChip}>{item.surface}</span>
+          <span>{timeAgo}</span>
+          <span>· {item.message_count} msj</span>
+        </div>
+      </button>
+      <div className={styles.itemActions}>
+        <button
+          type="button"
+          className={item.pinned
+            ? `${styles.actionBtn} ${styles.actionBtnPinned}`
+            : styles.actionBtn}
+          onClick={(e) => { e.stopPropagation(); void onPin(); }}
+          aria-label={item.pinned ? 'Desfijar' : 'Fijar'}
+          title={item.pinned ? 'Desfijar' : 'Fijar'}
+        >{item.pinned ? '📌 fijada' : '📌'}</button>
+        <button
+          type="button"
+          className={styles.actionBtn}
+          onClick={(e) => { e.stopPropagation(); void onDelete(); }}
+          aria-label="Borrar"
+          title="Borrar"
+        >🗑</button>
+      </div>
+    </div>
+  );
+};
+
+/** Spanish relative-time formatter with a minimal closed set of buckets.
+ *  Keeps the bundle free of Intl.RelativeTimeFormat negotiation churn
+ *  (the polyfilling story in this app's Vite config is "don't"). */
+function _relativeTime(iso: string): string {
+  try {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) return iso;
+    const diffSec = Math.round((Date.now() - then) / 1000);
+    if (diffSec < 60)        return 'recién';
+    if (diffSec < 60 * 60)   return `hace ${Math.floor(diffSec / 60)} min`;
+    if (diffSec < 60 * 60 * 24) return `hace ${Math.floor(diffSec / (60 * 60))} h`;
+    const days = Math.floor(diffSec / (60 * 60 * 24));
+    if (days < 30)  return `hace ${days} d`;
+    if (days < 365) return `hace ${Math.floor(days / 30)} m`;
+    return `hace ${Math.floor(days / 365)} a`;
+  } catch {
+    return iso;
+  }
+}
+
+export default AgentHistorySidebar;

--- a/frontend/src/components/AgentHistorySidebar.tsx
+++ b/frontend/src/components/AgentHistorySidebar.tsx
@@ -9,7 +9,7 @@
 // Pre-reg: docs/superpowers/specs/es/2026-05-22-conversation-history-pre-reg.md
 // ============================================================
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import {
   deleteConversation,
@@ -75,10 +75,16 @@ const AgentHistorySidebar: React.FC<AgentHistorySidebarProps> = ({
     onClose();
   };
 
+  // Per-item snapshot + functional setState so concurrent rapid clicks
+  // on different items don't clobber each other. PR #435 review issue
+  // #1: a list-wide `before = items` snapshot would have the third
+  // click's catch restore items A + B (already-successful deletes)
+  // alongside item C (the failure). Snapshotting only the target item
+  // avoids that.
   const handlePin = async (id: string) => {
-    // Optimistic toggle so the row reorders before the request
-    // returns. Revert on error.
-    const before = items;
+    const target = items.find((c) => c.conversation_id === id);
+    if (!target) return;
+    const prevPinned = target.pinned;
     setItems((cur) => cur.map((c) =>
       c.conversation_id === id ? { ...c, pinned: !c.pinned } : c,
     ));
@@ -88,17 +94,26 @@ const AgentHistorySidebar: React.FC<AgentHistorySidebarProps> = ({
         c.conversation_id === id ? { ...c, pinned: res.pinned } : c,
       ));
     } catch {
-      setItems(before);
+      setItems((cur) => cur.map((c) =>
+        c.conversation_id === id ? { ...c, pinned: prevPinned } : c,
+      ));
     }
   };
 
   const handleDelete = async (id: string) => {
-    const before = items;
+    const idx = items.findIndex((c) => c.conversation_id === id);
+    if (idx < 0) return;
+    const removed = items[idx];
     setItems((cur) => cur.filter((c) => c.conversation_id !== id));
     try {
       await deleteConversation(id);
     } catch {
-      setItems(before);
+      setItems((cur) => {
+        if (cur.some((c) => c.conversation_id === id)) return cur;
+        const next = [...cur];
+        next.splice(Math.min(idx, next.length), 0, removed);
+        return next;
+      });
     }
   };
 
@@ -149,6 +164,7 @@ const AgentHistorySidebar: React.FC<AgentHistorySidebarProps> = ({
             <ConversationItem
               key={c.conversation_id}
               item={c}
+              selectable={!!onSelectConversation}
               onSelect={() => handleSelect(c.conversation_id)}
               onPin={() => handlePin(c.conversation_id)}
               onDelete={() => handleDelete(c.conversation_id)}
@@ -161,42 +177,60 @@ const AgentHistorySidebar: React.FC<AgentHistorySidebarProps> = ({
 };
 
 interface ConversationItemProps {
-  item:    ConversationSummary;
-  onSelect: () => void;
-  onPin:    () => void;
-  onDelete: () => void;
+  item:       ConversationSummary;
+  onSelect:   () => void;
+  onPin:      () => void;
+  onDelete:   () => void;
+  selectable: boolean;
 }
 
 const ConversationItem: React.FC<ConversationItemProps> = ({
-  item, onSelect, onPin, onDelete,
+  item, onSelect, onPin, onDelete, selectable,
 }) => {
-  const timeAgo = useMemo(() => _relativeTime(item.last_ts), [item.last_ts]);
+  // _relativeTime is intentionally NOT memoized (PR #435 review
+  // issue #2): it reads Date.now() internally, so memoizing on
+  // last_ts alone would freeze "hace 5 min" forever as wall-clock
+  // advances. Function is a few subtractions + branches — cheaper
+  // than the memo bookkeeping.
+  const timeAgo = _relativeTime(item.last_ts);
   const klass = item.pinned
     ? `${styles.item} ${styles.itemPinned}`
     : styles.item;
 
+  const bodyContent = (
+    <>
+      <div
+        className={item.title ? styles.itemTitle : `${styles.itemTitle} ${styles.itemTitleEmpty}`}
+        title={item.title ?? item.conversation_id}
+      >
+        {item.title ?? 'Sin título'}
+      </div>
+      <div className={styles.itemMeta}>
+        <span className={styles.surfaceChip}>{item.surface}</span>
+        <span>{timeAgo}</span>
+        <span>· {item.message_count} msj</span>
+      </div>
+    </>
+  );
+
   return (
     <div role="listitem" className={klass}>
-      <button
-        type="button"
-        className={styles.itemBody}
-        onClick={onSelect}
-        aria-label={`Abrir conversación ${item.title ?? item.conversation_id}`}
-        style={{ background: 'none', border: 'none', color: 'inherit',
-                 textAlign: 'left', font: 'inherit', cursor: 'pointer' }}
-      >
-        <div
-          className={item.title ? styles.itemTitle : `${styles.itemTitle} ${styles.itemTitleEmpty}`}
-          title={item.title ?? item.conversation_id}
-        >
-          {item.title ?? 'Sin título'}
-        </div>
-        <div className={styles.itemMeta}>
-          <span className={styles.surfaceChip}>{item.surface}</span>
-          <span>{timeAgo}</span>
-          <span>· {item.message_count} msj</span>
-        </div>
-      </button>
+      {selectable ? (
+        <button
+          type="button"
+          className={styles.itemBody}
+          onClick={onSelect}
+          aria-label={`Abrir conversación ${item.title ?? item.conversation_id}`}
+          style={{ background: 'none', border: 'none', color: 'inherit',
+                   textAlign: 'left', font: 'inherit', cursor: 'pointer' }}
+        >{bodyContent}</button>
+      ) : (
+        // PR #435 review issue #6: until H.5 wires the rehydration,
+        // the parent passes no onSelectConversation. Rendering the
+        // body as a plain div avoids the "I clicked but nothing
+        // happened" UX while still letting pin/delete work.
+        <div className={styles.itemBody}>{bodyContent}</div>
+      )}
       <div className={styles.itemActions}>
         <button
           type="button"

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -609,11 +609,13 @@ const CopilotMessage: React.FC<CopilotMessageProps> = ({
             expired:   'Expirado',
             drift:     'Estado cambió — re-pregunta',
             error:     'Falló — re-pregunta',
+            stale:     'Propuesta ya no activa',
           };
           const stateClass =
             p.state === 'in_flight' ? styles.toolConfirmInFlight :
             p.state === 'ok'        ? styles.toolConfirmOk :
-            (p.state === 'expired' || p.state === 'drift' || p.state === 'error')
+            (p.state === 'expired' || p.state === 'drift' ||
+             p.state === 'error' || p.state === 'stale')
                                     ? styles.toolConfirmError :
             '';
           const isInteractive = p.state === 'pending';


### PR DESCRIPTION
Refs epic #428. Implements H.4 (frontend sidebar).
Depends on #432 (H.1 schema) + #433 (H.2 write path) + #434 (H.3 read endpoints) — all merged.

## What lands
- **`AgentHistorySidebar.tsx`** — slide-in panel anchored to the AgentDock. Lists conversations, debounced q-search, hover-revealed pin + delete actions, optimistic updates with revert-on-error.
- **Dock integration:** new "Historial" button in the dock header opens the sidebar overlaid on the dock.
- **Types + client:** `ConversationSummary`, `MessageRecord`, etc. mirror H.3 pydantic models. Client functions `listConversations` / `getConversationMessages` / `deleteConversation` / `togglePinConversation`.

## H.3 knock-on
`ProposalState` gains `'stale'` (the REST rehydration value). The live SSE wire still uses `'pending'`; only REST returns `'stale'`. Updated `AgentDock.tsx` and `SymbolDetail.tsx` `labelByState` mappings so TypeScript's `Record<ProposalState, string>` exhaustiveness check stays satisfied. Both render the chip as non-interactive (same UX as expired/error).

## H.5 boundary
The sidebar's `onSelectConversation` is wired but the parent (`AgentDock`) currently passes a no-op — clicking an item just closes the sidebar. H.5 will swap that for `useAgentStream.loadConversation(id)` which fetches `GET /messages` and replays into the transcript.

## Test plan
- [x] `npx vitest run AgentHistorySidebar.test.tsx` — 10/10 (render closed/empty/list/fallback title/error, click select, pin toggle, delete optimistic + revert, q-search debounce).
- [x] Full frontend suite: `npm test` → 119 passed / 7 skipped, no regressions.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` clean.
- [ ] CI green.
- [ ] After merge: open the dock in `trading.sdar.dev`, click "Historial", confirm list renders + pin/delete work end-to-end.

## Files
- `frontend/src/agent/types.ts` — H.3 response types + `'stale'` in ProposalState.
- `frontend/src/agent/client.ts` — 4 new history client functions.
- `frontend/src/components/AgentHistorySidebar.tsx` + `.module.css` + `.test.tsx`.
- `frontend/src/components/AgentDock.tsx` — Historial button + sidebar render + `'stale'` labelByState entry.
- `frontend/src/components/SymbolDetail.tsx` — `'stale'` labelByState entry.

## Next
H.5 (rehydration hook): `useAgentStream.loadConversation(id)` — fetch transcript, convert `MessageRecord[]` → `ChatMsg[]`, replace `msgs` state, update `conversationIdRef` so next turn continues the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)