### PR TITLE
feat(agent): H.5 conversation rehydration hook + dock wiring (#428)

### DIFF
--- a/frontend/src/agent/types.ts
+++ b/frontend/src/agent/types.ts
@@ -177,9 +177,10 @@ export type ProposalState =
   | 'in_flight'  // confirm POST in progress
   | 'ok'         // confirmed
   | 'expired'    // TTL passed without confirm
-  | 'drift'      // confirmed but server state had changed
+  | 'drift'      // live confirm: server state moved between propose + confirm
   | 'error'      // confirm failed
-  | 'stale';     // #428 H.3 REST rehydration: never-confirmed, TTL not yet up, but signed_payload is gone — not actionable
+  | 'stale'      // #428 H.3 REST rehydration: never-confirmed, TTL not yet up, but signed_payload is gone — not actionable
+  | 'conflict';  // REST rehydration: agent_side_effects recorded a conflict (idempotency collision) at the original confirm — read-only terminal state
 
 export interface ProposalChip {
   proposal_id:    string;

--- a/frontend/src/agent/useAgentStream.test.tsx
+++ b/frontend/src/agent/useAgentStream.test.tsx
@@ -766,6 +766,160 @@ describe('useAgentStream', () => {
     expect(chip.summary).toBe('Cerrar #42');
   });
 
+  it('loadConversation is a no-op during an in-flight sendTurn (#436 review #1)', async () => {
+    // Start a sendTurn that won't complete until we release it.
+    let releaseStream: () => void = () => {};
+    const streamPromise = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    const blockedStream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encode('data: ' + JSON.stringify({
+          type: 'text_delta', text: 'partial',
+        }) + '\n\n'));
+        await streamPromise;
+        controller.enqueue(encode('data: ' + JSON.stringify({
+          type: 'message_end',
+          usage: { input_tokens: 0, output_tokens: 0,
+                   cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+          stop_reason: 'end_turn', cost_usd: 0,
+        }) + '\n\n'));
+        controller.close();
+      },
+    });
+    // @ts-expect-error — overriding global for the test
+    global.fetch = vi.fn().mockResolvedValueOnce(new Response(blockedStream, {
+      status: 200, headers: { 'Content-Type': 'text/event-stream' },
+    }));
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    let sendPromise: Promise<void>;
+    act(() => { sendPromise = result.current.sendTurn('hi'); });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    // Attempt to hydrate while loading=true. Should refuse silently.
+    const historySpy = vi.fn();
+    // @ts-expect-error — overriding global
+    global.fetch = historySpy;
+    await act(async () => {
+      await result.current.loadConversation('would-corrupt');
+    });
+    // The history endpoint was NEVER called because the gate fired
+    // before any fetch.
+    expect(historySpy).not.toHaveBeenCalled();
+    expect(result.current.hydrating).toBe(false);
+
+    // Let the streaming turn finish cleanly.
+    releaseStream();
+    await act(async () => { await sendPromise!; });
+  });
+
+  it('sendTurn is a no-op while a loadConversation is hydrating (#436 review #1)', async () => {
+    // Block the history fetch's response until we release it.
+    let releaseFetch: (value: Response) => void = () => {};
+    const blockedFetchPromise = new Promise<Response>((resolve) => {
+      releaseFetch = resolve;
+    });
+    // @ts-expect-error — overriding global
+    global.fetch = vi.fn().mockReturnValueOnce(blockedFetchPromise);
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    let loadPromise: Promise<void>;
+    act(() => { loadPromise = result.current.loadConversation('slow-load'); });
+    await waitFor(() => expect(result.current.hydrating).toBe(true));
+
+    // Try to send during the hydration. Must no-op.
+    const sendSpy = vi.fn();
+    // @ts-expect-error — overriding global (would be used by sendTurn fetch)
+    global.fetch = sendSpy;
+    await act(async () => {
+      await result.current.sendTurn('mid-hydration');
+    });
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(result.current.msgs).toEqual([]);  // no user message appended
+
+    // Release the history fetch.
+    releaseFetch(new Response(JSON.stringify({
+      conversation_id: 'slow-load', title: 't',
+      surface: 'dock', pinned: false,
+      messages: [{ role: 'user', ts: 'T', content: 'preloaded',
+                   reasoning: null, tool_chips: [], proposals: [] }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    await act(async () => { await loadPromise!; });
+    expect(result.current.msgs).toHaveLength(1);
+    expect(result.current.msgs[0].text).toBe('preloaded');
+  });
+
+  it('rapid loadConversation invocations: the latest one wins (#436 review #1)', async () => {
+    // First load takes a while; second load fires before it returns.
+    let releaseFirst: (value: Response) => void = () => {};
+    const firstFetch = new Promise<Response>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const fetchMock = vi.fn()
+      .mockReturnValueOnce(firstFetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        conversation_id: 'B', title: 'segunda', surface: 'dock', pinned: false,
+        messages: [{ role: 'user', ts: 'T', content: 'desde B',
+                     reasoning: null, tool_chips: [], proposals: [] }],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    // @ts-expect-error — overriding global
+    global.fetch = fetchMock;
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    let firstPromise: Promise<void>;
+    let secondPromise: Promise<void>;
+    act(() => { firstPromise = result.current.loadConversation('A'); });
+    act(() => { secondPromise = result.current.loadConversation('B'); });
+    // Second one resolves first (its promise is already-resolved); the
+    // first one's resolution must be discarded by the token check.
+    await act(async () => { await secondPromise!; });
+    expect(result.current.msgs[0].text).toBe('desde B');
+
+    // Now release the first — it must NOT clobber B's state.
+    releaseFirst(new Response(JSON.stringify({
+      conversation_id: 'A', title: 'primera', surface: 'dock', pinned: false,
+      messages: [{ role: 'user', ts: 'T', content: 'desde A',
+                   reasoning: null, tool_chips: [], proposals: [] }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    await act(async () => { await firstPromise!; });
+    // B's content is still in place — A's late arrival was preempted.
+    expect(result.current.msgs[0].text).toBe('desde B');
+  });
+
+  it('unknown proposal action is filtered out + warned (#436 review #3)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    stubHistoryJson({
+      conversation_id: 'conv-unknown-action',
+      title: 't', surface: 'dock', pinned: false,
+      messages: [
+        { role: 'assistant', ts: 'T', content: 'algo',
+          reasoning: null, tool_chips: [],
+          proposals: [
+            { proposal_id: 'p-good', action: 'close_position',
+              args: {}, expires_at: 'T2', summary: 'cerrar', state: 'stale' },
+            { proposal_id: 'p-bad',  action: 'future_unknown_action',
+              args: {}, expires_at: 'T2', summary: 'hmm', state: 'stale' },
+          ] },
+      ],
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => {
+      await result.current.loadConversation('conv-unknown-action');
+    });
+
+    const proposals = result.current.msgs[0].proposals;
+    expect(proposals).toHaveLength(1);
+    expect(proposals![0].proposal_id).toBe('p-good');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unknown proposal action'),
+      'future_unknown_action',
+      'p-bad',
+    );
+    warnSpy.mockRestore();
+  });
+
   it('loadConversation failure leaves the existing transcript intact', async () => {
     // Seed the hook with a turn so msgs is non-empty.
     stubFetchOnce(sseReadable([

--- a/frontend/src/agent/useAgentStream.test.tsx
+++ b/frontend/src/agent/useAgentStream.test.tsx
@@ -637,4 +637,162 @@ describe('useAgentStream', () => {
       await firstPromise!;
     });
   });
+
+  // ── H.5: loadConversation hydration ────────────────────────────────
+
+  function stubHistoryJson(body: object, status = 200) {
+    // @ts-expect-error — overriding global for the test
+    global.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  }
+
+  it('loadConversation replaces msgs with the hydrated transcript', async () => {
+    stubHistoryJson({
+      conversation_id: 'conv-hydrate',
+      title:           'past chat',
+      surface:         'dock',
+      pinned:          false,
+      messages: [
+        { role: 'user',      ts: '2026-05-22T08:00:00Z', content: 'hola',
+          reasoning: null, tool_chips: [], proposals: [] },
+        { role: 'assistant', ts: '2026-05-22T08:00:01Z', content: 'qué tal',
+          reasoning: '<think>razonamiento</think>',
+          tool_chips: [{ tool: 'get_positions', status: 'ok' }],
+          proposals: [] },
+      ],
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => {
+      await result.current.loadConversation('conv-hydrate');
+    });
+
+    expect(result.current.msgs).toHaveLength(2);
+    expect(result.current.msgs[0]).toMatchObject({ role: 'user', text: 'hola' });
+    expect(result.current.msgs[1]).toMatchObject({
+      role:      'assistant',
+      text:      'qué tal',
+      reasoning: '<think>razonamiento</think>',
+    });
+    expect(result.current.msgs[1].tool_chips).toEqual([
+      { tool: 'get_positions', status: 'ok' },
+    ]);
+  });
+
+  it('loadConversation aligns conversation_id so the next sendTurn continues it', async () => {
+    // Hydrate first
+    stubHistoryJson({
+      conversation_id: 'continue-me',
+      title: 'old chat', surface: 'dock', pinned: false,
+      messages: [
+        { role: 'user',      ts: '2026-05-22T08:00:00Z', content: 'q1',
+          reasoning: null, tool_chips: [], proposals: [] },
+        { role: 'assistant', ts: '2026-05-22T08:00:01Z', content: 'a1',
+          reasoning: null, tool_chips: [], proposals: [] },
+      ],
+    });
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => {
+      await result.current.loadConversation('continue-me');
+    });
+
+    // Now stub the streaming POST and capture the URL the hook hits.
+    const fetchSpy = vi.fn().mockResolvedValueOnce(
+      new Response(
+        sseReadable([
+          { type: 'text_delta', text: 'ok' },
+          {
+            type: 'message_end',
+            usage: { input_tokens: 0, output_tokens: 0,
+                     cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+            stop_reason: 'end_turn', cost_usd: 0,
+          },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+      ),
+    );
+    // @ts-expect-error — overriding global for the test
+    global.fetch = fetchSpy;
+
+    await act(async () => {
+      await result.current.sendTurn('q2');
+    });
+
+    // The streaming POST URL must reference the hydrated conversation_id,
+    // NOT a fresh UUID — the continuation invariant.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = fetchSpy.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/agent/conversations/continue-me/turn');
+  });
+
+  it('loadConversation maps stale ProposalRecord to ProposalChip without signed_payload', async () => {
+    stubHistoryJson({
+      conversation_id: 'conv-with-proposal',
+      title: 't', surface: 'dock', pinned: false,
+      messages: [
+        { role: 'user', ts: '2026-05-22T08:00:00Z', content: 'cerra btc',
+          reasoning: null, tool_chips: [], proposals: [] },
+        { role: 'assistant', ts: '2026-05-22T08:00:01Z',
+          content: 'propongo cerrar',
+          reasoning: null, tool_chips: [], proposals: [
+            { proposal_id: 'prop-x',
+              action: 'close_position',
+              args: { position_id: 42 },
+              expires_at: '2026-08-22T08:00:00Z',
+              summary: 'Cerrar #42',
+              state: 'stale' },
+          ] },
+      ],
+    });
+
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => {
+      await result.current.loadConversation('conv-with-proposal');
+    });
+
+    const assistant = result.current.msgs[1];
+    expect(assistant.proposals).toHaveLength(1);
+    const chip = assistant.proposals![0];
+    expect(chip.state).toBe('stale');
+    expect(chip.proposal_id).toBe('prop-x');
+    // signed_payload is intentionally empty (REST never persists it);
+    // the dock disables the confirm button for any non-'pending' state.
+    expect(chip.signed_payload).toBe('');
+    expect(chip.action).toBe('close_position');
+    expect(chip.summary).toBe('Cerrar #42');
+  });
+
+  it('loadConversation failure leaves the existing transcript intact', async () => {
+    // Seed the hook with a turn so msgs is non-empty.
+    stubFetchOnce(sseReadable([
+      { type: 'text_delta', text: 'pre-existing' },
+      {
+        type: 'message_end',
+        usage: { input_tokens: 1, output_tokens: 1,
+                 cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        stop_reason: 'end_turn', cost_usd: 0,
+      },
+    ]));
+    const { result } = renderHook(() => useAgentStream({ surface: 'dock' }));
+    await act(async () => { await result.current.sendTurn('hola'); });
+    const before = result.current.msgs;
+
+    // Now stub a failed history load.
+    // @ts-expect-error — overriding global for the test
+    global.fetch = vi.fn().mockResolvedValueOnce(
+      new Response('{"detail":"boom"}', {
+        status: 500, headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    await act(async () => {
+      await result.current.loadConversation('bad-conv');
+    });
+
+    // Transcript untouched on failure (best-effort hydration).
+    expect(result.current.msgs).toEqual(before);
+  });
 });

--- a/frontend/src/agent/useAgentStream.ts
+++ b/frontend/src/agent/useAgentStream.ts
@@ -54,6 +54,11 @@ export interface UseAgentStreamOptions {
 export interface UseAgentStreamReturn {
   msgs:              ChatMsg[];
   loading:           boolean;
+  /** True while loadConversation's fetch is in flight. The dock gates
+   *  its input on (loading || hydrating) so a 2-second history fetch
+   *  doesn't let the user fire a sendTurn into a transcript that's
+   *  about to be replaced. PR #436 review issue #2. */
+  hydrating:         boolean;
   sendTurn:          (text: string, hints?: AgentContextHints) => Promise<void>;
   resetConversation: () => void;
   confirmProposal:   (proposal_id: string) => Promise<void>;
@@ -73,6 +78,7 @@ export interface UseAgentStreamReturn {
 export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamReturn {
   const [msgs, setMsgs] = useState<ChatMsg[]>([]);
   const [loading, setLoading] = useState(false);
+  const [hydrating, setHydrating] = useState(false);
   const conversationIdRef = useRef<string>(newConversationId());
   // Parallel ref kept in sync with msgs so sendTurn can read the latest
   // transcript without depending on closure freshness across renders.
@@ -84,6 +90,20 @@ export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamRetur
     msgsRef.current = msgs;
   }, [msgs]);
 
+  // PR #436 review issue #1: refs mirror loading / hydrating so the
+  // gating in loadConversation + sendTurn can read fresh state across
+  // callback re-creations without forcing dep arrays to track them
+  // (which would cause the callback to re-create on every state flip).
+  const loadingRef   = useRef(false);
+  const hydratingRef = useRef(false);
+  useEffect(() => { loadingRef.current   = loading;   }, [loading]);
+  useEffect(() => { hydratingRef.current = hydrating; }, [hydrating]);
+
+  // Load preemption token: each loadConversation invocation increments
+  // this ref before the fetch and re-checks after; if a newer load
+  // started in the interim, the stale fetch's result is discarded.
+  const loadTokenRef = useRef(0);
+
   const resetConversation = useCallback(() => {
     conversationIdRef.current = newConversationId();
     setMsgs([]);
@@ -92,7 +112,12 @@ export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamRetur
 
   const sendTurn = useCallback(
     async (text: string, hints?: AgentContextHints) => {
-      if (!text.trim() || loading) return;
+      // PR #436 review issue #1: hydratingRef.current short-circuits a
+      // type-and-Enter that races with a sidebar hydration fetch. Without
+      // it, the sendTurn captures the pre-hydration msgs + conversationId
+      // and the SSE bleed into the hydrated transcript when the fetch
+      // resolves mid-stream.
+      if (!text.trim() || loading || hydratingRef.current) return;
       // Read the transcript from the ref (always fresh across re-renders);
       // build the API messages BEFORE we append the user turn so the
       // request payload mirrors the on-screen state at submit-time.
@@ -177,12 +202,20 @@ export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamRetur
   }, []);
 
   const loadConversation = useCallback(async (conversation_id: string) => {
-    // Best-effort hydration. A network or parse failure logs to the
-    // console and leaves the dock in whatever state it was — calling
-    // resetConversation on failure would be more disruptive than a
-    // silent no-op (the user can re-click the row).
+    // PR #436 review issue #1: refuse to hydrate during an in-flight
+    // turn. Otherwise the resolving SSE text_delta events would
+    // continue to append to msgs[length-1] of the just-replaced
+    // hydrated transcript, mixing two unrelated conversations.
+    if (loadingRef.current) return;
+
+    // Preemption token: any newer loadConversation call invalidates this
+    // one's setMsgs at resolve time. Without it, two clicks in quick
+    // succession on rows A then B would race and either order could win.
+    const token = ++loadTokenRef.current;
+    setHydrating(true);
     try {
       const detail = await getConversationMessages(conversation_id);
+      if (token !== loadTokenRef.current) return;   // newer load preempted
       const hydrated: ChatMsg[] = detail.messages.map(_recordToChatMsg);
       conversationIdRef.current = conversation_id;
       setMsgs(hydrated);
@@ -191,10 +224,14 @@ export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamRetur
       if (typeof console !== 'undefined') {
         console.warn('loadConversation failed', conversation_id, err);
       }
+    } finally {
+      // Only clear hydrating if we're still the latest token — otherwise
+      // a newer load is still in flight and should keep the flag set.
+      if (token === loadTokenRef.current) setHydrating(false);
     }
   }, []);
 
-  return { msgs, loading, sendTurn, resetConversation, confirmProposal, loadConversation };
+  return { msgs, loading, hydrating, sendTurn, resetConversation, confirmProposal, loadConversation };
 }
 
 // ── REST → transcript shape ─────────────────────────────────────────────
@@ -205,11 +242,33 @@ function _recordToChatMsg(rec: MessageRecord): ChatMsg {
     text:       rec.content,
     reasoning:  rec.reasoning ?? undefined,
     tool_chips: rec.tool_chips ?? [],
-    proposals:  (rec.proposals ?? []).map(_proposalRecordToChip),
+    proposals:  (rec.proposals ?? [])
+      .map(_proposalRecordToChipOrNull)
+      .filter((c): c is ProposalChip => c !== null),
   };
 }
 
-function _proposalRecordToChip(p: ProposalRecord): ProposalChip {
+const _KNOWN_PROPOSAL_ACTIONS: ReadonlySet<AgentProposalEvent['action']> =
+  new Set(['close_position', 'reactivate_symbol', 'apply_tune']);
+
+function _proposalRecordToChipOrNull(p: ProposalRecord): ProposalChip | null {
+  // PR #436 review issue #3: ProposalRecord.action is `string` (open)
+  // → ProposalChip.action is a closed Literal. A naive `as` cast would
+  // lie if the backend adds a new action without bumping frontend
+  // types. Filter unknown actions out + log a warning so the gap is
+  // visible in dev/staging telemetry. The dock just won't show a chip
+  // for that proposal — better than rendering a button that switches
+  // on the closed enum and silently misses the case.
+  if (!_KNOWN_PROPOSAL_ACTIONS.has(p.action as AgentProposalEvent['action'])) {
+    if (typeof console !== 'undefined') {
+      console.warn(
+        'loadConversation: unknown proposal action — chip skipped',
+        p.action, p.proposal_id,
+      );
+    }
+    return null;
+  }
+
   // The REST shape doesn't carry signed_payload (HMAC TTL minutes vs
   // 90-day retention — it'd be storing an expired credential). The
   // confirm button is disabled for every state except 'pending', and

--- a/frontend/src/agent/useAgentStream.ts
+++ b/frontend/src/agent/useAgentStream.ts
@@ -14,15 +14,19 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   AgentStreamError,
   confirmAgentProposal,
+  getConversationMessages,
   newConversationId,
   streamAgentTurn,
 } from './client';
 import type {
   AgentApiMessage,
   AgentContextHints,
+  AgentProposalEvent,
   AgentStreamEvent,
   AgentSurface,
+  MessageRecord,
   ProposalChip,
+  ProposalRecord,
   ProposalState,
   ToolChip,
 } from './types';
@@ -53,6 +57,11 @@ export interface UseAgentStreamReturn {
   sendTurn:          (text: string, hints?: AgentContextHints) => Promise<void>;
   resetConversation: () => void;
   confirmProposal:   (proposal_id: string) => Promise<void>;
+  /** H.5 rehydration: pull a past conversation from the REST history
+   *  endpoint, replace the local transcript with its messages, and
+   *  point conversationIdRef at the loaded id so the next sendTurn
+   *  continues the conversation instead of starting a new one. */
+  loadConversation:  (conversation_id: string) => Promise<void>;
 }
 
 /**
@@ -167,7 +176,57 @@ export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamRetur
     }
   }, []);
 
-  return { msgs, loading, sendTurn, resetConversation, confirmProposal };
+  const loadConversation = useCallback(async (conversation_id: string) => {
+    // Best-effort hydration. A network or parse failure logs to the
+    // console and leaves the dock in whatever state it was — calling
+    // resetConversation on failure would be more disruptive than a
+    // silent no-op (the user can re-click the row).
+    try {
+      const detail = await getConversationMessages(conversation_id);
+      const hydrated: ChatMsg[] = detail.messages.map(_recordToChatMsg);
+      conversationIdRef.current = conversation_id;
+      setMsgs(hydrated);
+      msgsRef.current = hydrated;
+    } catch (err) {
+      if (typeof console !== 'undefined') {
+        console.warn('loadConversation failed', conversation_id, err);
+      }
+    }
+  }, []);
+
+  return { msgs, loading, sendTurn, resetConversation, confirmProposal, loadConversation };
+}
+
+// ── REST → transcript shape ─────────────────────────────────────────────
+
+function _recordToChatMsg(rec: MessageRecord): ChatMsg {
+  return {
+    role:       rec.role,
+    text:       rec.content,
+    reasoning:  rec.reasoning ?? undefined,
+    tool_chips: rec.tool_chips ?? [],
+    proposals:  (rec.proposals ?? []).map(_proposalRecordToChip),
+  };
+}
+
+function _proposalRecordToChip(p: ProposalRecord): ProposalChip {
+  // The REST shape doesn't carry signed_payload (HMAC TTL minutes vs
+  // 90-day retention — it'd be storing an expired credential). The
+  // confirm button is disabled for every state except 'pending', and
+  // REST rehydration never returns 'pending' (it returns 'stale' for
+  // the never-confirmed-not-yet-expired case — pre-reg D.6 + #434
+  // review issue #6). So signed_payload is unreachable from the UI
+  // and we put an empty string. If a future code path tries to use
+  // it, the HMAC verify on the backend will reject — defense in depth.
+  return {
+    proposal_id:    p.proposal_id,
+    signed_payload: '',
+    action:         p.action as AgentProposalEvent['action'],
+    args:           p.args,
+    expires_at:     p.expires_at,
+    summary:        p.summary,
+    state:          p.state,
+  };
 }
 
 /**

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -51,7 +51,7 @@ const AgentDock: React.FC<AgentDockProps> = ({
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { msgs, loading, sendTurn, confirmProposal, loadConversation } =
+  const { msgs, loading, hydrating, sendTurn, confirmProposal, loadConversation } =
     useAgentStream({ surface: SURFACE_DOCK });
   // Synthetic welcome bubble before the first real turn so the dock
   // isn't an empty void on open. Lives outside the stream hook because
@@ -134,6 +134,7 @@ const AgentDock: React.FC<AgentDockProps> = ({
                 type="button"
                 className={styles.historyOpen}
                 onClick={() => setHistoryOpen(true)}
+                disabled={loading || hydrating}
                 aria-label="Abrir historial"
               >Historial</button>
               <button className={styles.close} onClick={onClose} aria-label="Cerrar">×</button>
@@ -176,12 +177,21 @@ const AgentDock: React.FC<AgentDockProps> = ({
             <input
               ref={inputRef}
               className={styles.input}
-              placeholder={loading ? 'pensando…' : 'pregúntame algo sobre el mercado, tus posiciones, un par…'}
+              placeholder={
+                hydrating ? 'cargando historial…' :
+                loading   ? 'pensando…' :
+                            'pregúntame algo sobre el mercado, tus posiciones, un par…'
+              }
               value={input}
               onChange={(e) => setInput(e.target.value)}
+              disabled={hydrating}
               autoFocus
             />
-            <button className={styles.send} type="submit" disabled={loading || !input.trim()}>↵</button>
+            <button
+              className={styles.send}
+              type="submit"
+              disabled={loading || hydrating || !input.trim()}
+            >↵</button>
           </form>
         </aside>
       )}

--- a/frontend/src/components/AgentDock.tsx
+++ b/frontend/src/components/AgentDock.tsx
@@ -51,7 +51,8 @@ const AgentDock: React.FC<AgentDockProps> = ({
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const { msgs, loading, sendTurn, confirmProposal } = useAgentStream({ surface: SURFACE_DOCK });
+  const { msgs, loading, sendTurn, confirmProposal, loadConversation } =
+    useAgentStream({ surface: SURFACE_DOCK });
   // Synthetic welcome bubble before the first real turn so the dock
   // isn't an empty void on open. Lives outside the stream hook because
   // it never goes on the wire — purely UI. Derived (useMemo) instead
@@ -185,12 +186,14 @@ const AgentDock: React.FC<AgentDockProps> = ({
         </aside>
       )}
 
-      {/* H.4 sidebar — slides in on top of the dock. H.5 will wire
-          onSelectConversation through useAgentStream to rehydrate the
-          transcript; for H.4 it just closes the sidebar (no-op load). */}
+      {/* History sidebar (H.4 UI + H.5 rehydration). loadConversation
+          replaces the dock transcript with the picked conversation's
+          messages and aligns conversationIdRef so the next user turn
+          continues that thread. */}
       <AgentHistorySidebar
         open={open && historyOpen}
         onClose={() => setHistoryOpen(false)}
+        onSelectConversation={(id) => { void loadConversation(id); }}
       />
     </>
   );
@@ -301,12 +304,16 @@ const ProposalConfirm: React.FC<ProposalConfirmProps> = ({ proposal, onConfirm }
     // copy distinguishes "TTL passed" from "you saw this in a previous
     // session and the signed_payload wasn't persisted".
     stale:     'Propuesta ya no activa',
+    // #428 H.3: surfaced when agent_side_effects recorded a conflict
+    // (idempotency collision) at the original confirm time.
+    conflict:  'Conflicto al confirmar',
   };
   const stateClass =
     proposal.state === 'in_flight' ? styles.toolConfirmInFlight :
     proposal.state === 'ok'        ? styles.toolConfirmOk :
     (proposal.state === 'expired' || proposal.state === 'drift' ||
-     proposal.state === 'error' || proposal.state === 'stale')
+     proposal.state === 'error' || proposal.state === 'stale' ||
+     proposal.state === 'conflict')
                                    ? styles.toolConfirmError :
     '';
   const isInteractive = proposal.state === 'pending';

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -610,12 +610,14 @@ const CopilotMessage: React.FC<CopilotMessageProps> = ({
             drift:     'Estado cambió — re-pregunta',
             error:     'Falló — re-pregunta',
             stale:     'Propuesta ya no activa',
+            conflict:  'Conflicto al confirmar',
           };
           const stateClass =
             p.state === 'in_flight' ? styles.toolConfirmInFlight :
             p.state === 'ok'        ? styles.toolConfirmOk :
             (p.state === 'expired' || p.state === 'drift' ||
-             p.state === 'error' || p.state === 'stale')
+             p.state === 'error' || p.state === 'stale' ||
+             p.state === 'conflict')
                                     ? styles.toolConfirmError :
             '';
           const isInteractive = p.state === 'pending';


### PR DESCRIPTION
Refs epic #428. Implements H.5 (frontend rehydration).
Depends on #432-#435 — all merged.

## Summary
`useAgentStream.loadConversation(id)` rehydrates a past conversation:

1. Calls H.3 `GET /agent/conversations/{id}/messages`.
2. Converts `MessageRecord[]` → `ChatMsg[]` (transcript shape).
3. Replaces local `msgs` state.
4. Points `conversationIdRef.current` at the loaded id so the next `sendTurn` continues that thread (POSTs to `/agent/conversations/{loaded_id}/turn`).

AgentDock wires `AgentHistorySidebar.onSelectConversation` to `loadConversation` — picking a row in the sidebar replays the chosen transcript in the dock and closes the sidebar.

## Proposal rehydration nuance
`ProposalRecord` (REST) has no `signed_payload` — the HMAC's minute-scale TTL makes persisting it across 90 days useless. The conversion (`_proposalRecordToChip`) sets `signed_payload = ''`. This is safe because:

- The REST `state` is never `'pending'` (worst case is `'stale'` per #434 review issue #6).
- The dock disables the confirm button for any non-`'pending'` state.

So the empty string is unreachable from the UI — defense in depth means the backend's HMAC verify would reject anyway.

## `ProposalState` gains `'conflict'`
The REST `ProposalRecord.state` literal includes `'conflict'` (when `agent_side_effects.result` records a confirm collision). I extended `ProposalState` and both `AgentDock` + `SymbolDetail` `labelByState` maps. TypeScript's exhaustiveness check on `Record<ProposalState, string>` catches the gap if either consumer drifts again.

## Test plan
- [x] `npx vitest run useAgentStream.test.tsx` — 21/21 (17 prior + 4 new).
- [x] Full frontend suite: 129 passed / 7 skipped, no regressions.
- [x] `tsc --noEmit` clean.
- [ ] CI green.
- [ ] After merge: open dock → click Historial → pick row → transcript replaces in dock, next user message continues the thread (check `agent_messages` rows arrive under the same `conversation_id`).

## Files
- `frontend/src/agent/useAgentStream.ts` — `loadConversation` + two private mappers.
- `frontend/src/agent/types.ts` — `'conflict'` in `ProposalState`.
- `frontend/src/agent/useAgentStream.test.tsx` — 4 new tests.
- `frontend/src/components/AgentDock.tsx` — wired `onSelectConversation`, extended `labelByState`.
- `frontend/src/components/SymbolDetail.tsx` — extended `labelByState`.

## Closing the loop
H.4 sidebar UI + H.5 rehydration finish the user-visible thread of the epic. Remaining sub-issues (H.6 retention + cleanup, H.7 extra threat-model tests) are backend hygiene; the UX is complete after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)