### PR TITLE
fix(auth): refuse to boot prod service if pytest leaked into the runtime

### DIFF
--- a/btc_api.py
+++ b/btc_api.py
@@ -218,6 +218,26 @@ def _bootstrap_first_user() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Defense-in-depth (2026-05-22, post-#436 smoke). The auth middleware's
+    # bypass already requires `'pytest' in sys.modules` as a third guard
+    # alongside two env vars (auth/middleware.py:_bypass_role_or_none). This
+    # extra gate refuses to boot the service entirely if pytest somehow
+    # leaked into the prod runtime — a supply-chain accident, an
+    # accidentally-pinned dev dep, a console mistake. Both signals must
+    # coincide to crash:
+    #   - RUN_AS_SERVICE=1 (set by `__main__` for `python btc_api.py` and
+    #     by the systemd unit's Environment= for the prod uvicorn launch),
+    #     NOT set by pytest test runs.
+    #   - 'pytest' in sys.modules.
+    # The TestClient `with` block in tests/test_setup.py exercises lifespan
+    # under pytest, so the env-var gate is what keeps that test green.
+    if os.getenv("RUN_AS_SERVICE") == "1" and "pytest" in sys.modules:
+        raise RuntimeError(
+            "pytest leaked into the production service runtime — "
+            "AUTH_TEST_BYPASS_* would silently open the auth middleware. "
+            "Refusing to start.",
+        )
+
     # Auth (2026-04-29): fail fast if AUTH_JWT_SECRET is not configured. We
     # call _jwt_secret() once here so a misconfigured deploy crashes at boot
     # rather than on the first /auth/login request.
@@ -590,4 +610,12 @@ def test_webhook():
 
 if __name__ == "__main__":
     import uvicorn
+
+    # Signal to the lifespan gate that this is a real service launch, not a
+    # test collection. The systemd unit sets the same env var for the
+    # `uvicorn btc_api:app` prod path. Use setdefault so an explicit
+    # override (e.g. a future operator who needs the gate disarmed for a
+    # specific debug session) takes precedence.
+    os.environ.setdefault("RUN_AS_SERVICE", "1")
+
     uvicorn.run("btc_api:app", host=API_HOST, port=API_PORT, reload=False)

--- a/docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md
+++ b/docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md
@@ -396,6 +396,10 @@ After=network.target
 Type=simple
 User=ubuntu
 WorkingDirectory=/var/www/trading
+# Defense-in-depth: arms the lifespan gate that refuses to boot if pytest
+# leaked into the runtime (auth bypass triple-guard would otherwise open
+# without a JWT). See btc_api.py:lifespan + auth/middleware.py:_bypass_role_or_none.
+Environment=RUN_AS_SERVICE=1
 EnvironmentFile=/var/www/trading/.env
 ExecStart=/var/www/trading/.venv/bin/uvicorn btc_api:app --host 127.0.0.1 --port 8100
 Restart=on-failure

--- a/tests/test_pytest_leak_gate.py
+++ b/tests/test_pytest_leak_gate.py
@@ -1,0 +1,61 @@
+"""Defense-in-depth: the lifespan refuses to boot if pytest leaks into
+a production runtime (RUN_AS_SERVICE=1 + 'pytest' in sys.modules).
+
+This complements the auth middleware's bypass triple-guard
+(auth/middleware.py:_bypass_role_or_none). The middleware gates the
+*request* path; this gate stops the *service* from coming up at all.
+
+Filed after the #428 H.5 smoke surfaced that the bypass is only
+defended by env-var + middleware check, with no startup assertion.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_lifespan_refuses_to_boot_when_pytest_leaks(monkeypatch):
+    """Both signals coincide → boot crashes. The `with TestClient(app)`
+    block drives the lifespan; without the env var the same test would
+    pass (covered by test_setup.py)."""
+    monkeypatch.setenv("RUN_AS_SERVICE", "1")
+    assert "pytest" in sys.modules  # sanity: we ARE under pytest
+
+    import btc_api
+    with pytest.raises(RuntimeError, match="pytest leaked"):
+        with TestClient(btc_api.app):
+            pass  # never reaches here — lifespan raised before yield
+
+
+def test_lifespan_does_not_crash_without_run_as_service_env(monkeypatch):
+    """Negative control: the gate is silent when RUN_AS_SERVICE is unset.
+    This is the path test_setup.py + every other `with TestClient`
+    test relies on — confirms we didn't break them."""
+    monkeypatch.delenv("RUN_AS_SERVICE", raising=False)
+    assert "pytest" in sys.modules
+
+    import btc_api
+    # Smoke: lifespan should enter and exit cleanly. test_setup.py
+    # covers the full lifespan happy path; here we just confirm the
+    # new gate doesn't fire.
+    with TestClient(btc_api.app):
+        pass  # if this raises, the gate is over-eager — must NOT happen
+
+
+def test_main_entry_sets_run_as_service():
+    """`if __name__ == '__main__'` block contains
+    `os.environ.setdefault("RUN_AS_SERVICE", "1")` before the uvicorn.run
+    call. We can't easily exec the __main__ block (it would launch
+    uvicorn and block); instead, assert the source-level invariant
+    by reading the file and pattern-matching. Brittle but pins the
+    guarantee that direct `python btc_api.py` invocations arm the gate.
+    """
+    from pathlib import Path
+    src = Path(__file__).resolve().parent.parent / "btc_api.py"
+    text = src.read_text(encoding="utf-8")
+    assert 'os.environ.setdefault("RUN_AS_SERVICE", "1")' in text, (
+        "btc_api.py's __main__ block must set RUN_AS_SERVICE=1 so direct "
+        "`python btc_api.py` invocations arm the lifespan gate."
+    )


### PR DESCRIPTION
Follow-up from PR #436's smoke-test review. The auth bypass triple-guard (`AUTH_TEST_BYPASS_ALLOWED` + `AUTH_TEST_BYPASS_ROLE` + `'pytest' in sys.modules`) defends against env-var leaks in prod. But the third condition is implicit — if pytest itself ever landed in the prod Python (supply-chain accident, dev dep that shouldn't be installed, console mistake), all three signals would align silently. This PR turns the implicit "shouldn't happen" into an explicit "won't start if it does".

## Two-signal gate in the lifespan

```python
if os.getenv("RUN_AS_SERVICE") == "1" and "pytest" in sys.modules:
    raise RuntimeError("pytest leaked into the production service runtime ...")
```

The gate is inside `lifespan()`, not at module import time — the test suite imports `btc_api` at collection (and `pytest` IS in `sys.modules` then), so a module-level check would crash CI.

`RUN_AS_SERVICE=1` is the discriminator that tells the gate "you're running for real":
- `__main__` block sets it before `uvicorn.run(...)` (covers `python btc_api.py`).
- systemd unit `Environment=RUN_AS_SERVICE=1` (covers prod uvicorn — pre-existing `EnvironmentFile=/var/www/trading/.env` is the other knob, see "Activation" below).
- Tests don't set it → gate stays silent.

`tests/test_setup.py` already uses `with TestClient(app)` to drive the lifespan; its 12 cases pass because `RUN_AS_SERVICE` isn't set in pytest invocations.

## Activation on the existing prod instance

The next `systemctl restart trading-spacial` after this merges will pick up the new `Environment=` line IF a re-bootstrap fired (it won't). For zero-downtime activation on the existing instance:

```bash
ssh ubuntu@<prod>
echo 'RUN_AS_SERVICE=1' | sudo tee -a /var/www/trading/.env
sudo systemctl restart trading-spacial
sudo systemctl status trading-spacial   # confirm 'active (running)'
```

The systemd unit's existing `EnvironmentFile=/var/www/trading/.env` reads the file; one new line arms the gate. Reversible — just remove the line + restart.

## Tests
- `test_lifespan_refuses_to_boot_when_pytest_leaks` — monkeypatch `RUN_AS_SERVICE=1`, enter `with TestClient(app)`, expect `RuntimeError`. ✅
- `test_lifespan_does_not_crash_without_run_as_service_env` — negative control matching the path `test_setup.py` already relies on. ✅
- `test_main_entry_sets_run_as_service` — source-level pin that `__main__` block sets the env var. ✅
- Regression: 134/134 pass across agent history suite + test_setup + multi-tenant B.7 IDOR. No drift.

## Files
- `btc_api.py` — gate in `lifespan()` + `setdefault` in `__main__`.
- `docs/superpowers/specs/es/2026-04-29-trading-sdar-dev-deploy-design.md` — `Environment=RUN_AS_SERVICE=1` in the unit template (future bootstraps).
- `tests/test_pytest_leak_gate.py` — 3 tests.

## Scope decision
Not gated on env var only (Option 2 from #436 review). Lifespan-only (Option 1) would have crashed `test_setup.py` because that suite uses `with TestClient(app)`. Combining both — gate inside lifespan AND require `RUN_AS_SERVICE=1` — keeps the test suite green while preserving the prod assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)