### PR TITLE
fix(agent/ui): sidebar theme — use --nbc-fg, not --nbc-primary-fg, for text

### DIFF
--- a/frontend/src/components/AgentHistorySidebar.module.css
+++ b/frontend/src/components/AgentHistorySidebar.module.css
@@ -20,7 +20,7 @@
   max-width: 90vw;
   background: var(--nbc-surface-solid, #0a0d15);
   border-left: 1px solid var(--bull, #6ad7ff);
-  color: var(--nbc-primary-fg, #e8edf3);
+  color: var(--nbc-fg, #e8edf3);
   z-index: 96;
   display: flex;
   flex-direction: column;
@@ -55,7 +55,7 @@
 .closeBtn {
   background: none;
   border: none;
-  color: var(--nbc-primary-fg, #e8edf3);
+  color: var(--nbc-fg, #e8edf3);
   font-size: 22px;
   line-height: 1;
   cursor: pointer;
@@ -92,7 +92,7 @@
 .errorState {
   padding: 24px 16px;
   font-size: 13px;
-  color: rgba(232, 237, 243, 0.55);
+  color: var(--nbc-fg-muted, #8093a0);
   text-align: center;
 }
 .errorState { color: var(--bear, #ff5b6e); }
@@ -126,11 +126,11 @@
 }
 .itemTitleEmpty {
   font-style: italic;
-  color: rgba(232, 237, 243, 0.45);
+  color: var(--nbc-fg-dim, #58707a);
 }
 .itemMeta {
   font-size: 11px;
-  color: rgba(232, 237, 243, 0.55);
+  color: var(--nbc-fg-muted, #8093a0);
   display: flex;
   gap: 8px;
   align-items: center;
@@ -160,7 +160,7 @@
 .actionBtn {
   background: none;
   border: 1px solid rgba(106, 215, 255, 0.18);
-  color: rgba(232, 237, 243, 0.65);
+  color: var(--nbc-fg-muted, #8093a0);
   cursor: pointer;
   font-size: 11px;
   padding: 2px 6px;


### PR DESCRIPTION
Surfaced when papá tried the live sidebar on `trading.sdar.dev` post-#436 and couldn't read conversation titles — they rendered black-on-dark.

## Root cause
`.panel` was setting `color: var(--nbc-primary-fg)` as the body text color. That token (`#06121a`, nearly black) is the design system's "foreground for buttons sitting ON `--nbc-primary` cyan background", **not** the panel body text. Every descendant that inherited from `.panel` — conversation titles, search input, close button — rendered black-on-dark and was effectively invisible.

The right token is `--nbc-fg` (`#dcecf7`, light gray, tuned for WCAG AA against the surface backgrounds). One letter, completely different semantics.

## Fix
- `.panel` + `.closeBtn`: `--nbc-primary-fg` → `--nbc-fg`.
- While here: align the dimmed text colors with design tokens (file was using raw `rgba(232, 237, 243, alpha)` which approximates but doesn't match `--nbc-fg-muted` / `--nbc-fg-dim`):

| Was | Now | Where |
|---|---|---|
| `rgba(232, 237, 243, 0.45)` | `var(--nbc-fg-dim)` | `.itemTitleEmpty` |
| `rgba(232, 237, 243, 0.55)` | `var(--nbc-fg-muted)` | `.empty` / `.loading` / `.itemMeta` |
| `rgba(232, 237, 243, 0.65)` | `var(--nbc-fg-muted)` | `.actionBtn` |

A future theme swap (data-cb, light theme, anything) now flows through automatically; pre-fix the raw alphas would have stuck at the dark-theme values.

## Tests
- `npx vitest run AgentHistorySidebar.test.tsx` — 16/16 (CSS-only change, no test impact).
- `tsc --noEmit` clean.

## Files
- `frontend/src/components/AgentHistorySidebar.module.css` — 6 lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)