### PR TITLE
fix(signals): exact crypto-grade precision in entry / SL / TP

### DIFF
--- a/api/telegram.py
+++ b/api/telegram.py
@@ -20,6 +20,7 @@ import requests as req_lib
 
 from db.connection import get_db
 from notifier import notify, SignalEvent
+from notifier._templates import fmt_price
 
 log = logging.getLogger("api.telegram")
 
@@ -59,7 +60,7 @@ def build_telegram_message(rep: dict) -> str:
         "",
         f"`{estado}`",
         "",
-        f"*Precio:* `${price:,.2f}`",
+        f"*Precio:* `${fmt_price(price)}`",
         f"*LRC 1H:* `{lrc.get('pct')}%`  _(zona <= 25% = LONG)_",
         f"*Score:* `{score}/9`  _{slabel}_",
         f"*Macro 4H:* `{'Alcista' if macro.get('price_above') else 'Adversa'}`  _(Precio vs SMA100)_",

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -324,7 +324,13 @@ def scan(symbol: str = None):
             "estado": f"🛑 {symbol} PAUSED por kill switch (#138) — reactivar manualmente",
             "señal_activa": False,
             "direction": None,
-            "price": round(float(price), 2),
+            # PR #438 follow-up: NO 2-decimal rounding on crypto prices.
+            # For sub-dollar tokens, round(x, 2) silently collapses to
+            # $0.00; for larger tokens it strips sub-cent SL/TP precision
+            # that's the difference between a real entry and a missed one.
+            # Use 8 decimals (satoshi-grade) which covers every crypto
+            # tick size and stays within float64 precision.
+            "price": round(float(price), 8),
             "health_state": "PAUSED",
         })
         return rep
@@ -523,7 +529,7 @@ def scan(symbol: str = None):
     if _so is False:
         # Symbol disabled — no signal
         rep.update({"estado": f"⛔ {symbol} deshabilitado en config", "señal_activa": False,
-                    "direction": None, "price": round(price, 2)})
+                    "direction": None, "price": round(price, 8)})
         return rep
     resolved = resolve_direction_params(_sym_overrides, symbol, direction)
     if resolved is None:
@@ -534,7 +540,7 @@ def scan(symbol: str = None):
             "señal_activa": False,
             "direction": direction,
             "direction_disabled": True,
-            "price": round(price, 2),
+            "price": round(price, 8),
         })
         return rep
     _sl_m = resolved["atr_sl_mult"]
@@ -550,11 +556,11 @@ def scan(symbol: str = None):
     tp_dist    = atr_val * _tp_m
 
     if direction == "SHORT":
-        sl_price   = round(price + sl_dist, 2)   # SL arriba para SHORT
-        tp_price   = round(price - tp_dist, 2)   # TP abajo para SHORT
+        sl_price   = round(price + sl_dist, 8)   # SL arriba para SHORT
+        tp_price   = round(price - tp_dist, 8)   # TP abajo para SHORT
     else:
-        sl_price   = round(price - sl_dist, 2)   # SL abajo para LONG
-        tp_price   = round(price + tp_dist, 2)   # TP arriba para LONG
+        sl_price   = round(price - sl_dist, 8)   # SL abajo para LONG
+        tp_price   = round(price + tp_dist, 8)   # TP arriba para LONG
 
     sl_pct_val = round(sl_dist / price * 100, 2)
     tp_pct_val = round(tp_dist / price * 100, 2)
@@ -707,7 +713,7 @@ def scan(symbol: str = None):
         "regime":         regime_data.get("regime"),
         "regime_score":   regime_data.get("score"),
         "regime_details": regime_data.get("details"),
-        "price":          round(price, 2),
+        "price":          round(price, 8),
         "lrc_1h": {
             "pct":   lrc_pct,
             "upper": lrc_up,

--- a/notifier/_templates.py
+++ b/notifier/_templates.py
@@ -12,6 +12,47 @@ from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from notifier.events import _BaseEvent
 
 
+def fmt_price(value: Any) -> str:
+    """Format a crypto price with adaptive precision so we never silently
+    drop sub-cent information on small-value tokens.
+
+    Why this exists: the old `"%.2f"|format(entry)` in the j2 templates
+    truncated entries / SL / TP to 2 decimals. For a token at $0.001234,
+    that turned into $0.00 — losing the entire signal. Even for $5.4203
+    RUNE, the SL/TP precision was getting chopped to 2dp ($5.42), which
+    is the difference between a real entry and a missed one.
+
+    Tiers (chosen for the curated 10 symbols' price range; survives
+    smaller tokens too):
+
+      ≥ 100   → 2 decimals, thousand separators (BTC 80,000.50)
+      ≥ 1     → up to 4 decimals, trailing zeros stripped (RUNE 5.4203)
+      ≥ 0.01  → up to 6 decimals (DOGE 0.15234)
+      < 0.01  → up to 8 decimals (sub-cent tokens)
+
+    None / non-numeric input returns "—" (jinja's StrictUndefined would
+    normally raise, but a filter that swallows a missing field
+    cleanly is safer than 500-ing a notification render).
+    """
+    if value is None:
+        return "—"
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    if f == 0:
+        return "0"
+    sign = "-" if f < 0 else ""
+    abs_f = abs(f)
+    if abs_f >= 100:
+        return f"{sign}{abs_f:,.2f}"
+    if abs_f >= 1:
+        return f"{sign}{abs_f:.4f}".rstrip("0").rstrip(".")
+    if abs_f >= 0.01:
+        return f"{sign}{abs_f:.6f}".rstrip("0").rstrip(".")
+    return f"{sign}{abs_f:.8f}".rstrip("0").rstrip(".")
+
+
 _TEMPLATE_DIR = Path(__file__).parent / "templates"
 _env = Environment(
     loader=FileSystemLoader(str(_TEMPLATE_DIR)),
@@ -20,6 +61,7 @@ _env = Environment(
     trim_blocks=True,
     lstrip_blocks=True,
 )
+_env.filters["fmt_price"] = fmt_price
 
 
 def render(event: _BaseEvent, channel: str) -> str:

--- a/notifier/templates/position_exit.email.j2
+++ b/notifier/templates/position_exit.email.j2
@@ -1,7 +1,7 @@
 Position closed: {{ symbol }} ({{ direction }})
 
 Exit reason: {{ exit_reason }}
-Entry: {{ "%.2f"|format(entry_price) }}
-Exit:  {{ "%.2f"|format(exit_price) }}
+Entry: {{ entry_price|fmt_price }}
+Exit:  {{ exit_price|fmt_price }}
 
 P&L: {{ "%+.2f"|format(pnl_usd) }} USD ({{ "%+.2f"|format(pnl_pct) }}%)

--- a/notifier/templates/position_exit.telegram.j2
+++ b/notifier/templates/position_exit.telegram.j2
@@ -1,3 +1,3 @@
 {%- if exit_reason == "TP" %}🎯 *TP hit*{% elif exit_reason == "SL" %}🛑 *SL hit*{% elif exit_reason == "BE" %}⚖️ *Break-even*{% elif exit_reason == "TIME_LIMIT" %}⏰ *Time-limit hit*{% else %}📕 *Position closed*{% endif %} `{{ symbol }}` ({{ direction }})
-Entry: `{{ "%.2f"|format(entry_price) }}` → Exit: `{{ "%.2f"|format(exit_price) }}`
+Entry: `{{ entry_price|fmt_price }}` → Exit: `{{ exit_price|fmt_price }}`
 P&L: `{{ "%+.2f"|format(pnl_usd) }}` USD ({{ "%+.2f"|format(pnl_pct) }}%)

--- a/notifier/templates/position_exit.webhook.j2
+++ b/notifier/templates/position_exit.webhook.j2
@@ -3,8 +3,8 @@
   "symbol": "{{ symbol }}",
   "direction": "{{ direction }}",
   "exit_reason": "{{ exit_reason }}",
-  "entry_price": {{ "%.2f"|format(entry_price) }},
-  "exit_price": {{ "%.2f"|format(exit_price) }},
+  "entry_price": {{ entry_price|tojson }},
+  "exit_price": {{ exit_price|tojson }},
   "pnl_usd": {{ "%.2f"|format(pnl_usd) }},
   "pnl_pct": {{ "%.2f"|format(pnl_pct) }}
 }

--- a/notifier/templates/signal.email.j2
+++ b/notifier/templates/signal.email.j2
@@ -1,7 +1,7 @@
 Signal: {{ symbol }} (score {{ score }} {{ direction }})
 
-Entry: {{ "%.2f"|format(entry) }}
-SL:    {{ "%.2f"|format(sl) }}
-TP:    {{ "%.2f"|format(tp) }}
+Entry: {{ entry|fmt_price }}
+SL:    {{ sl|fmt_price }}
+TP:    {{ tp|fmt_price }}
 
 Health state: {{ health_state }}

--- a/notifier/templates/signal.telegram.j2
+++ b/notifier/templates/signal.telegram.j2
@@ -3,4 +3,4 @@
 {% endif -%}
 *Signal* `{{ symbol }}`
 Score: *{{ score }}* ({{ direction }})
-Entry: `{{ "%.2f"|format(entry) }}` | SL: `{{ "%.2f"|format(sl) }}` | TP: `{{ "%.2f"|format(tp) }}`
+Entry: `{{ entry|fmt_price }}` | SL: `{{ sl|fmt_price }}` | TP: `{{ tp|fmt_price }}`

--- a/notifier/templates/signal.webhook.j2
+++ b/notifier/templates/signal.webhook.j2
@@ -3,8 +3,8 @@
   "symbol": "{{ symbol }}",
   "score": {{ score }},
   "direction": "{{ direction }}",
-  "entry": {{ "%.2f"|format(entry) }},
-  "sl": {{ "%.2f"|format(sl) }},
-  "tp": {{ "%.2f"|format(tp) }},
+  "entry": {{ entry|tojson }},
+  "sl": {{ sl|tojson }},
+  "tp": {{ tp|tojson }},
   "health_state": "{{ health_state }}"
 }

--- a/tests/_baselines/scan_btcusdt.json
+++ b/tests/_baselines/scan_btcusdt.json
@@ -155,9 +155,9 @@
     "riesgo_usd": 10.0,
     "sl_mode": "atr",
     "sl_pct": "0.44%",
-    "sl_precio": 76259.83,
+    "sl_precio": 76259.83071429,
     "tp_pct": "1.77%",
-    "tp_precio": 77950.68,
+    "tp_precio": 77950.67714286,
     "valor_pos": 980.0
   },
   "symbol": "BTCUSDT",

--- a/tests/_baselines/signals.json
+++ b/tests/_baselines/signals.json
@@ -56,7 +56,7 @@
       "setup": 0,
       "se\u00f1al": 1,
       "symbol": "BTCUSDT",
-      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
+      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
       "ts": "2026-01-15T10:05:00Z"
     },
     "status": 200
@@ -74,14 +74,14 @@
       "score_label": "premium",
       "sizing": {},
       "symbol": "BTCUSDT",
-      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
+      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
       "ts": "2026-01-15T10:05:00Z"
     },
     "status": 200
   },
   "GET /signals/latest/message": {
     "body": {
-      "message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
+      "message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
       "scan_id": 2,
       "symbol": "BTCUSDT",
       "ts": "2026-01-15T10:05:00Z"
@@ -101,7 +101,7 @@
       "score_label": "premium",
       "sizing": {},
       "symbol": "BTCUSDT",
-      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0.00`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
+      "telegram_message": "*Scanner Update BTCUSDT*\n``\n\n``\n\n*Precio:* `$0`\n*LRC 1H:* `None%`  _(zona <= 25% = LONG)_\n*Score:* `0/9`  __\n*Macro 4H:* `Adversa`  _(Precio vs SMA100)_\n\n\n*Verificar manualmente:* noticias macro, racha, capital, DXY\n_BTCUSDT Spot 1H V6_",
       "ts": "2026-01-15T10:05:00Z"
     },
     "status": 200

--- a/tests/test_notifier_signal_parity.py
+++ b/tests/test_notifier_signal_parity.py
@@ -32,6 +32,6 @@ def test_signal_template_stable_for_fixed_input():
     expected = (
         "*Signal* `BTCUSDT`\n"
         "Score: *6* (LONG)\n"
-        "Entry: `50000.00` | SL: `49000.00` | TP: `55000.00`"
+        "Entry: `50,000.00` | SL: `49,000.00` | TP: `55,000.00`"
     )
     assert got == expected, f"template drift detected:\nexpected:\n{expected!r}\ngot:\n{got!r}"

--- a/tests/test_notifier_templates.py
+++ b/tests/test_notifier_templates.py
@@ -105,6 +105,6 @@ def test_signal_telegram_no_prefix_for_normal():
     expected = (
         "*Signal* `BTCUSDT`\n"
         "Score: *6* (LONG)\n"
-        "Entry: `50000.00` | SL: `49000.00` | TP: `55000.00`"
+        "Entry: `50,000.00` | SL: `49,000.00` | TP: `55,000.00`"
     )
     assert msg == expected, f"parity broken: {msg!r}"

--- a/tests/test_signal_precision.py
+++ b/tests/test_signal_precision.py
@@ -1,0 +1,182 @@
+"""Signal precision regression — entry/SL/TP must keep crypto-grade
+precision through scanner → DB → template rendering.
+
+Surfaced when papá saw signal prices truncated to 2 decimals on
+trading.sdar.dev: `round(price, 2)` in btc_scanner.py was collapsing
+sub-cent SL/TP precision (catastrophic for small-value tokens, lossy
+for everything ≥ $1).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from notifier._templates import fmt_price
+
+
+# ---------------------------------------------------------------------------
+# fmt_price filter — adaptive precision
+# ---------------------------------------------------------------------------
+
+
+class TestFmtPriceTiers:
+    """The four tiers cover every crypto price range we care about
+    without dropping precision or showing 8-decimal trailing zeros."""
+
+    def test_large_token_uses_2dp_with_thousands_separator(self):
+        # BTC tier — humans want "80,000.50", not "80000.5".
+        assert fmt_price(80000.5) == "80,000.50"
+        assert fmt_price(80000.50123) == "80,000.50"  # 2dp here is fine
+
+    def test_mid_token_strips_trailing_zeros_up_to_4dp(self):
+        # RUNE ~$5.4203 — 4dp is enough, but no trailing zeros.
+        assert fmt_price(5.4203) == "5.4203"
+        assert fmt_price(5.42) == "5.42"
+        assert fmt_price(5.4) == "5.4"
+        assert fmt_price(5.0) == "5"
+
+    def test_sub_dollar_token_uses_up_to_6dp(self):
+        # DOGE / XLM tier — half-cent precision matters.
+        assert fmt_price(0.15234) == "0.15234"
+        assert fmt_price(0.5) == "0.5"
+        assert fmt_price(0.05) == "0.05"
+
+    def test_micro_token_uses_up_to_8dp(self):
+        # SHIB / sub-cent tokens — collapsing to 2dp would have
+        # shown "$0.00" pre-fix. This is the catastrophic case.
+        assert fmt_price(0.00012345) == "0.00012345"
+        assert fmt_price(0.001) == "0.001"
+        assert fmt_price(0.00000001) == "0.00000001"
+
+
+class TestFmtPriceEdgeCases:
+    def test_zero_is_zero(self):
+        assert fmt_price(0) == "0"
+        assert fmt_price(0.0) == "0"
+
+    def test_negative_value(self):
+        assert fmt_price(-5.4203) == "-5.4203"
+        assert fmt_price(-80000.5) == "-80,000.50"
+
+    def test_none_returns_em_dash(self):
+        # Filter MUST NOT raise on missing fields — a 500 in a
+        # notification render is worse than a "—" in the message.
+        assert fmt_price(None) == "—"
+
+    def test_non_numeric_returns_em_dash(self):
+        assert fmt_price("not a number") == "—"
+        assert fmt_price({}) == "—"
+
+    def test_accepts_int_input(self):
+        # Some upstream values arrive as Python ints (e.g. score-tier
+        # USD thresholds). Must format the same as floats.
+        assert fmt_price(80000) == "80,000.00"
+
+
+# ---------------------------------------------------------------------------
+# Signal templates render with full precision (no silent truncation)
+# ---------------------------------------------------------------------------
+
+
+def _render(event, channel):
+    from notifier._templates import render
+    return render(event, channel)
+
+
+def _signal_event(entry, sl, tp):
+    from notifier.events import SignalEvent
+    return SignalEvent(
+        symbol="RUNEUSDT", score=5, direction="LONG",
+        entry=entry, sl=sl, tp=tp,
+        health_state="NORMAL",
+    )
+
+
+class TestSignalTemplates:
+    def test_telegram_renders_full_precision_entry_sl_tp(self):
+        msg = _render(_signal_event(5.4203, 5.10, 6.0), "telegram")
+        # 5.4203 must NOT be "5.42" — that's the pre-fix bug.
+        assert "5.4203" in msg
+        assert "5.42" not in msg.replace("5.4203", "")
+        assert "5.1" in msg  # SL — trailing zero stripped from 5.10
+        assert "6" in msg
+
+    def test_webhook_emits_json_with_raw_precision(self):
+        msg = _render(_signal_event(5.4203, 5.10, 6.0), "webhook")
+        # Parse the rendered JSON — it must be valid + numeric.
+        parsed = json.loads(msg)
+        assert parsed["entry"] == 5.4203
+        assert parsed["sl"] == 5.10
+        assert parsed["tp"] == 6.0
+
+    def test_telegram_small_token_no_zero_collapse(self):
+        # The catastrophic pre-fix case: a $0.00012345 token rendered
+        # as "$0.00". Now must preserve the value end-to-end.
+        msg = _render(_signal_event(0.00012345, 0.00012000, 0.00013000), "telegram")
+        assert "0.00012345" in msg
+
+    def test_webhook_small_token_json_is_lossless(self):
+        msg = _render(_signal_event(0.00012345, 0.00012, 0.00013), "webhook")
+        parsed = json.loads(msg)
+        assert parsed["entry"] == pytest.approx(0.00012345)
+
+
+# ---------------------------------------------------------------------------
+# Position exit templates likewise preserve precision
+# ---------------------------------------------------------------------------
+
+
+def _exit_event(entry_price, exit_price, pnl_usd=10.0, pnl_pct=2.5):
+    from notifier.events import PositionExitEvent
+    return PositionExitEvent(
+        symbol="RUNEUSDT", direction="LONG", exit_reason="TP",
+        entry_price=entry_price, exit_price=exit_price,
+        pnl_usd=pnl_usd, pnl_pct=pnl_pct,
+    )
+
+
+class TestPositionExitTemplates:
+    def test_telegram_keeps_entry_exit_precision(self):
+        msg = _render(_exit_event(5.4203, 5.6789), "telegram")
+        assert "5.4203" in msg
+        assert "5.6789" in msg
+
+    def test_webhook_emits_lossless_json(self):
+        msg = _render(_exit_event(5.4203, 5.6789), "webhook")
+        parsed = json.loads(msg)
+        assert parsed["entry_price"] == 5.4203
+        assert parsed["exit_price"] == 5.6789
+        # pnl_usd / pnl_pct remain at 2dp — those are USD amounts and
+        # percentages, where 2dp is the correct convention.
+        assert parsed["pnl_usd"] == 10.0
+        assert parsed["pnl_pct"] == 2.5
+
+
+# ---------------------------------------------------------------------------
+# Scanner no longer rounds entry / SL / TP to 2dp
+# ---------------------------------------------------------------------------
+
+
+class TestScannerPriceRoundingTier:
+    """Statically verify btc_scanner.py uses round(_, 8) for every
+    place that builds the signal-payload price/sl/tp. The actual
+    end-to-end signal-generation flow is exercised by the integration
+    tests in test_scanner.py — here we just pin the source invariant."""
+
+    def test_btc_scanner_uses_8dp_for_price_rounding(self):
+        from pathlib import Path
+        src = Path(__file__).resolve().parent.parent / "btc_scanner.py"
+        text = src.read_text(encoding="utf-8")
+        # No `round(price, 2)` or `round(price + sl_dist, 2)` left for
+        # the signal-payload prices. The diagnostic indicators (SMA,
+        # BB) still use round(_, 2) — those are NOT in the signal
+        # payload that drives the user's order.
+        assert "round(price, 2)" not in text, (
+            "btc_scanner.py still rounds signal price to 2dp; "
+            "use round(_, 8) for crypto precision."
+        )
+        assert "round(price + sl_dist, 2)" not in text
+        assert "round(price - sl_dist, 2)" not in text
+        assert "round(price + tp_dist, 2)" not in text
+        assert "round(price - tp_dist, 2)" not in text


### PR DESCRIPTION
Papá flagged this on prod: signal amounts were getting truncated to 2 decimals, which is "nefasto" in crypto — for sub-dollar tokens it silently collapses to **`\$0.00`**; for everything ≥ \$1 it strips sub-cent SL/TP precision that's the difference between a real entry and a missed one.

## Two-front fix

### 1. Scanner — store the exact value, not the truncated one

`btc_scanner.py`: every `round(price, 2)` and `round(price ± dist, 2)` that builds the **signal payload's** `price` / `sl_price` / `tp_price` now uses `round(_, 8)`. Eight decimals is satoshi-grade (covers every crypto tick size in practice) and stays well within float64 precision.

The diagnostic indicators (SMA, BB, `dist_resistencia_pct`, `vol_ratio`) keep their 2dp rounding — those are percentages / informational, not order-entry values.

### 2. Templates — render with adaptive precision

New `fmt_price` jinja filter in `notifier/_templates.py` with four tiers matched to the curated 10-symbol price range:

| Magnitude | Format | Example |
|---|---|---|
| ≥ 100 | 2dp + thousands sep | BTC `80,000.50` |
| ≥ 1 | up to 4dp, no trailing zeros | RUNE `5.4203`, PENDLE `5.42` |
| ≥ 0.01 | up to 6dp | DOGE `0.15234` |
| < 0.01 | up to 8dp | micro `0.00012345` |

Plus negatives and `None`/non-numeric input → `"—"` (a notification render must never 500 on a missing field).

**Human templates** (`signal.telegram.j2`, `signal.email.j2`, `position_exit.telegram.j2`, `position_exit.email.j2`): use `|fmt_price` for entry/SL/TP/entry_price/exit_price. `pnl_usd` + `pnl_pct` stay at `%+.2f` (USD amounts and percentages — 2dp is correct).

**Webhook templates** (`signal.webhook.j2`, `position_exit.webhook.j2`): use `|tojson` instead of `"%.2f"|format(...)`. Webhook payload is machine-consumed (n8n, downstream automations); emitting `"5.42"` as a JSON number when the real value was `5.4203` was actively misleading.

**Legacy `api/telegram.py:62`** (deprecated `build_telegram_message`): same `fmt_price` import.

## Test plan
- [x] `pytest tests/test_signal_precision.py -v` — 16/16. Tier coverage, edge cases (None/negatives/ints), end-to-end signal + position_exit renders, **catastrophic sub-cent-token case** (\$0.00012345 must survive end-to-end), JSON webhook lossless round-trip, source-level pin that scanner uses 8dp.
- [x] Regression: scanner + notifier + api + new tests — **304 passed**, no drift.
- [x] Updated 2 existing tests whose hardcoded `"50000.00"` strings now expect `"50,000.00"` (thousand separator from the new format).
- [ ] CI green.
- [ ] After merge + deploy: next real signal renders with full precision in Telegram.

## Out of scope (intentional)
- Frontend `toFixed(2)` on `pnl_pct` / `pnl_usd` — percentages and USD, 2dp is correct.
- Frontend confirm-dialog price displays (`App.tsx:417, :489`) — same pattern; can swap later, but the current pain is the Telegram signal path.
- `auto_tune.py` / `backtest.py` / `btc_report.py` `%.2f` formats — reporting / backtest output, not live signal flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)