### PR TITLE
fix(db): close sqlite connections on exception via get_db() context manager (closes #128)

### DIFF
--- a/api/agent/audit.py
+++ b/api/agent/audit.py
@@ -73,8 +73,7 @@ def record_turn(
         DeepSeekProvider adapter. NULL or 0 elsewhere.
     """
     try:
-        con = get_db()
-        try:
+        with get_db() as con:
             con.execute(
                 """INSERT INTO agent_conversations
                    (tenant_id, surface, conversation_id, ts, role, model,
@@ -100,8 +99,6 @@ def record_turn(
                 ),
             )
             con.commit()
-        finally:
-            con.close()
     except Exception:  # noqa: BLE001
         log.warning(
             "record_turn failed for tenant=%s conv=%s — audit row dropped",
@@ -195,8 +192,7 @@ def record_history(
         ]
         rows_inserted = 0
 
-        con = get_db()
-        try:
+        with get_db() as con:
             # Cross-tenant guard (PR #433 review fix). The H.1 schema
             # makes conversation_id the sole PK on agent_conversation_meta,
             # so two tenants writing the same conversation_id collide.
@@ -271,8 +267,6 @@ def record_history(
                 ),
             )
             con.commit()
-        finally:
-            con.close()
     except Exception:  # noqa: BLE001
         log.warning(
             "record_history failed for tenant=%s conv=%s — history rows dropped",

--- a/api/agent/circuit_breaker.py
+++ b/api/agent/circuit_breaker.py
@@ -103,16 +103,13 @@ def _global_spend_last_24h() -> float:
     """
     now = datetime.now(timezone.utc)
     cutoff = (now - timedelta(hours=24)).isoformat()
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT COALESCE(SUM(cost_usd), 0) AS total "
             "FROM agent_conversations "
             "WHERE ts >= ? AND role = 'assistant'",
             (cutoff,),
         ).fetchone()
-    finally:
-        con.close()
     return float(dict(row)["total"] or 0.0)
 
 

--- a/api/agent/history.py
+++ b/api/agent/history.py
@@ -221,8 +221,7 @@ def list_conversations(
     Pre-reg D.7: tenant_id from JWT, never from query/body.
     """
     now = _now_iso()
-    con = get_db()
-    try:
+    with get_db() as con:
         # Parameters live in two buckets so the order in execute() lines
         # up with the placeholder order in the final SQL: JOIN clause
         # comes BEFORE WHERE, so any `?` in the JOIN must be earlier in
@@ -295,8 +294,6 @@ def list_conversations(
             limit=limit,
             offset=offset,
         )
-    finally:
-        con.close()
 
 
 # ── GET /agent/conversations/{id}/messages ─────────────────────────────
@@ -324,8 +321,7 @@ def get_messages(
     signed_payload is never persisted and therefore never returned.
     """
     now = _now_iso()
-    con = get_db()
-    try:
+    with get_db() as con:
         meta = con.execute(
             "SELECT conversation_id, tenant_id, title, surface, pinned, expires_at "
             "FROM agent_conversation_meta WHERE conversation_id = ?",
@@ -389,8 +385,6 @@ def get_messages(
             pinned=bool(meta["pinned"]),
             messages=messages,
         )
-    finally:
-        con.close()
 
 
 # ── DELETE /agent/conversations/{id} — soft delete ─────────────────────
@@ -419,8 +413,7 @@ def delete_conversation(
     returns 404 — no observable difference from "doesn't exist".
     """
     now = _now_iso()
-    con = get_db()
-    try:
+    with get_db() as con:
         cursor = con.execute(
             "UPDATE agent_conversation_meta SET expires_at = ? "
             "WHERE conversation_id = ? AND tenant_id = ? AND expires_at > ?",
@@ -439,8 +432,6 @@ def delete_conversation(
         )
         con.commit()
         return DeleteResponse(ok=True)
-    finally:
-        con.close()
 
 
 # ── POST /agent/conversations/{id}/pin — toggle ────────────────────────
@@ -465,8 +456,7 @@ def toggle_pin(
     """Toggle pinned (0 → 1, 1 → 0). IDOR-safe: UPDATE WHERE tenant_id;
     rowcount = 0 → 404 with the same body as 'doesn't exist'."""
     now = _now_iso()
-    con = get_db()
-    try:
+    with get_db() as con:
         cursor = con.execute(
             "UPDATE agent_conversation_meta SET pinned = 1 - pinned "
             "WHERE conversation_id = ? AND tenant_id = ? AND expires_at > ?",
@@ -485,5 +475,3 @@ def toggle_pin(
             (conversation_id, tenant_id),
         ).fetchone()
         return PinResponse(ok=True, pinned=bool(new_state["pinned"]))
-    finally:
-        con.close()

--- a/api/agent/proposals.py
+++ b/api/agent/proposals.py
@@ -278,38 +278,35 @@ def persist_proposal(
     token_urlsafe each time).
     """
     import sqlite3
-    con = get_db()
     try:
-        con.execute(
-            """INSERT INTO agent_side_effects
-               (tenant_id, conversation_id, ts, action, args_json,
-                idempotency_key, result, http_status, expires_at)
-               VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?)""",
-            (
-                tenant_id,
-                conversation_id,
-                datetime.now(timezone.utc).isoformat(),
-                proposal.action,
-                json.dumps(proposal.args, sort_keys=True),
-                proposal.proposal_id,
-                proposal.expires_at,
-            ),
-        )
-        con.commit()
+        with get_db() as con:
+            con.execute(
+                """INSERT INTO agent_side_effects
+                   (tenant_id, conversation_id, ts, action, args_json,
+                    idempotency_key, result, http_status, expires_at)
+                   VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?)""",
+                (
+                    tenant_id,
+                    conversation_id,
+                    datetime.now(timezone.utc).isoformat(),
+                    proposal.action,
+                    json.dumps(proposal.args, sort_keys=True),
+                    proposal.proposal_id,
+                    proposal.expires_at,
+                ),
+            )
+            con.commit()
     except sqlite3.IntegrityError:
         log.warning(
             "persist_proposal: idempotency_key collision for %s — ignoring",
             proposal.proposal_id,
         )
-    finally:
-        con.close()
 
 
 def load_proposal_row(proposal_id: str) -> Optional[dict]:
     """Fetch the row from agent_side_effects. Returns None if absent.
     Caller compares result column to decide pending vs consumed."""
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             """SELECT id, tenant_id, conversation_id, ts, action, args_json,
                       idempotency_key, result, http_status, expires_at
@@ -317,8 +314,6 @@ def load_proposal_row(proposal_id: str) -> Optional[dict]:
                WHERE idempotency_key = ?""",
             (proposal_id,),
         ).fetchone()
-    finally:
-        con.close()
     return dict(row) if row else None
 
 
@@ -345,8 +340,7 @@ def mark_proposal_result(
     agent_side_effects rows with result IS NULL — they should match.
     """
     try:
-        con = get_db()
-        try:
+        with get_db() as con:
             con.execute(
                 "UPDATE agent_side_effects "
                 "SET result = ?, http_status = ? "
@@ -354,8 +348,6 @@ def mark_proposal_result(
                 (result, http_status, proposal_id),
             )
             con.commit()
-        finally:
-            con.close()
     except Exception:  # noqa: BLE001
         log.warning(
             "mark_proposal_result failed for proposal_id=%s — audit drift; "

--- a/api/agent/quotas.py
+++ b/api/agent/quotas.py
@@ -147,8 +147,7 @@ def _read_or_seed_row(tenant_id: int) -> sqlite3.Row:
     """Return the agent_quotas row for `tenant_id`. INSERT default
     values if absent. Resets stale daily/monthly windows IN-LINE so
     the returned row already reflects the current window."""
-    con = get_db()
-    try:
+    with get_db() as con:
         today = _today_iso()
         month = _this_month_iso()
         row = con.execute(
@@ -199,8 +198,6 @@ def _read_or_seed_row(tenant_id: int) -> sqlite3.Row:
                 (tenant_id,),
             ).fetchone()
         return row
-    finally:
-        con.close()
 
 
 def _to_snapshot(row: sqlite3.Row) -> QuotaSnapshot:
@@ -231,8 +228,7 @@ def _materialize_snapshot(row: sqlite3.Row) -> QuotaSnapshot:
 def _apply_spend(tenant_id: int, cost_usd: float) -> None:
     """Increment daily + monthly counters atomically. Resets first if
     a window passed (mirrors _read_or_seed_row's reset logic)."""
-    con = get_db()
-    try:
+    with get_db() as con:
         today = _today_iso()
         month = _this_month_iso()
         row = con.execute(
@@ -275,5 +271,3 @@ def _apply_spend(tenant_id: int, cost_usd: float) -> None:
             (daily, today, monthly, month, tenant_id),
         )
         con.commit()
-    finally:
-        con.close()

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -389,14 +389,11 @@ def _execute_proposed_action(
         # SL/TP/TIME_LIMIT between propose and confirm):
         #   1. row must still exist for this tenant (IDOR null pattern)
         #   2. row must still be `open` (not closed by another flow)
-        con = btc_api.get_db()
-        try:
+        with btc_api.get_db() as con:
             current = con.execute(
                 "SELECT status FROM positions WHERE id=? AND tenant_id=?",
                 (position_id, tenant_id),
             ).fetchone()
-        finally:
-            con.close()
         if current is None or dict(current).get("status") != "open":
             raise HTTPException(status_code=409, detail="state_drift")
         pos = db_close_position(
@@ -503,8 +500,7 @@ def get_agent_metrics():
     cutoff_iso = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
     today_iso  = datetime.now(timezone.utc).date().isoformat() + "T00:00:00+00:00"
 
-    con = btc_api.get_db()
-    try:
+    with btc_api.get_db() as con:
         today_row = con.execute(
             "SELECT "
             "  COUNT(*) AS turn_count, "
@@ -576,8 +572,6 @@ def get_agent_metrics():
             except (TypeError, ValueError):
                 reason = "unknown"
             error_breakdown_24h.append({"reason": reason, "count": d["count"]})
-    finally:
-        con.close()
 
     return {
         "breaker":             breaker_state,

--- a/api/agent/tools/handlers.py
+++ b/api/agent/tools/handlers.py
@@ -131,14 +131,11 @@ def get_position_detail(*, tenant_id: int, position_id: int) -> dict:
     row exists but doesn't belong to this tenant, return 'not_found' —
     never reveals existence cross-tenant.
     """
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT * FROM positions WHERE id=? AND tenant_id=?",
             (position_id, tenant_id),
         ).fetchone()
-    finally:
-        con.close()
     if row is None:
         return {"error": "not_found"}
     return _position_to_summary(_row_to_dict(row))

--- a/api/agent/tools/propose_handlers.py
+++ b/api/agent/tools/propose_handlers.py
@@ -78,15 +78,12 @@ def propose_close_position(
     rationale:       str,
 ) -> dict:
     """Verify ownership, sign a close_position proposal, persist."""
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT symbol, direction, status, entry_price, size_usd "
             "FROM positions WHERE id = ? AND tenant_id = ?",
             (position_id, tenant_id),
         ).fetchone()
-    finally:
-        con.close()
     if row is None:
         return {"error": "not_found"}
     pos = dict(row)
@@ -129,14 +126,11 @@ def propose_reactivate_symbol(
     norm = symbol.upper().strip()
     if not norm.endswith("USDT"):
         norm = f"{norm}USDT"
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT state FROM symbol_health WHERE symbol = ?",
             (norm,),
         ).fetchone()
-    finally:
-        con.close()
     if row is None:
         return {"error": "not_found"}
     state = dict(row)["state"]

--- a/api/auth.py
+++ b/api/auth.py
@@ -220,8 +220,7 @@ def _clear_auth_cookies(response: Response) -> None:
 
 
 def _user_by_email(email: str) -> Optional[User]:
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             """
             SELECT id, email, password_hash, role, is_active, created_at,
@@ -230,8 +229,6 @@ def _user_by_email(email: str) -> Optional[User]:
             """,
             (email,),
         ).fetchone()
-    finally:
-        con.close()
     if not row:
         return None
     return User(
@@ -250,26 +247,20 @@ def _user_by_email(email: str) -> Optional[User]:
 def _password_hash_for_email(email: str) -> Optional[str]:
     """Fetch the bcrypt hash for an email. Used by login + change_password.
     Returns None if user does not exist."""
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT password_hash FROM users WHERE email = ?", (email,)
         ).fetchone()
-    finally:
-        con.close()
     return row["password_hash"] if row else None
 
 
 def _update_last_login(user_id: int) -> None:
-    con = get_db()
-    try:
+    with get_db() as con:
         con.execute(
             "UPDATE users SET last_login_at = ? WHERE id = ?",
             (datetime.now(timezone.utc).isoformat(), user_id),
         )
         con.commit()
-    finally:
-        con.close()
 
 
 # ─── Routes ─────────────────────────────────────────────────────────────────
@@ -557,16 +548,13 @@ def change_password(
 
     new_hash = hash_password(body.new_password)
     now = datetime.now(timezone.utc).isoformat()
-    con = get_db()
-    try:
+    with get_db() as con:
         con.execute(
             "UPDATE users SET password_hash = ?, password_changed_at = ? "
             "WHERE id = ?",
             (new_hash, now, user.id),
         )
         con.commit()
-    finally:
-        con.close()
 
     # Revoke ALL refresh tokens for this user — forces re-login on every
     # device they have. Spec compliance: a password change should invalidate
@@ -590,8 +578,7 @@ def change_password(
 def _hydrate_user(user_id: int) -> Optional[User]:
     """Refresh-flow user hydration. Mirrors the middleware helper but returns
     None if user is gone or deactivated (caller decides what to do)."""
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             """
             SELECT id, email, role, is_active, created_at, password_changed_at,
@@ -600,8 +587,6 @@ def _hydrate_user(user_id: int) -> Optional[User]:
             """,
             (user_id,),
         ).fetchone()
-    finally:
-        con.close()
     if not row:
         return None
     return User(

--- a/api/health.py
+++ b/api/health.py
@@ -34,16 +34,13 @@ class ReactivateRequest(BaseModel):
 @router.get("/health/symbols", dependencies=[Depends(verify_api_key)])
 def get_health_symbols():
     """List current health state per symbol."""
-    con = get_db()
-    try:
+    with get_db() as con:
         rows = con.execute(
             """SELECT symbol, state, state_since, last_evaluated_at,
                       last_metrics_json, manual_override
                FROM symbol_health
                ORDER BY symbol"""
         ).fetchall()
-    finally:
-        con.close()
     cols = ("symbol", "state", "state_since", "last_evaluated_at",
             "last_metrics_json", "manual_override")
     return {"symbols": [dict(zip(cols, r)) for r in rows]}
@@ -55,8 +52,7 @@ def get_health_events(
     limit: int = Query(50, ge=1, le=500, description="Max rows to return (capped to prevent unbounded scans)"),
 ):
     """Transition history. Optionally filter by symbol."""
-    con = get_db()
-    try:
+    with get_db() as con:
         if symbol:
             rows = con.execute(
                 """SELECT id, symbol, from_state, to_state, trigger_reason,
@@ -72,8 +68,6 @@ def get_health_events(
                    FROM symbol_health_events ORDER BY ts DESC LIMIT ?""",
                 (limit,),
             ).fetchall()
-    finally:
-        con.close()
     cols = ("id", "symbol", "from_state", "to_state", "trigger_reason",
             "metrics_json", "ts")
     return {"events": [dict(zip(cols, r)) for r in rows]}
@@ -121,9 +115,8 @@ def health_check():
 
     # Database connectivity
     try:
-        con = get_db()
-        con.execute("SELECT 1")
-        con.close()
+        with get_db() as con:
+            con.execute("SELECT 1")
         checks["database"] = "ok"
     except Exception as e:
         checks["database"] = f"error: {e}"

--- a/api/kill_switch.py
+++ b/api/kill_switch.py
@@ -87,8 +87,7 @@ def kill_switch_list_recommendations(
     """List auto-calibrator recommendations, latest first."""
     import json as _json
 
-    conn = get_db()
-    try:
+    with get_db() as conn:
         sql = (
             "SELECT id, ts, triggered_by, slider_value, projected_pnl, "
             "projected_dd, status, applied_ts, applied_by, report_json "
@@ -104,8 +103,6 @@ def kill_switch_list_recommendations(
         sql += " ORDER BY ts DESC LIMIT ?"
         params.append(int(limit))
         rows = conn.execute(sql, params).fetchall()
-    finally:
-        conn.close()
 
     result = []
     for r in rows:
@@ -154,15 +151,12 @@ def kill_switch_apply_recommendation(rec_id: int):
     from datetime import datetime, timezone
 
     try:
-        conn = get_db()
-        try:
+        with get_db() as conn:
             row = conn.execute(
                 """SELECT id, status, slider_value
                    FROM kill_switch_recommendations WHERE id = ?""",
                 (rec_id,),
             ).fetchone()
-        finally:
-            conn.close()
 
         if row is None:
             raise HTTPException(status_code=404, detail=f"recommendation {rec_id} not found")
@@ -197,8 +191,7 @@ def kill_switch_apply_recommendation(rec_id: int):
 
         # Update DB row
         now_iso = datetime.now(tz=timezone.utc).isoformat()
-        conn = get_db()
-        try:
+        with get_db() as conn:
             conn.execute(
                 """UPDATE kill_switch_recommendations
                    SET status = 'applied', applied_ts = ?, applied_by = 'operator'
@@ -212,8 +205,6 @@ def kill_switch_apply_recommendation(rec_id: int):
                    FROM kill_switch_recommendations WHERE id = ?""",
                 (rec_id,),
             ).fetchone()
-        finally:
-            conn.close()
 
         log.warning(
             "Kill switch v2: operator applied recomendación id=%d slider=%d",
@@ -253,14 +244,11 @@ def kill_switch_ignore_recommendation(rec_id: int):
     from datetime import datetime, timezone
 
     try:
-        conn = get_db()
-        try:
+        with get_db() as conn:
             row = conn.execute(
                 """SELECT id, status FROM kill_switch_recommendations WHERE id = ?""",
                 (rec_id,),
             ).fetchone()
-        finally:
-            conn.close()
 
         if row is None:
             raise HTTPException(status_code=404, detail=f"recommendation {rec_id} not found")
@@ -271,8 +259,7 @@ def kill_switch_ignore_recommendation(rec_id: int):
             )
 
         now_iso = datetime.now(tz=timezone.utc).isoformat()
-        conn = get_db()
-        try:
+        with get_db() as conn:
             conn.execute(
                 """UPDATE kill_switch_recommendations
                    SET status = 'ignored', applied_ts = ?, applied_by = 'operator'
@@ -286,8 +273,6 @@ def kill_switch_ignore_recommendation(rec_id: int):
                    FROM kill_switch_recommendations WHERE id = ?""",
                 (rec_id,),
             ).fetchone()
-        finally:
-            conn.close()
 
         log.warning(
             "Kill switch v2: operator ignored recomendación id=%d", rec_id,

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -39,8 +39,7 @@ def get_notifications(
     from notifier._storage import list_unread
     if not unread:
         # Full list (both read + unread) — direct query (list_unread filters on read_at).
-        con = get_db()
-        try:
+        with get_db() as con:
             rows = con.execute(
                 """SELECT id, event_type, event_key, priority, payload_json,
                           channels_sent, delivery_status, sent_at, read_at, error_log
@@ -50,8 +49,6 @@ def get_notifications(
                    LIMIT ?""",
                 (tenant_id, limit),
             ).fetchall()
-        finally:
-            con.close()
         cols = ("id", "event_type", "event_key", "priority", "payload_json",
                 "channels_sent", "delivery_status", "sent_at", "read_at", "error_log")
         return {"notifications": [dict(zip(cols, r)) for r in rows]}

--- a/api/positions.py
+++ b/api/positions.py
@@ -134,11 +134,10 @@ def check_position_stops(symbol: str, price: float, now: datetime | None = None)
     """
     if now is None:
         now = datetime.now(timezone.utc)
-    con = get_db()
-    rows = con.execute(
-        "SELECT * FROM positions WHERE symbol=? AND status='open'", (symbol.upper(),)
-    ).fetchall()
-    con.close()
+    with get_db() as con:
+        rows = con.execute(
+            "SELECT * FROM positions WHERE symbol=? AND status='open'", (symbol.upper(),)
+        ).fetchall()
 
     cfg = load_config()
 
@@ -153,26 +152,24 @@ def check_position_stops(symbol: str, price: float, now: datetime | None = None)
             be_threshold = pos["entry_price"] + round(atr_entry * _be_mult, 2)
             if price >= be_threshold and pos["sl_price"] < pos["entry_price"]:
                 new_sl = pos["entry_price"]
-                con_trail = get_db()
-                con_trail.execute(
-                    "UPDATE positions SET sl_price = ? WHERE id = ?",
-                    (new_sl, pos["id"])
-                )
-                con_trail.commit()
-                con_trail.close()
+                with get_db() as con_trail:
+                    con_trail.execute(
+                        "UPDATE positions SET sl_price = ? WHERE id = ?",
+                        (new_sl, pos["id"])
+                    )
+                    con_trail.commit()
                 pos["sl_price"] = new_sl
                 log.info(f"Trailing: #{pos['id']} {symbol} SL moved to breakeven ${new_sl:.2f}")
         elif atr_entry and pos["direction"] == "SHORT" and pos["sl_price"]:
             be_threshold = pos["entry_price"] - round(atr_entry * _be_mult, 2)
             if price <= be_threshold and pos["sl_price"] > pos["entry_price"]:
                 new_sl = pos["entry_price"]
-                con_trail = get_db()
-                con_trail.execute(
-                    "UPDATE positions SET sl_price = ? WHERE id = ?",
-                    (new_sl, pos["id"])
-                )
-                con_trail.commit()
-                con_trail.close()
+                with get_db() as con_trail:
+                    con_trail.execute(
+                        "UPDATE positions SET sl_price = ? WHERE id = ?",
+                        (new_sl, pos["id"])
+                    )
+                    con_trail.commit()
                 pos["sl_price"] = new_sl
                 log.info(f"Trailing: #{pos['id']} {symbol} SL moved to breakeven ${new_sl:.2f}")
 
@@ -352,16 +349,14 @@ def delete_position(
 ):
     # B.5 #258: ownership-enforced via inline SELECT (db helper doesn't have
     # delete primitive yet; refactor deferred to follow-up)
-    con = get_db()
-    row = con.execute(
-        "SELECT id FROM positions WHERE id=? AND tenant_id=?",
-        (pos_id, tenant_id),
-    ).fetchone()
-    if not row:
-        con.close()
-        raise HTTPException(status_code=404, detail=f"Posicion #{pos_id} no encontrada")
-    con.execute("UPDATE positions SET status='cancelled' WHERE id=?", (pos_id,))
-    con.commit()
-    con.close()
+    with get_db() as con:
+        row = con.execute(
+            "SELECT id FROM positions WHERE id=? AND tenant_id=?",
+            (pos_id, tenant_id),
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail=f"Posicion #{pos_id} no encontrada")
+        con.execute("UPDATE positions SET status='cancelled' WHERE id=?", (pos_id,))
+        con.commit()
     update_positions_json()
     return {"ok": True, "message": f"Posicion #{pos_id} cancelada"}

--- a/api/setup.py
+++ b/api/setup.py
@@ -145,8 +145,7 @@ def setup_post(
     ip = _client_ip(request)
     ua = (request.headers.get("User-Agent") or "")[:512] or None
 
-    con = get_db()
-    try:
+    with get_db() as con:
         cur = con.execute(
             """
             INSERT INTO users
@@ -158,8 +157,6 @@ def setup_post(
         )
         user_id = int(cur.lastrowid or 0)
         con.commit()
-    finally:
-        con.close()
 
     mark_setup_completed(ip=ip, method="web")
     consume_token()

--- a/api/signals.py
+++ b/api/signals.py
@@ -241,13 +241,12 @@ def get_signals_performance(
     (tenant_id=NULL) are invisible. Each user sees their own performance
     tracking.
     """
-    con = get_db()
     # Solo señales completadas (24h de historia) — filtradas por tenant
-    rows = con.execute(
-        "SELECT * FROM signal_outcomes WHERE status = 'completed' AND tenant_id = ?",
-        (tenant_id,),
-    ).fetchall()
-    con.close()
+    with get_db() as con:
+        rows = con.execute(
+            "SELECT * FROM signal_outcomes WHERE status = 'completed' AND tenant_id = ?",
+            (tenant_id,),
+        ).fetchall()
 
     if not rows:
         return {
@@ -349,9 +348,8 @@ def latest_message(
 
 @router.get("/{scan_id}", summary="Detalle de un escaneo por ID")
 def signal_by_id(scan_id: int):
-    con = get_db()
-    row = con.execute("SELECT * FROM scans WHERE id=?", (scan_id,)).fetchone()
-    con.close()
+    with get_db() as con:
+        row = con.execute("SELECT * FROM scans WHERE id=?", (scan_id,)).fetchone()
     if not row:
         raise HTTPException(status_code=404, detail=f"Escaneo #{scan_id} no encontrado")
     row     = dict(row)

--- a/api/telegram.py
+++ b/api/telegram.py
@@ -201,13 +201,12 @@ def push_webhook(rep: dict, scan_id: int, cfg: dict):
         url = validate_outbound_url(url, allow_private=allow_private)
     except ValueError as e:
         log.warning("Webhook push abortado: '%s' rechazado por SSRF guard — %s", url, e)
-        con = get_db()
-        con.execute(
-            "INSERT INTO webhooks_sent (scan_id, ts, url, status, ok) VALUES (?,?,?,?,?)",
-            (scan_id, datetime.now(timezone.utc).isoformat(), url, 0, 0)
-        )
-        con.commit()
-        con.close()
+        with get_db() as con:
+            con.execute(
+                "INSERT INTO webhooks_sent (scan_id, ts, url, status, ok) VALUES (?,?,?,?,?)",
+                (scan_id, datetime.now(timezone.utc).isoformat(), url, 0, 0)
+            )
+            con.commit()
         return
 
     msg     = build_telegram_message(rep)
@@ -251,10 +250,9 @@ def push_webhook(rep: dict, scan_id: int, cfg: dict):
         status, ok = 0, False
         log.warning(f"Webhook fallo -> {e}")
 
-    con = get_db()
-    con.execute(
-        "INSERT INTO webhooks_sent (scan_id, ts, url, status, ok) VALUES (?,?,?,?,?)",
-        (scan_id, datetime.now(timezone.utc).isoformat(), url, status, 1 if ok else 0)
-    )
-    con.commit()
-    con.close()
+    with get_db() as con:
+        con.execute(
+            "INSERT INTO webhooks_sent (scan_id, ts, url, status, ok) VALUES (?,?,?,?,?)",
+            (scan_id, datetime.now(timezone.utc).isoformat(), url, status, 1 if ok else 0)
+        )
+        con.commit()

--- a/api/tune.py
+++ b/api/tune.py
@@ -27,11 +27,10 @@ router = APIRouter(prefix="/tune", tags=["tune"])
 @router.get("/latest", summary="Latest tune result")
 def tune_latest():
     """Returns the most recent tune_result row (with parsed results_json) or null."""
-    con = get_db()
-    row = con.execute(
-        "SELECT * FROM tune_results ORDER BY id DESC LIMIT 1"
-    ).fetchone()
-    con.close()
+    with get_db() as con:
+        row = con.execute(
+            "SELECT * FROM tune_results ORDER BY id DESC LIMIT 1"
+        ).fetchone()
     if not row:
         return None
     result = dict(row)
@@ -52,61 +51,58 @@ def tune_latest():
 )
 def tune_apply():
     """Applies the latest pending tune proposal to config.json symbol_overrides."""
-    con = get_db()
-    row = con.execute(
-        "SELECT * FROM tune_results WHERE status = 'pending' ORDER BY id DESC LIMIT 1"
-    ).fetchone()
-    if not row:
-        con.close()
-        raise HTTPException(status_code=404, detail="No pending tune proposal found")
+    with get_db() as con:
+        row = con.execute(
+            "SELECT * FROM tune_results WHERE status = 'pending' ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="No pending tune proposal found")
 
-    result = dict(row)
-    tune_id = result["id"]
+        result = dict(row)
+        tune_id = result["id"]
 
-    # Parse results_json to extract CHANGE recommendations
-    try:
-        results = json.loads(result["results_json"]) if result.get("results_json") else {}
-    except (json.JSONDecodeError, TypeError):
-        con.close()
-        raise HTTPException(status_code=500, detail="Invalid results_json in tune proposal")
+        # Parse results_json to extract CHANGE recommendations
+        try:
+            results = json.loads(result["results_json"]) if result.get("results_json") else {}
+        except (json.JSONDecodeError, TypeError):
+            raise HTTPException(status_code=500, detail="Invalid results_json in tune proposal")
 
-    # Create config backup
-    now_str = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    backup_name = f"config_backup_{now_str}.json"
-    backup_path = os.path.join(_SCRIPT_DIR, backup_name)
-    if os.path.exists(CONFIG_FILE):
-        shutil.copy2(CONFIG_FILE, backup_path)
+        # Create config backup
+        now_str = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        backup_name = f"config_backup_{now_str}.json"
+        backup_path = os.path.join(_SCRIPT_DIR, backup_name)
+        if os.path.exists(CONFIG_FILE):
+            shutil.copy2(CONFIG_FILE, backup_path)
 
-    # Load config and apply changes
-    cfg = load_config()
-    overrides = cfg.get("symbol_overrides", {})
-    applied_count = 0
+        # Load config and apply changes
+        cfg = load_config()
+        overrides = cfg.get("symbol_overrides", {})
+        applied_count = 0
 
-    # Extract CHANGE recommendations from results
-    recommendations = results.get("recommendations", [])
-    for rec in recommendations:
-        if rec.get("action") != "CHANGE":
-            continue
-        symbol = rec.get("symbol", "")
-        params = rec.get("params", {})
-        if symbol and params:
-            if symbol not in overrides:
-                overrides[symbol] = {}
-            overrides[symbol].update(params)
-            applied_count += 1
+        # Extract CHANGE recommendations from results
+        recommendations = results.get("recommendations", [])
+        for rec in recommendations:
+            if rec.get("action") != "CHANGE":
+                continue
+            symbol = rec.get("symbol", "")
+            params = rec.get("params", {})
+            if symbol and params:
+                if symbol not in overrides:
+                    overrides[symbol] = {}
+                overrides[symbol].update(params)
+                applied_count += 1
 
-    cfg["symbol_overrides"] = overrides
-    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-        json.dump(cfg, f, indent=2, ensure_ascii=False)
-    log.info(f"Auto-tune applied: {applied_count} changes, backup: {backup_name}")
+        cfg["symbol_overrides"] = overrides
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=2, ensure_ascii=False)
+        log.info(f"Auto-tune applied: {applied_count} changes, backup: {backup_name}")
 
-    # Update tune_result status
-    con.execute(
-        "UPDATE tune_results SET status = 'applied', applied_ts = ?, changes_count = ? WHERE id = ?",
-        (datetime.now(timezone.utc).isoformat(), applied_count, tune_id)
-    )
-    con.commit()
-    con.close()
+        # Update tune_result status
+        con.execute(
+            "UPDATE tune_results SET status = 'applied', applied_ts = ?, changes_count = ? WHERE id = ?",
+            (datetime.now(timezone.utc).isoformat(), applied_count, tune_id)
+        )
+        con.commit()
 
     return {"ok": True, "applied": applied_count, "backup": backup_name}
 
@@ -119,18 +115,16 @@ def tune_apply():
 )
 def tune_reject():
     """Rejects the latest pending tune proposal."""
-    con = get_db()
-    row = con.execute(
-        "SELECT id FROM tune_results WHERE status = 'pending' ORDER BY id DESC LIMIT 1"
-    ).fetchone()
-    if not row:
-        con.close()
-        raise HTTPException(status_code=404, detail="No pending tune proposal found")
+    with get_db() as con:
+        row = con.execute(
+            "SELECT id FROM tune_results WHERE status = 'pending' ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="No pending tune proposal found")
 
-    con.execute(
-        "UPDATE tune_results SET status = 'rejected' WHERE id = ?",
-        (row["id"],)
-    )
-    con.commit()
-    con.close()
+        con.execute(
+            "UPDATE tune_results SET status = 'rejected' WHERE id = ?",
+            (row["id"],)
+        )
+        con.commit()
     return {"ok": True}

--- a/auth/audit.py
+++ b/auth/audit.py
@@ -53,8 +53,7 @@ def log_auth_event(
     ts = datetime.now(timezone.utc).isoformat()
 
     try:
-        con = get_db()
-        try:
+        with get_db() as con:
             con.execute(
                 """
                 INSERT INTO auth_events
@@ -72,8 +71,6 @@ def log_auth_event(
                 ),
             )
             con.commit()
-        finally:
-            con.close()
     except Exception as exc:
         # Audit failure must NOT break the calling flow. Log to stderr with
         # enough detail to reconstruct the event later from server logs.

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -134,8 +134,7 @@ def _hydrate_user_from_db(user_id: int) -> User | None:
     sqlite read per protected request — acceptable for 2-5 users at one
     request every few seconds.
     """
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             """
             SELECT id, email, role, is_active, created_at, password_changed_at,
@@ -144,8 +143,6 @@ def _hydrate_user_from_db(user_id: int) -> User | None:
             """,
             (user_id,),
         ).fetchone()
-    finally:
-        con.close()
     if not row:
         return None
     if not row["is_active"]:

--- a/auth/tokens.py
+++ b/auth/tokens.py
@@ -130,8 +130,7 @@ def create_refresh_token(
     fid = family_id or uuid.uuid4().hex
     expires = now + timedelta(days=_refresh_days())
 
-    con = get_db()
-    try:
+    with get_db() as con:
         con.execute(
             """
             INSERT INTO refresh_tokens
@@ -151,8 +150,6 @@ def create_refresh_token(
             ),
         )
         con.commit()
-    finally:
-        con.close()
     return token
 
 
@@ -161,8 +158,7 @@ def lookup_refresh(token: str) -> Optional[RefreshTokenRecord]:
     if not token:
         return None
     h = _hash_refresh(token)
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             """
             SELECT id, token_hash, user_id, family_id, parent_hash,
@@ -171,8 +167,6 @@ def lookup_refresh(token: str) -> Optional[RefreshTokenRecord]:
             """,
             (h,),
         ).fetchone()
-    finally:
-        con.close()
     if not row:
         return None
     return RefreshTokenRecord(
@@ -193,16 +187,13 @@ def revoke_refresh(token_hash: str, *, now: Optional[datetime] = None) -> None:
     """Mark one refresh token as revoked (does not DELETE — audit trail)."""
     if now is None:
         now = datetime.now(timezone.utc)
-    con = get_db()
-    try:
+    with get_db() as con:
         con.execute(
             "UPDATE refresh_tokens SET revoked_at = ? "
             "WHERE token_hash = ? AND revoked_at IS NULL",
             (now.isoformat(), token_hash),
         )
         con.commit()
-    finally:
-        con.close()
 
 
 def revoke_family(family_id: str, *, now: Optional[datetime] = None) -> int:
@@ -213,8 +204,7 @@ def revoke_family(family_id: str, *, now: Optional[datetime] = None) -> int:
     """
     if now is None:
         now = datetime.now(timezone.utc)
-    con = get_db()
-    try:
+    with get_db() as con:
         cur = con.execute(
             "UPDATE refresh_tokens SET revoked_at = ? "
             "WHERE family_id = ? AND revoked_at IS NULL",
@@ -222,8 +212,6 @@ def revoke_family(family_id: str, *, now: Optional[datetime] = None) -> int:
         )
         con.commit()
         return cur.rowcount or 0
-    finally:
-        con.close()
 
 
 def revoke_all_for_user(user_id: int, *, now: Optional[datetime] = None) -> int:
@@ -233,8 +221,7 @@ def revoke_all_for_user(user_id: int, *, now: Optional[datetime] = None) -> int:
     """
     if now is None:
         now = datetime.now(timezone.utc)
-    con = get_db()
-    try:
+    with get_db() as con:
         cur = con.execute(
             "UPDATE refresh_tokens SET revoked_at = ? "
             "WHERE user_id = ? AND revoked_at IS NULL",
@@ -242,5 +229,3 @@ def revoke_all_for_user(user_id: int, *, now: Optional[datetime] = None) -> int:
         )
         con.commit()
         return cur.rowcount or 0
-    finally:
-        con.close()

--- a/btc_api.py
+++ b/btc_api.py
@@ -155,8 +155,7 @@ def _bootstrap_first_user() -> None:
         from datetime import datetime, timezone
         now = datetime.now(timezone.utc).isoformat()
         pwd_hash = hash_password(init_pwd)
-        con = get_db()
-        try:
+        with get_db() as con:
             cur = con.execute(
                 "INSERT INTO users (email, password_hash, role, is_active, "
                 "created_at, password_changed_at) VALUES (?, ?, 'admin', 1, ?, ?)",
@@ -164,8 +163,6 @@ def _bootstrap_first_user() -> None:
             )
             uid = int(cur.lastrowid or 0)
             con.commit()
-        finally:
-            con.close()
         mark_setup_completed(ip=None, method="env_vars")
         log_auth_event(
             event_type="initial_setup_completed",

--- a/db/auth_schema.py
+++ b/db/auth_schema.py
@@ -20,8 +20,7 @@ log = logging.getLogger("db.auth_schema")
 
 def init_auth_db() -> None:
     """Create auth tables if missing. Safe to call repeatedly."""
-    con = get_db()
-    try:
+    with get_db() as con:
         con.execute(
             """
             CREATE TABLE IF NOT EXISTS users (
@@ -86,19 +85,14 @@ def init_auth_db() -> None:
             "ON auth_events(ts DESC)"
         )
         con.commit()
-    finally:
-        con.close()
 
 
 def has_any_user() -> bool:
     """True if at least one user exists. Used by app boot to print a hint
     when the DB is fresh and nobody has run scripts/create_user.py yet."""
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute("SELECT 1 FROM users LIMIT 1").fetchone()
         return row is not None
-    finally:
-        con.close()
 
 
 # ─── system_state (added 2026-04-29 with first-time setup) ─────────────────
@@ -112,8 +106,7 @@ def has_any_user() -> bool:
 
 def init_system_state() -> None:
     """Idempotent — create system_state if missing."""
-    con = get_db()
-    try:
+    with get_db() as con:
         con.execute(
             """
             CREATE TABLE IF NOT EXISTS system_state (
@@ -124,8 +117,6 @@ def init_system_state() -> None:
             """
         )
         con.commit()
-    finally:
-        con.close()
 
 
 def is_setup_completed() -> bool:
@@ -136,14 +127,11 @@ def is_setup_completed() -> bool:
     system stays inaccessible via web. Recovery requires CLI or a manual
     DELETE on this row (documented in README).
     """
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT 1 FROM system_state WHERE key = 'setup_completed_at'"
         ).fetchone()
         return row is not None
-    finally:
-        con.close()
 
 
 def mark_setup_completed(*, ip: str | None, method: str) -> None:
@@ -156,8 +144,7 @@ def mark_setup_completed(*, ip: str | None, method: str) -> None:
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc).isoformat()
-    con = get_db()
-    try:
+    with get_db() as con:
         con.execute(
             "INSERT OR REPLACE INTO system_state(key, value, updated_at) "
             "VALUES ('setup_completed_at', ?, ?)",
@@ -174,5 +161,3 @@ def mark_setup_completed(*, ip: str | None, method: str) -> None:
             (method, now),
         )
         con.commit()
-    finally:
-        con.close()

--- a/db/capital.py
+++ b/db/capital.py
@@ -23,13 +23,10 @@ INITIAL_CAPITAL_DEFAULT = 10_000.0
 
 def db_get_capital(tenant_id: int) -> Optional[dict]:
     """Return current capital row for tenant, or None if uninitialized."""
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT * FROM capital WHERE tenant_id = ?", (tenant_id,),
         ).fetchone()
-    finally:
-        con.close()
     return dict(row) if row else None
 
 
@@ -42,13 +39,10 @@ def db_list_active_tenant_ids() -> list[int]:
     onboarded tenants" and callers should treat that as a no-op rather
     than computing implicit single-system aggregates.
     """
-    con = get_db()
-    try:
+    with get_db() as con:
         rows = con.execute(
             "SELECT tenant_id FROM capital ORDER BY tenant_id ASC"
         ).fetchall()
-    finally:
-        con.close()
     return [int(r[0]) for r in rows]
 
 
@@ -102,8 +96,7 @@ def db_upsert_capital(
     Returns the resulting row.
     """
     now = datetime.now(timezone.utc).isoformat()
-    con = get_db()
-    try:
+    with get_db() as con:
         existing = con.execute(
             "SELECT id, peak_balance, max_drawdown_pct FROM capital WHERE tenant_id = ?",
             (tenant_id,),
@@ -135,6 +128,4 @@ def db_upsert_capital(
         row = con.execute(
             "SELECT * FROM capital WHERE tenant_id = ?", (tenant_id,),
         ).fetchone()
-    finally:
-        con.close()
     return dict(row)

--- a/db/connection.py
+++ b/db/connection.py
@@ -3,9 +3,15 @@
 Extracted from btc_api.py:798-857 in PR0 of the api+db domain refactor (2026-04-27).
 
 Design:
-- get_db() returns a fresh sqlite3.Connection per call (no singleton).
-  This is critical for thread safety: scanner_loop and FastAPI request
-  handlers share the same DB file but each opens its own connection.
+- get_db() returns a fresh `_DbHandle` per call (no singleton). The handle
+  wraps a sqlite3.Connection and works as both:
+    (a) context manager — `with get_db() as con: …` closes on exit,
+        including on exception (#128 fix).
+    (b) legacy raw-connection — `con = get_db(); …; con.close()` still
+        works via attribute delegation. The test suite + a couple of
+        scripts still use this; the production code is migrated to (a).
+  Fresh-per-call is critical for thread safety: scanner_loop and FastAPI
+  request handlers share the same DB file but each opens its own connection.
 - _DictRow is a tuple subclass that supports both indexed access (row[0])
   AND dict-style access (row["column"]). It exists because health
   persistence tests rely on tuple equality while route code wants
@@ -69,8 +75,61 @@ class _DictRow(tuple):
         return self._mapping.keys()
 
 
-def get_db() -> sqlite3.Connection:
+class _DbHandle:
+    """Wrapper around sqlite3.Connection that supports both call patterns.
+
+    Returned by get_db(). Usable in two ways:
+
+        # Preferred — context manager, closes on exit even on exception (#128).
+        with get_db() as con:
+            con.execute(...)
+            con.commit()
+
+        # Legacy — manual close. Still works (read-only attribute access
+        # delegates to the wrapped connection); caller is responsible for
+        # close(). This path is kept so the test suite (200+ legacy call
+        # sites) doesn't have to migrate in lockstep with the production fix.
+        con = get_db()
+        try:
+            con.execute(...)
+            con.commit()
+        finally:
+            con.close()
+
+    Production code on this branch is on the context-manager pattern; tests
+    and one-off scripts may continue using the legacy pattern until a
+    follow-up sweep migrates them.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._closed = False
+
+    def __enter__(self) -> _DbHandle:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        self.close()
+        return False
+
+    def __getattr__(self, name: str):
+        # Delegate execute/commit/cursor/... to the underlying connection.
+        # __getattr__ only fires for missing attributes — _conn / _closed
+        # are real instance attrs and hit normally.
+        return getattr(self._conn, name)
+
+    def close(self) -> None:
+        if not self._closed:
+            self._conn.close()
+            self._closed = True
+
+
+def get_db() -> _DbHandle:
     """Open a fresh DB connection with the dict-row factory.
+
+    Returns a _DbHandle that works as both a context manager and (legacy) a
+    raw connection. Prefer the context-manager pattern — it closes on
+    exception, which is the #128 fix.
 
     Sub-fix (2026-04-29): set busy_timeout=5000ms to prevent immediate
     "database is locked" errors under contention. Was 0 (default),
@@ -80,7 +139,7 @@ def get_db() -> sqlite3.Connection:
     con = sqlite3.connect(_resolve_db_file())
     con.row_factory = _DictRow
     con.execute("PRAGMA busy_timeout = 5000")
-    return con
+    return _DbHandle(con)
 
 
 def backup_db() -> None:

--- a/db/positions.py
+++ b/db/positions.py
@@ -44,36 +44,35 @@ def db_create_position(data: dict, tenant_id: Optional[int] = None) -> dict:
     Per B.5: API callers always pass tenant_id from JWT; internal/legacy
     callers may pass None (row inserted with tenant_id NULL).
     """
-    con = get_db()
     entry = float(data["entry_price"])
     qty   = float(data.get("qty") or (float(data.get("size_usd", 0) or 0) / entry if entry else 0))
     ts    = data.get("entry_ts") or datetime.now(timezone.utc).isoformat()
-    cur = con.execute("""
-        INSERT INTO positions
-            (scan_id, symbol, direction, status, entry_price, entry_ts,
-             sl_price, tp_price, size_usd, qty, atr_entry, be_mult, notes,
-             tenant_id)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-    """, (
-        data.get("scan_id"),
-        data["symbol"].upper(),
-        data.get("direction", "LONG").upper(),
-        "open",
-        entry,
-        ts,
-        data.get("sl_price"),
-        data.get("tp_price"),
-        data.get("size_usd"),
-        qty,
-        data.get("atr_entry"),
-        data.get("be_mult"),
-        data.get("notes", ""),
-        tenant_id,  # NULL if not provided — legacy behavior
-    ))
-    pos_id = cur.lastrowid
-    con.commit()
-    row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
-    con.close()
+    with get_db() as con:
+        cur = con.execute("""
+            INSERT INTO positions
+                (scan_id, symbol, direction, status, entry_price, entry_ts,
+                 sl_price, tp_price, size_usd, qty, atr_entry, be_mult, notes,
+                 tenant_id)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """, (
+            data.get("scan_id"),
+            data["symbol"].upper(),
+            data.get("direction", "LONG").upper(),
+            "open",
+            entry,
+            ts,
+            data.get("sl_price"),
+            data.get("tp_price"),
+            data.get("size_usd"),
+            qty,
+            data.get("atr_entry"),
+            data.get("be_mult"),
+            data.get("notes", ""),
+            tenant_id,  # NULL if not provided — legacy behavior
+        ))
+        pos_id = cur.lastrowid
+        con.commit()
+        row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
     return dict(row)
 
 
@@ -84,23 +83,22 @@ def db_last_exit_ts(symbol: str, tenant_id: Optional[int] = None) -> Optional[da
     across ALL users — correct semantic for scanner cooldown (system-wide).
     When tenant_id is int, filters to that user's exits only.
     """
-    con = get_db()
-    if tenant_id is None:
-        row = con.execute(
-            "SELECT exit_ts FROM positions "
-            "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
-            "ORDER BY exit_ts DESC LIMIT 1",
-            (symbol.upper(),),
-        ).fetchone()
-    else:
-        row = con.execute(
-            "SELECT exit_ts FROM positions "
-            "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
-            "AND tenant_id=? "
-            "ORDER BY exit_ts DESC LIMIT 1",
-            (symbol.upper(), tenant_id),
-        ).fetchone()
-    con.close()
+    with get_db() as con:
+        if tenant_id is None:
+            row = con.execute(
+                "SELECT exit_ts FROM positions "
+                "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
+                "ORDER BY exit_ts DESC LIMIT 1",
+                (symbol.upper(),),
+            ).fetchone()
+        else:
+            row = con.execute(
+                "SELECT exit_ts FROM positions "
+                "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
+                "AND tenant_id=? "
+                "ORDER BY exit_ts DESC LIMIT 1",
+                (symbol.upper(), tenant_id),
+            ).fetchone()
     if not row or not row[0]:
         return None
     try:
@@ -128,7 +126,6 @@ def db_get_positions(
     caller doesn't load the full history into Python just to discard it
     (PR #403 review issue 3).
     """
-    con = get_db()
     clauses: list[str] = []
     params: list = []
     if status and status != "all":
@@ -145,10 +142,10 @@ def db_get_positions(
         clauses.append(f"{ts_col} >= ?")
         params.append(since)
     where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-    rows = con.execute(
-        f"SELECT * FROM positions{where} ORDER BY id DESC", params,
-    ).fetchall()
-    con.close()
+    with get_db() as con:
+        rows = con.execute(
+            f"SELECT * FROM positions{where} ORDER BY id DESC", params,
+        ).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -163,31 +160,29 @@ def db_close_position(
     If tenant_id is provided and the position does NOT belong to that tenant,
     returns None (IDOR protection — caller sees same behavior as 'not found').
     """
-    con = get_db()
-    if tenant_id is None:
-        row = con.execute(
-            "SELECT * FROM positions WHERE id=?", (pos_id,),
-        ).fetchone()
-    else:
-        row = con.execute(
-            "SELECT * FROM positions WHERE id=? AND tenant_id=?",
-            (pos_id, tenant_id),
-        ).fetchone()
-    if not row:
-        con.close()
-        return None
-    pos = dict(row)
-    qty = pos.get("qty") or 0
-    pnl_usd, pnl_pct = _calc_pnl(pos["direction"], pos["entry_price"], exit_price, qty)
-    exit_ts = datetime.now(timezone.utc).isoformat()
-    con.execute("""
-        UPDATE positions
-        SET status=?, exit_price=?, exit_ts=?, exit_reason=?, pnl_usd=?, pnl_pct=?
-        WHERE id=?
-    """, ("closed", exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, pos_id))
-    con.commit()
-    row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
-    con.close()
+    with get_db() as con:
+        if tenant_id is None:
+            row = con.execute(
+                "SELECT * FROM positions WHERE id=?", (pos_id,),
+            ).fetchone()
+        else:
+            row = con.execute(
+                "SELECT * FROM positions WHERE id=? AND tenant_id=?",
+                (pos_id, tenant_id),
+            ).fetchone()
+        if not row:
+            return None
+        pos = dict(row)
+        qty = pos.get("qty") or 0
+        pnl_usd, pnl_pct = _calc_pnl(pos["direction"], pos["entry_price"], exit_price, qty)
+        exit_ts = datetime.now(timezone.utc).isoformat()
+        con.execute("""
+            UPDATE positions
+            SET status=?, exit_price=?, exit_ts=?, exit_reason=?, pnl_usd=?, pnl_pct=?
+            WHERE id=?
+        """, ("closed", exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, pos_id))
+        con.commit()
+        row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
     closed = dict(row)
     # Kill switch #138: trigger health evaluation for this symbol.
     try:
@@ -213,20 +208,18 @@ def db_update_position(
     updates = {k: v for k, v in data.items() if k in allowed}
     if not updates:
         return None
-    con = get_db()
-    # Ownership pre-check when tenant_id provided
-    if tenant_id is not None:
-        owner_row = con.execute(
-            "SELECT id FROM positions WHERE id=? AND tenant_id=?",
-            (pos_id, tenant_id),
-        ).fetchone()
-        if not owner_row:
-            con.close()
-            return None
-    sets = ", ".join(f"{k}=?" for k in updates)
-    vals = list(updates.values()) + [pos_id]
-    con.execute(f"UPDATE positions SET {sets} WHERE id=?", vals)
-    con.commit()
-    row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
-    con.close()
+    with get_db() as con:
+        # Ownership pre-check when tenant_id provided
+        if tenant_id is not None:
+            owner_row = con.execute(
+                "SELECT id FROM positions WHERE id=? AND tenant_id=?",
+                (pos_id, tenant_id),
+            ).fetchone()
+            if not owner_row:
+                return None
+        sets = ", ".join(f"{k}=?" for k in updates)
+        vals = list(updates.values()) + [pos_id]
+        con.execute(f"UPDATE positions SET {sets} WHERE id=?", vals)
+        con.commit()
+        row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
     return dict(row) if row else None

--- a/db/schema.py
+++ b/db/schema.py
@@ -40,251 +40,248 @@ log = logging.getLogger("db.schema")
 
 def init_db() -> None:
     """Create or migrate all tables. Idempotent."""
-    con = get_db()
-    con.execute("PRAGMA journal_mode=WAL")
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS scans (
-            id          INTEGER PRIMARY KEY AUTOINCREMENT,
-            ts          TEXT    NOT NULL,
-            symbol      TEXT    NOT NULL DEFAULT 'BTCUSDT',
-            estado      TEXT    NOT NULL,
-            señal       INTEGER NOT NULL DEFAULT 0,
-            setup       INTEGER NOT NULL DEFAULT 0,
-            price       REAL,
-            lrc_pct     REAL,
-            rsi_1h      REAL,
-            score       INTEGER,
-            score_label TEXT,
-            macro_ok    INTEGER,
-            gatillo     INTEGER,
-            payload     TEXT
-        )
-    """)
-    # Migración: agregar columna symbol si la tabla ya existía sin ella
-    try:
-        con.execute("ALTER TABLE scans ADD COLUMN symbol TEXT NOT NULL DEFAULT 'BTCUSDT'")
-        log.info("DB migrada: columna 'symbol' añadida.")
-    except sqlite3.OperationalError:
-        pass  # columna ya existe
+    with get_db() as con:
+        con.execute("PRAGMA journal_mode=WAL")
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS scans (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts          TEXT    NOT NULL,
+                symbol      TEXT    NOT NULL DEFAULT 'BTCUSDT',
+                estado      TEXT    NOT NULL,
+                señal       INTEGER NOT NULL DEFAULT 0,
+                setup       INTEGER NOT NULL DEFAULT 0,
+                price       REAL,
+                lrc_pct     REAL,
+                rsi_1h      REAL,
+                score       INTEGER,
+                score_label TEXT,
+                macro_ok    INTEGER,
+                gatillo     INTEGER,
+                payload     TEXT
+            )
+        """)
+        # Migración: agregar columna symbol si la tabla ya existía sin ella
+        try:
+            con.execute("ALTER TABLE scans ADD COLUMN symbol TEXT NOT NULL DEFAULT 'BTCUSDT'")
+            log.info("DB migrada: columna 'symbol' añadida.")
+        except sqlite3.OperationalError:
+            pass  # columna ya existe
 
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS webhooks_sent (
-            id      INTEGER PRIMARY KEY AUTOINCREMENT,
-            scan_id INTEGER REFERENCES scans(id),
-            ts      TEXT,
-            url     TEXT,
-            status  INTEGER,
-            ok      INTEGER
-        )
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS positions (
-            id          INTEGER PRIMARY KEY AUTOINCREMENT,
-            scan_id     INTEGER REFERENCES scans(id),
-            symbol      TEXT    NOT NULL,
-            direction   TEXT    NOT NULL DEFAULT 'LONG',
-            status      TEXT    NOT NULL DEFAULT 'open',
-            entry_price REAL    NOT NULL,
-            entry_ts    TEXT    NOT NULL,
-            sl_price    REAL,
-            tp_price    REAL,
-            size_usd    REAL,
-            qty         REAL,
-            exit_price  REAL,
-            exit_ts     TEXT,
-            exit_reason TEXT,
-            pnl_usd     REAL,
-            pnl_pct     REAL,
-            atr_entry   REAL,
-            be_mult     REAL,
-            notes       TEXT
-        )
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS signal_outcomes (
-            id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            scan_id         INTEGER UNIQUE REFERENCES scans(id),
-            symbol          TEXT    NOT NULL,
-            signal_ts       TEXT    NOT NULL,
-            signal_price    REAL    NOT NULL,
-            score           INTEGER,
-            macro_ok        INTEGER,
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS webhooks_sent (
+                id      INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_id INTEGER REFERENCES scans(id),
+                ts      TEXT,
+                url     TEXT,
+                status  INTEGER,
+                ok      INTEGER
+            )
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS positions (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_id     INTEGER REFERENCES scans(id),
+                symbol      TEXT    NOT NULL,
+                direction   TEXT    NOT NULL DEFAULT 'LONG',
+                status      TEXT    NOT NULL DEFAULT 'open',
+                entry_price REAL    NOT NULL,
+                entry_ts    TEXT    NOT NULL,
+                sl_price    REAL,
+                tp_price    REAL,
+                size_usd    REAL,
+                qty         REAL,
+                exit_price  REAL,
+                exit_ts     TEXT,
+                exit_reason TEXT,
+                pnl_usd     REAL,
+                pnl_pct     REAL,
+                atr_entry   REAL,
+                be_mult     REAL,
+                notes       TEXT
+            )
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS signal_outcomes (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                scan_id         INTEGER UNIQUE REFERENCES scans(id),
+                symbol          TEXT    NOT NULL,
+                signal_ts       TEXT    NOT NULL,
+                signal_price    REAL    NOT NULL,
+                score           INTEGER,
+                macro_ok        INTEGER,
 
-            -- Performance medida en intervalos
-            price_1h        REAL,
-            price_4h        REAL,
-            price_24h       REAL,
+                -- Performance medida en intervalos
+                price_1h        REAL,
+                price_4h        REAL,
+                price_24h       REAL,
 
-            -- Puntos extremos en 24h
-            max_runup_pct   REAL,  -- mejor retorno %
-            max_drawdown_pct REAL,  -- peor retorno %
+                -- Puntos extremos en 24h
+                max_runup_pct   REAL,  -- mejor retorno %
+                max_drawdown_pct REAL,  -- peor retorno %
 
-            status          TEXT NOT NULL DEFAULT 'pending', -- 'pending' | 'completed'
-            last_checked_ts TEXT
-        )
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS tune_results (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            ts TEXT NOT NULL,
-            status TEXT DEFAULT 'pending',
-            results_json TEXT,
-            report_md TEXT,
-            applied_ts TEXT,
-            changes_count INTEGER DEFAULT 0
-        )
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS notifications_sent (
-            id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            event_type      TEXT    NOT NULL,
-            event_key       TEXT    NOT NULL,
-            priority        TEXT    NOT NULL DEFAULT 'info',
-            payload_json    TEXT    NOT NULL,
-            channels_sent   TEXT    NOT NULL,
-            delivery_status TEXT    NOT NULL DEFAULT 'ok',
-            sent_at         TEXT    NOT NULL,
-            read_at         TEXT,
-            error_log       TEXT
-        )
-    """)
-    con.execute("""
-        CREATE INDEX IF NOT EXISTS idx_notif_sent_unread
-            ON notifications_sent(sent_at DESC) WHERE read_at IS NULL
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS symbol_health (
-            symbol              TEXT PRIMARY KEY,
-            state               TEXT NOT NULL DEFAULT 'NORMAL',
-            state_since         TEXT NOT NULL,
-            last_evaluated_at   TEXT NOT NULL,
-            last_metrics_json   TEXT,
-            manual_override     INTEGER NOT NULL DEFAULT 0
-        )
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS symbol_health_events (
-            id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            symbol          TEXT NOT NULL,
-            from_state      TEXT NOT NULL,
-            to_state        TEXT NOT NULL,
-            trigger_reason  TEXT NOT NULL,
-            metrics_json    TEXT NOT NULL,
-            ts              TEXT NOT NULL
-        )
-    """)
-    con.execute("""
-        CREATE INDEX IF NOT EXISTS idx_health_events_symbol
-            ON symbol_health_events(symbol, ts DESC)
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS kill_switch_decisions (
-            id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            ts              TEXT NOT NULL,
-            scan_id         INTEGER,
-            symbol          TEXT NOT NULL,
-            engine          TEXT NOT NULL,
-            per_symbol_tier TEXT NOT NULL,
-            portfolio_tier  TEXT NOT NULL,
-            velocity_active INTEGER DEFAULT 0,
-            size_factor     REAL NOT NULL,
-            skip            INTEGER NOT NULL,
-            reasons_json    TEXT,
-            slider_value    REAL
-        )
-    """)
-    con.execute("""
-        CREATE INDEX IF NOT EXISTS idx_ks_decisions_ts
-            ON kill_switch_decisions(ts)
-    """)
-    con.execute("""
-        CREATE INDEX IF NOT EXISTS idx_ks_decisions_symbol_ts
-            ON kill_switch_decisions(symbol, ts)
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS kill_switch_v2_state (
-            symbol                    TEXT PRIMARY KEY,
-            velocity_cooldown_until   TEXT,
-            velocity_last_trigger_ts  TEXT,
-            updated_at                TEXT NOT NULL
-        )
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS kill_switch_v2_baseline (
-            symbol         TEXT PRIMARY KEY,
-            baseline_wr    REAL NOT NULL,
-            baseline_sigma REAL NOT NULL,
-            trades_count   INTEGER NOT NULL,
-            computed_at    TEXT NOT NULL
-        )
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS kill_switch_recommendations (
-            id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            ts              TEXT NOT NULL,
-            triggered_by    TEXT NOT NULL,
-            slider_value    REAL,
-            projected_pnl   REAL,
-            projected_dd    REAL,
-            status          TEXT NOT NULL,
-            applied_ts      TEXT,
-            applied_by      TEXT,
-            report_json     TEXT NOT NULL
-        )
-    """)
-    con.execute("""
-        CREATE INDEX IF NOT EXISTS idx_recommendations_ts
-            ON kill_switch_recommendations(ts)
-    """)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS portfolio_health_events (
-            id              INTEGER PRIMARY KEY AUTOINCREMENT,
-            from_tier       TEXT NOT NULL,
-            to_tier         TEXT NOT NULL,
-            reason          TEXT NOT NULL,
-            dd_pct          REAL,
-            concurrent      INTEGER,
-            ts              TEXT NOT NULL
-        )
-    """)
-    con.execute("""
-        CREATE INDEX IF NOT EXISTS idx_portfolio_events_ts
-            ON portfolio_health_events(ts DESC)
-    """)
-    con.commit()
-    con.close()
+                status          TEXT NOT NULL DEFAULT 'pending', -- 'pending' | 'completed'
+                last_checked_ts TEXT
+            )
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS tune_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL,
+                status TEXT DEFAULT 'pending',
+                results_json TEXT,
+                report_md TEXT,
+                applied_ts TEXT,
+                changes_count INTEGER DEFAULT 0
+            )
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS notifications_sent (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_type      TEXT    NOT NULL,
+                event_key       TEXT    NOT NULL,
+                priority        TEXT    NOT NULL DEFAULT 'info',
+                payload_json    TEXT    NOT NULL,
+                channels_sent   TEXT    NOT NULL,
+                delivery_status TEXT    NOT NULL DEFAULT 'ok',
+                sent_at         TEXT    NOT NULL,
+                read_at         TEXT,
+                error_log       TEXT
+            )
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_notif_sent_unread
+                ON notifications_sent(sent_at DESC) WHERE read_at IS NULL
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS symbol_health (
+                symbol              TEXT PRIMARY KEY,
+                state               TEXT NOT NULL DEFAULT 'NORMAL',
+                state_since         TEXT NOT NULL,
+                last_evaluated_at   TEXT NOT NULL,
+                last_metrics_json   TEXT,
+                manual_override     INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS symbol_health_events (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                symbol          TEXT NOT NULL,
+                from_state      TEXT NOT NULL,
+                to_state        TEXT NOT NULL,
+                trigger_reason  TEXT NOT NULL,
+                metrics_json    TEXT NOT NULL,
+                ts              TEXT NOT NULL
+            )
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_health_events_symbol
+                ON symbol_health_events(symbol, ts DESC)
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS kill_switch_decisions (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts              TEXT NOT NULL,
+                scan_id         INTEGER,
+                symbol          TEXT NOT NULL,
+                engine          TEXT NOT NULL,
+                per_symbol_tier TEXT NOT NULL,
+                portfolio_tier  TEXT NOT NULL,
+                velocity_active INTEGER DEFAULT 0,
+                size_factor     REAL NOT NULL,
+                skip            INTEGER NOT NULL,
+                reasons_json    TEXT,
+                slider_value    REAL
+            )
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_ks_decisions_ts
+                ON kill_switch_decisions(ts)
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_ks_decisions_symbol_ts
+                ON kill_switch_decisions(symbol, ts)
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS kill_switch_v2_state (
+                symbol                    TEXT PRIMARY KEY,
+                velocity_cooldown_until   TEXT,
+                velocity_last_trigger_ts  TEXT,
+                updated_at                TEXT NOT NULL
+            )
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS kill_switch_v2_baseline (
+                symbol         TEXT PRIMARY KEY,
+                baseline_wr    REAL NOT NULL,
+                baseline_sigma REAL NOT NULL,
+                trades_count   INTEGER NOT NULL,
+                computed_at    TEXT NOT NULL
+            )
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS kill_switch_recommendations (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts              TEXT NOT NULL,
+                triggered_by    TEXT NOT NULL,
+                slider_value    REAL,
+                projected_pnl   REAL,
+                projected_dd    REAL,
+                status          TEXT NOT NULL,
+                applied_ts      TEXT,
+                applied_by      TEXT,
+                report_json     TEXT NOT NULL
+            )
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_recommendations_ts
+                ON kill_switch_recommendations(ts)
+        """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS portfolio_health_events (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                from_tier       TEXT NOT NULL,
+                to_tier         TEXT NOT NULL,
+                reason          TEXT NOT NULL,
+                dd_pct          REAL,
+                concurrent      INTEGER,
+                ts              TEXT NOT NULL
+            )
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_portfolio_events_ts
+                ON portfolio_health_events(ts DESC)
+        """)
+        con.commit()
     log.info(f"DB inicializada: {_resolve_db_file()}")
 
     # Migrate: add atr_entry and be_mult columns if missing
     try:
-        con_mig = get_db()
-        cols = [r[1] for r in con_mig.execute("PRAGMA table_info(positions)").fetchall()]
-        if "atr_entry" not in cols:
-            con_mig.execute("ALTER TABLE positions ADD COLUMN atr_entry REAL")
-            con_mig.commit()
-            log.info("DB migration: added atr_entry column to positions")
-        if "be_mult" not in cols:
-            con_mig.execute("ALTER TABLE positions ADD COLUMN be_mult REAL")
-            con_mig.commit()
-            log.info("DB migration: added be_mult column to positions")
-        con_mig.close()
+        with get_db() as con_mig:
+            cols = [r[1] for r in con_mig.execute("PRAGMA table_info(positions)").fetchall()]
+            if "atr_entry" not in cols:
+                con_mig.execute("ALTER TABLE positions ADD COLUMN atr_entry REAL")
+                con_mig.commit()
+                log.info("DB migration: added atr_entry column to positions")
+            if "be_mult" not in cols:
+                con_mig.execute("ALTER TABLE positions ADD COLUMN be_mult REAL")
+                con_mig.commit()
+                log.info("DB migration: added be_mult column to positions")
     except Exception as e:
         log.warning(f"DB migration check: {e}")
 
     # B5 PROBATION migration: add 3 columns to symbol_health if missing (#199)
     try:
-        con_mig2 = get_db()
-        cols2 = [r[1] for r in con_mig2.execute("PRAGMA table_info(symbol_health)").fetchall()]
-        for col, ddl in (
-            ("probation_trades_remaining", "INTEGER"),
-            ("probation_started_at", "TEXT"),
-            ("paused_days_at_entry", "INTEGER"),
-        ):
-            if col not in cols2:
-                con_mig2.execute(f"ALTER TABLE symbol_health ADD COLUMN {col} {ddl}")
-                con_mig2.commit()
-                log.info(f"DB migration: added {col} column to symbol_health")
-        con_mig2.close()
+        with get_db() as con_mig2:
+            cols2 = [r[1] for r in con_mig2.execute("PRAGMA table_info(symbol_health)").fetchall()]
+            for col, ddl in (
+                ("probation_trades_remaining", "INTEGER"),
+                ("probation_started_at", "TEXT"),
+                ("paused_days_at_entry", "INTEGER"),
+            ):
+                if col not in cols2:
+                    con_mig2.execute(f"ALTER TABLE symbol_health ADD COLUMN {col} {ddl}")
+                    con_mig2.commit()
+                    log.info(f"DB migration: added {col} column to symbol_health")
     except Exception as e:
         log.warning(f"DB migration B5 PROBATION: {e}")
 
@@ -327,8 +324,7 @@ def _migrate_multi_tenant_b1() -> None:
     tables via CREATE TABLE IF NOT EXISTS; new indexes via CREATE INDEX IF NOT
     EXISTS. Safe to call repeatedly.
     """
-    con = get_db()
-    try:
+    with get_db() as con:
         # Step 1: Add nullable tenant_id to each per-user table
         for table in PER_USER_TABLES:
             try:
@@ -394,8 +390,6 @@ def _migrate_multi_tenant_b1() -> None:
         )
 
         con.commit()
-    finally:
-        con.close()
 
 
 def _migrate_agent_audit() -> None:
@@ -406,145 +400,143 @@ def _migrate_agent_audit() -> None:
 
     Schema source: docs/superpowers/specs/es/2026-05-19-trading-copilot-production-grade-pre-reg.md §9.1.
     """
-    con = get_db()
     try:
-        # agent_conversations: every turn (user / assistant / tool_result)
-        # written by the server-side loop. content_json is the redacted
-        # payload — full tool_use input/output is NOT persisted here; the
-        # tool side-effect surface lives in agent_side_effects below.
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS agent_conversations (
-                id                          INTEGER PRIMARY KEY AUTOINCREMENT,
-                tenant_id                   INTEGER NOT NULL,
-                surface                     TEXT    NOT NULL,
-                conversation_id             TEXT    NOT NULL,
-                ts                          TEXT    NOT NULL,
-                role                        TEXT,
-                model                       TEXT,
-                input_tokens                INTEGER,
-                output_tokens               INTEGER,
-                cache_read_input_tokens     INTEGER,
-                cache_creation_input_tokens INTEGER,
-                latency_ms                  INTEGER,
-                cost_usd                    REAL,
-                content_json                TEXT,
-                refused                     INTEGER NOT NULL DEFAULT 0
-            )
-            """
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_agent_conv_tenant_ts "
-            "ON agent_conversations(tenant_id, ts DESC)"
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_agent_conv_conversation "
-            "ON agent_conversations(conversation_id, ts ASC)"
-        )
-
-        # agent_side_effects: the propose/confirm ledger. idempotency_key
-        # is UNIQUE so a double-click confirm cannot execute twice. action
-        # is one of: close_position | reactivate_symbol | apply_tune.
-        # result: ok | error | conflict | expired.
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS agent_side_effects (
-                id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                tenant_id       INTEGER NOT NULL,
-                conversation_id TEXT,
-                ts              TEXT    NOT NULL,
-                action          TEXT    NOT NULL,
-                args_json       TEXT,
-                idempotency_key TEXT    NOT NULL UNIQUE,
-                result          TEXT,
-                http_status     INTEGER
-            )
-            """
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_agent_side_effects_tenant_ts "
-            "ON agent_side_effects(tenant_id, ts DESC)"
-        )
-
-        # agent_quotas: one row per tenant. daily_window_start and
-        # monthly_window_start drive the computed-on-read reset (pre-reg
-        # §9.1) — no cron needed. UNIQUE on tenant_id so upserts via
-        # ON CONFLICT(tenant_id) DO UPDATE work.
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS agent_quotas (
-                tenant_id            INTEGER PRIMARY KEY,
-                daily_usd_used       REAL    NOT NULL DEFAULT 0,
-                daily_usd_cap        REAL    NOT NULL DEFAULT 1.0,
-                daily_window_start   TEXT    NOT NULL,
-                monthly_usd_used     REAL    NOT NULL DEFAULT 0,
-                monthly_window_start TEXT    NOT NULL
-            )
-            """
-        )
-
-        # Phase 3 (#400): agent_side_effects gains `expires_at` so the
-        # confirm endpoint can short-circuit expired proposals without
-        # re-deriving the TTL from the signed payload. Idempotent ADD
-        # COLUMN (the existing rows have NULL — they predate the column,
-        # and a NULL expires_at is treated as "no TTL enforcement" for
-        # rows seeded before this migration).
-        try:
-            con.execute("ALTER TABLE agent_side_effects ADD COLUMN expires_at TEXT")
-            log.info("DB migration: added expires_at column to agent_side_effects")
-        except sqlite3.OperationalError:
-            pass  # column already exists
-
-        # Fase 4 of the multi-provider epic: agent_conversations gains
-        # `provider` + `reasoning_tokens` columns so /agent/metrics can
-        # report per-provider spend + R1 reasoning telemetry.
-        #   - provider: closed enum 'anthropic' | 'deepseek' | ... (the
-        #     vendor name from PROVIDER_NAME_BY_PREFIX). NULL for rows
-        #     pre-Fase-4 if backfill skipped them (it shouldn't — the
-        #     UPDATE below covers every known prefix).
-        #   - reasoning_tokens: only DS-reasoner populates this today
-        #     (DS's usage.completion_tokens_details.reasoning_tokens
-        #     field). NULL or 0 elsewhere; metrics treat NULL as 0.
-        # Both ALTERs are idempotent (try/except on OperationalError).
-        # The backfill is also idempotent because it only touches rows
-        # WHERE provider IS NULL — running it twice is a no-op.
-        try:
-            con.execute("ALTER TABLE agent_conversations ADD COLUMN provider TEXT")
-            log.info("DB migration: added provider column to agent_conversations")
-        except sqlite3.OperationalError:
-            pass  # column already exists
-        try:
-            con.execute("ALTER TABLE agent_conversations ADD COLUMN reasoning_tokens INTEGER")
-            log.info("DB migration: added reasoning_tokens column to agent_conversations")
-        except sqlite3.OperationalError:
-            pass  # column already exists
-
-        # Backfill provider from model. Only touches rows where provider
-        # IS NULL (i.e. pre-Fase-4 rows) — safe to re-run. The mapping
-        # uses model-prefix matching that mirrors PROVIDER_NAME_BY_PREFIX
-        # in api/agent/providers/registry.py; if a future provider adds
-        # a new prefix, mirror it HERE too (single source of truth would
-        # be ideal but importing the registry from db.schema introduces
-        # a circular at startup).
-        try:
+        with get_db() as con:
+            # agent_conversations: every turn (user / assistant / tool_result)
+            # written by the server-side loop. content_json is the redacted
+            # payload — full tool_use input/output is NOT persisted here; the
+            # tool side-effect surface lives in agent_side_effects below.
             con.execute(
-                "UPDATE agent_conversations SET provider = 'anthropic' "
-                "WHERE provider IS NULL AND model LIKE 'claude-%'"
+                """
+                CREATE TABLE IF NOT EXISTS agent_conversations (
+                    id                          INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tenant_id                   INTEGER NOT NULL,
+                    surface                     TEXT    NOT NULL,
+                    conversation_id             TEXT    NOT NULL,
+                    ts                          TEXT    NOT NULL,
+                    role                        TEXT,
+                    model                       TEXT,
+                    input_tokens                INTEGER,
+                    output_tokens               INTEGER,
+                    cache_read_input_tokens     INTEGER,
+                    cache_creation_input_tokens INTEGER,
+                    latency_ms                  INTEGER,
+                    cost_usd                    REAL,
+                    content_json                TEXT,
+                    refused                     INTEGER NOT NULL DEFAULT 0
+                )
+                """
             )
             con.execute(
-                "UPDATE agent_conversations SET provider = 'deepseek' "
-                "WHERE provider IS NULL AND model LIKE 'deepseek-%'"
+                "CREATE INDEX IF NOT EXISTS idx_agent_conv_tenant_ts "
+                "ON agent_conversations(tenant_id, ts DESC)"
             )
-            log.info("DB migration: backfilled provider column from model prefix")
-        except sqlite3.OperationalError as e:
-            log.warning("DB migration: provider backfill failed: %s", e)
+            con.execute(
+                "CREATE INDEX IF NOT EXISTS idx_agent_conv_conversation "
+                "ON agent_conversations(conversation_id, ts ASC)"
+            )
 
-        con.commit()
-        log.info("DB migration: agent_conversations + agent_side_effects + agent_quotas ready")
+            # agent_side_effects: the propose/confirm ledger. idempotency_key
+            # is UNIQUE so a double-click confirm cannot execute twice. action
+            # is one of: close_position | reactivate_symbol | apply_tune.
+            # result: ok | error | conflict | expired.
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS agent_side_effects (
+                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tenant_id       INTEGER NOT NULL,
+                    conversation_id TEXT,
+                    ts              TEXT    NOT NULL,
+                    action          TEXT    NOT NULL,
+                    args_json       TEXT,
+                    idempotency_key TEXT    NOT NULL UNIQUE,
+                    result          TEXT,
+                    http_status     INTEGER
+                )
+                """
+            )
+            con.execute(
+                "CREATE INDEX IF NOT EXISTS idx_agent_side_effects_tenant_ts "
+                "ON agent_side_effects(tenant_id, ts DESC)"
+            )
+
+            # agent_quotas: one row per tenant. daily_window_start and
+            # monthly_window_start drive the computed-on-read reset (pre-reg
+            # §9.1) — no cron needed. UNIQUE on tenant_id so upserts via
+            # ON CONFLICT(tenant_id) DO UPDATE work.
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS agent_quotas (
+                    tenant_id            INTEGER PRIMARY KEY,
+                    daily_usd_used       REAL    NOT NULL DEFAULT 0,
+                    daily_usd_cap        REAL    NOT NULL DEFAULT 1.0,
+                    daily_window_start   TEXT    NOT NULL,
+                    monthly_usd_used     REAL    NOT NULL DEFAULT 0,
+                    monthly_window_start TEXT    NOT NULL
+                )
+                """
+            )
+
+            # Phase 3 (#400): agent_side_effects gains `expires_at` so the
+            # confirm endpoint can short-circuit expired proposals without
+            # re-deriving the TTL from the signed payload. Idempotent ADD
+            # COLUMN (the existing rows have NULL — they predate the column,
+            # and a NULL expires_at is treated as "no TTL enforcement" for
+            # rows seeded before this migration).
+            try:
+                con.execute("ALTER TABLE agent_side_effects ADD COLUMN expires_at TEXT")
+                log.info("DB migration: added expires_at column to agent_side_effects")
+            except sqlite3.OperationalError:
+                pass  # column already exists
+
+            # Fase 4 of the multi-provider epic: agent_conversations gains
+            # `provider` + `reasoning_tokens` columns so /agent/metrics can
+            # report per-provider spend + R1 reasoning telemetry.
+            #   - provider: closed enum 'anthropic' | 'deepseek' | ... (the
+            #     vendor name from PROVIDER_NAME_BY_PREFIX). NULL for rows
+            #     pre-Fase-4 if backfill skipped them (it shouldn't — the
+            #     UPDATE below covers every known prefix).
+            #   - reasoning_tokens: only DS-reasoner populates this today
+            #     (DS's usage.completion_tokens_details.reasoning_tokens
+            #     field). NULL or 0 elsewhere; metrics treat NULL as 0.
+            # Both ALTERs are idempotent (try/except on OperationalError).
+            # The backfill is also idempotent because it only touches rows
+            # WHERE provider IS NULL — running it twice is a no-op.
+            try:
+                con.execute("ALTER TABLE agent_conversations ADD COLUMN provider TEXT")
+                log.info("DB migration: added provider column to agent_conversations")
+            except sqlite3.OperationalError:
+                pass  # column already exists
+            try:
+                con.execute("ALTER TABLE agent_conversations ADD COLUMN reasoning_tokens INTEGER")
+                log.info("DB migration: added reasoning_tokens column to agent_conversations")
+            except sqlite3.OperationalError:
+                pass  # column already exists
+
+            # Backfill provider from model. Only touches rows where provider
+            # IS NULL (i.e. pre-Fase-4 rows) — safe to re-run. The mapping
+            # uses model-prefix matching that mirrors PROVIDER_NAME_BY_PREFIX
+            # in api/agent/providers/registry.py; if a future provider adds
+            # a new prefix, mirror it HERE too (single source of truth would
+            # be ideal but importing the registry from db.schema introduces
+            # a circular at startup).
+            try:
+                con.execute(
+                    "UPDATE agent_conversations SET provider = 'anthropic' "
+                    "WHERE provider IS NULL AND model LIKE 'claude-%'"
+                )
+                con.execute(
+                    "UPDATE agent_conversations SET provider = 'deepseek' "
+                    "WHERE provider IS NULL AND model LIKE 'deepseek-%'"
+                )
+                log.info("DB migration: backfilled provider column from model prefix")
+            except sqlite3.OperationalError as e:
+                log.warning("DB migration: provider backfill failed: %s", e)
+
+            con.commit()
+            log.info("DB migration: agent_conversations + agent_side_effects + agent_quotas ready")
     except Exception as e:  # noqa: BLE001
         log.warning("DB migration agent audit: %s", e)
-    finally:
-        con.close()
 
 
 def _migrate_agent_history() -> None:
@@ -568,77 +560,75 @@ def _migrate_agent_history() -> None:
     agent_side_effects (proposals execution log), agent_quotas (cost
     budget). Those keep their own lifecycle and retention.
     """
-    con = get_db()
     try:
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS agent_messages (
-                id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                tenant_id       INTEGER NOT NULL,
-                conversation_id TEXT    NOT NULL,
-                ts              TEXT    NOT NULL,
-                role            TEXT    NOT NULL,
-                content         TEXT    NOT NULL,
-                reasoning       TEXT,
-                tool_chips_json TEXT,
-                proposals_json  TEXT,
-                expires_at      TEXT    NOT NULL
+        with get_db() as con:
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS agent_messages (
+                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tenant_id       INTEGER NOT NULL,
+                    conversation_id TEXT    NOT NULL,
+                    ts              TEXT    NOT NULL,
+                    role            TEXT    NOT NULL,
+                    content         TEXT    NOT NULL,
+                    reasoning       TEXT,
+                    tool_chips_json TEXT,
+                    proposals_json  TEXT,
+                    expires_at      TEXT    NOT NULL
+                )
+                """
             )
-            """
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_agent_messages_tenant_conv_ts "
-            "ON agent_messages(tenant_id, conversation_id, ts ASC)"
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_agent_messages_tenant_ts "
-            "ON agent_messages(tenant_id, ts DESC)"
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_agent_messages_expires "
-            "ON agent_messages(expires_at)"
-        )
-
-        # conversation_id is the natural PK — UUID generated by the
-        # frontend (newConversationId() in frontend/src/agent/client.ts).
-        # The explicit NOT NULL is required: SQLite enforces NOT NULL
-        # implicitly only on `INTEGER PRIMARY KEY` (the rowid alias),
-        # not on TEXT PRIMARY KEY — without it, NULL would slip past
-        # the PK check and corrupt the index.
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS agent_conversation_meta (
-                conversation_id TEXT    NOT NULL PRIMARY KEY,
-                tenant_id       INTEGER NOT NULL,
-                title           TEXT,
-                surface         TEXT    NOT NULL,
-                first_ts        TEXT    NOT NULL,
-                last_ts         TEXT    NOT NULL,
-                message_count   INTEGER NOT NULL DEFAULT 0,
-                pinned          INTEGER NOT NULL DEFAULT 0,
-                expires_at      TEXT    NOT NULL
+            con.execute(
+                "CREATE INDEX IF NOT EXISTS idx_agent_messages_tenant_conv_ts "
+                "ON agent_messages(tenant_id, conversation_id, ts ASC)"
             )
-            """
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_agent_conv_meta_tenant_last "
-            "ON agent_conversation_meta(tenant_id, last_ts DESC)"
-        )
-        # Pinned conversations float to the top of the sidebar; the
-        # secondary key on last_ts DESC keeps non-pinned ordered by
-        # recency within their bucket. Index ordering matters: SQLite
-        # uses leading columns for filtering and trailing for ordering.
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_agent_conv_meta_tenant_pinned "
-            "ON agent_conversation_meta(tenant_id, pinned DESC, last_ts DESC)"
-        )
+            con.execute(
+                "CREATE INDEX IF NOT EXISTS idx_agent_messages_tenant_ts "
+                "ON agent_messages(tenant_id, ts DESC)"
+            )
+            con.execute(
+                "CREATE INDEX IF NOT EXISTS idx_agent_messages_expires "
+                "ON agent_messages(expires_at)"
+            )
 
-        con.commit()
-        log.info("DB migration: agent_messages + agent_conversation_meta ready")
+            # conversation_id is the natural PK — UUID generated by the
+            # frontend (newConversationId() in frontend/src/agent/client.ts).
+            # The explicit NOT NULL is required: SQLite enforces NOT NULL
+            # implicitly only on `INTEGER PRIMARY KEY` (the rowid alias),
+            # not on TEXT PRIMARY KEY — without it, NULL would slip past
+            # the PK check and corrupt the index.
+            con.execute(
+                """
+                CREATE TABLE IF NOT EXISTS agent_conversation_meta (
+                    conversation_id TEXT    NOT NULL PRIMARY KEY,
+                    tenant_id       INTEGER NOT NULL,
+                    title           TEXT,
+                    surface         TEXT    NOT NULL,
+                    first_ts        TEXT    NOT NULL,
+                    last_ts         TEXT    NOT NULL,
+                    message_count   INTEGER NOT NULL DEFAULT 0,
+                    pinned          INTEGER NOT NULL DEFAULT 0,
+                    expires_at      TEXT    NOT NULL
+                )
+                """
+            )
+            con.execute(
+                "CREATE INDEX IF NOT EXISTS idx_agent_conv_meta_tenant_last "
+                "ON agent_conversation_meta(tenant_id, last_ts DESC)"
+            )
+            # Pinned conversations float to the top of the sidebar; the
+            # secondary key on last_ts DESC keeps non-pinned ordered by
+            # recency within their bucket. Index ordering matters: SQLite
+            # uses leading columns for filtering and trailing for ordering.
+            con.execute(
+                "CREATE INDEX IF NOT EXISTS idx_agent_conv_meta_tenant_pinned "
+                "ON agent_conversation_meta(tenant_id, pinned DESC, last_ts DESC)"
+            )
+
+            con.commit()
+            log.info("DB migration: agent_messages + agent_conversation_meta ready")
     except Exception as e:  # noqa: BLE001
         log.warning("DB migration agent history: %s", e)
-    finally:
-        con.close()
 
 
 def backfill_tenant(user_id: int) -> dict[str, int]:
@@ -661,8 +651,7 @@ def backfill_tenant(user_id: int) -> dict[str, int]:
         Dict mapping table name to count of rows updated.
     """
     affected: dict[str, int] = {}
-    con = get_db()
-    try:
+    with get_db() as con:
         for table in PER_USER_TABLES:
             cursor = con.execute(
                 f"UPDATE {table} SET tenant_id = ? WHERE tenant_id IS NULL",
@@ -670,6 +659,4 @@ def backfill_tenant(user_id: int) -> dict[str, int]:
             )
             affected[table] = cursor.rowcount
         con.commit()
-    finally:
-        con.close()
     return affected

--- a/db/signals.py
+++ b/db/signals.py
@@ -28,28 +28,26 @@ def save_scan(rep: dict) -> int:
     gatillo = 1 if rep.get("gatillo_activo") else 0
     ts      = rep.get("timestamp", datetime.now(timezone.utc).isoformat())
 
-    con = get_db()
-    cur = con.execute("""
-        INSERT INTO scans
-            (ts, symbol, estado, señal, setup, price, lrc_pct, rsi_1h,
-             score, score_label, macro_ok, gatillo, payload)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
-    """, (ts, symbol, estado, señal, setup, price, lrc_pct, rsi_1h,
-          score, slabel, macro, gatillo, json.dumps(rep, ensure_ascii=False)))
-    scan_id = cur.lastrowid
-    con.commit()
-    con.close()
+    with get_db() as con:
+        cur = con.execute("""
+            INSERT INTO scans
+                (ts, symbol, estado, señal, setup, price, lrc_pct, rsi_1h,
+                 score, score_label, macro_ok, gatillo, payload)
+            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """, (ts, symbol, estado, señal, setup, price, lrc_pct, rsi_1h,
+              score, slabel, macro, gatillo, json.dumps(rep, ensure_ascii=False)))
+        scan_id = cur.lastrowid
+        con.commit()
 
     # Si es señal activa, registrar para seguimiento de performance
     if señal:
         try:
-            con_out = get_db()
-            con_out.execute("""
-                INSERT OR IGNORE INTO signal_outcomes (scan_id, symbol, signal_ts, signal_price, score, macro_ok)
-                VALUES (?, ?, ?, ?, ?, ?)
-            """, (scan_id, symbol, ts, price, score, macro))
-            con_out.commit()
-            con_out.close()
+            with get_db() as con_out:
+                con_out.execute("""
+                    INSERT OR IGNORE INTO signal_outcomes (scan_id, symbol, signal_ts, signal_price, score, macro_ok)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """, (scan_id, symbol, ts, price, score, macro))
+                con_out.commit()
         except Exception as e:
             log.warning(f"Error iniciando tracking de señal: {e}")
 
@@ -59,7 +57,6 @@ def save_scan(rep: dict) -> int:
 def get_scans(limit=50, only_signals=False, only_setups=False,
               since_hours: Optional[float] = None,
               symbol: Optional[str] = None) -> list:
-    con    = get_db()
     conds  = []
     params = []
     if symbol:
@@ -75,10 +72,10 @@ def get_scans(limit=50, only_signals=False, only_setups=False,
         params.append(cutoff)
     where = ("WHERE " + " AND ".join(conds)) if conds else ""
     params.append(limit)
-    rows  = con.execute(
-        f"SELECT * FROM scans {where} ORDER BY id DESC LIMIT ?", params
-    ).fetchall()
-    con.close()
+    with get_db() as con:
+        rows = con.execute(
+            f"SELECT * FROM scans {where} ORDER BY id DESC LIMIT ?", params
+        ).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -103,7 +100,6 @@ def get_latest_scan_per_symbol(
     project rows by that id set and order by ts DESC. Identical
     filtering semantics to `get_scans()`.
     """
-    con = get_db()
     conds: list[str] = []
     params: list = []
     if only_signals:
@@ -114,57 +110,54 @@ def get_latest_scan_per_symbol(
         params.append(cutoff)
     where = ("WHERE " + " AND ".join(conds)) if conds else ""
     params.append(limit)
-    rows = con.execute(
-        f"""SELECT * FROM scans
-            WHERE id IN (
-                SELECT MAX(id) FROM scans {where}
-                GROUP BY symbol
-            )
-            ORDER BY ts DESC
-            LIMIT ?""",
-        params,
-    ).fetchall()
-    con.close()
+    with get_db() as con:
+        rows = con.execute(
+            f"""SELECT * FROM scans
+                WHERE id IN (
+                    SELECT MAX(id) FROM scans {where}
+                    GROUP BY symbol
+                )
+                ORDER BY ts DESC
+                LIMIT ?""",
+            params,
+        ).fetchall()
     return [dict(r) for r in rows]
 
 
 def get_latest_signal(symbol: Optional[str] = None) -> Optional[dict]:
-    con = get_db()
-    if symbol:
-        row = con.execute(
-            "SELECT * FROM scans WHERE señal=1 AND symbol=? ORDER BY id DESC LIMIT 1",
-            (symbol.upper(),)
-        ).fetchone()
-    else:
-        row = con.execute(
-            "SELECT * FROM scans WHERE señal=1 ORDER BY id DESC LIMIT 1"
-        ).fetchone()
-    con.close()
+    with get_db() as con:
+        if symbol:
+            row = con.execute(
+                "SELECT * FROM scans WHERE señal=1 AND symbol=? ORDER BY id DESC LIMIT 1",
+                (symbol.upper(),)
+            ).fetchone()
+        else:
+            row = con.execute(
+                "SELECT * FROM scans WHERE señal=1 ORDER BY id DESC LIMIT 1"
+            ).fetchone()
     return dict(row) if row else None
 
 
 def get_latest_scan(symbol: Optional[str] = None) -> Optional[dict]:
-    con = get_db()
-    if symbol:
-        row = con.execute(
-            "SELECT * FROM scans WHERE symbol=? ORDER BY id DESC LIMIT 1",
-            (symbol.upper(),)
-        ).fetchone()
-    else:
-        row = con.execute("SELECT * FROM scans ORDER BY id DESC LIMIT 1").fetchone()
-    con.close()
+    with get_db() as con:
+        if symbol:
+            row = con.execute(
+                "SELECT * FROM scans WHERE symbol=? ORDER BY id DESC LIMIT 1",
+                (symbol.upper(),)
+            ).fetchone()
+        else:
+            row = con.execute("SELECT * FROM scans ORDER BY id DESC LIMIT 1").fetchone()
     return dict(row) if row else None
 
 
 def get_signals_summary() -> list:
     """Último escaneo de cada símbolo activo, ordenado por señal y score."""
-    con  = get_db()
-    rows = con.execute("""
-        SELECT s.* FROM scans s
-        INNER JOIN (
-            SELECT symbol, MAX(id) as max_id FROM scans GROUP BY symbol
-        ) latest ON s.id = latest.max_id
-        ORDER BY s.señal DESC, s.score DESC
-    """).fetchall()
-    con.close()
+    with get_db() as con:
+        rows = con.execute("""
+            SELECT s.* FROM scans s
+            INNER JOIN (
+                SELECT symbol, MAX(id) as max_id FROM scans GROUP BY symbol
+            ) latest ON s.id = latest.max_id
+            ORDER BY s.señal DESC, s.score DESC
+        """).fetchall()
     return [dict(r) for r in rows]

--- a/db/user_preferences.py
+++ b/db/user_preferences.py
@@ -43,13 +43,10 @@ def _decode_row(row) -> dict:
 
 def db_get_user_preferences(tenant_id: int) -> Optional[dict]:
     """Return preferences row for tenant, or None if not yet set."""
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
         ).fetchone()
-    finally:
-        con.close()
     if row is None:
         return None
     return _decode_row(row)
@@ -71,8 +68,7 @@ def db_upsert_user_preferences(
     Returns resulting row with JSON fields parsed.
     """
     now = datetime.now(timezone.utc).isoformat()
-    con = get_db()
-    try:
+    with get_db() as con:
         existing = con.execute(
             "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
         ).fetchone()
@@ -104,6 +100,4 @@ def db_upsert_user_preferences(
         row = con.execute(
             "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
         ).fetchone()
-    finally:
-        con.close()
     return _decode_row(row)

--- a/health.py
+++ b/health.py
@@ -388,8 +388,7 @@ def _decrement_probation_counter(symbol: str) -> None:
     Floored at 0. No-op if the symbol is not in PROBATION (uses a state-guarded
     UPDATE so we don't accidentally write to non-PROBATION rows).
     """
-    conn = _conn()
-    try:
+    with _conn() as conn:
         conn.execute(
             """UPDATE symbol_health
                SET probation_trades_remaining = MAX(
@@ -399,8 +398,6 @@ def _decrement_probation_counter(symbol: str) -> None:
             (symbol,),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def _is_portfolio_normal(cfg: dict[str, Any]) -> bool:
@@ -423,14 +420,11 @@ def _is_portfolio_normal(cfg: dict[str, Any]) -> bool:
 
         # Concurrent failures: a property of symbol_health (system-wide), so
         # we read it once and reuse it across the per-tenant loop.
-        conn = _conn()
-        try:
+        with _conn() as conn:
             n_failures = conn.execute(
                 """SELECT COUNT(*) FROM symbol_health
                    WHERE state IN ('ALERT', 'REDUCED', 'PAUSED', 'PROBATION')"""
             ).fetchone()[0]
-        finally:
-            conn.close()
 
         for tid in tenant_ids:
             portfolio_dd = _compute_current_portfolio_dd(cfg, tenant_id=tid)
@@ -495,14 +489,11 @@ def _conn():
 
 def get_symbol_state(symbol: str) -> str:
     """Return the current state of a symbol, or 'NORMAL' if it has no row."""
-    conn = _conn()
-    try:
+    with _conn() as conn:
         row = conn.execute(
             "SELECT state FROM symbol_health WHERE symbol=?",
             (symbol,),
         ).fetchone()
-    finally:
-        conn.close()
     return row[0] if row else "NORMAL"
 
 
@@ -544,16 +535,13 @@ def summarize_recent_alerts(
     `kill_switch_decisions` for `velocity_burst`. Returns {"items": [...]}
     where each item has kind/text/severity/ts.
     """
-    if conn is None:
-        conn = _conn()
-        owns_conn = True
-    else:
-        owns_conn = False
+    from contextlib import nullcontext
+    cm = _conn() if conn is None else nullcontext(conn)
 
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=window_hours)).isoformat()
     items: list[dict[str, Any]] = []
 
-    try:
+    with cm as conn:
         # symbol_failures: distinct symbols entering ALERT/REDUCED/PAUSED
         rows = conn.execute(
             """SELECT DISTINCT symbol, MAX(ts) AS latest
@@ -606,9 +594,6 @@ def summarize_recent_alerts(
 
         # Sort newest-first
         items.sort(key=lambda x: x["ts"], reverse=True)
-    finally:
-        if owns_conn:
-            conn.close()
 
     return {"items": items}
 
@@ -616,9 +601,8 @@ def summarize_recent_alerts(
 def _record_evaluation(symbol: str, metrics: dict[str, Any], new_state: str) -> None:
     """Update last_evaluated_at + last_metrics_json without changing state.
     Creates the row if it doesn't exist. No event is emitted."""
-    conn = _conn()
     now = _now_iso()
-    try:
+    with _conn() as conn:
         conn.execute(
             """INSERT INTO symbol_health (symbol, state, state_since, last_evaluated_at, last_metrics_json)
                VALUES (?, ?, ?, ?, ?)
@@ -628,8 +612,6 @@ def _record_evaluation(symbol: str, metrics: dict[str, Any], new_state: str) -> 
             (symbol, new_state, now, now, json.dumps(metrics, default=str)),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def apply_transition(
@@ -650,8 +632,7 @@ def apply_transition(
     now = _now_iso()
     metrics_json = json.dumps(metrics, default=str)
 
-    conn = _conn()
-    try:
+    with _conn() as conn:
         extra_sets = ""
         if manual_override is not None:
             extra_sets = ", manual_override = excluded.manual_override"
@@ -696,8 +677,6 @@ def apply_transition(
                 (symbol, from_state, new_state, reason, metrics_json, now),
             )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def _get_symbol_health_row(symbol: str) -> dict[str, Any] | None:
@@ -706,8 +685,7 @@ def _get_symbol_health_row(symbol: str) -> dict[str, Any] | None:
     Selected columns: state, state_since, manual_override,
     probation_trades_remaining, probation_started_at, paused_days_at_entry.
     """
-    conn = _conn()
-    try:
+    with _conn() as conn:
         row = conn.execute(
             """SELECT state, state_since, manual_override,
                       probation_trades_remaining, probation_started_at,
@@ -715,8 +693,6 @@ def _get_symbol_health_row(symbol: str) -> dict[str, Any] | None:
                FROM symbol_health WHERE symbol=?""",
             (symbol,),
         ).fetchone()
-    finally:
-        conn.close()
     if row is None:
         return None
     return {
@@ -786,8 +762,7 @@ def reactivate_symbol(
     # B5 C2 fix: single atomic transaction (state + probation columns + event row)
     # to close the race window where a concurrent trigger_health_evaluation could
     # read NULL counter and silently revert state to NORMAL between two writes.
-    conn = _conn()
-    try:
+    with _conn() as conn:
         conn.execute(
             """INSERT INTO symbol_health
                (symbol, state, state_since, last_evaluated_at, last_metrics_json,
@@ -816,8 +791,6 @@ def reactivate_symbol(
             (symbol, current, f"reactivated_{reason}", metrics_json, now_iso),
         )
         conn.commit()
-    finally:
-        conn.close()
 
     # B5 C1 fix: notify on PROBATION entry (auto + manual reactivations).
     # Previously dead code in evaluate_and_record (which never returns
@@ -847,11 +820,8 @@ def evaluate_and_record(symbol: str, cfg: dict[str, Any], now: datetime | None =
     if now is None:
         now = datetime.now(timezone.utc)
 
-    conn = _conn()
-    try:
+    with _conn() as conn:
         metrics = compute_rolling_metrics(symbol, conn, now=now)
-    finally:
-        conn.close()
 
     # B5: inject current probation_trades_remaining into metrics so evaluate_state
     # can apply the PROBATION branch. Read from the symbol_health row.
@@ -1016,8 +986,7 @@ def record_portfolio_transition(
     """
     if from_tier == to_tier:
         return
-    conn = _conn()
-    try:
+    with _conn() as conn:
         conn.execute(
             """INSERT INTO portfolio_health_events
                (from_tier, to_tier, reason, dd_pct, concurrent, ts)
@@ -1025,22 +994,17 @@ def record_portfolio_transition(
             (from_tier, to_tier, reason, float(dd_pct), int(concurrent), _now_iso()),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def recent_portfolio_transitions(limit: int = 5) -> list[dict[str, Any]]:
     """B6: Last N portfolio-tier transitions, newest first."""
-    conn = _conn()
-    try:
+    with _conn() as conn:
         rows = conn.execute(
             """SELECT from_tier, to_tier, reason, dd_pct, concurrent, ts
                FROM portfolio_health_events
                ORDER BY ts DESC LIMIT ?""",
             (limit,),
         ).fetchall()
-    finally:
-        conn.close()
     return [
         {
             "from_tier": r[0], "to_tier": r[1], "reason": r[2],
@@ -1075,8 +1039,7 @@ def get_dashboard_state(
     ks_cfg = (cfg.get("kill_switch") or {})
     now = datetime.now(timezone.utc)
 
-    conn = _conn()
-    try:
+    with _conn() as conn:
         # Build symbol list: union of DEFAULT_SYMBOLS + any DB rows. This way
         # the dashboard always shows the curated 10 (as NORMAL placeholders if
         # not yet evaluated) AND any historical/legacy rows in symbol_health.
@@ -1276,8 +1239,6 @@ def get_dashboard_state(
                 "severity": severity,
                 "ts": now.isoformat(),
             })
-    finally:
-        conn.close()
 
     return {
         "symbols": symbols_out,

--- a/notifier/_storage.py
+++ b/notifier/_storage.py
@@ -39,8 +39,7 @@ def record_delivery(
     error_log: str | None = None,
     tenant_id: Optional[int] = None,
 ) -> int:
-    conn = _conn()
-    try:
+    with _conn() as conn:
         cur = conn.execute(
             """INSERT INTO notifications_sent
                (event_type, event_key, priority, payload_json,
@@ -55,16 +54,13 @@ def record_delivery(
         )
         conn.commit()
         return cur.lastrowid
-    finally:
-        conn.close()
 
 
 def list_unread(
     limit: int = 50,
     tenant_id: Optional[int] = None,
 ) -> list[dict[str, Any]]:
-    conn = _conn()
-    try:
+    with _conn() as conn:
         if tenant_id is None:
             rows = conn.execute(
                 """SELECT id, event_type, event_key, priority, payload_json,
@@ -85,8 +81,6 @@ def list_unread(
                    LIMIT ?""",
                 (tenant_id, limit),
             ).fetchall()
-    finally:
-        conn.close()
     cols = ["id", "event_type", "event_key", "priority", "payload_json",
             "channels_sent", "delivery_status", "sent_at", "read_at", "error_log"]
     return [dict(zip(cols, r)) for r in rows]
@@ -101,8 +95,7 @@ def mark_read(
     Returns True if a row was updated, False if not (e.g., IDOR: trying to
     mark another user's notification).
     """
-    conn = _conn()
-    try:
+    with _conn() as conn:
         if tenant_id is None:
             cur = conn.execute(
                 "UPDATE notifications_sent SET read_at = ? WHERE id = ?",
@@ -116,14 +109,11 @@ def mark_read(
             )
         conn.commit()
         return cur.rowcount > 0
-    finally:
-        conn.close()
 
 
 def mark_all_read(tenant_id: Optional[int] = None) -> int:
     """Mark all unread as read. Scope-limited by tenant_id when provided."""
-    conn = _conn()
-    try:
+    with _conn() as conn:
         if tenant_id is None:
             cur = conn.execute(
                 "UPDATE notifications_sent SET read_at = ? WHERE read_at IS NULL",
@@ -137,5 +127,3 @@ def mark_all_read(tenant_id: Optional[int] = None) -> int:
             )
         conn.commit()
         return cur.rowcount
-    finally:
-        conn.close()

--- a/notifier/dedupe.py
+++ b/notifier/dedupe.py
@@ -37,8 +37,7 @@ def should_send(
         return True
 
     import btc_api
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         cutoff = datetime.now(timezone.utc) - timedelta(seconds=window_seconds)
         row = conn.execute(
             """SELECT 1 FROM notifications_sent
@@ -46,6 +45,4 @@ def should_send(
                LIMIT 1""",
             (event_type, event_key, cutoff.isoformat()),
         ).fetchone()
-    finally:
-        conn.close()
     return row is None

--- a/notifier/dispatch_per_user.py
+++ b/notifier/dispatch_per_user.py
@@ -36,17 +36,15 @@ def _list_active_users() -> list[dict]:
     so callers fall back to the legacy broadcast path.
     """
     import sqlite3
-    con = get_db()
     try:
-        rows = con.execute(
-            "SELECT id, email FROM users WHERE is_active = 1 ORDER BY id"
-        ).fetchall()
+        with get_db() as con:
+            rows = con.execute(
+                "SELECT id, email FROM users WHERE is_active = 1 ORDER BY id"
+            ).fetchall()
     except sqlite3.OperationalError as e:
         if "no such table" in str(e).lower():
             return []
         raise
-    finally:
-        con.close()
     return [dict(r) for r in rows]
 
 

--- a/observability.py
+++ b/observability.py
@@ -39,8 +39,7 @@ def record_decision(
     velocity_active: bool = False,
 ) -> int:
     """Insert a decision row. Returns the row id."""
-    conn = _conn()
-    try:
+    with _conn() as conn:
         cur = conn.execute(
             """INSERT INTO kill_switch_decisions
                (ts, scan_id, symbol, engine, per_symbol_tier, portfolio_tier,
@@ -54,8 +53,6 @@ def record_decision(
         )
         conn.commit()
         return cur.lastrowid
-    finally:
-        conn.close()
 
 
 def query_decisions(
@@ -65,8 +62,7 @@ def query_decisions(
     limit: int = 50,
 ) -> list[dict[str, Any]]:
     """Query decisions, newest first. Optional filters by symbol, engine, time."""
-    conn = _conn()
-    try:
+    with _conn() as conn:
         where: list[str] = []
         params: list[Any] = []
         if symbol:
@@ -98,8 +94,6 @@ def query_decisions(
             d["velocity_active"] = bool(d["velocity_active"])
             result.append(d)
         return result
-    finally:
-        conn.close()
 
 
 def compute_portfolio_aggregate(
@@ -130,8 +124,7 @@ def get_current_state(
     Takes the latest decision per symbol from the log (filtered to the
     given engine) and computes portfolio aggregate.
     """
-    conn = _conn()
-    try:
+    with _conn() as conn:
         rows = conn.execute(
             """SELECT d.symbol, d.per_symbol_tier, d.portfolio_tier, d.size_factor,
                       d.skip, d.velocity_active, d.ts, d.reasons_json
@@ -146,8 +139,6 @@ def get_current_state(
                WHERE d.engine = ?""",
             (engine, engine),
         ).fetchall()
-    finally:
-        conn.close()
 
     cols = ["symbol", "per_symbol_tier", "portfolio_tier", "size_factor",
             "skip", "velocity_active", "ts", "reasons_json"]

--- a/scanner/runtime.py
+++ b/scanner/runtime.py
@@ -138,9 +138,8 @@ def check_pending_signal_outcomes(current_prices: dict[str, float]):
     """
     from datetime import datetime, timezone  # noqa: PLC0415
 
-    con = get_db()
-    rows = con.execute("SELECT * FROM signal_outcomes WHERE status = 'pending'").fetchall()
-    con.close()
+    with get_db() as con:
+        rows = con.execute("SELECT * FROM signal_outcomes WHERE status = 'pending'").fetchall()
 
     if not rows:
         return
@@ -202,10 +201,9 @@ def check_pending_signal_outcomes(current_prices: dict[str, float]):
                 set_clause = ", ".join([f"{k} = ?" for k in updates.keys()])
                 params     = list(updates.values()) + [r["id"]]
 
-                con_up = get_db()
-                con_up.execute(f"UPDATE signal_outcomes SET {set_clause} WHERE id = ?", params)
-                con_up.commit()
-                con_up.close()
+                with get_db() as con_up:
+                    con_up.execute(f"UPDATE signal_outcomes SET {set_clause} WHERE id = ?", params)
+                    con_up.commit()
                 updated_count += 1
 
         except Exception as e:

--- a/scripts/create_user.py
+++ b/scripts/create_user.py
@@ -67,21 +67,17 @@ def _prompt_password() -> str:
 
 
 def _email_exists(email: str) -> bool:
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT 1 FROM users WHERE email = ?", (email,)
         ).fetchone()
         return row is not None
-    finally:
-        con.close()
 
 
 def _create_user(email: str, password_hash: str, role: str) -> int:
     """Insert and return the new user_id."""
     now = datetime.now(timezone.utc).isoformat()
-    con = get_db()
-    try:
+    with get_db() as con:
         cur = con.execute(
             """
             INSERT INTO users
@@ -93,8 +89,6 @@ def _create_user(email: str, password_hash: str, role: str) -> int:
         )
         con.commit()
         return int(cur.lastrowid or 0)
-    finally:
-        con.close()
 
 
 def main() -> None:

--- a/scripts/migrate_to_multitenant.py
+++ b/scripts/migrate_to_multitenant.py
@@ -52,29 +52,22 @@ log = logging.getLogger("migrate_to_multitenant")
 
 def _validate_user(user_id: int) -> Optional[dict]:
     """Return user row dict or None if not found."""
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT id, email FROM users WHERE id = ?", (user_id,),
         ).fetchone()
-    finally:
-        con.close()
     return dict(row) if row else None
 
 
 def _list_known_users() -> list[dict]:
-    con = get_db()
-    try:
+    with get_db() as con:
         rows = con.execute("SELECT id, email FROM users ORDER BY id").fetchall()
-    finally:
-        con.close()
     return [dict(r) for r in rows]
 
 
 def _snapshot_counts() -> dict[str, dict[str, int]]:
     """For each per-user table: total + null_tenant counts."""
-    con = get_db()
-    try:
+    with get_db() as con:
         out: dict[str, dict[str, int]] = {}
         for table in PER_USER_TABLES:
             total = con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
@@ -82,22 +75,17 @@ def _snapshot_counts() -> dict[str, dict[str, int]]:
                 f"SELECT COUNT(*) FROM {table} WHERE tenant_id IS NULL"
             ).fetchone()[0]
             out[table] = {"total": int(total), "null_tenant": int(null_n)}
-    finally:
-        con.close()
     return out
 
 
 def _spot_check_positions(tenant_id: int, limit: int = 10) -> list[dict]:
-    con = get_db()
-    try:
+    with get_db() as con:
         rows = con.execute(
             "SELECT id, symbol, status, entry_ts, exit_ts, pnl_usd "
             "FROM positions WHERE tenant_id = ? "
             "ORDER BY id DESC LIMIT ?",
             (tenant_id, limit),
         ).fetchall()
-    finally:
-        con.close()
     return [dict(r) for r in rows]
 
 

--- a/scripts/reset_password.py
+++ b/scripts/reset_password.py
@@ -52,13 +52,10 @@ def _prompt_email(initial: str | None) -> str:
 
 
 def _find_user(email: str) -> tuple[int, bool] | None:
-    con = get_db()
-    try:
+    with get_db() as con:
         row = con.execute(
             "SELECT id, is_active FROM users WHERE email = ?", (email,)
         ).fetchone()
-    finally:
-        con.close()
     if not row:
         return None
     return int(row["id"]), bool(row["is_active"])
@@ -80,16 +77,13 @@ def _prompt_new_password() -> str:
 
 def _update_password(user_id: int, pwd_hash: str) -> None:
     now = datetime.now(timezone.utc).isoformat()
-    con = get_db()
-    try:
+    with get_db() as con:
         con.execute(
             "UPDATE users SET password_hash = ?, password_changed_at = ? "
             "WHERE id = ?",
             (pwd_hash, now, user_id),
         )
         con.commit()
-    finally:
-        con.close()
 
 
 def main() -> None:

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -221,8 +221,7 @@ def _persist_recommendation(
             f"_persist_recommendation: result dict missing required keys: {missing}"
         )
 
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         cursor = conn.execute(
             """INSERT INTO kill_switch_recommendations
                  (ts, triggered_by, slider_value, projected_pnl, projected_dd,
@@ -240,20 +239,15 @@ def _persist_recommendation(
         )
         conn.commit()
         return int(cursor.lastrowid)
-    finally:
-        conn.close()
 
 
 def _load_last_recalibration_ts() -> str | None:
     """Return the latest ts from kill_switch_recommendations, or None."""
     import btc_api
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         row = conn.execute(
             "SELECT MAX(ts) FROM kill_switch_recommendations",
         ).fetchone()
-    finally:
-        conn.close()
     return row[0] if row and row[0] else None
 
 
@@ -262,14 +256,11 @@ def _count_recalibrations_today(now) -> int:
     import btc_api
 
     today_prefix = now.strftime("%Y-%m-%d")
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         row = conn.execute(
             "SELECT COUNT(*) FROM kill_switch_recommendations WHERE ts LIKE ?",
             (today_prefix + "%",),
         ).fetchone()
-    finally:
-        conn.close()
     return int(row[0]) if row else 0
 
 
@@ -277,8 +268,7 @@ def _load_last_applied_recommendation() -> dict[str, Any] | None:
     """Return the most recent applied recommendation row as a dict, or None."""
     import btc_api
 
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         row = conn.execute(
             """SELECT id, ts, slider_value, projected_pnl, projected_dd,
                       status, applied_ts, applied_by, report_json
@@ -287,8 +277,6 @@ def _load_last_applied_recommendation() -> dict[str, Any] | None:
                ORDER BY applied_ts DESC, id DESC
                LIMIT 1""",
         ).fetchone()
-    finally:
-        conn.close()
     if row is None:
         return None
     return {
@@ -308,14 +296,11 @@ def _load_last_calibration_regime_score() -> float | None:
     import json
     import btc_api
 
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         row = conn.execute(
             """SELECT report_json FROM kill_switch_recommendations
                ORDER BY ts DESC, id DESC LIMIT 1""",
         ).fetchone()
-    finally:
-        conn.close()
     if not row or not row[0]:
         return None
     try:
@@ -340,8 +325,7 @@ def _count_symbols_with_recent_alerts(window_hours: float) -> int:
 
     now = datetime.now(tz=timezone.utc)
     cutoff = (now - timedelta(hours=float(window_hours))).isoformat()
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         row = conn.execute(
             """SELECT COUNT(DISTINCT symbol)
                FROM kill_switch_decisions
@@ -351,8 +335,6 @@ def _count_symbols_with_recent_alerts(window_hours: float) -> int:
                       OR portfolio_tier IN ('REDUCED', 'FROZEN'))""",
             (cutoff,),
         ).fetchone()
-    finally:
-        conn.close()
     return int(row[0]) if row else 0
 
 
@@ -360,8 +342,7 @@ def _mark_prior_pending_as_superseded(new_id: int) -> None:
     """Mark all pending recommendations except `new_id` as superseded."""
     import btc_api
 
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         conn.execute(
             """UPDATE kill_switch_recommendations
                SET status = 'superseded'
@@ -369,8 +350,6 @@ def _mark_prior_pending_as_superseded(new_id: int) -> None:
             (int(new_id),),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def _send_telegram_recommendation(

--- a/strategy/kill_switch_v2_optimizer.py
+++ b/strategy/kill_switch_v2_optimizer.py
@@ -24,8 +24,7 @@ def _load_closed_positions_window(window_days: float, now) -> list[dict[str, Any
     import btc_api
 
     cutoff = (now - timedelta(days=float(window_days))).isoformat()
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         rows = conn.execute(
             """SELECT symbol, entry_ts, exit_ts, exit_reason, pnl_usd
                FROM positions
@@ -36,8 +35,6 @@ def _load_closed_positions_window(window_days: float, now) -> list[dict[str, Any
                ORDER BY entry_ts""",
             (cutoff,),
         ).fetchall()
-    finally:
-        conn.close()
     return [
         {"symbol": r[0], "entry_ts": r[1], "exit_ts": r[2],
          "exit_reason": r[3], "pnl_usd": r[4]}

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -49,8 +49,7 @@ def _load_closed_trades(*, tenant_id: int) -> list[dict[str, Any]]:
     tenant. Aggregating across tenants implicitly is not allowed.
     """
     import btc_api
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         rows = conn.execute(
             """SELECT symbol, exit_ts, pnl_usd
                FROM positions
@@ -59,8 +58,6 @@ def _load_closed_trades(*, tenant_id: int) -> list[dict[str, Any]]:
                ORDER BY exit_ts""",
             (tenant_id,),
         ).fetchall()
-    finally:
-        conn.close()
     return [
         {"symbol": r[0], "exit_ts": r[1], "pnl_usd": r[2] or 0.0}
         for r in rows
@@ -73,16 +70,13 @@ def _load_open_positions(*, tenant_id: int) -> list[dict[str, Any]]:
     See `_load_closed_trades` for the multi-tenant policy rationale.
     """
     import btc_api
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         rows = conn.execute(
             """SELECT symbol, entry_price, qty, direction
                FROM positions
                WHERE status = 'open' AND tenant_id = ?""",
             (tenant_id,),
         ).fetchall()
-    finally:
-        conn.close()
     return [
         {
             "symbol": r[0],
@@ -109,8 +103,7 @@ def _load_recent_sl_timestamps(
     from datetime import timedelta
     import btc_api
     cutoff = (now - timedelta(hours=float(window_hours))).isoformat()
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         rows = conn.execute(
             """SELECT exit_ts
                FROM positions
@@ -121,24 +114,19 @@ def _load_recent_sl_timestamps(
                  AND exit_ts >= ?""",
             (symbol, cutoff),
         ).fetchall()
-    finally:
-        conn.close()
     return [r[0] for r in rows if r[0]]
 
 
 def _load_v2_state(symbol: str) -> dict[str, Any]:
     """Load per-symbol v2 state. Returns keys with None defaults if row missing."""
     import btc_api
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         row = conn.execute(
             """SELECT velocity_cooldown_until, velocity_last_trigger_ts
                FROM kill_switch_v2_state
                WHERE symbol = ?""",
             (symbol,),
         ).fetchone()
-    finally:
-        conn.close()
     if row is None:
         return {
             "velocity_cooldown_until": None,
@@ -153,8 +141,7 @@ def _load_v2_state(symbol: str) -> dict[str, Any]:
 def _upsert_v2_state(symbol: str, state: dict[str, Any], now) -> None:
     """Upsert v2 state for a symbol. updated_at is set to now.isoformat()."""
     import btc_api
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         conn.execute(
             """INSERT INTO kill_switch_v2_state
                  (symbol, velocity_cooldown_until, velocity_last_trigger_ts, updated_at)
@@ -171,8 +158,6 @@ def _upsert_v2_state(symbol: str, state: dict[str, Any], now) -> None:
             ),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def _evaluate_velocity(symbol: str, cfg: dict[str, Any]) -> bool:
@@ -223,8 +208,7 @@ def _evaluate_velocity(symbol: str, cfg: dict[str, Any]) -> bool:
 def _load_closed_trades_for_symbol(symbol: str) -> list[dict[str, Any]]:
     """Load closed positions for a symbol with non-NULL exit_ts."""
     import btc_api
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         rows = conn.execute(
             """SELECT exit_ts, pnl_usd
                FROM positions
@@ -234,24 +218,19 @@ def _load_closed_trades_for_symbol(symbol: str) -> list[dict[str, Any]]:
                ORDER BY exit_ts""",
             (symbol,),
         ).fetchall()
-    finally:
-        conn.close()
     return [{"exit_ts": r[0], "pnl_usd": r[1]} for r in rows]
 
 
 def _load_baseline(symbol: str) -> dict[str, Any] | None:
     """Load per-symbol baseline. Returns None if no row exists."""
     import btc_api
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         row = conn.execute(
             """SELECT baseline_wr, baseline_sigma, trades_count, computed_at
                FROM kill_switch_v2_baseline
                WHERE symbol = ?""",
             (symbol,),
         ).fetchone()
-    finally:
-        conn.close()
     if row is None:
         return None
     return {
@@ -277,8 +256,7 @@ def _upsert_baseline(symbol: str, baseline: dict[str, Any], now) -> None:
             f"_upsert_baseline: baseline dict missing required keys: {missing}"
         )
 
-    conn = btc_api.get_db()
-    try:
+    with btc_api.get_db() as conn:
         conn.execute(
             """INSERT INTO kill_switch_v2_baseline
                  (symbol, baseline_wr, baseline_sigma, trades_count, computed_at)
@@ -297,8 +275,6 @@ def _upsert_baseline(symbol: str, baseline: dict[str, Any], now) -> None:
             ),
         )
         conn.commit()
-    finally:
-        conn.close()
 
 
 def _is_baseline_stale(


### PR DESCRIPTION
## Summary
- Convert `get_db()` from a raw connection factory to a small `_DbHandle` wrapper. Callers that use `with get_db() as con: …` are now guaranteed close-on-exit, including on exception — that's the #128 fix.
- Migrate every production caller (40 files: `auth/`, `db/`, `scripts/`, `api/`, `notifier/`, `scanner/runtime.py`, `strategy/kill_switch_v2_*`, `health.py`, `observability.py`, `btc_api.py`) to the `with` pattern.
- The wrapper also delegates attribute access via `__getattr__`, so the legacy `con = get_db(); …; con.close()` pattern still works. That keeps the test suite (~200 call sites) functioning without a lockstep migration — a follow-up can sweep them to `with` later.

## Why the hot path was the worst case

The leak that #128 describes existed everywhere `con = get_db()` ran without `try/finally`, but the worst offender was `api/positions.py::check_position_stops`. That function runs every ~5 min × open position × symbol (the live SL/TP/time-limit ticker) and opened a *fresh* connection per iteration inside the trailing-ratchet loop, also without `try/finally`. A single `sqlite3` exception (lock, IO, etc.) would leak the handle per iteration and compound across cycles. With this PR it goes through `with get_db() as con_trail:` per iteration; close is guaranteed.

## What changed in `db/connection.py`

`get_db()` now returns `_DbHandle`, which:
- Acts as a context manager: `__enter__` returns `self`, `__exit__` closes the underlying connection (idempotent).
- Delegates `execute / commit / cursor / …` to the wrapped `sqlite3.Connection` via `__getattr__`, so legacy callers keep working without changes.
- Tracks `_closed` so a manual `con.close()` followed by the `with` block exit doesn't double-close.

The dict-row factory and `PRAGMA busy_timeout = 5000` setup is preserved.

## Test plan
- [x] 466 tests covering `test_agent_*`, `test_api_*`, `test_auth*`, `test_multi_tenant_*`, `test_db_*`, `test_api_*_parity`, `test_api_telegram_unit`, `test_api_user_preferences`, `test_webhook_url_validation` — all green (61s).
- [x] 321 tests covering `test_health_*`, `test_strategy_kill_switch_v2*`, `test_notifier_dedupe` — all green (25s).
- [x] Smoke imports: every migrated production module loads.
- [ ] Full 2492-test suite end-to-end. The local run was interrupted at ~19% (no failures observed up to that point); CI should run it to completion.
- [ ] Manual smoke in prod after merge: confirm scanner cycle completes, `check_position_stops` keeps closing positions correctly, `/health/dashboard` still responds.

## Out of scope (follow-ups)
- Migrating the test suite (~200 legacy `con = get_db()` call sites) to `with`. The wrapper makes that optional — the leak fix is independent of test-side aesthetics.
- `tools/*.py` open `sqlite3.connect(...)` directly against papá's backup path outside the repo; they don't go through `get_db()` and were intentionally left alone.

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)