### PR TITLE
feat: introduce PositionClosure operator + demote db/ to pure SQL layer (closes #446 #447 #448 #449)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,19 +235,64 @@ The original guardrail (Epic A passes + Epic B implemented) was **overridden 202
 
 ## Database access
 
-All DB access goes through `db.transaction.transaction()`. The context manager owns `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK` / `close`. Callers never call `con.commit()`, `con.rollback()`, or `con.close()` inside the block.
+Three-layer separation:
+
+### 1. Pure SQL helpers (`db/*.py`, `auth/*.py`, etc.)
+
+Receive `con: sqlite3.Connection` as a mandatory first argument. They run SQL and return data. No `transaction()` calls. No side-effects (no HTTP, no file I/O, no logging beyond DEBUG). Examples: `db_close_position_sql`, `db_get_capital`, `apply_pnl_to_capital`, `db_create_position`.
+
+**Documented exceptions** (Cat. 2 hidden business operators living in helper directories — operator-extraction deferred to separate tickets per the rationale in `docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md`):
+
+- `db/schema.py::init_db` — bootstrap orchestrator; opens its own `transaction()` and calls migration helpers.
+- `db/signals.py::save_scan` — dual-transaction pattern (scan write + outcomes write); calls `transaction()` directly twice.
+- `auth/audit.py::log_auth_event` — fallback to stderr if DB write fails; calls `transaction()` directly.
+- `notifier/dispatch_per_user.py::dispatch_signal_to_users` — fan-out orchestrator; calls `transaction()` directly and fires `notify()` side-effect.
+
+These four are recognized exceptions today. When their operator-extraction lands, they migrate to `operators/` and this list shrinks.
+
+### 2. Business operators (`operators/*.py`)
+
+Own `transaction()` for one named business transition. Orchestrate side-effects. Declare atomicity. The only legal entry point for the transitions they represent. Currently: `PositionClosure` (closing a position with atomic capital roll-in + post-commit health/notify/event-log/snapshot).
 
 Pattern:
 
 ```python
-from db.transaction import transaction
+from operators.position_closure import PositionClosure
 
-with transaction() as con:
-    con.execute("INSERT INTO ...", (...,))
-    rows = con.execute("SELECT ...").fetchall()
+with PositionClosure(
+    pos_id=42, exit_price=110.0, exit_reason="TP_HIT",
+    mode="USER", caller_tenant_id=tenant_id,
+) as closure:
+    outcome = closure.execute()
 ```
 
-For multi-statement atomicity, keep all statements inside one `with transaction()` block. Helpers like `db_close_position` currently own their own transactions; cross-helper atomicity is a future refinement (see plan `docs/superpowers/plans/2026-05-24-transaction-unit-of-work.md`).
+### 3. Direct `with transaction()` for ad-hoc unit-of-work
+
+When the caller needs a transactional scope around one or more pure SQL helpers but the operation isn't a named business transition, wrap the helpers in `with transaction() as con:` directly:
+
+```python
+from db.transaction import transaction
+from db.signals import get_latest_signal
+
+with transaction() as con:
+    sig = get_latest_signal(con, "BTCUSDT")
+```
+
+### 4. Read-only pre-validation outside any transaction (`read_only_connection()`)
+
+When an operator needs to read state BEFORE deciding whether to open a write transaction (e.g., ownership check that should not acquire a writer lock), use `read_only_connection()` from `db.transaction`:
+
+```python
+from db.transaction import read_only_connection
+
+with read_only_connection() as con:
+    row = db_get_position_by_id(con, pos_id)
+# no transaction was opened; no lock held.
+```
+
+Only used by operators today (`PositionClosure.__enter__`). Pure SQL helpers never call this — they receive `con` from their caller.
+
+New business operators emerge from evidence (caller composes >1 helper + side-effect with conditional behavior), not preemptively. See `docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md` for the rationale (Voronov, 2026-05-25).
 
 ## Known Limitations
 - `watchdog.py` uses Windows-specific commands (`tasklist`, `taskkill`, `wmic`, `netstat`) and won't run on Linux/Mac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,10 @@ Only used by operators today (`PositionClosure.__enter__`). Pure SQL helpers nev
 
 New business operators emerge from evidence (caller composes >1 helper + side-effect with conditional behavior), not preemptively. See `docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md` for the rationale (Voronov, 2026-05-25).
 
+### Known scope gap
+
+`F-05` (trading invariant "every mutation derived from one tick of price decision belongs to one serializable transaction") **applies per-close** in Phase 2 of `check_position_stops`, **not per-tick**. The Phase 2 loop wraps each `PositionClosure(SYSTEM)` in `try/except: continue`, so partial-failure observability across N positions in the same tick is currently absent. See #453 for the issue tracking the integrity-observational debt (Voronov reframe of Serrano F-NEW Plano 1, 2026-05-25).
+
 ## Known Limitations
 - `watchdog.py` uses Windows-specific commands (`tasklist`, `taskkill`, `wmic`, `netstat`) and won't run on Linux/Mac
 - The webhook process itself is not supervised by the watchdog (only btc_api.py is)

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -380,16 +380,16 @@ def _execute_proposed_action(
         # 'role_required' in audit.
         raise HTTPException(status_code=403, detail="role_required")
     if action == ACTION_CLOSE_POSITION:
-        from db.positions import db_close_position
-        import btc_api
+        from operators.position_closure import PositionClosure  # noqa: PLC0415
         position_id = int(args["position_id"])
         exit_price = float(args["exit_price"])
-        # TOCTOU guards (both have to fire — db_close_position itself
+        # TOCTOU guards (both have to fire — PositionClosure itself
         # only filters by id+tenant, NOT by status, and would happily
         # overwrite the exit_reason of a position already closed via
         # SL/TP/TIME_LIMIT between propose and confirm):
         #   1. row must still exist for this tenant (IDOR null pattern)
         #   2. row must still be `open` (not closed by another flow)
+        # Pre-check outside the write tx for quick rejection:
         with transaction() as con:
             current = con.execute(
                 "SELECT status FROM positions WHERE id=? AND tenant_id=?",
@@ -397,13 +397,17 @@ def _execute_proposed_action(
             ).fetchone()
         if current is None or dict(current).get("status") != "open":
             raise HTTPException(status_code=409, detail="state_drift")
-        pos = db_close_position(
-            position_id, exit_price, "MANUAL_AGENT",
-            tenant_id=tenant_id,
-        )
-        if pos is None:
+        with PositionClosure(
+            pos_id=position_id,
+            exit_price=exit_price,
+            exit_reason="MANUAL_AGENT",
+            mode="USER",
+            caller_tenant_id=tenant_id,
+        ) as closure:
+            outcome = closure.execute()
+        if outcome.status != "closed":
             raise HTTPException(status_code=409, detail="state_drift")
-        return {"position": pos}
+        return {"position": outcome.position}
 
     if action == ACTION_REACTIVATE_SYMBOL:
         from health import get_symbol_state, reactivate_symbol

--- a/api/agent/tools/handlers.py
+++ b/api/agent/tools/handlers.py
@@ -91,7 +91,8 @@ def get_portfolio_overview(*, tenant_id: int) -> dict:
     from health import get_dashboard_state
     from api.config import load_config
 
-    open_positions = db_get_positions(status="open", tenant_id=tenant_id)
+    with transaction() as con:
+        open_positions = db_get_positions(con, status="open", tenant_id=tenant_id)
     open_count = len(open_positions)
     total_notional = sum(float(p.get("size_usd") or 0) for p in open_positions)
 
@@ -120,7 +121,8 @@ def get_portfolio_overview(*, tenant_id: int) -> dict:
 def get_positions(*, tenant_id: int) -> dict:
     """Currently open positions, summarized."""
     from db.positions import db_get_positions
-    rows = db_get_positions(status="open", tenant_id=tenant_id)
+    with transaction() as con:
+        rows = db_get_positions(con, status="open", tenant_id=tenant_id)
     return {"positions": [_position_to_summary(p) for p in rows]}
 
 
@@ -152,7 +154,8 @@ def get_symbols_with_signals(*, tenant_id: int, limit: int = 10) -> dict:  # noq
     than `limit` raw scan rows that may all be the same symbol.
     """
     from db.signals import get_latest_scan_per_symbol
-    rows = get_latest_scan_per_symbol(limit=limit, only_signals=False)
+    with transaction() as con:
+        rows = get_latest_scan_per_symbol(con, limit=limit, only_signals=False)
     return {
         "symbols": [
             {
@@ -173,7 +176,8 @@ def get_symbol_setup(*, tenant_id: int, symbol: str) -> dict:  # noqa: ARG001
     """
     from db.signals import get_scans
     norm = _normalize_symbol(symbol)
-    rows = get_scans(limit=1, symbol=norm)
+    with transaction() as con:
+        rows = get_scans(con, limit=1, symbol=norm)
     if not rows:
         return {"error": "not_found"}
     r = rows[0]
@@ -221,7 +225,8 @@ def get_recent_signals(*, tenant_id: int, limit: int = 10, since_hours: int = 24
     signal for every tenant; the per-user split lives in the dispatcher
     layer added in B.4 #257)."""
     from db.signals import get_scans
-    rows = get_scans(limit=limit, only_signals=True, since_hours=since_hours)
+    with transaction() as con:
+        rows = get_scans(con, limit=limit, only_signals=True, since_hours=since_hours)
     return {
         "signals": [
             {
@@ -246,14 +251,15 @@ def get_closed_trades(*, tenant_id: int, window: str = "30d") -> dict:
     from datetime import datetime, timedelta, timezone
     from db.positions import db_get_positions
 
-    if window == "all":
-        rows = db_get_positions(status="closed", tenant_id=tenant_id)
-    else:
-        days = {"7d": 7, "30d": 30, "90d": 90}.get(window, 30)
-        cutoff_iso = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-        rows = db_get_positions(
-            status="closed", tenant_id=tenant_id, since=cutoff_iso,
-        )
+    with transaction() as con:
+        if window == "all":
+            rows = db_get_positions(con, status="closed", tenant_id=tenant_id)
+        else:
+            days = {"7d": 7, "30d": 30, "90d": 90}.get(window, 30)
+            cutoff_iso = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+            rows = db_get_positions(
+                con, status="closed", tenant_id=tenant_id, since=cutoff_iso,
+            )
     return {"trades": [_position_to_summary(r) for r in rows]}
 
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -344,7 +344,8 @@ def login(request: Request, response: Response, body: LoginRequest):
     _update_last_login(user.id)
 
     access_token = create_access_token(user)
-    refresh_token = create_refresh_token(user, user_agent=ua, ip=ip)
+    with transaction() as con:
+        refresh_token = create_refresh_token(con, user, user_agent=ua, ip=ip)
     csrf_token = secrets.token_urlsafe(32)
 
     _set_auth_cookies(
@@ -374,7 +375,8 @@ def refresh(request: Request, response: Response):
             detail="refresh token missing",
         )
 
-    record = lookup_refresh(presented)
+    with transaction() as con:
+        record = lookup_refresh(con, presented)
     if record is None:
         # Token has never existed (or is malformed). Either bot or stale cookie.
         log_auth_event(
@@ -407,7 +409,8 @@ def refresh(request: Request, response: Response):
     if record.is_revoked():
         # Token theft signal — RFC 6819 §5.2.2.3. Revoke entire family so any
         # legitimate device that's still active also has to re-login.
-        revoked_count = revoke_family(record.family_id, now=now)
+        with transaction() as con:
+            revoked_count = revoke_family(con, record.family_id, now=now)
         log_auth_event(
             event_type="refresh_reuse_detected",
             success=False,
@@ -427,7 +430,8 @@ def refresh(request: Request, response: Response):
     # ── Rotate ───────────────────────────────────────────────────────────
     user = _hydrate_user(record.user_id)
     if user is None or not user.is_active:
-        revoke_refresh(record.token_hash, now=now)
+        with transaction() as con:
+            revoke_refresh(con, record.token_hash, now=now)
         log_auth_event(
             event_type="refresh",
             success=False,
@@ -441,15 +445,17 @@ def refresh(request: Request, response: Response):
             detail="invalid refresh token",
         )
 
-    revoke_refresh(record.token_hash, now=now)
-    new_refresh = create_refresh_token(
-        user,
-        user_agent=ua,
-        ip=ip,
-        family_id=record.family_id,
-        parent_hash=record.token_hash,
-        now=now,
-    )
+    with transaction() as con:
+        revoke_refresh(con, record.token_hash, now=now)
+        new_refresh = create_refresh_token(
+            con,
+            user,
+            user_agent=ua,
+            ip=ip,
+            family_id=record.family_id,
+            parent_hash=record.token_hash,
+            now=now,
+        )
     new_access = create_access_token(user, now=now)
     new_csrf = secrets.token_urlsafe(32)
 
@@ -482,11 +488,12 @@ def logout(request: Request, response: Response):
     user_id = None
 
     if presented:
-        record = lookup_refresh(presented)
-        if record is not None:
-            user_id = record.user_id
-            if not record.is_revoked():
-                revoke_refresh(record.token_hash)
+        with transaction() as con:
+            record = lookup_refresh(con, presented)
+            if record is not None:
+                user_id = record.user_id
+                if not record.is_revoked():
+                    revoke_refresh(con, record.token_hash)
 
     _clear_auth_cookies(response)
     log_auth_event(
@@ -557,7 +564,8 @@ def change_password(
     # Revoke ALL refresh tokens for this user — forces re-login on every
     # device they have. Spec compliance: a password change should invalidate
     # other sessions.
-    revoke_all_for_user(user.id)
+    with transaction() as con:
+        revoke_all_for_user(con, user.id)
     _clear_auth_cookies(response)
 
     log_auth_event(

--- a/api/capital.py
+++ b/api/capital.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
 from db.capital import db_get_capital, db_upsert_capital
+from db.transaction import transaction
 
 log = logging.getLogger("api.capital")
 
@@ -29,7 +30,8 @@ class CapitalPutBody(BaseModel):
 
 @router.get("", summary="Get current capital state for current tenant")
 def get_capital(tenant_id: int = Depends(get_current_tenant_id)):
-    row = db_get_capital(tenant_id)
+    with transaction() as con:
+        row = db_get_capital(con, tenant_id)
     if row is None:
         raise HTTPException(
             status_code=404,
@@ -50,10 +52,12 @@ def put_capital(
     body: CapitalPutBody,
     tenant_id: int = Depends(get_current_tenant_id),
 ):
-    row = db_upsert_capital(
-        tenant_id,
-        balance=body.balance,
-        peak_balance=body.peak_balance,
-        max_drawdown_pct=body.max_drawdown_pct,
-    )
+    with transaction() as con:
+        row = db_upsert_capital(
+            con,
+            tenant_id,
+            balance=body.balance,
+            peak_balance=body.peak_balance,
+            max_drawdown_pct=body.max_drawdown_pct,
+        )
     return {"ok": True, "capital": row}

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -52,7 +52,8 @@ def get_notifications(
         cols = ("id", "event_type", "event_key", "priority", "payload_json",
                 "channels_sent", "delivery_status", "sent_at", "read_at", "error_log")
         return {"notifications": [dict(zip(cols, r)) for r in rows]}
-    return {"notifications": list_unread(limit=limit, tenant_id=tenant_id)}
+    with transaction() as con:
+        return {"notifications": list_unread(con, limit=limit, tenant_id=tenant_id)}
 
 
 @router.post("/{notif_id}/read", dependencies=[Depends(verify_api_key)])
@@ -66,7 +67,8 @@ def post_notification_read(
     protection — same response as 'not found').
     """
     from notifier._storage import mark_read
-    updated = mark_read(notif_id, tenant_id=tenant_id)
+    with transaction() as con:
+        updated = mark_read(con, notif_id, tenant_id=tenant_id)
     if not updated:
         raise HTTPException(
             status_code=404, detail=f"Notification #{notif_id} not found",
@@ -83,5 +85,6 @@ def post_notifications_read_all(
     B.5 #258: scope-limited to tenant_id — affects only current user's queue.
     """
     from notifier._storage import mark_all_read
-    n = mark_all_read(tenant_id=tenant_id)
+    with transaction() as con:
+        n = mark_all_read(con, tenant_id=tenant_id)
     return {"ok": True, "marked": n}

--- a/api/positions.py
+++ b/api/positions.py
@@ -49,17 +49,16 @@ _EVENT_LOG_LABELS = {
 }
 
 
-def _apply_close_to_capital(closed_pos: dict, *, con=None) -> None:
+def _apply_close_to_capital(closed_pos: dict, *, con) -> None:
     """B.2 #255: roll realized P&L from a just-closed position into the
     owner's capital ledger.
 
     Skips positions with tenant_id=NULL (legacy/scanner pre-multi-tenant) or
     pnl_usd=None (no quantified outcome — e.g. qty=0). Locks: pre-reg §2.1, §2.2.
 
-    Per Task 8.5: optional `con` threads the capital update into the caller's
-    open transaction (e.g. `check_position_stops` folding close + capital
-    into one unit of work). Standalone callers (manual /positions/{id}/close)
-    leave `con=None` and let `apply_pnl_to_capital` open its own tx.
+    Task 5 (#446): `con` is now mandatory keyword-only. The caller owns the
+    surrounding `transaction()` block so the close + capital roll-in serialize
+    atomically with the read.
     """
     tenant_id = closed_pos.get("tenant_id")
     pnl_usd = closed_pos.get("pnl_usd")
@@ -70,7 +69,7 @@ def _apply_close_to_capital(closed_pos: dict, *, con=None) -> None:
         )
         return
     try:
-        apply_pnl_to_capital(int(tenant_id), float(pnl_usd), con=con)
+        apply_pnl_to_capital(con, int(tenant_id), float(pnl_usd))
     except Exception as e:
         # Capital update is best-effort: a ledger failure must NOT block the
         # position-close lifecycle. Operator reconciles via separate audit.
@@ -407,8 +406,11 @@ def close_position(
     if not pos:
         raise HTTPException(status_code=404, detail=f"Posicion #{pos_id} no encontrada")
     _write_position_event_log(pos, exit_reason, float(exit_price))
-    # B.2 #255: roll realized P&L into the JWT-authenticated owner's capital
-    _apply_close_to_capital(pos)
+    # B.2 #255: roll realized P&L into the JWT-authenticated owner's capital.
+    # Task 5 (#446): `_apply_close_to_capital` now requires `con` — open a
+    # short tx just for the ledger write.
+    with transaction() as con:
+        _apply_close_to_capital(pos, con=con)
     update_positions_json()
     return {"ok": True, "position": pos}
 

--- a/api/positions.py
+++ b/api/positions.py
@@ -16,10 +16,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from api.config import load_config
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id, require_role
-from db.capital import apply_pnl_to_capital
 from db.positions import (
     _calc_pnl,
-    db_close_position,
     db_create_position,
     db_get_positions,
     db_update_position,
@@ -47,36 +45,6 @@ _EVENT_LOG_LABELS = {
     "TIME_LIMIT_HIT": "TIME LIMIT",
     "SL_HIT": "STOP LOSS",
 }
-
-
-def _apply_close_to_capital(closed_pos: dict, *, con) -> None:
-    """B.2 #255: roll realized P&L from a just-closed position into the
-    owner's capital ledger.
-
-    Skips positions with tenant_id=NULL (legacy/scanner pre-multi-tenant) or
-    pnl_usd=None (no quantified outcome — e.g. qty=0). Locks: pre-reg §2.1, §2.2.
-
-    Task 5 (#446): `con` is now mandatory keyword-only. The caller owns the
-    surrounding `transaction()` block so the close + capital roll-in serialize
-    atomically with the read.
-    """
-    tenant_id = closed_pos.get("tenant_id")
-    pnl_usd = closed_pos.get("pnl_usd")
-    if tenant_id is None or pnl_usd is None:
-        log.debug(
-            "skip capital update for position #%s (tenant_id=%s, pnl_usd=%s)",
-            closed_pos.get("id"), tenant_id, pnl_usd,
-        )
-        return
-    try:
-        apply_pnl_to_capital(con, int(tenant_id), float(pnl_usd))
-    except Exception as e:
-        # Capital update is best-effort: a ledger failure must NOT block the
-        # position-close lifecycle. Operator reconciles via separate audit.
-        log.warning(
-            "apply_pnl_to_capital failed for position #%s (tenant_id=%s): %s",
-            closed_pos.get("id"), tenant_id, e,
-        )
 
 
 def _validated_time_limit_hours(value, symbol: str) -> float | None:
@@ -138,18 +106,23 @@ def check_position_stops(
     *,
     symbol_price_overrides: dict[str, float] | None = None,
 ):
-    """Auto-cierra posiciones abiertas si el precio toca TP, SL o time-limit. Sends notifications.
+    """Auto-cierra posiciones abiertas si el precio toca TP, SL o time-limit.
 
-    One transaction per (symbol, price) tick covers BOTH the SELECT of open
-    positions AND the per-position trailing-SL UPDATE. This names the trading
-    invariant (plan 2026-05-24-transaction-unit-of-work, F-05): every mutation
-    derived from one tick of price decision belongs to one serializable
-    transaction. Concurrent operator edits serialize via BEGIN IMMEDIATE.
+    Per-tick decision flow split into two phases (Task 6 of #446):
 
-    Position-close mutations are delegated to `db_close_position` (which owns
-    its own connection today — migration deferred to Tasks 6-9 of the plan).
-    Notifications and event-log writes are side effects kept OUTSIDE the
-    transaction by design (file I/O + network must not extend the DB lock).
+      Phase 1 (one tx) — read open positions for this symbol AND apply
+      trailing-SL ratchet writes. This names the trading invariant from plan
+      2026-05-24-transaction-unit-of-work F-05: every mutation derived from
+      one tick of price decision belongs to one serializable transaction.
+      Concurrent operator edits serialize via BEGIN IMMEDIATE. Trailing-SL
+      is per-tick mutation, NOT part of the close-flow.
+
+      Phase 2 (per-position) — for each position marked to close, run
+      `PositionClosure(mode="SYSTEM")` outside the trailing-SL tx. Each
+      closure owns its own atomic close + capital roll-in tx, then fires
+      post-commit side-effects (event log, health trigger, notify, snapshot)
+      via __exit__. Failures are logged and the loop continues so one bad
+      position cannot stall the scanner.
 
     `now` is injectable for deterministic testing; defaults to current UTC time.
 
@@ -174,16 +147,10 @@ def check_position_stops(
 
     cfg = load_config()
 
-    # Task 8.5: ONE unit of work now covers read + trail-SL + close +
-    # capital ledger update. Previously the close + capital lived in their
-    # own transactions, so a crash between them left a closed position
-    # whose P&L was never folded into the tenant's balance. Now the close
-    # and capital roll-in serialize atomically with the read.
-    #
-    # Side effects (event-log file write + Telegram notify) stay OUTSIDE
-    # the transaction by design — file I/O / network must not extend the
-    # DB lock. We collect them in `post_tx_actions` and run after commit.
-    post_tx_actions: list[dict] = []
+    # Phase 1: read open positions + apply trailing-SL writes in one tx.
+    # Collect (pos_id, exit_price, reason) tuples for positions that should
+    # close; the close-flow itself runs in Phase 2 via PositionClosure.
+    pos_list_to_close: list[tuple[int, float, str]] = []
 
     with transaction() as con:
         rows = con.execute(
@@ -270,68 +237,30 @@ def check_position_stops(
                         reason, exit_price = "TIME_LIMIT_HIT", price
 
             if reason:
-                # Task 8.5: pass `con=con` so the close write joins this tx.
-                closed = db_close_position(pos["id"], exit_price, reason, con=con)
-                log.info(f"POSICION #{pos['id']} {symbol} {reason} @ ${exit_price}")
-                # B.2 #255: roll realized P&L into owner's capital, in the
-                # same tx (close + capital atomic together).
-                if closed:
-                    _apply_close_to_capital(closed, con=con)
+                pos_list_to_close.append((int(pos["id"]), float(exit_price), reason))
+    # Trailing-SL writes are now durable.
 
-                # Defer file-log + Telegram notify to AFTER commit. These are
-                # slow I/O (file / HTTP) and must not extend the DB writer lock.
-                post_tx_actions.append({
-                    "pos": pos,
-                    "reason": reason,
-                    "exit_price": exit_price,
-                })
-
-    # Out-of-transaction side effects: event log + health trigger + exit
-    # notification. db_close_position skipped the health trigger because we
-    # passed `con=con` (it would deadlock on the still-open writer lock),
-    # so we fire it here post-commit.
-    for action in post_tx_actions:
-        pos = action["pos"]
-        reason = action["reason"]
-        exit_price = action["exit_price"]
-
-        _write_position_event_log(pos, reason, exit_price)
-
-        # Kill switch #138: deferred health trigger (Task 8.5).
+    # Phase 2: close each marked position via PositionClosure in SYSTEM mode.
+    # Each closure owns its own atomic close + capital tx and fires
+    # post-commit side-effects (event log, health, notify, snapshot) via
+    # __exit__. Wrap each in try/except so a single failure cannot stall
+    # the scanner across the remaining positions for this tick.
+    from operators.position_closure import PositionClosure  # noqa: PLC0415
+    for pos_id, exit_price, reason in pos_list_to_close:
         try:
-            from health import trigger_health_evaluation  # noqa: PLC0415
-            trigger_health_evaluation(pos["symbol"], cfg)
-        except Exception as e:
-            log.warning("health trigger skipped for position close: %s", e)
-
-        # Send exit notification via the centralized notifier (#162 PR B).
-        entry = pos.get("entry_price", 0)
-        qty = pos.get("qty", 0)
-        pnl_usd, pnl_pct = _calc_pnl(pos["direction"], entry, exit_price, qty)
-
-        try:
-            from notifier import notify, PositionExitEvent  # noqa: PLC0415
-            # Map legacy reason strings ("SL_HIT"/"TP_HIT"/"TIME_LIMIT_HIT")
-            # to tier codes used by the notifier templates.
-            exit_reason_code = "SL" if reason == "SL_HIT" else (
-                "TP" if reason == "TP_HIT" else (
-                    "TIME_LIMIT" if reason == "TIME_LIMIT_HIT" else reason
-                )
-            )
-            notify(
-                PositionExitEvent(
-                    symbol=symbol,
-                    direction=pos.get("direction", "LONG"),
-                    exit_reason=exit_reason_code,
-                    entry_price=float(entry or 0.0),
-                    exit_price=float(exit_price or 0.0),
-                    pnl_usd=float(pnl_usd or 0.0),
-                    pnl_pct=float(pnl_pct or 0.0),
-                ),
+            with PositionClosure(
+                pos_id=pos_id,
+                exit_price=exit_price,
+                exit_reason=reason,
+                mode="SYSTEM",
                 cfg=cfg,
-            )
-        except Exception as e:
-            log.warning(f"Failed to notify {reason} for {symbol}: {e}")
+                now=now,
+            ) as closure:
+                closure.execute()
+            log.info(f"POSICION #{pos_id} {symbol} {reason} @ ${exit_price}")
+        except Exception:
+            log.exception("PositionClosure failed for pos_id=%s", pos_id)
+            continue
 
 
 @router.get("", summary="Listar posiciones")
@@ -397,22 +326,33 @@ def close_position(
     body: dict = Body(...),
     tenant_id: int = Depends(get_current_tenant_id),
 ):
-    exit_price  = body.get("exit_price")
+    """Close a position. USER-mode PositionClosure handles all the choreography
+    (atomicity, ownership enforcement via IDOR-safe NOT_FOUND collapse,
+    capital roll-in, post-commit side-effects: event log + health trigger +
+    notify + snapshot)."""
+    from operators.position_closure import PositionClosure  # noqa: PLC0415
+
+    exit_price = body.get("exit_price")
     exit_reason = body.get("exit_reason", "MANUAL")
     if exit_price is None:
         raise HTTPException(status_code=422, detail="Falta exit_price")
-    # B.5 #258: ownership-enforced
-    pos = db_close_position(pos_id, float(exit_price), exit_reason, tenant_id=tenant_id)
-    if not pos:
+
+    with PositionClosure(
+        pos_id=pos_id,
+        exit_price=float(exit_price),
+        exit_reason=exit_reason,
+        mode="USER",
+        caller_tenant_id=tenant_id,
+    ) as closure:
+        outcome = closure.execute()
+
+    # IDOR-safe: NOT_FOUND collapses ownership-mismatch and truly-missing
+    # into one indistinguishable 404 (PositionClosure.__enter__ contract).
+    if outcome.status == "not_found":
         raise HTTPException(status_code=404, detail=f"Posicion #{pos_id} no encontrada")
-    _write_position_event_log(pos, exit_reason, float(exit_price))
-    # B.2 #255: roll realized P&L into the JWT-authenticated owner's capital.
-    # Task 5 (#446): `_apply_close_to_capital` now requires `con` — open a
-    # short tx just for the ledger write.
-    with transaction() as con:
-        _apply_close_to_capital(pos, con=con)
-    update_positions_json()
-    return {"ok": True, "position": pos}
+    if outcome.status == "already_closed":
+        return {"ok": True, "position": outcome.position, "already_closed": True}
+    return {"ok": True, "position": outcome.position}
 
 
 @router.delete(

--- a/api/positions.py
+++ b/api/positions.py
@@ -77,7 +77,8 @@ def update_positions_json():
     """Escribe data/positions_summary.json con estado de posiciones."""
     try:
         _ensure_dirs()
-        all_pos   = db_get_positions()
+        with transaction() as con:
+            all_pos   = db_get_positions(con)
         open_pos  = [p for p in all_pos if p["status"] == "open"]
         closed_pos = [p for p in all_pos if p["status"] == "closed"]
         realized  = sum((p["pnl_usd"] or 0) for p in closed_pos)
@@ -269,7 +270,8 @@ def list_positions(
     tenant_id: int = Depends(get_current_tenant_id),
 ):
     # B.5 #258: tenant_id from JWT, never from request param/header/body
-    positions = db_get_positions(status, tenant_id=tenant_id)
+    with transaction() as con:
+        positions = db_get_positions(con, status, tenant_id=tenant_id)
     return {"total": len(positions), "positions": positions}
 
 
@@ -289,7 +291,8 @@ def open_position(
         raise HTTPException(status_code=422, detail=f"Faltan campos: {missing}")
     try:
         # B.5 #258: tenant_id from JWT — body's tenant_id (if any) silently dropped
-        pos = db_create_position(body, tenant_id=tenant_id)
+        with transaction() as con:
+            pos = db_create_position(con, body, tenant_id=tenant_id)
         update_positions_json()
         return {"ok": True, "position": pos}
     except Exception as e:
@@ -308,7 +311,8 @@ def edit_position(
     tenant_id: int = Depends(get_current_tenant_id),
 ):
     # B.5 #258: ownership-enforced. Returns None if pos doesn't belong to tenant.
-    pos = db_update_position(pos_id, body, tenant_id=tenant_id)
+    with transaction() as con:
+        pos = db_update_position(con, pos_id, body, tenant_id=tenant_id)
     if not pos:
         raise HTTPException(status_code=404, detail=f"Posicion #{pos_id} no encontrada")
     update_positions_json()

--- a/api/setup.py
+++ b/api/setup.py
@@ -56,7 +56,8 @@ def _setup_done() -> bool:
     /setup if there's still a user; you'd also need to delete that user.
     Conversely, if the user gets deleted but setup_completed_at remains,
     /setup stays dead — by design (recovery is via CLI per the README)."""
-    return has_any_user() or is_setup_completed()
+    with transaction() as con:
+        return has_any_user(con) or is_setup_completed(con)
 
 
 def _check_rate_limit_or_404(request: Request) -> None:
@@ -156,8 +157,8 @@ def setup_post(
             (email_clean, pwd_hash, now, now),
         )
         user_id = int(cur.lastrowid or 0)
+        mark_setup_completed(con, ip=ip, method="web")
 
-    mark_setup_completed(ip=ip, method="web")
     consume_token()
 
     log_auth_event(

--- a/api/signals.py
+++ b/api/signals.py
@@ -203,9 +203,10 @@ def list_signals(
     since_hours:  Optional[float] = Query(None,  description="Ultimas N horas"),
     symbol:       Optional[str]   = Query(None,  description="Filtrar por par (ej: ETHUSDT)"),
 ):
-    rows = get_scans(limit=limit, only_signals=only_signals,
-                     only_setups=only_setups, since_hours=since_hours,
-                     symbol=symbol)
+    with transaction() as con:
+        rows = get_scans(con, limit=limit, only_signals=only_signals,
+                         only_setups=only_setups, since_hours=since_hours,
+                         symbol=symbol)
     return {
         "total": len(rows),
         "signals": [
@@ -299,7 +300,8 @@ def get_signals_performance(
 def latest_signal(
     symbol: Optional[str] = Query(None, description="Filtrar por par (ej: SOLUSDT)")
 ):
-    row = get_latest_signal(symbol)
+    with transaction() as con:
+        row = get_latest_signal(con, symbol)
     if not row:
         msg = f"Sin señales para {symbol}." if symbol else "Sin señales registradas."
         return {"message": msg, "señal": None}
@@ -331,7 +333,8 @@ def latest_signal(
 def latest_message(
     symbol: Optional[str] = Query(None, description="Filtrar por par")
 ):
-    row = get_latest_signal(symbol)
+    with transaction() as con:
+        row = get_latest_signal(con, symbol)
     if not row:
         return {"message": "Sin señales registradas aun."}
     try:

--- a/api/telegram.py
+++ b/api/telegram.py
@@ -148,7 +148,10 @@ def push_telegram_direct(rep: dict, cfg: dict):
     # to the legacy broadcast so the signal isn't silently dropped during
     # the bootstrap window.
     from notifier.dispatch_per_user import dispatch_signal_to_users, _list_active_users
-    if _list_active_users():
+    from db.transaction import transaction as _tx_for_users
+    with _tx_for_users() as _users_con:
+        _has_users = bool(_list_active_users(_users_con))
+    if _has_users:
         per_user = dispatch_signal_to_users(event, cfg)
         # "ok" = at least one user received via at least one channel.
         return any(

--- a/api/user_preferences.py
+++ b/api/user_preferences.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
+from db.transaction import transaction
 from db.user_preferences import (
     db_get_user_preferences,
     db_upsert_user_preferences,
@@ -68,7 +69,8 @@ def _mask_token(token: str) -> str:
 
 @router.get("", summary="Get preferences for current tenant (defaults if unset)")
 def get_preferences(tenant_id: int = Depends(get_current_tenant_id)):
-    row = db_get_user_preferences(tenant_id)
+    with transaction() as con:
+        row = db_get_user_preferences(con, tenant_id)
     if row is None:
         # Return sensible defaults — per pre-reg §3.2
         return {
@@ -101,18 +103,21 @@ def put_preferences(
     # types something new". See spec §Security note.
     notify_channels = body.notify_channels
     if notify_channels and _MASK_MARKER in (notify_channels.get("telegram_bot_token") or ""):
-        existing = db_get_user_preferences(tenant_id)
+        with transaction() as con:
+            existing = db_get_user_preferences(con, tenant_id)
         existing_token = (
             (existing or {}).get("notify_channels") or {}
         ).get("telegram_bot_token", "")
         notify_channels = {**notify_channels, "telegram_bot_token": existing_token}
 
-    row = db_upsert_user_preferences(
-        tenant_id,
-        symbol_filter=body.symbol_filter,
-        min_score=body.min_score,
-        notify_channels=notify_channels,
-    )
+    with transaction() as con:
+        row = db_upsert_user_preferences(
+            con,
+            tenant_id,
+            symbol_filter=body.symbol_filter,
+            min_score=body.min_score,
+            notify_channels=notify_channels,
+        )
     # Mask the bot_token in the response for consistency with GET.
     if row and (row.get("notify_channels") or {}).get("telegram_bot_token"):
         nc = row["notify_channels"]
@@ -145,7 +150,8 @@ def post_preferences_test(tenant_id: int = Depends(get_current_tenant_id)):
     """
     from notifier.channels.telegram import TelegramChannel  # noqa: PLC0415
 
-    prefs = db_get_user_preferences(tenant_id) or {}
+    with transaction() as con:
+        prefs = db_get_user_preferences(con, tenant_id) or {}
     notify_channels = prefs.get("notify_channels") or {}
 
     token = (notify_channels.get("telegram_bot_token") or "").strip()

--- a/auth/audit.py
+++ b/auth/audit.py
@@ -9,12 +9,11 @@ from __future__ import annotations
 
 import json
 import logging
-import sqlite3
 import sys
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from db.transaction import _tx_or_use
+from db.transaction import transaction
 
 log = logging.getLogger("auth.audit")
 
@@ -39,13 +38,14 @@ def log_auth_event(
     ip: Optional[str] = None,
     user_agent: Optional[str] = None,
     metadata: Optional[dict[str, Any]] = None,
-    con: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Insert one row into auth_events. Never raises.
 
     Sensitive fields (passwords, tokens — even hashed) MUST NOT appear in
     `metadata`. Callers are responsible. Common metadata keys: 'reason',
     'family_id', 'rotation_count', 'old_role'/'new_role'.
+
+    Cat. 2 hidden operator: owns its own transaction() directly.
     """
     if event_type not in VALID_EVENT_TYPES:
         # Defensive: unknown event types still get logged but flagged.
@@ -55,7 +55,7 @@ def log_auth_event(
     ts = datetime.now(timezone.utc).isoformat()
 
     try:
-        with _tx_or_use(con) as con:
+        with transaction() as con:
             con.execute(
                 """
                 INSERT INTO auth_events

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -163,12 +163,17 @@ def _hydrate_user_from_db(user_id: int) -> User | None:
 def _synthetic_test_user(role: str) -> User:
     """Return a fake User used only when AUTH_TEST_BYPASS_ROLE is set.
 
-    id=0 by convention (no real user has id=0 since AUTOINCREMENT starts
-    at 1). Email is unique-ish so audit logs don't collide if tests
+    id=99 by convention. Originally id=0 (chosen because AUTOINCREMENT
+    starts at 1), but #446 Task 6 surfaced that PositionClosure's USER
+    mode enforces `caller_tenant_id > 0` to match production semantics
+    (real tenants start at 1). Using id=99 keeps the test identity
+    distinct from production tenant id=1 (Samuel) and from common
+    cross-tenant fixtures like OTHER_USER_ID=999 in the IDOR suite.
+    Email is unique-ish so audit logs don't collide if tests
     deliberately log events.
     """
     return User(
-        id=0,
+        id=99,
         email=f"test-{role}@bypass.local",
         role=role,
         is_active=True,

--- a/auth/tokens.py
+++ b/auth/tokens.py
@@ -25,7 +25,6 @@ from typing import Any, Optional
 import jwt
 
 from auth.models import RefreshTokenRecord, User
-from db.transaction import _tx_or_use
 
 
 # ─── Configuration helpers ──────────────────────────────────────────────────
@@ -110,6 +109,7 @@ def _hash_refresh(token: str) -> str:
 
 
 def create_refresh_token(
+    con: sqlite3.Connection,
     user: User,
     *,
     user_agent: Optional[str] = None,
@@ -117,7 +117,6 @@ def create_refresh_token(
     family_id: Optional[str] = None,
     parent_hash: Optional[str] = None,
     now: Optional[datetime] = None,
-    con: Optional[sqlite3.Connection] = None,
 ) -> str:
     """Mint a new refresh token, persist its hash, return the plaintext.
 
@@ -132,46 +131,43 @@ def create_refresh_token(
     fid = family_id or uuid.uuid4().hex
     expires = now + timedelta(days=_refresh_days())
 
-    with _tx_or_use(con) as con:
-        con.execute(
-            """
-            INSERT INTO refresh_tokens
-                (token_hash, user_id, family_id, parent_hash,
-                 expires_at, revoked_at, created_at, user_agent, ip)
-            VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)
-            """,
-            (
-                token_hash,
-                user.id,
-                fid,
-                parent_hash,
-                expires.isoformat(),
-                now.isoformat(),
-                user_agent,
-                ip,
-            ),
-        )
+    con.execute(
+        """
+        INSERT INTO refresh_tokens
+            (token_hash, user_id, family_id, parent_hash,
+             expires_at, revoked_at, created_at, user_agent, ip)
+        VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)
+        """,
+        (
+            token_hash,
+            user.id,
+            fid,
+            parent_hash,
+            expires.isoformat(),
+            now.isoformat(),
+            user_agent,
+            ip,
+        ),
+    )
     return token
 
 
 def lookup_refresh(
+    con: sqlite3.Connection,
     token: str,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> Optional[RefreshTokenRecord]:
     """Find a refresh token row by hash. Returns None if not found."""
     if not token:
         return None
     h = _hash_refresh(token)
-    with _tx_or_use(con) as con:
-        row = con.execute(
-            """
-            SELECT id, token_hash, user_id, family_id, parent_hash,
-                   expires_at, revoked_at, created_at, user_agent, ip
-            FROM refresh_tokens WHERE token_hash = ?
-            """,
-            (h,),
-        ).fetchone()
+    row = con.execute(
+        """
+        SELECT id, token_hash, user_id, family_id, parent_hash,
+               expires_at, revoked_at, created_at, user_agent, ip
+        FROM refresh_tokens WHERE token_hash = ?
+        """,
+        (h,),
+    ).fetchone()
     if not row:
         return None
     return RefreshTokenRecord(
@@ -189,27 +185,26 @@ def lookup_refresh(
 
 
 def revoke_refresh(
+    con: sqlite3.Connection,
     token_hash: str,
     *,
     now: Optional[datetime] = None,
-    con: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Mark one refresh token as revoked (does not DELETE — audit trail)."""
     if now is None:
         now = datetime.now(timezone.utc)
-    with _tx_or_use(con) as con:
-        con.execute(
-            "UPDATE refresh_tokens SET revoked_at = ? "
-            "WHERE token_hash = ? AND revoked_at IS NULL",
-            (now.isoformat(), token_hash),
-        )
+    con.execute(
+        "UPDATE refresh_tokens SET revoked_at = ? "
+        "WHERE token_hash = ? AND revoked_at IS NULL",
+        (now.isoformat(), token_hash),
+    )
 
 
 def revoke_family(
+    con: sqlite3.Connection,
     family_id: str,
     *,
     now: Optional[datetime] = None,
-    con: Optional[sqlite3.Connection] = None,
 ) -> int:
     """Mark every still-active token in this family as revoked.
 
@@ -218,20 +213,19 @@ def revoke_family(
     """
     if now is None:
         now = datetime.now(timezone.utc)
-    with _tx_or_use(con) as con:
-        cur = con.execute(
-            "UPDATE refresh_tokens SET revoked_at = ? "
-            "WHERE family_id = ? AND revoked_at IS NULL",
-            (now.isoformat(), family_id),
-        )
-        return cur.rowcount or 0
+    cur = con.execute(
+        "UPDATE refresh_tokens SET revoked_at = ? "
+        "WHERE family_id = ? AND revoked_at IS NULL",
+        (now.isoformat(), family_id),
+    )
+    return cur.rowcount or 0
 
 
 def revoke_all_for_user(
+    con: sqlite3.Connection,
     user_id: int,
     *,
     now: Optional[datetime] = None,
-    con: Optional[sqlite3.Connection] = None,
 ) -> int:
     """Revoke every active refresh token belonging to this user.
 
@@ -239,10 +233,9 @@ def revoke_all_for_user(
     """
     if now is None:
         now = datetime.now(timezone.utc)
-    with _tx_or_use(con) as con:
-        cur = con.execute(
-            "UPDATE refresh_tokens SET revoked_at = ? "
-            "WHERE user_id = ? AND revoked_at IS NULL",
-            (now.isoformat(), user_id),
-        )
-        return cur.rowcount or 0
+    cur = con.execute(
+        "UPDATE refresh_tokens SET revoked_at = ? "
+        "WHERE user_id = ? AND revoked_at IS NULL",
+        (now.isoformat(), user_id),
+    )
+    return cur.rowcount or 0

--- a/btc_api.py
+++ b/btc_api.py
@@ -96,7 +96,7 @@ from db.schema import init_db  # used in lifespan() at line 67; also btc_api.ini
 # get_latest_signal, get_scans, save_scan: called as btc_api.<name> in test_api.py
 from db.signals import get_latest_scan, get_latest_signal, get_scans, get_signals_summary, save_scan  # noqa: F401
 # db_*: called as btc_api.db_* in test_api.py (position CRUD, lines 827–1088)
-from db.positions import db_close_position, db_create_position, db_get_positions, db_update_position  # noqa: F401
+from db.positions import db_create_position, db_get_positions, db_update_position  # noqa: F401
 from notifier import notify, SystemEvent  # used directly at line 171
 from scanner.runtime import (
     _scanner_state, execute_scan_for_symbol, check_pending_signal_outcomes,

--- a/btc_api.py
+++ b/btc_api.py
@@ -127,8 +127,9 @@ def _bootstrap_first_user() -> None:
     skip this entire function.
     """
     # Already done — the most common case after first boot.
-    if has_any_user() or is_setup_completed():
-        return
+    with transaction() as con:
+        if has_any_user(con) or is_setup_completed(con):
+            return
 
     init_email = os.environ.get("AUTH_INITIAL_ADMIN_EMAIL", "").strip()
     init_pwd = os.environ.get("AUTH_INITIAL_ADMIN_PASSWORD", "")
@@ -161,7 +162,7 @@ def _bootstrap_first_user() -> None:
                 (init_email.lower(), pwd_hash, now, now),
             )
             uid = int(cur.lastrowid or 0)
-        mark_setup_completed(ip=None, method="env_vars")
+            mark_setup_completed(con, ip=None, method="env_vars")
         log_auth_event(
             event_type="initial_setup_completed",
             success=True,
@@ -241,8 +242,9 @@ async def lifespan(app: FastAPI):
 
     log.info("Initializing DB schema…")
     init_db()
-    init_auth_db()
-    init_system_state()
+    with transaction() as con:
+        init_auth_db(con)
+        init_system_state(con)
 
     # First-time setup gate. Picks one of three paths (env / cli / web)
     # or no-ops if a user already exists.
@@ -422,7 +424,8 @@ def list_symbols():
     """Retorna el último escaneo de cada símbolo, ordenado por señal y score."""
     import json as _json  # noqa: PLC0415 — local import keeps the module-level surface unchanged
     symbols = _scanner_state.get("symbols_active") or get_active_symbols()
-    rows    = get_signals_summary()
+    with transaction() as con:
+        rows    = get_signals_summary(con)
     by_sym  = {r["symbol"]: r for r in rows}
     result  = []
     for sym in symbols:
@@ -454,7 +457,8 @@ def list_symbols():
 @app.get("/status", summary="Estado detallado del scanner",
          dependencies=[Depends(verify_api_key)])
 def status():
-    latest = get_latest_scan()
+    with transaction() as con:
+        latest = get_latest_scan(con)
     return {
         "scanner_state": _scanner_state,
         "ultimo_escaneo": {

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -149,7 +149,9 @@ def _build_e5_cooldown(symbol: str, cfg: dict) -> dict:
 
     try:
         from db.positions import db_last_exit_ts  # noqa: PLC0415
-        last_exit_dt = db_last_exit_ts(symbol)
+        from db.transaction import transaction  # noqa: PLC0415
+        with transaction() as con:
+            last_exit_dt = db_last_exit_ts(con, symbol)
     except Exception as e:  # noqa: BLE001
         # Throttle: one log line per (symbol, exc-type) per process.
         # SQLite Operational/Database errors surface as `error` (real bug

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -303,7 +303,11 @@ def scan(symbol: str = None):
         # portfolio MTM + DD are computed against each tenant's own positions.
         # When no tenants are onboarded yet, skip (no portfolios to evaluate).
         from db.capital import db_list_active_tenant_ids
-        for _tid in db_list_active_tenant_ids():
+        from db.transaction import transaction as _tx_for_tenants
+        # Task 5 (#446): `db_list_active_tenant_ids` now requires `con`.
+        with _tx_for_tenants() as _tenants_con:
+            _active_tids = db_list_active_tenant_ids(_tenants_con)
+        for _tid in _active_tids:
             try:
                 emit_shadow_decision(
                     symbol=symbol,

--- a/db/auth_schema.py
+++ b/db/auth_schema.py
@@ -13,95 +13,88 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from typing import Optional
-
-from db.transaction import _tx_or_use
 
 log = logging.getLogger("db.auth_schema")
 
 
-def init_auth_db(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> None:
+def init_auth_db(con: sqlite3.Connection) -> None:
     """Create auth tables if missing. Safe to call repeatedly.
 
-    Per Task 8.5: optional `con` for caller-controlled transaction composition.
+    Task 8 (#446): `con` is now mandatory positional. Callers must pass an
+    open `sqlite3.Connection` from a surrounding `transaction()` block.
     """
-    with _tx_or_use(con) as con:
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS users (
-                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-                email               TEXT NOT NULL UNIQUE,
-                password_hash       TEXT NOT NULL,
-                role                TEXT NOT NULL DEFAULT 'viewer'
-                                          CHECK (role IN ('admin', 'viewer')),
-                is_active           INTEGER NOT NULL DEFAULT 1,
-                totp_secret         TEXT,
-                oauth_provider      TEXT,
-                created_at          TEXT NOT NULL,
-                last_login_at       TEXT,
-                password_changed_at TEXT NOT NULL
-            )
-            """
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            email               TEXT NOT NULL UNIQUE,
+            password_hash       TEXT NOT NULL,
+            role                TEXT NOT NULL DEFAULT 'viewer'
+                                      CHECK (role IN ('admin', 'viewer')),
+            is_active           INTEGER NOT NULL DEFAULT 1,
+            totp_secret         TEXT,
+            oauth_provider      TEXT,
+            created_at          TEXT NOT NULL,
+            last_login_at       TEXT,
+            password_changed_at TEXT NOT NULL
         )
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS refresh_tokens (
-                id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                token_hash   TEXT NOT NULL UNIQUE,
-                user_id      INTEGER NOT NULL REFERENCES users(id),
-                family_id    TEXT NOT NULL,
-                parent_hash  TEXT,
-                expires_at   TEXT NOT NULL,
-                revoked_at   TEXT,
-                created_at   TEXT NOT NULL,
-                user_agent   TEXT,
-                ip           TEXT
-            )
-            """
+        """
+    )
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS refresh_tokens (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            token_hash   TEXT NOT NULL UNIQUE,
+            user_id      INTEGER NOT NULL REFERENCES users(id),
+            family_id    TEXT NOT NULL,
+            parent_hash  TEXT,
+            expires_at   TEXT NOT NULL,
+            revoked_at   TEXT,
+            created_at   TEXT NOT NULL,
+            user_agent   TEXT,
+            ip           TEXT
         )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_refresh_user "
-            "ON refresh_tokens(user_id, revoked_at)"
+        """
+    )
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_refresh_user "
+        "ON refresh_tokens(user_id, revoked_at)"
+    )
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_refresh_family "
+        "ON refresh_tokens(family_id)"
+    )
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS auth_events (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id       INTEGER REFERENCES users(id),
+            event_type    TEXT NOT NULL,
+            ip            TEXT,
+            user_agent    TEXT,
+            ts            TEXT NOT NULL,
+            success       INTEGER NOT NULL,
+            metadata_json TEXT
         )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_refresh_family "
-            "ON refresh_tokens(family_id)"
-        )
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS auth_events (
-                id            INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id       INTEGER REFERENCES users(id),
-                event_type    TEXT NOT NULL,
-                ip            TEXT,
-                user_agent    TEXT,
-                ts            TEXT NOT NULL,
-                success       INTEGER NOT NULL,
-                metadata_json TEXT
-            )
-            """
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_auth_events_user_ts "
-            "ON auth_events(user_id, ts DESC)"
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_auth_events_ts "
-            "ON auth_events(ts DESC)"
-        )
+        """
+    )
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_auth_events_user_ts "
+        "ON auth_events(user_id, ts DESC)"
+    )
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_auth_events_ts "
+        "ON auth_events(ts DESC)"
+    )
 
 
-def has_any_user(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> bool:
+def has_any_user(con: sqlite3.Connection) -> bool:
     """True if at least one user exists. Used by app boot to print a hint
-    when the DB is fresh and nobody has run scripts/create_user.py yet."""
-    with _tx_or_use(con) as con:
-        row = con.execute("SELECT 1 FROM users LIMIT 1").fetchone()
+    when the DB is fresh and nobody has run scripts/create_user.py yet.
+
+    Task 8 (#446): `con` is now mandatory positional.
+    """
+    row = con.execute("SELECT 1 FROM users LIMIT 1").fetchone()
     return row is not None
 
 
@@ -114,69 +107,67 @@ def has_any_user(
 # place without schema churn.
 
 
-def init_system_state(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> None:
-    """Idempotent — create system_state if missing."""
-    with _tx_or_use(con) as con:
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS system_state (
-                key        TEXT PRIMARY KEY,
-                value      TEXT,
-                updated_at TEXT NOT NULL
-            )
-            """
+def init_system_state(con: sqlite3.Connection) -> None:
+    """Idempotent — create system_state if missing.
+
+    Task 8 (#446): `con` is now mandatory positional.
+    """
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS system_state (
+            key        TEXT PRIMARY KEY,
+            value      TEXT,
+            updated_at TEXT NOT NULL
         )
+        """
+    )
 
 
-def is_setup_completed(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> bool:
+def is_setup_completed(con: sqlite3.Connection) -> bool:
     """True if setup_completed_at row exists.
 
     We deliberately do NOT also infer "completed" from has_any_user(): the
     spec is explicit that if the admin row gets deleted accidentally, the
     system stays inaccessible via web. Recovery requires CLI or a manual
     DELETE on this row (documented in README).
+
+    Task 8 (#446): `con` is now mandatory positional.
     """
-    with _tx_or_use(con) as con:
-        row = con.execute(
-            "SELECT 1 FROM system_state WHERE key = 'setup_completed_at'"
-        ).fetchone()
+    row = con.execute(
+        "SELECT 1 FROM system_state WHERE key = 'setup_completed_at'"
+    ).fetchone()
     return row is not None
 
 
 def mark_setup_completed(
+    con: sqlite3.Connection,
     *,
     ip: str | None,
     method: str,
-    con: Optional[sqlite3.Connection] = None,
 ) -> None:
     """Persist that initial setup ran. method ∈ {web, cli, env_vars}.
 
     Stored as two separate rows so a SELECT * shows both fields. Uses
     INSERT OR REPLACE so a manual rerun (after deleting the rows for
     recovery) doesn't blow up.
+
+    Task 8 (#446): `con` is now mandatory positional first arg.
     """
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc).isoformat()
-    with _tx_or_use(con) as con:
-        con.execute(
-            "INSERT OR REPLACE INTO system_state(key, value, updated_at) "
-            "VALUES ('setup_completed_at', ?, ?)",
-            (now, now),
-        )
-        con.execute(
-            "INSERT OR REPLACE INTO system_state(key, value, updated_at) "
-            "VALUES ('setup_completed_ip', ?, ?)",
-            (ip or "", now),
-        )
-        con.execute(
-            "INSERT OR REPLACE INTO system_state(key, value, updated_at) "
-            "VALUES ('setup_completed_method', ?, ?)",
-            (method, now),
-        )
+    con.execute(
+        "INSERT OR REPLACE INTO system_state(key, value, updated_at) "
+        "VALUES ('setup_completed_at', ?, ?)",
+        (now, now),
+    )
+    con.execute(
+        "INSERT OR REPLACE INTO system_state(key, value, updated_at) "
+        "VALUES ('setup_completed_ip', ?, ?)",
+        (ip or "", now),
+    )
+    con.execute(
+        "INSERT OR REPLACE INTO system_state(key, value, updated_at) "
+        "VALUES ('setup_completed_method', ?, ?)",
+        (method, now),
+    )

--- a/db/capital.py
+++ b/db/capital.py
@@ -12,8 +12,6 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-from db.transaction import _tx_or_use
-
 log = logging.getLogger("db.capital")
 
 # Default starting balance for a tenant whose first position closes before
@@ -23,24 +21,22 @@ INITIAL_CAPITAL_DEFAULT = 10_000.0
 
 
 def db_get_capital(
+    con: sqlite3.Connection,
     tenant_id: int,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> Optional[dict]:
     """Return current capital row for tenant, or None if uninitialized.
 
-    Per Task 8.5: optional `con` for caller-controlled transaction composition.
+    Task 5 (#446): `con` is now mandatory positional. Callers must pass an
+    open `sqlite3.Connection` from a surrounding `transaction()` block.
     """
-    with _tx_or_use(con) as con:
-        row = con.execute(
-            "SELECT * FROM capital WHERE tenant_id = ?", (tenant_id,),
-        ).fetchone()
+    row = con.execute(
+        "SELECT * FROM capital WHERE tenant_id = ?", (tenant_id,),
+    ).fetchone()
     return dict(row) if row else None
 
 
 def db_list_active_tenant_ids(
-    *,
-    con: Optional[sqlite3.Connection] = None,
+    con: sqlite3.Connection,
 ) -> list[int]:
     """Return tenant ids with an existing capital row, sorted ascending.
 
@@ -50,20 +46,18 @@ def db_list_active_tenant_ids(
     onboarded tenants" and callers should treat that as a no-op rather
     than computing implicit single-system aggregates.
 
-    Per Task 8.5: optional `con` for caller-controlled transaction composition.
+    Task 5 (#446): `con` is now mandatory positional.
     """
-    with _tx_or_use(con) as con:
-        rows = con.execute(
-            "SELECT tenant_id FROM capital ORDER BY tenant_id ASC"
-        ).fetchall()
+    rows = con.execute(
+        "SELECT tenant_id FROM capital ORDER BY tenant_id ASC"
+    ).fetchall()
     return [int(r[0]) for r in rows]
 
 
 def apply_pnl_to_capital(
+    con: sqlite3.Connection,
     tenant_id: int,
     pnl_usd: float,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> Optional[dict]:
     """B.2 hook: a position closed for `tenant_id` with realized `pnl_usd`.
 
@@ -74,44 +68,42 @@ def apply_pnl_to_capital(
     Returns the resulting capital row. Locks are documented in
     docs/superpowers/plans/2026-05-16-multi-tenant-b2-capital-tracker-pre-reg.md §2.3.
 
-    Per Task 8.5: single-tx refactor. Previously this opened two separate
-    transactions (db_get_capital + db_upsert_capital), giving a small read-
-    then-write race window. We now wrap both inside one `_tx_or_use(con)`
-    block so the get→compute→upsert sequence is atomic on whichever
-    connection the caller owns (or a fresh one if `con is None`).
+    Task 5 (#446): `con` is now mandatory positional first arg. The helper
+    is pure Cat. 1 SQL — get → compute → upsert all run inline on the
+    caller's connection. Atomicity is the caller's responsibility (open
+    one `transaction()` around the close + capital roll-in).
     """
-    with _tx_or_use(con) as inner_con:
-        row = db_get_capital(tenant_id, con=inner_con)
-        if row is None:
-            prior_balance = INITIAL_CAPITAL_DEFAULT
-            prior_peak = INITIAL_CAPITAL_DEFAULT
-        else:
-            prior_balance = float(row["balance"])
-            prior_peak = float(row["peak_balance"])
+    row = db_get_capital(con, tenant_id)
+    if row is None:
+        prior_balance = INITIAL_CAPITAL_DEFAULT
+        prior_peak = INITIAL_CAPITAL_DEFAULT
+    else:
+        prior_balance = float(row["balance"])
+        prior_peak = float(row["peak_balance"])
 
-        new_balance = prior_balance + float(pnl_usd)
-        new_peak = max(prior_peak, new_balance)  # monotonic — never decreases
-        if new_peak > 0:
-            new_dd_pct = (new_peak - new_balance) / new_peak * 100.0
-        else:
-            new_dd_pct = None  # peak ≤ 0 leaves drawdown undefined
+    new_balance = prior_balance + float(pnl_usd)
+    new_peak = max(prior_peak, new_balance)  # monotonic — never decreases
+    if new_peak > 0:
+        new_dd_pct = (new_peak - new_balance) / new_peak * 100.0
+    else:
+        new_dd_pct = None  # peak ≤ 0 leaves drawdown undefined
 
-        return db_upsert_capital(
-            tenant_id,
-            balance=new_balance,
-            peak_balance=new_peak,
-            max_drawdown_pct=new_dd_pct,
-            con=inner_con,
-        )
+    return db_upsert_capital(
+        con,
+        tenant_id,
+        balance=new_balance,
+        peak_balance=new_peak,
+        max_drawdown_pct=new_dd_pct,
+    )
 
 
 def db_upsert_capital(
+    con: sqlite3.Connection,
     tenant_id: int,
     *,
     balance: float,
     peak_balance: Optional[float] = None,
     max_drawdown_pct: Optional[float] = None,
-    con: Optional[sqlite3.Connection] = None,
 ) -> dict:
     """Insert or replace capital row for tenant.
 
@@ -122,38 +114,37 @@ def db_upsert_capital(
 
     Returns the resulting row.
 
-    Per Task 8.5: optional `con` for caller-controlled transaction composition.
+    Task 5 (#446): `con` is now mandatory positional first arg.
     """
     now = datetime.now(timezone.utc).isoformat()
-    with _tx_or_use(con) as con:
-        existing = con.execute(
-            "SELECT id, peak_balance, max_drawdown_pct FROM capital WHERE tenant_id = ?",
-            (tenant_id,),
-        ).fetchone()
+    existing = con.execute(
+        "SELECT id, peak_balance, max_drawdown_pct FROM capital WHERE tenant_id = ?",
+        (tenant_id,),
+    ).fetchone()
 
-        if existing is None:
-            effective_peak = peak_balance if peak_balance is not None else balance
-            effective_dd = max_drawdown_pct
-            con.execute(
-                """INSERT INTO capital (tenant_id, balance, peak_balance,
-                                        max_drawdown_pct, updated_at)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (tenant_id, balance, effective_peak, effective_dd, now),
-            )
-        else:
-            effective_peak = peak_balance if peak_balance is not None else existing["peak_balance"]
-            effective_dd = (
-                max_drawdown_pct if max_drawdown_pct is not None
-                else existing["max_drawdown_pct"]
-            )
-            con.execute(
-                """UPDATE capital
-                   SET balance = ?, peak_balance = ?, max_drawdown_pct = ?,
-                       updated_at = ?
-                   WHERE tenant_id = ?""",
-                (balance, effective_peak, effective_dd, now, tenant_id),
-            )
-        row = con.execute(
-            "SELECT * FROM capital WHERE tenant_id = ?", (tenant_id,),
-        ).fetchone()
+    if existing is None:
+        effective_peak = peak_balance if peak_balance is not None else balance
+        effective_dd = max_drawdown_pct
+        con.execute(
+            """INSERT INTO capital (tenant_id, balance, peak_balance,
+                                    max_drawdown_pct, updated_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (tenant_id, balance, effective_peak, effective_dd, now),
+        )
+    else:
+        effective_peak = peak_balance if peak_balance is not None else existing["peak_balance"]
+        effective_dd = (
+            max_drawdown_pct if max_drawdown_pct is not None
+            else existing["max_drawdown_pct"]
+        )
+        con.execute(
+            """UPDATE capital
+               SET balance = ?, peak_balance = ?, max_drawdown_pct = ?,
+                   updated_at = ?
+               WHERE tenant_id = ?""",
+            (balance, effective_peak, effective_dd, now, tenant_id),
+        )
+    row = con.execute(
+        "SELECT * FROM capital WHERE tenant_id = ?", (tenant_id,),
+    ).fetchone()
     return dict(row)

--- a/db/positions.py
+++ b/db/positions.py
@@ -166,66 +166,6 @@ def db_get_positions(
     return [dict(r) for r in rows]
 
 
-def db_close_position(
-    pos_id: int,
-    exit_price: float,
-    exit_reason: str,
-    tenant_id: Optional[int] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> Optional[dict]:
-    """Close position by id. Per B.5: ownership-enforced when tenant_id given.
-
-    If tenant_id is provided and the position does NOT belong to that tenant,
-    returns None (IDOR protection — caller sees same behavior as 'not found').
-
-    Per Task 8.5: optional `con` lets a caller (e.g. `check_position_stops`)
-    fold the close + capital + outcomes mutations into one outer transaction
-    instead of three separate atomic boundaries.
-    """
-    _caller_owned_con = con  # remember whether caller threaded a tx in
-    with _tx_or_use(con) as con:
-        if tenant_id is None:
-            row = con.execute(
-                "SELECT * FROM positions WHERE id=?", (pos_id,),
-            ).fetchone()
-        else:
-            row = con.execute(
-                "SELECT * FROM positions WHERE id=? AND tenant_id=?",
-                (pos_id, tenant_id),
-            ).fetchone()
-        if not row:
-            return None
-        pos = dict(row)
-        qty = pos.get("qty") or 0
-        pnl_usd, pnl_pct = _calc_pnl(pos["direction"], pos["entry_price"], exit_price, qty)
-        exit_ts = datetime.now(timezone.utc).isoformat()
-        con.execute("""
-            UPDATE positions
-            SET status=?, exit_price=?, exit_ts=?, exit_reason=?, pnl_usd=?, pnl_pct=?
-            WHERE id=?
-        """, ("closed", exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, pos_id))
-        row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
-    closed = dict(row)
-    # Kill switch #138: trigger health evaluation for this symbol.
-    #
-    # Task 8.5: when the caller passes its own `con`, it owns an outer
-    # transaction that hasn't committed yet. `trigger_health_evaluation`
-    # opens a FRESH connection and would BEGIN IMMEDIATE against the
-    # writer lock the outer tx still holds → deadlock. The caller is
-    # responsible for triggering health evaluation post-commit in that
-    # case. When called standalone (con is None), our own tx has already
-    # committed by the time we reach here, so the trigger is safe.
-    if _caller_owned_con is None:
-        try:
-            from health import trigger_health_evaluation  # noqa: PLC0415
-            from api.config import load_config  # noqa: PLC0415
-            trigger_health_evaluation(pos["symbol"], load_config())
-        except Exception as e:
-            log.warning("health trigger skipped for position close: %s", e)
-    return closed
-
-
 def db_get_position_by_id(
     con: sqlite3.Connection, pos_id: int,
 ) -> Optional[dict]:

--- a/db/positions.py
+++ b/db/positions.py
@@ -226,6 +226,52 @@ def db_close_position(
     return closed
 
 
+def db_get_position_by_id(
+    con: sqlite3.Connection, pos_id: int,
+) -> Optional[dict]:
+    """Read a single position by id. Pure SQL — no tenant filter.
+
+    Caller is responsible for tenant ownership check (per Task 8.5 design
+    where helpers are pure SQL operators; ownership lives in the business
+    operator).
+    """
+    row = con.execute(
+        "SELECT * FROM positions WHERE id = ?", (pos_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def db_close_position_sql(
+    con: sqlite3.Connection,
+    pos_id: int,
+    exit_price: float,
+    exit_reason: str,
+    exit_ts: str,
+    pnl_usd: float,
+    pnl_pct: float,
+) -> dict:
+    """Pure SQL: UPDATE the position to closed. Returns the updated row.
+
+    No health trigger, no notify, no logging beyond ERROR. Caller (operator)
+    owns lifecycle, transaction, and side-effects.
+    """
+    con.execute(
+        """UPDATE positions
+           SET status = 'closed',
+               exit_price = ?,
+               exit_ts = ?,
+               exit_reason = ?,
+               pnl_usd = ?,
+               pnl_pct = ?
+           WHERE id = ?""",
+        (exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, pos_id),
+    )
+    row = con.execute(
+        "SELECT * FROM positions WHERE id = ?", (pos_id,),
+    ).fetchone()
+    return dict(row)
+
+
 def db_update_position(
     pos_id: int,
     data: dict,

--- a/db/positions.py
+++ b/db/positions.py
@@ -24,8 +24,6 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Optional
 
-from db.transaction import _tx_or_use
-
 log = logging.getLogger("db.positions")
 
 
@@ -40,55 +38,51 @@ def _calc_pnl(direction: str, entry: float, exit_p: float, qty: float):
 
 
 def db_create_position(
+    con: sqlite3.Connection,
     data: dict,
     tenant_id: Optional[int] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> dict:
     """Create position. If tenant_id provided, persisted on the row.
 
     Per B.5: API callers always pass tenant_id from JWT; internal/legacy
     callers may pass None (row inserted with tenant_id NULL).
 
-    Per Task 8.5: optional `con` lets a caller fold this write into an
-    outer transaction (cross-helper atomicity).
+    Task 8 (#446): `con` is now mandatory positional first arg.
     """
     entry = float(data["entry_price"])
     qty   = float(data.get("qty") or (float(data.get("size_usd", 0) or 0) / entry if entry else 0))
     ts    = data.get("entry_ts") or datetime.now(timezone.utc).isoformat()
-    with _tx_or_use(con) as con:
-        cur = con.execute("""
-            INSERT INTO positions
-                (scan_id, symbol, direction, status, entry_price, entry_ts,
-                 sl_price, tp_price, size_usd, qty, atr_entry, be_mult, notes,
-                 tenant_id)
-            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-        """, (
-            data.get("scan_id"),
-            data["symbol"].upper(),
-            data.get("direction", "LONG").upper(),
-            "open",
-            entry,
-            ts,
-            data.get("sl_price"),
-            data.get("tp_price"),
-            data.get("size_usd"),
-            qty,
-            data.get("atr_entry"),
-            data.get("be_mult"),
-            data.get("notes", ""),
-            tenant_id,  # NULL if not provided — legacy behavior
-        ))
-        pos_id = cur.lastrowid
-        row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
+    cur = con.execute("""
+        INSERT INTO positions
+            (scan_id, symbol, direction, status, entry_price, entry_ts,
+             sl_price, tp_price, size_usd, qty, atr_entry, be_mult, notes,
+             tenant_id)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+    """, (
+        data.get("scan_id"),
+        data["symbol"].upper(),
+        data.get("direction", "LONG").upper(),
+        "open",
+        entry,
+        ts,
+        data.get("sl_price"),
+        data.get("tp_price"),
+        data.get("size_usd"),
+        qty,
+        data.get("atr_entry"),
+        data.get("be_mult"),
+        data.get("notes", ""),
+        tenant_id,  # NULL if not provided — legacy behavior
+    ))
+    pos_id = cur.lastrowid
+    row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
     return dict(row)
 
 
 def db_last_exit_ts(
+    con: sqlite3.Connection,
     symbol: str,
     tenant_id: Optional[int] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> Optional[datetime]:
     """Return last exit_ts (UTC, tz-aware) for symbol's closed positions, or None.
 
@@ -96,24 +90,23 @@ def db_last_exit_ts(
     across ALL users — correct semantic for scanner cooldown (system-wide).
     When tenant_id is int, filters to that user's exits only.
 
-    Per Task 8.5: optional `con` for caller-controlled transaction composition.
+    Task 8 (#446): `con` is now mandatory positional first arg.
     """
-    with _tx_or_use(con) as con:
-        if tenant_id is None:
-            row = con.execute(
-                "SELECT exit_ts FROM positions "
-                "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
-                "ORDER BY exit_ts DESC LIMIT 1",
-                (symbol.upper(),),
-            ).fetchone()
-        else:
-            row = con.execute(
-                "SELECT exit_ts FROM positions "
-                "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
-                "AND tenant_id=? "
-                "ORDER BY exit_ts DESC LIMIT 1",
-                (symbol.upper(), tenant_id),
-            ).fetchone()
+    if tenant_id is None:
+        row = con.execute(
+            "SELECT exit_ts FROM positions "
+            "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
+            "ORDER BY exit_ts DESC LIMIT 1",
+            (symbol.upper(),),
+        ).fetchone()
+    else:
+        row = con.execute(
+            "SELECT exit_ts FROM positions "
+            "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
+            "AND tenant_id=? "
+            "ORDER BY exit_ts DESC LIMIT 1",
+            (symbol.upper(), tenant_id),
+        ).fetchone()
     if not row or not row[0]:
         return None
     try:
@@ -126,11 +119,10 @@ def db_last_exit_ts(
 
 
 def db_get_positions(
+    con: sqlite3.Connection,
     status: Optional[str] = None,
     tenant_id: Optional[int] = None,
     since: Optional[str] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> list:
     """List positions, optionally filtered by status, tenant_id, and since.
 
@@ -142,6 +134,8 @@ def db_get_positions(
     historial) or `entry_ts >= since` otherwise. Pushed into SQL so the
     caller doesn't load the full history into Python just to discard it
     (PR #403 review issue 3).
+
+    Task 8 (#446): `con` is now mandatory positional first arg.
     """
     clauses: list[str] = []
     params: list = []
@@ -159,10 +153,9 @@ def db_get_positions(
         clauses.append(f"{ts_col} >= ?")
         params.append(since)
     where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-    with _tx_or_use(con) as con:
-        rows = con.execute(
-            f"SELECT * FROM positions{where} ORDER BY id DESC", params,
-        ).fetchall()
+    rows = con.execute(
+        f"SELECT * FROM positions{where} ORDER BY id DESC", params,
+    ).fetchall()
     return [dict(r) for r in rows]
 
 
@@ -213,34 +206,32 @@ def db_close_position_sql(
 
 
 def db_update_position(
+    con: sqlite3.Connection,
     pos_id: int,
     data: dict,
     tenant_id: Optional[int] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> Optional[dict]:
     """Update position fields. Per B.5: ownership-enforced when tenant_id given.
 
     Returns None if position not found OR (when tenant_id provided) the
     position does not belong to that tenant.
 
-    Per Task 8.5: optional `con` for caller-controlled transaction composition.
+    Task 8 (#446): `con` is now mandatory positional first arg.
     """
     allowed = {"sl_price", "tp_price", "size_usd", "qty", "notes", "entry_price", "atr_entry", "be_mult"}
     updates = {k: v for k, v in data.items() if k in allowed}
     if not updates:
         return None
-    with _tx_or_use(con) as con:
-        # Ownership pre-check when tenant_id provided
-        if tenant_id is not None:
-            owner_row = con.execute(
-                "SELECT id FROM positions WHERE id=? AND tenant_id=?",
-                (pos_id, tenant_id),
-            ).fetchone()
-            if not owner_row:
-                return None
-        sets = ", ".join(f"{k}=?" for k in updates)
-        vals = list(updates.values()) + [pos_id]
-        con.execute(f"UPDATE positions SET {sets} WHERE id=?", vals)
-        row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
+    # Ownership pre-check when tenant_id provided
+    if tenant_id is not None:
+        owner_row = con.execute(
+            "SELECT id FROM positions WHERE id=? AND tenant_id=?",
+            (pos_id, tenant_id),
+        ).fetchone()
+        if not owner_row:
+            return None
+    sets = ", ".join(f"{k}=?" for k in updates)
+    vals = list(updates.values()) + [pos_id]
+    con.execute(f"UPDATE positions SET {sets} WHERE id=?", vals)
+    row = con.execute("SELECT * FROM positions WHERE id=?", (pos_id,)).fetchone()
     return dict(row) if row else None

--- a/db/schema.py
+++ b/db/schema.py
@@ -32,10 +32,8 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from typing import Optional
-
 from db.connection import _open_configured_connection, _resolve_db_file
-from db.transaction import transaction, _tx_or_use
+from db.transaction import transaction
 
 log = logging.getLogger("db.schema")
 
@@ -298,13 +296,15 @@ def init_db() -> None:
     # Multi-tenant B.1 migration (Epic B #253, issue #254) — 2026-05-15.
     # Adds nullable tenant_id to per-user tables + new capital + user_preferences.
     # Pre-reg: docs/superpowers/plans/2026-05-15-multi-tenant-b1-schema-pre-reg.md
-    _migrate_multi_tenant_b1()
+    with transaction() as con_b1:
+        _migrate_multi_tenant_b1(con_b1)
 
     # Agent (copilot) audit + budget tables — epic #400 Phase 1.
     # Pre-reg §9 / §10.1: every turn is audited, every side-effect carries
     # an idempotency key, every tenant has a daily/monthly USD budget that
     # resets computed-on-read (no cron).
-    _migrate_agent_audit()
+    with transaction() as con_audit:
+        _migrate_agent_audit(con_audit)
 
     # Agent (copilot) per-tenant conversation history — epic #428 H.1.
     # Persists raw user/assistant text + reasoning + tool chips + proposals
@@ -312,7 +312,8 @@ def init_db() -> None:
     # (which stays as audit ledger) so the retention policies are
     # independent. Pre-reg D.1 in
     # docs/superpowers/specs/es/2026-05-22-conversation-history-pre-reg.md.
-    _migrate_agent_history()
+    with transaction() as con_hist:
+        _migrate_agent_history(con_hist)
 
 
 # Per-user tables that need a tenant_id column (Epic B B.1).
@@ -326,236 +327,229 @@ PER_USER_TABLES: tuple[str, ...] = (
 )
 
 
-def _migrate_multi_tenant_b1(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> None:
+def _migrate_multi_tenant_b1(con: sqlite3.Connection) -> None:
     """Idempotent multi-tenant B.1 migration: add tenant_id to per-user tables
     + new capital + user_preferences tables + indexes.
 
     Pre-reg §3.1-§3.2: ALTER TABLE in try/except (column-exists handling); new
     tables via CREATE TABLE IF NOT EXISTS; new indexes via CREATE INDEX IF NOT
     EXISTS. Safe to call repeatedly.
+
+    Task 8 (#446): `con` is now mandatory positional.
     """
-    with _tx_or_use(con) as con:
-        # Step 1: Add nullable tenant_id to each per-user table
-        for table in PER_USER_TABLES:
-            try:
-                con.execute(f"ALTER TABLE {table} ADD COLUMN tenant_id INTEGER")
-                log.info(f"DB migration B.1: added tenant_id column to {table}")
-            except sqlite3.OperationalError:
-                pass  # column already exists
+    # Step 1: Add nullable tenant_id to each per-user table
+    for table in PER_USER_TABLES:
+        try:
+            con.execute(f"ALTER TABLE {table} ADD COLUMN tenant_id INTEGER")
+            log.info(f"DB migration B.1: added tenant_id column to {table}")
+        except sqlite3.OperationalError:
+            pass  # column already exists
 
-        # Step 2: Create capital table (single row per user)
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS capital (
-                id                INTEGER PRIMARY KEY AUTOINCREMENT,
-                tenant_id         INTEGER NOT NULL,
-                balance           REAL NOT NULL,
-                peak_balance      REAL NOT NULL,
-                max_drawdown_pct  REAL,
-                updated_at        TEXT NOT NULL
-            )
-            """
+    # Step 2: Create capital table (single row per user)
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS capital (
+            id                INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id         INTEGER NOT NULL,
+            balance           REAL NOT NULL,
+            peak_balance      REAL NOT NULL,
+            max_drawdown_pct  REAL,
+            updated_at        TEXT NOT NULL
         )
-        con.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_capital_tenant "
-            "ON capital(tenant_id)"
-        )
+        """
+    )
+    con.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_capital_tenant "
+        "ON capital(tenant_id)"
+    )
 
-        # Step 3: Create user_preferences table (single row per user)
-        con.execute(
-            """
-            CREATE TABLE IF NOT EXISTS user_preferences (
-                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
-                tenant_id            INTEGER NOT NULL,
-                symbol_filter_json   TEXT,
-                min_score            INTEGER DEFAULT 4,
-                notify_channels_json TEXT,
-                updated_at           TEXT NOT NULL
-            )
-            """
+    # Step 3: Create user_preferences table (single row per user)
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_preferences (
+            id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id            INTEGER NOT NULL,
+            symbol_filter_json   TEXT,
+            min_score            INTEGER DEFAULT 4,
+            notify_channels_json TEXT,
+            updated_at           TEXT NOT NULL
         )
-        con.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS idx_user_prefs_tenant "
-            "ON user_preferences(tenant_id)"
-        )
+        """
+    )
+    con.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_user_prefs_tenant "
+        "ON user_preferences(tenant_id)"
+    )
 
-        # Step 4: Tenant-scoped indexes on per-user tables
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_positions_tenant "
-            "ON positions(tenant_id)"
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_signal_outcomes_tenant "
-            "ON signal_outcomes(tenant_id)"
-        )
-        # New tenant-aware unread index (does NOT drop the existing global one;
-        # both can coexist — SQLite picks the more selective for each query)
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_notif_tenant_unread "
-            "ON notifications_sent(tenant_id, sent_at DESC) WHERE read_at IS NULL"
-        )
-        con.execute(
-            "CREATE INDEX IF NOT EXISTS idx_portfolio_events_tenant_ts "
-            "ON portfolio_health_events(tenant_id, ts DESC)"
-        )
+    # Step 4: Tenant-scoped indexes on per-user tables
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_positions_tenant "
+        "ON positions(tenant_id)"
+    )
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_signal_outcomes_tenant "
+        "ON signal_outcomes(tenant_id)"
+    )
+    # New tenant-aware unread index (does NOT drop the existing global one;
+    # both can coexist — SQLite picks the more selective for each query)
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notif_tenant_unread "
+        "ON notifications_sent(tenant_id, sent_at DESC) WHERE read_at IS NULL"
+    )
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_portfolio_events_tenant_ts "
+        "ON portfolio_health_events(tenant_id, ts DESC)"
+    )
 
 
-def _migrate_agent_audit(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> None:
+def _migrate_agent_audit(con: sqlite3.Connection) -> None:
     """Idempotent Phase 1 migration for the copilot audit + budget surface.
 
     Creates three tables and their indexes. Safe to call repeatedly:
     CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
 
     Schema source: docs/superpowers/specs/es/2026-05-19-trading-copilot-production-grade-pre-reg.md §9.1.
+
+    Task 8 (#446): `con` is now mandatory positional.
     """
     try:
-        with _tx_or_use(con) as con:
-            # agent_conversations: every turn (user / assistant / tool_result)
-            # written by the server-side loop. content_json is the redacted
-            # payload — full tool_use input/output is NOT persisted here; the
-            # tool side-effect surface lives in agent_side_effects below.
-            con.execute(
-                """
-                CREATE TABLE IF NOT EXISTS agent_conversations (
-                    id                          INTEGER PRIMARY KEY AUTOINCREMENT,
-                    tenant_id                   INTEGER NOT NULL,
-                    surface                     TEXT    NOT NULL,
-                    conversation_id             TEXT    NOT NULL,
-                    ts                          TEXT    NOT NULL,
-                    role                        TEXT,
-                    model                       TEXT,
-                    input_tokens                INTEGER,
-                    output_tokens               INTEGER,
-                    cache_read_input_tokens     INTEGER,
-                    cache_creation_input_tokens INTEGER,
-                    latency_ms                  INTEGER,
-                    cost_usd                    REAL,
-                    content_json                TEXT,
-                    refused                     INTEGER NOT NULL DEFAULT 0
-                )
-                """
+        # agent_conversations: every turn (user / assistant / tool_result)
+        # written by the server-side loop. content_json is the redacted
+        # payload — full tool_use input/output is NOT persisted here; the
+        # tool side-effect surface lives in agent_side_effects below.
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_conversations (
+                id                          INTEGER PRIMARY KEY AUTOINCREMENT,
+                tenant_id                   INTEGER NOT NULL,
+                surface                     TEXT    NOT NULL,
+                conversation_id             TEXT    NOT NULL,
+                ts                          TEXT    NOT NULL,
+                role                        TEXT,
+                model                       TEXT,
+                input_tokens                INTEGER,
+                output_tokens               INTEGER,
+                cache_read_input_tokens     INTEGER,
+                cache_creation_input_tokens INTEGER,
+                latency_ms                  INTEGER,
+                cost_usd                    REAL,
+                content_json                TEXT,
+                refused                     INTEGER NOT NULL DEFAULT 0
             )
-            con.execute(
-                "CREATE INDEX IF NOT EXISTS idx_agent_conv_tenant_ts "
-                "ON agent_conversations(tenant_id, ts DESC)"
-            )
-            con.execute(
-                "CREATE INDEX IF NOT EXISTS idx_agent_conv_conversation "
-                "ON agent_conversations(conversation_id, ts ASC)"
-            )
+            """
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_conv_tenant_ts "
+            "ON agent_conversations(tenant_id, ts DESC)"
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_conv_conversation "
+            "ON agent_conversations(conversation_id, ts ASC)"
+        )
 
-            # agent_side_effects: the propose/confirm ledger. idempotency_key
-            # is UNIQUE so a double-click confirm cannot execute twice. action
-            # is one of: close_position | reactivate_symbol | apply_tune.
-            # result: ok | error | conflict | expired.
+        # agent_side_effects: the propose/confirm ledger. idempotency_key
+        # is UNIQUE so a double-click confirm cannot execute twice. action
+        # is one of: close_position | reactivate_symbol | apply_tune.
+        # result: ok | error | conflict | expired.
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_side_effects (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                tenant_id       INTEGER NOT NULL,
+                conversation_id TEXT,
+                ts              TEXT    NOT NULL,
+                action          TEXT    NOT NULL,
+                args_json       TEXT,
+                idempotency_key TEXT    NOT NULL UNIQUE,
+                result          TEXT,
+                http_status     INTEGER
+            )
+            """
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_side_effects_tenant_ts "
+            "ON agent_side_effects(tenant_id, ts DESC)"
+        )
+
+        # agent_quotas: one row per tenant. daily_window_start and
+        # monthly_window_start drive the computed-on-read reset (pre-reg
+        # §9.1) — no cron needed. UNIQUE on tenant_id so upserts via
+        # ON CONFLICT(tenant_id) DO UPDATE work.
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_quotas (
+                tenant_id            INTEGER PRIMARY KEY,
+                daily_usd_used       REAL    NOT NULL DEFAULT 0,
+                daily_usd_cap        REAL    NOT NULL DEFAULT 1.0,
+                daily_window_start   TEXT    NOT NULL,
+                monthly_usd_used     REAL    NOT NULL DEFAULT 0,
+                monthly_window_start TEXT    NOT NULL
+            )
+            """
+        )
+
+        # Phase 3 (#400): agent_side_effects gains `expires_at` so the
+        # confirm endpoint can short-circuit expired proposals without
+        # re-deriving the TTL from the signed payload. Idempotent ADD
+        # COLUMN (the existing rows have NULL — they predate the column,
+        # and a NULL expires_at is treated as "no TTL enforcement" for
+        # rows seeded before this migration).
+        try:
+            con.execute("ALTER TABLE agent_side_effects ADD COLUMN expires_at TEXT")
+            log.info("DB migration: added expires_at column to agent_side_effects")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+
+        # Fase 4 of the multi-provider epic: agent_conversations gains
+        # `provider` + `reasoning_tokens` columns so /agent/metrics can
+        # report per-provider spend + R1 reasoning telemetry.
+        #   - provider: closed enum 'anthropic' | 'deepseek' | ... (the
+        #     vendor name from PROVIDER_NAME_BY_PREFIX). NULL for rows
+        #     pre-Fase-4 if backfill skipped them (it shouldn't — the
+        #     UPDATE below covers every known prefix).
+        #   - reasoning_tokens: only DS-reasoner populates this today
+        #     (DS's usage.completion_tokens_details.reasoning_tokens
+        #     field). NULL or 0 elsewhere; metrics treat NULL as 0.
+        # Both ALTERs are idempotent (try/except on OperationalError).
+        # The backfill is also idempotent because it only touches rows
+        # WHERE provider IS NULL — running it twice is a no-op.
+        try:
+            con.execute("ALTER TABLE agent_conversations ADD COLUMN provider TEXT")
+            log.info("DB migration: added provider column to agent_conversations")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        try:
+            con.execute("ALTER TABLE agent_conversations ADD COLUMN reasoning_tokens INTEGER")
+            log.info("DB migration: added reasoning_tokens column to agent_conversations")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+
+        # Backfill provider from model. Only touches rows where provider
+        # IS NULL (i.e. pre-Fase-4 rows) — safe to re-run. The mapping
+        # uses model-prefix matching that mirrors PROVIDER_NAME_BY_PREFIX
+        # in api/agent/providers/registry.py; if a future provider adds
+        # a new prefix, mirror it HERE too (single source of truth would
+        # be ideal but importing the registry from db.schema introduces
+        # a circular at startup).
+        try:
             con.execute(
-                """
-                CREATE TABLE IF NOT EXISTS agent_side_effects (
-                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                    tenant_id       INTEGER NOT NULL,
-                    conversation_id TEXT,
-                    ts              TEXT    NOT NULL,
-                    action          TEXT    NOT NULL,
-                    args_json       TEXT,
-                    idempotency_key TEXT    NOT NULL UNIQUE,
-                    result          TEXT,
-                    http_status     INTEGER
-                )
-                """
+                "UPDATE agent_conversations SET provider = 'anthropic' "
+                "WHERE provider IS NULL AND model LIKE 'claude-%'"
             )
             con.execute(
-                "CREATE INDEX IF NOT EXISTS idx_agent_side_effects_tenant_ts "
-                "ON agent_side_effects(tenant_id, ts DESC)"
+                "UPDATE agent_conversations SET provider = 'deepseek' "
+                "WHERE provider IS NULL AND model LIKE 'deepseek-%'"
             )
-
-            # agent_quotas: one row per tenant. daily_window_start and
-            # monthly_window_start drive the computed-on-read reset (pre-reg
-            # §9.1) — no cron needed. UNIQUE on tenant_id so upserts via
-            # ON CONFLICT(tenant_id) DO UPDATE work.
-            con.execute(
-                """
-                CREATE TABLE IF NOT EXISTS agent_quotas (
-                    tenant_id            INTEGER PRIMARY KEY,
-                    daily_usd_used       REAL    NOT NULL DEFAULT 0,
-                    daily_usd_cap        REAL    NOT NULL DEFAULT 1.0,
-                    daily_window_start   TEXT    NOT NULL,
-                    monthly_usd_used     REAL    NOT NULL DEFAULT 0,
-                    monthly_window_start TEXT    NOT NULL
-                )
-                """
-            )
-
-            # Phase 3 (#400): agent_side_effects gains `expires_at` so the
-            # confirm endpoint can short-circuit expired proposals without
-            # re-deriving the TTL from the signed payload. Idempotent ADD
-            # COLUMN (the existing rows have NULL — they predate the column,
-            # and a NULL expires_at is treated as "no TTL enforcement" for
-            # rows seeded before this migration).
-            try:
-                con.execute("ALTER TABLE agent_side_effects ADD COLUMN expires_at TEXT")
-                log.info("DB migration: added expires_at column to agent_side_effects")
-            except sqlite3.OperationalError:
-                pass  # column already exists
-
-            # Fase 4 of the multi-provider epic: agent_conversations gains
-            # `provider` + `reasoning_tokens` columns so /agent/metrics can
-            # report per-provider spend + R1 reasoning telemetry.
-            #   - provider: closed enum 'anthropic' | 'deepseek' | ... (the
-            #     vendor name from PROVIDER_NAME_BY_PREFIX). NULL for rows
-            #     pre-Fase-4 if backfill skipped them (it shouldn't — the
-            #     UPDATE below covers every known prefix).
-            #   - reasoning_tokens: only DS-reasoner populates this today
-            #     (DS's usage.completion_tokens_details.reasoning_tokens
-            #     field). NULL or 0 elsewhere; metrics treat NULL as 0.
-            # Both ALTERs are idempotent (try/except on OperationalError).
-            # The backfill is also idempotent because it only touches rows
-            # WHERE provider IS NULL — running it twice is a no-op.
-            try:
-                con.execute("ALTER TABLE agent_conversations ADD COLUMN provider TEXT")
-                log.info("DB migration: added provider column to agent_conversations")
-            except sqlite3.OperationalError:
-                pass  # column already exists
-            try:
-                con.execute("ALTER TABLE agent_conversations ADD COLUMN reasoning_tokens INTEGER")
-                log.info("DB migration: added reasoning_tokens column to agent_conversations")
-            except sqlite3.OperationalError:
-                pass  # column already exists
-
-            # Backfill provider from model. Only touches rows where provider
-            # IS NULL (i.e. pre-Fase-4 rows) — safe to re-run. The mapping
-            # uses model-prefix matching that mirrors PROVIDER_NAME_BY_PREFIX
-            # in api/agent/providers/registry.py; if a future provider adds
-            # a new prefix, mirror it HERE too (single source of truth would
-            # be ideal but importing the registry from db.schema introduces
-            # a circular at startup).
-            try:
-                con.execute(
-                    "UPDATE agent_conversations SET provider = 'anthropic' "
-                    "WHERE provider IS NULL AND model LIKE 'claude-%'"
-                )
-                con.execute(
-                    "UPDATE agent_conversations SET provider = 'deepseek' "
-                    "WHERE provider IS NULL AND model LIKE 'deepseek-%'"
-                )
-                log.info("DB migration: backfilled provider column from model prefix")
-            except sqlite3.OperationalError as e:
-                log.warning("DB migration: provider backfill failed: %s", e)
+            log.info("DB migration: backfilled provider column from model prefix")
+        except sqlite3.OperationalError as e:
+            log.warning("DB migration: provider backfill failed: %s", e)
 
         log.info("DB migration: agent_conversations + agent_side_effects + agent_quotas ready")
     except Exception as e:  # noqa: BLE001
         log.warning("DB migration agent audit: %s", e)
 
 
-def _migrate_agent_history(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> None:
+def _migrate_agent_history(con: sqlite3.Connection) -> None:
     """Idempotent H.1 migration for the per-tenant conversation history.
 
     Creates two tables and their indexes. Safe to call repeatedly:
@@ -575,71 +569,72 @@ def _migrate_agent_history(
     NOT touched by this migration: agent_conversations (audit ledger),
     agent_side_effects (proposals execution log), agent_quotas (cost
     budget). Those keep their own lifecycle and retention.
+
+    Task 8 (#446): `con` is now mandatory positional.
     """
     try:
-        with _tx_or_use(con) as con:
-            con.execute(
-                """
-                CREATE TABLE IF NOT EXISTS agent_messages (
-                    id              INTEGER PRIMARY KEY AUTOINCREMENT,
-                    tenant_id       INTEGER NOT NULL,
-                    conversation_id TEXT    NOT NULL,
-                    ts              TEXT    NOT NULL,
-                    role            TEXT    NOT NULL,
-                    content         TEXT    NOT NULL,
-                    reasoning       TEXT,
-                    tool_chips_json TEXT,
-                    proposals_json  TEXT,
-                    expires_at      TEXT    NOT NULL
-                )
-                """
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_messages (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                tenant_id       INTEGER NOT NULL,
+                conversation_id TEXT    NOT NULL,
+                ts              TEXT    NOT NULL,
+                role            TEXT    NOT NULL,
+                content         TEXT    NOT NULL,
+                reasoning       TEXT,
+                tool_chips_json TEXT,
+                proposals_json  TEXT,
+                expires_at      TEXT    NOT NULL
             )
-            con.execute(
-                "CREATE INDEX IF NOT EXISTS idx_agent_messages_tenant_conv_ts "
-                "ON agent_messages(tenant_id, conversation_id, ts ASC)"
-            )
-            con.execute(
-                "CREATE INDEX IF NOT EXISTS idx_agent_messages_tenant_ts "
-                "ON agent_messages(tenant_id, ts DESC)"
-            )
-            con.execute(
-                "CREATE INDEX IF NOT EXISTS idx_agent_messages_expires "
-                "ON agent_messages(expires_at)"
-            )
+            """
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_messages_tenant_conv_ts "
+            "ON agent_messages(tenant_id, conversation_id, ts ASC)"
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_messages_tenant_ts "
+            "ON agent_messages(tenant_id, ts DESC)"
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_messages_expires "
+            "ON agent_messages(expires_at)"
+        )
 
-            # conversation_id is the natural PK — UUID generated by the
-            # frontend (newConversationId() in frontend/src/agent/client.ts).
-            # The explicit NOT NULL is required: SQLite enforces NOT NULL
-            # implicitly only on `INTEGER PRIMARY KEY` (the rowid alias),
-            # not on TEXT PRIMARY KEY — without it, NULL would slip past
-            # the PK check and corrupt the index.
-            con.execute(
-                """
-                CREATE TABLE IF NOT EXISTS agent_conversation_meta (
-                    conversation_id TEXT    NOT NULL PRIMARY KEY,
-                    tenant_id       INTEGER NOT NULL,
-                    title           TEXT,
-                    surface         TEXT    NOT NULL,
-                    first_ts        TEXT    NOT NULL,
-                    last_ts         TEXT    NOT NULL,
-                    message_count   INTEGER NOT NULL DEFAULT 0,
-                    pinned          INTEGER NOT NULL DEFAULT 0,
-                    expires_at      TEXT    NOT NULL
-                )
-                """
+        # conversation_id is the natural PK — UUID generated by the
+        # frontend (newConversationId() in frontend/src/agent/client.ts).
+        # The explicit NOT NULL is required: SQLite enforces NOT NULL
+        # implicitly only on `INTEGER PRIMARY KEY` (the rowid alias),
+        # not on TEXT PRIMARY KEY — without it, NULL would slip past
+        # the PK check and corrupt the index.
+        con.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_conversation_meta (
+                conversation_id TEXT    NOT NULL PRIMARY KEY,
+                tenant_id       INTEGER NOT NULL,
+                title           TEXT,
+                surface         TEXT    NOT NULL,
+                first_ts        TEXT    NOT NULL,
+                last_ts         TEXT    NOT NULL,
+                message_count   INTEGER NOT NULL DEFAULT 0,
+                pinned          INTEGER NOT NULL DEFAULT 0,
+                expires_at      TEXT    NOT NULL
             )
-            con.execute(
-                "CREATE INDEX IF NOT EXISTS idx_agent_conv_meta_tenant_last "
-                "ON agent_conversation_meta(tenant_id, last_ts DESC)"
-            )
-            # Pinned conversations float to the top of the sidebar; the
-            # secondary key on last_ts DESC keeps non-pinned ordered by
-            # recency within their bucket. Index ordering matters: SQLite
-            # uses leading columns for filtering and trailing for ordering.
-            con.execute(
-                "CREATE INDEX IF NOT EXISTS idx_agent_conv_meta_tenant_pinned "
-                "ON agent_conversation_meta(tenant_id, pinned DESC, last_ts DESC)"
-            )
+            """
+        )
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_conv_meta_tenant_last "
+            "ON agent_conversation_meta(tenant_id, last_ts DESC)"
+        )
+        # Pinned conversations float to the top of the sidebar; the
+        # secondary key on last_ts DESC keeps non-pinned ordered by
+        # recency within their bucket. Index ordering matters: SQLite
+        # uses leading columns for filtering and trailing for ordering.
+        con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_agent_conv_meta_tenant_pinned "
+            "ON agent_conversation_meta(tenant_id, pinned DESC, last_ts DESC)"
+        )
 
         log.info("DB migration: agent_messages + agent_conversation_meta ready")
     except Exception as e:  # noqa: BLE001
@@ -647,9 +642,8 @@ def _migrate_agent_history(
 
 
 def backfill_tenant(
+    con: sqlite3.Connection,
     user_id: int,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> dict[str, int]:
     """Set `tenant_id = user_id` for all rows where tenant_id IS NULL.
 
@@ -659,22 +653,26 @@ def backfill_tenant(
     NOT called from init_db(). Caller (B.8 migration script or test setup)
     invokes explicitly. Typical usage:
 
+      from db.transaction import transaction
       from db.schema import backfill_tenant
-      counts = backfill_tenant(samuel_user_id)
+      with transaction() as con:
+          counts = backfill_tenant(con, samuel_user_id)
       log.info(f"Backfill complete: {counts}")
 
+    Task 8 (#446): `con` is now mandatory positional first arg.
+
     Args:
+        con: open sqlite3 Connection from a surrounding transaction.
         user_id: target user ID to receive ownership of pre-multi-tenant rows.
 
     Returns:
         Dict mapping table name to count of rows updated.
     """
     affected: dict[str, int] = {}
-    with _tx_or_use(con) as con:
-        for table in PER_USER_TABLES:
-            cursor = con.execute(
-                f"UPDATE {table} SET tenant_id = ? WHERE tenant_id IS NULL",
-                (user_id,),
-            )
-            affected[table] = cursor.rowcount
+    for table in PER_USER_TABLES:
+        cursor = con.execute(
+            f"UPDATE {table} SET tenant_id = ? WHERE tenant_id IS NULL",
+            (user_id,),
+        )
+        affected[table] = cursor.rowcount
     return affected

--- a/db/signals.py
+++ b/db/signals.py
@@ -10,7 +10,7 @@ import sqlite3
 from datetime import datetime, timezone, timedelta
 from typing import Optional
 
-from db.transaction import transaction, _tx_or_use
+from db.transaction import transaction
 
 log = logging.getLogger("db.signals")
 
@@ -62,11 +62,15 @@ def save_scan(rep: dict) -> int:
     return scan_id
 
 
-def get_scans(limit=50, only_signals=False, only_setups=False,
-              since_hours: Optional[float] = None,
-              symbol: Optional[str] = None,
-              *,
-              con: Optional[sqlite3.Connection] = None) -> list:
+def get_scans(
+    con: sqlite3.Connection,
+    limit=50,
+    only_signals=False,
+    only_setups=False,
+    since_hours: Optional[float] = None,
+    symbol: Optional[str] = None,
+) -> list:
+    """Task 8 (#446): `con` is now mandatory positional first arg."""
     conds  = []
     params = []
     if symbol:
@@ -82,19 +86,17 @@ def get_scans(limit=50, only_signals=False, only_setups=False,
         params.append(cutoff)
     where = ("WHERE " + " AND ".join(conds)) if conds else ""
     params.append(limit)
-    with _tx_or_use(con) as con:
-        rows  = con.execute(
-            f"SELECT * FROM scans {where} ORDER BY id DESC LIMIT ?", params
-        ).fetchall()
+    rows  = con.execute(
+        f"SELECT * FROM scans {where} ORDER BY id DESC LIMIT ?", params
+    ).fetchall()
     return [dict(r) for r in rows]
 
 
 def get_latest_scan_per_symbol(
+    con: sqlite3.Connection,
     limit: int = 10,
     only_signals: bool = False,
     since_hours: Optional[float] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> list:
     """Return the latest scan per symbol, newest-first, capped at `limit`.
 
@@ -111,6 +113,8 @@ def get_latest_scan_per_symbol(
     is INSERT-only with monotonically increasing ids = newest), then
     project rows by that id set and order by ts DESC. Identical
     filtering semantics to `get_scans()`.
+
+    Task 8 (#446): `con` is now mandatory positional first arg.
     """
     conds: list[str] = []
     params: list = []
@@ -122,65 +126,61 @@ def get_latest_scan_per_symbol(
         params.append(cutoff)
     where = ("WHERE " + " AND ".join(conds)) if conds else ""
     params.append(limit)
-    with _tx_or_use(con) as con:
-        rows = con.execute(
-            f"""SELECT * FROM scans
-                WHERE id IN (
-                    SELECT MAX(id) FROM scans {where}
-                    GROUP BY symbol
-                )
-                ORDER BY ts DESC
-                LIMIT ?""",
-            params,
-        ).fetchall()
+    rows = con.execute(
+        f"""SELECT * FROM scans
+            WHERE id IN (
+                SELECT MAX(id) FROM scans {where}
+                GROUP BY symbol
+            )
+            ORDER BY ts DESC
+            LIMIT ?""",
+        params,
+    ).fetchall()
     return [dict(r) for r in rows]
 
 
 def get_latest_signal(
+    con: sqlite3.Connection,
     symbol: Optional[str] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> Optional[dict]:
-    with _tx_or_use(con) as con:
-        if symbol:
-            row = con.execute(
-                "SELECT * FROM scans WHERE señal=1 AND symbol=? ORDER BY id DESC LIMIT 1",
-                (symbol.upper(),)
-            ).fetchone()
-        else:
-            row = con.execute(
-                "SELECT * FROM scans WHERE señal=1 ORDER BY id DESC LIMIT 1"
-            ).fetchone()
+    """Task 8 (#446): `con` is now mandatory positional first arg."""
+    if symbol:
+        row = con.execute(
+            "SELECT * FROM scans WHERE señal=1 AND symbol=? ORDER BY id DESC LIMIT 1",
+            (symbol.upper(),)
+        ).fetchone()
+    else:
+        row = con.execute(
+            "SELECT * FROM scans WHERE señal=1 ORDER BY id DESC LIMIT 1"
+        ).fetchone()
     return dict(row) if row else None
 
 
 def get_latest_scan(
+    con: sqlite3.Connection,
     symbol: Optional[str] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> Optional[dict]:
-    with _tx_or_use(con) as con:
-        if symbol:
-            row = con.execute(
-                "SELECT * FROM scans WHERE symbol=? ORDER BY id DESC LIMIT 1",
-                (symbol.upper(),)
-            ).fetchone()
-        else:
-            row = con.execute("SELECT * FROM scans ORDER BY id DESC LIMIT 1").fetchone()
+    """Task 8 (#446): `con` is now mandatory positional first arg."""
+    if symbol:
+        row = con.execute(
+            "SELECT * FROM scans WHERE symbol=? ORDER BY id DESC LIMIT 1",
+            (symbol.upper(),)
+        ).fetchone()
+    else:
+        row = con.execute("SELECT * FROM scans ORDER BY id DESC LIMIT 1").fetchone()
     return dict(row) if row else None
 
 
-def get_signals_summary(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> list:
-    """Último escaneo de cada símbolo activo, ordenado por señal y score."""
-    with _tx_or_use(con) as con:
-        rows = con.execute("""
-            SELECT s.* FROM scans s
-            INNER JOIN (
-                SELECT symbol, MAX(id) as max_id FROM scans GROUP BY symbol
-            ) latest ON s.id = latest.max_id
-            ORDER BY s.señal DESC, s.score DESC
-        """).fetchall()
+def get_signals_summary(con: sqlite3.Connection) -> list:
+    """Último escaneo de cada símbolo activo, ordenado por señal y score.
+
+    Task 8 (#446): `con` is now mandatory positional.
+    """
+    rows = con.execute("""
+        SELECT s.* FROM scans s
+        INNER JOIN (
+            SELECT symbol, MAX(id) as max_id FROM scans GROUP BY symbol
+        ) latest ON s.id = latest.max_id
+        ORDER BY s.señal DESC, s.score DESC
+    """).fetchall()
     return [dict(r) for r in rows]

--- a/db/transaction.py
+++ b/db/transaction.py
@@ -81,3 +81,24 @@ def _tx_or_use(con: sqlite3.Connection | None) -> Iterator[sqlite3.Connection]:
             yield new_con
     else:
         yield con
+
+
+@contextmanager
+def read_only_connection() -> Iterator[sqlite3.Connection]:
+    """Open a configured connection for read-only work outside any transaction.
+
+    Use when an operator needs pre-validation reads (ownership check,
+    existence check) that must NOT hold a writer lock. The connection
+    closes on exit; no BEGIN/COMMIT is issued.
+
+    Caller contract:
+    - MAY use con.execute for SELECT.
+    - MUST NOT issue INSERT/UPDATE/DELETE — if SQLite's autocommit triggers,
+      the write happens without the operator's atomicity guarantee.
+    - MUST NOT escape the connection past the `with` block.
+    """
+    con = _open_configured_connection()
+    try:
+        yield con
+    finally:
+        con.close()

--- a/db/transaction.py
+++ b/db/transaction.py
@@ -57,33 +57,6 @@ def transaction() -> Iterator[sqlite3.Connection]:
 
 
 @contextmanager
-def _tx_or_use(con: sqlite3.Connection | None) -> Iterator[sqlite3.Connection]:
-    """If `con` is None, open a new transaction(). Otherwise yield the
-    provided connection (the caller already owns a transaction).
-
-    Usage in helpers that may be called both standalone and inside a caller-
-    controlled transaction:
-
-        def db_close_position(pos_id, ..., con: sqlite3.Connection | None = None):
-            with _tx_or_use(con) as con:
-                con.execute("UPDATE positions SET status='closed' WHERE id=?", (pos_id,))
-
-    Rationale (Task 8.5 of plan 2026-05-24-transaction-unit-of-work): helpers
-    that own their own `transaction()` cannot be composed inside an outer
-    caller-owned transaction without deadlocking on BEGIN IMMEDIATE (the
-    inner conn waits for the outer's writer lock, busy_timeout fires).
-    This wrapper resolves that by letting the outer caller pass `con` to
-    each helper, while standalone callers (passing `con=None`) still get
-    their own atomic boundary.
-    """
-    if con is None:
-        with transaction() as new_con:
-            yield new_con
-    else:
-        yield con
-
-
-@contextmanager
 def read_only_connection() -> Iterator[sqlite3.Connection]:
     """Open a configured connection for read-only work outside any transaction.
 

--- a/db/user_preferences.py
+++ b/db/user_preferences.py
@@ -17,8 +17,6 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from db.transaction import _tx_or_use
-
 log = logging.getLogger("db.user_preferences")
 
 
@@ -43,30 +41,29 @@ def _decode_row(row) -> dict:
 
 
 def db_get_user_preferences(
+    con: sqlite3.Connection,
     tenant_id: int,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> Optional[dict]:
     """Return preferences row for tenant, or None if not yet set.
 
-    Per Task 8.5: optional `con` for caller-controlled transaction composition.
+    Task 8 (#446): `con` is now mandatory positional. Callers must pass an
+    open `sqlite3.Connection` from a surrounding `transaction()` block.
     """
-    with _tx_or_use(con) as con:
-        row = con.execute(
-            "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
-        ).fetchone()
+    row = con.execute(
+        "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
+    ).fetchone()
     if row is None:
         return None
     return _decode_row(row)
 
 
 def db_upsert_user_preferences(
+    con: sqlite3.Connection,
     tenant_id: int,
     *,
     symbol_filter: Optional[list[str]] = None,
     min_score: Optional[int] = None,
     notify_channels: Optional[dict[str, Any]] = None,
-    con: Optional[sqlite3.Connection] = None,
 ) -> dict:
     """Insert or replace user_preferences row for tenant.
 
@@ -76,38 +73,37 @@ def db_upsert_user_preferences(
 
     Returns resulting row with JSON fields parsed.
 
-    Per Task 8.5: optional `con` for caller-controlled transaction composition.
+    Task 8 (#446): `con` is now mandatory positional first arg.
     """
     now = datetime.now(timezone.utc).isoformat()
-    with _tx_or_use(con) as con:
-        existing = con.execute(
-            "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
-        ).fetchone()
+    existing = con.execute(
+        "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
+    ).fetchone()
 
-        sf_json = json.dumps(symbol_filter) if symbol_filter is not None else None
-        nc_json = json.dumps(notify_channels) if notify_channels is not None else None
+    sf_json = json.dumps(symbol_filter) if symbol_filter is not None else None
+    nc_json = json.dumps(notify_channels) if notify_channels is not None else None
 
-        if existing is None:
-            con.execute(
-                """INSERT INTO user_preferences
-                   (tenant_id, symbol_filter_json, min_score, notify_channels_json,
-                    updated_at)
-                   VALUES (?, ?, COALESCE(?, 4), ?, ?)""",
-                (tenant_id, sf_json, min_score, nc_json, now),
-            )
-        else:
-            # Preserve fields when None passed
-            effective_sf = sf_json if sf_json is not None else existing["symbol_filter_json"]
-            effective_ms = min_score if min_score is not None else existing["min_score"]
-            effective_nc = nc_json if nc_json is not None else existing["notify_channels_json"]
-            con.execute(
-                """UPDATE user_preferences
-                   SET symbol_filter_json = ?, min_score = ?,
-                       notify_channels_json = ?, updated_at = ?
-                   WHERE tenant_id = ?""",
-                (effective_sf, effective_ms, effective_nc, now, tenant_id),
-            )
-        row = con.execute(
-            "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
-        ).fetchone()
+    if existing is None:
+        con.execute(
+            """INSERT INTO user_preferences
+               (tenant_id, symbol_filter_json, min_score, notify_channels_json,
+                updated_at)
+               VALUES (?, ?, COALESCE(?, 4), ?, ?)""",
+            (tenant_id, sf_json, min_score, nc_json, now),
+        )
+    else:
+        # Preserve fields when None passed
+        effective_sf = sf_json if sf_json is not None else existing["symbol_filter_json"]
+        effective_ms = min_score if min_score is not None else existing["min_score"]
+        effective_nc = nc_json if nc_json is not None else existing["notify_channels_json"]
+        con.execute(
+            """UPDATE user_preferences
+               SET symbol_filter_json = ?, min_score = ?,
+                   notify_channels_json = ?, updated_at = ?
+               WHERE tenant_id = ?""",
+            (effective_sf, effective_ms, effective_nc, now, tenant_id),
+        )
+    row = con.execute(
+        "SELECT * FROM user_preferences WHERE tenant_id = ?", (tenant_id,),
+    ).fetchone()
     return _decode_row(row)

--- a/docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md
+++ b/docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md
@@ -1,0 +1,223 @@
+# Issue #446 — Pre-conditions Synthesis
+
+**Branch:** `feat/fix-tx-or-use-dual-contract-446`
+**Commit base:** `de70052` (analysis + direction commit)
+**Date:** 2026-05-25
+**Purpose:** Evidence base for the executable plan. Voronov's 3 deferred questions from `2026-05-25-446-tx-or-use-analysis-and-direction.md` answered here.
+
+---
+
+## Pre-condition 1 — Audit of 44 call sites
+
+### Classification taxonomy (per Voronov)
+
+- **Cat. 1 — Pure SQL operator:** receives `con`, runs SQL, returns. No side-effects.
+- **Cat. 2 — Hidden business operator:** composes >1 SQL helper AND/OR triggers side-effects.
+- **Cat. 3 — Edge case:** requires human judgment.
+
+### Totals
+
+| Category | Count |
+|---|---|
+| Cat. 1 — Pure SQL | **34** |
+| Cat. 2 — Hidden operator | **5** |
+| Cat. 3 — Edge case | **7** |
+| **Total** | **46** (vs 44 estimated — extra helpers found in `db/signals.py`, `db/schema.py`, `notifier/dispatch_per_user.py`) |
+
+### Cat. 2 — Hidden business operators (candidates for migration to business operator layer)
+
+1. **`db/signals.py::save_scan`** — dual-transaction pattern + WARN log. Business policy.
+2. **`db/schema.py::init_db`** — DB bootstrap orchestrator; multiple txns + sub-migrations.
+3. **`auth/audit.py::log_auth_event`** — INSERT + sys.stderr fallback + "Never raises" contract.
+4. **`notifier/dispatch_per_user.py::dispatch_signal_to_users`** — composes SQL helpers + fires `notify()` (network).
+5. **`db/positions.py::db_close_position`** — Cat. 3 by primary classification but functionally Cat. 2 in standalone path (the canonical bug of #446).
+
+### Cat. 3 — Edge cases (human judgment required)
+
+1. **`db_close_position`** — dual personality based on `_caller_owned_con`. THE canonical issue.
+2. **`apply_pnl_to_capital`** — auto-recursive composition with `inner_con`. Business semantics (peak/drawdown) in helper shape.
+3. **`_migrate_multi_tenant_b1`** — DDL with `log.info`. Sub-category Cat. 1 (DDL)?
+4. **`_migrate_agent_audit`** — DDL + UPDATE backfill (business logic in mapping).
+5. **`_migrate_agent_history`** — DDL with logging. Same shape as B1.
+6. **`mark_setup_completed`** — pure SQL with system-lifecycle semantics (`ip`, `method` as audit params).
+7. **`_list_active_users`** — defensive catch of `sqlite3.OperationalError` for missing table.
+
+### Migration scope estimate (per Voronov's option C)
+
+- 34 Cat. 1 helpers: drop `con: Optional` → `con: Connection` (mandatory). Mechanical sweep.
+- 5 Cat. 2 helpers: extract side-effects to operators or document as business operators in their own layer.
+- 7 Cat. 3 helpers: case-by-case decision in the plan.
+
+---
+
+## Pre-condition 2 — Opening flow decision
+
+### Decision: **DEFER `PositionOpening`**
+
+### Evidence
+
+`POST /positions` → `open_position()` (lines 354–368):
+1. Validate `symbol`, `entry_price` → HTTP 422 if missing.
+2. `db_create_position(body, tenant_id=tenant_id)` — single DB write.
+3. `update_positions_json()` — file side-effect (atomic via `.tmp` + `os.replace`).
+4. Return `{"ok": True, "position": pos}`.
+
+| Voronov symptom | Present in opening flow? |
+|---|---|
+| Contract interrogation (`if con is None`) | **No** |
+| Conditional side-effects | **No** |
+| Helper composition + side-effect | Minimal: 1 helper + 1 unconditional side-effect |
+
+### Reasoning
+
+Voronov's evidential rule: create operator when caller already exhibits the symptoms. Opening doesn't yet. Create `PositionOpening` when (and only when) evidence emerges — e.g., a future caller adds capital adjustment on open, or a notification on open with conditional logic, or a multi-helper composition. Until then, the path stays as-is (mechanical migration to `db_create_position(con: Connection)` only).
+
+**Implication for the plan:** scope is `PositionClosure` only in this PR.
+
+---
+
+## Pre-condition 3 — Multi-tenancy invariant map
+
+### A) Validation locations
+
+| Function | Validates tenant_id? | Mechanism | Failure mode if skipped |
+|---|---|---|---|
+| `get_current_tenant_id` (`auth/dependencies.py:55`) | **Always** | Reads from JWT-authenticated `request.state.user`; 401 if not auth | N/A (source of truth) |
+| `close_position` endpoint (`api/positions.py:396`) | **Yes** | `Depends(get_current_tenant_id)` | If removed: any caller could close any position knowing only `pos_id` |
+| `db_close_position` (`db/positions.py:169`) | **Conditional** — only when `tenant_id is not None` | `WHERE id=? AND tenant_id=?` | If called with `tenant_id=None`: closes without ownership check |
+| `_apply_close_to_capital` (`api/positions.py:52`) | **Indirect** — uses tenant_id from closed row | Trusts row data; skips silently if `NULL` | P&L credited to wrong tenant or skipped |
+| `check_position_stops` (`api/positions.py:135`) | **No** — opaque by design | `SELECT WHERE symbol=? AND status='open'` no tenant filter | Closes all tenants' positions on SL/TP/TIME_LIMIT |
+
+### B) Pre-transaction vs intra-transaction
+
+- **Pre-tx (JWT Depends):** clean early rejection. Risk: someone purifies the `Depends` of a new route.
+- **Intra-tx (SQL WHERE):** second line. Risk: `db_close_position(tenant_id=None)` silently bypasses ownership.
+
+**Real gap identified:** `check_position_stops` calls `db_close_position(... con=con)` without `tenant_id`. Intentional for scanner but structurally fragile — if an attacker controls `pos_list` (today: gated by symbol + status='open' filter), they could close any tenant's position.
+
+### C) Three invariants for the operator
+
+1. **ownership-before-lock:** USER mode must verify `position.tenant_id == caller_tenant_id` BEFORE `BEGIN IMMEDIATE`. Failure → operator returns without opening write tx.
+2. **capital-consistency:** P&L applied to capital MUST match tenant who owns position. Same tenant_id, atomic within same transaction.
+3. **system-mode no-IDOR-leak:** failures in SYSTEM mode observationally indistinguishable between "doesn't exist" and "exists under another tenant".
+
+---
+
+## Pre-condition 4 — PositionClosure operator contract spec
+
+### Purpose
+
+Materialize the business transition: one open `positions` row → `status='closed'` + P&L atomic in `capital` + post-commit observable side-effects (health, event log, notify, snapshot). The only legal entry point for closing a position from application code.
+
+### Caller modes
+
+**Mode 1: USER** — instantiated by user-auth endpoint. `caller_tenant_id` from JWT (never None). Ownership enforced. Capital roll-in targets `caller_tenant_id` (= `position.tenant_id` by invariant).
+
+**Mode 2: SYSTEM** — instantiated by scanner. No caller tenant. Ownership skipped by construction. Capital roll-in targets `position.tenant_id` from row; `NULL` → skip with WARN.
+
+Mode is **explicit** (`Literal["USER", "SYSTEM"]`), not derived from `caller_tenant_id is None`.
+
+### Construction
+
+```text
+PositionClosure(
+    pos_id: int,
+    exit_price: float,                              # > 0
+    exit_reason: Literal["MANUAL","SL_HIT","TP_HIT","TIME_LIMIT_HIT"],
+    *,
+    mode: Literal["USER", "SYSTEM"],
+    caller_tenant_id: Optional[int] = None,         # required iff mode == "USER"
+    cfg: Optional[dict] = None,                     # defaults to load_config() lazily
+    now: Optional[datetime] = None,                 # injectable for tests
+)
+```
+
+Validation raises `ValueError` before any DB work. Operator is single-use.
+
+### Lifecycle as context manager
+
+**`__enter__`** — outside any tx. Open short read-only conn, `SELECT *`, cache as `_pre_row`. If row missing or USER-mode ownership mismatch → state `NOT_FOUND`. If `status != 'open'` → state `ALREADY_CLOSED`.
+
+**`execute() -> CloseOutcome`** — branches on state:
+- `NOT_FOUND` / `ALREADY_CLOSED` → return outcome, no tx, no side-effects.
+- `OK_TO_PROCEED` → ONE `with transaction() as con:` block. Inside, in order:
+  1. Re-SELECT inside write tx (covers race window).
+  2. `_calc_pnl(...)`.
+  3. `db_close_position_sql(con, ...)` — pure UPDATE.
+  4. Re-SELECT → `closed_row`.
+  5. If tenant_id present + pnl_usd present: `apply_pnl_to_capital(con, tenant_id, pnl_usd)` — **IN-TX**. (Design call resolving #450 in favor of atomicity.)
+
+**`__exit__` on success** — post-commit side-effects in fixed order, each best-effort log-and-continue:
+1. `_write_position_event_log(...)` — file append.
+2. `trigger_health_evaluation(...)` — own conn, safe now (lock released).
+3. `notify(PositionExitEvent(...), cfg)` — Telegram.
+4. `update_positions_json()` — snapshot.
+
+**`__exit__` on exception** — tx already rolled back. No side-effects. Log at ERROR with structured context. Exception propagates.
+
+### Composed SQL helpers (pure Cat. 1)
+
+- `db_get_position_by_id(con, pos_id) -> Optional[dict]`
+- `db_close_position_sql(con, pos_id, exit_price, exit_reason, exit_ts, pnl_usd, pnl_pct) -> dict`
+- `db_get_capital(con, tenant_id) -> Optional[dict]`
+- `db_upsert_capital(con, tenant_id, *, balance, peak_balance, max_drawdown_pct) -> dict`
+- `apply_pnl_to_capital(con, tenant_id, pnl_usd) -> dict` — `con` mandatory; `_tx_or_use` shim gone
+
+`_calc_pnl(...)` stays pure arithmetic helper.
+
+### Post-commit side-effects — compensation policy
+
+| Side-effect | Phase | Compensation |
+|---|---|---|
+| `apply_pnl_to_capital` | **IN-TX** | Failure aborts close (caller sees error, position stays open). Resolves #450. |
+| `trigger_health_evaluation` | POST-COMMIT | Best-effort, log WARN. Next scanner tick re-evaluates. |
+| `notify` (Telegram) | POST-COMMIT | Best-effort, log WARN. Dedup is notifier's responsibility. |
+| `_write_position_event_log` | POST-COMMIT | Best-effort, log WARN. DB is source of truth. |
+| `update_positions_json` | POST-COMMIT | Best-effort, log WARN. Eventually consistent. |
+
+### 9 testable invariants (anchor for #451)
+
+1. **Atomicity of close + capital** — both visible or neither.
+2. **Ownership-before-lock** — USER ownership mismatch → no `BEGIN IMMEDIATE`.
+3. **IDOR-equivalence in USER mode** — "doesn't exist" and "another tenant's" → identical observable.
+4. **System-mode no-IDOR-leak** — SYSTEM closes correct tenant's position with correct capital, no cross-leak.
+5. **No post-commit side-effect on exception** — if exception propagates, all 4 side-effects: zero calls.
+6. **Single side-effect firing on success** — each post-commit side-effect: exactly 1 call.
+7. **Idempotent re-close** — `ALREADY_CLOSED` outcome, no re-fire, no double P&L.
+8. **No writer-lock held across I/O** — all side-effects fire strictly after tx exit.
+9. **No-tenant capital skip** — `tenant_id IS NULL` legacy row → close commits, capital skipped.
+
+### Migration impact
+
+**`close_position` endpoint** — ~10 lines removed, ~8 lines added. `_apply_close_to_capital` shim deleted.
+
+**`check_position_stops` scanner** — ~60 lines removed (`post_tx_actions` machinery, deferred-health imports, inline notify dispatch with code-mapping), ~20 lines added. Trailing-SL writes stay in their own tx (per-tick mutation set); each close moves to its own `PositionClosure(mode="SYSTEM")` outside that tx.
+
+**Note:** trailing-SL and close now in separate transactions. Atomicity #446 cares about is per-close, not per-tick. This is a deliberate concession.
+
+### Open questions deferred (NOT blocking the plan)
+
+1. **Outbox for true compensable delivery** — v1 is log-and-continue. Outbox + retry is separate epic.
+2. **SYSTEM mode: flag vs subclass** — flag is simpler now; subclass when divergence is concrete.
+3. **Retry hooks / observability surface** — defer to observability stack decision.
+4. **Cross-tenant batch SYSTEM close** — SQLite has one writer; not relevant until different DB.
+5. **Partial close / cancellation** — separate operators when they emerge, not flags on this one.
+
+---
+
+## Synthesis — what the executable plan now writes
+
+With all 4 pre-conditions complete:
+
+- **Scope locked:** only `PositionClosure` operator in this PR. No `PositionOpening`.
+- **Helper layer redefined:** 34 Cat. 1 helpers become pure SQL operators (`con: Connection` mandatory). `_tx_or_use` disappears.
+- **5 Cat. 2 hidden operators** are documented for migration but only `db_close_position` is in scope (extracted into `db_close_position_sql` + `PositionClosure`). The other 4 stay where they are with deferred operator-extraction tickets.
+- **7 Cat. 3 edge cases** mostly resolve to Cat. 1 under the plan (`apply_pnl_to_capital` becomes pure SQL with `con` mandatory; `_migrate_*` stay as DDL helpers with documented exception for `log.info`).
+- **Multi-tenancy:** operator owns ownership-before-lock + IDOR-safe outcomes + SYSTEM mode explicit.
+- **#450 resolved:** `apply_pnl_to_capital` runs IN-TX. Trade-off explicit: capital failure aborts close.
+- **#451 anchor:** 9 testable invariants written. Test goes against the operator, not the helpers.
+- **#447 dissolved:** `PositionClosure` is the first inhabitant of the business operator layer. The layer itself is the issue's resolution.
+- **#448 dissolved:** helpers no longer accept `con` from external callers; only the operator passes `con`. Validation question disappears structurally.
+- **#449:** health trigger lives in operator's `__exit__`, eliminated as separate concern within close-flow.
+
+Ready to write the executable plan.

--- a/docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md
+++ b/docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md
@@ -1,0 +1,208 @@
+# Issue #446 — Análisis Clínico + Dirección Ontológica
+
+**Branch:** `feat/fix-tx-or-use-dual-contract-446`
+**Commit base:** `b5b05889` (merge de PR #445)
+**Fecha:** 2026-05-25
+**Autores:** Dr. Adrian V. Serrano (análisis) + Dr. Aurelius K. Voronov (dirección)
+
+---
+
+## Parte I — Análisis clínico (Serrano)
+
+> Nota del editor: análisis devuelto íntegro por Serrano en handoff a Voronov. Estado: implementable hoy (código corre), pero contiene 4 BLOCKERs y 5 HIGHs.
+
+### A) Resumen diagnóstico
+
+`_tx_or_use(con)` (`db/transaction.py:60-83`) es síntoma sintáctico de helper con **dos contratos operacionales bajo un único símbolo**, instalado por Task 8.5 del plan transaction-unit-of-work y mergeado en PR #445. No es wrapper inocuo: es **dispatcher condicional** que el caller debe interrogar para razonar correctamente sobre atomicidad, side-effects, y ciclo de vida del lock. La evidencia material está en `db/positions.py:186` (`_caller_owned_con = con`), `db/positions.py:219` (`if _caller_owned_con is None:`), y `api/positions.py:290-294` (compensación post-commit que el caller debe saber ejecutar). El bug no es un defecto de implementación — el bug es **contractual**.
+
+### B) Estado actual — mapa exhaustivo
+
+**44 call sites en 16 archivos** (excluyendo definición y tests):
+
+| Módulo | Llamadas | Notas |
+|---|---|---|
+| `db/positions.py` | 5 | Todas las funciones públicas exponen `con: Optional` |
+| `db/capital.py` | 4 | `apply_pnl_to_capital` se llama recursivamente a sí misma con `inner_con` |
+| `db/signals.py` | 5 | — |
+| `db/schema.py` | 4 | Schema/migration helpers |
+| `db/auth_schema.py` | 5 | — |
+| `db/user_preferences.py` | 2 | — |
+| `auth/tokens.py` | 5 | — |
+| `auth/audit.py` | 1 | — |
+| `notifier/_storage.py` | 4 | — |
+| `notifier/dedupe.py` | 1 | — |
+| `notifier/dispatch_per_user.py` | 1 | — |
+| `health.py` | 3 | Imports locales (`from db.transaction import _tx_or_use` dentro de funciones) |
+| `strategy/kill_switch_v2_shadow.py` | 2 | Idem (local imports) |
+
+**Patrones donde el código interroga el contrato vigente:**
+
+1. `db/positions.py:186-225` — `db_close_position` recuerda `_caller_owned_con = con` y suprime `trigger_health_evaluation` cuando el caller threadeó tx.
+2. `api/positions.py:290-306` — `check_position_stops` ejecuta el side-effect compensatorio (`trigger_health_evaluation`) post-commit en bucle sobre `post_tx_actions`.
+3. `health.py:588-592` — re-implementa la lógica de `_tx_or_use` inline en el mismo archivo que ya importa el wrapper en otros 3 sitios (drift entre abstracción y adopción).
+
+### C) Espacio de soluciones admisibles (enumeración no exhaustiva)
+
+**Opción A — Bifurcar firmas** (`*_standalone()` vs `*_within_tx(con, ...)`). Eliminar `_tx_or_use`. ~30-44 call sites a renombrar. Doble superficie API; deriva potencial.
+
+**Opción B — Side-effects fuera del helper** (helpers como SQL puro; caller orquesta). Re-localiza `trigger_health_evaluation` en TODO caller. Riesgo: garantía implícita deja de vivir en helper.
+
+**Opción C — Named operator** (`class PositionClosure` o equivalente). El operator es el único que abre tx, orquesta side-effects, decide compensación. Helpers SQL pierden `con`. Riesgo god-object / proliferación.
+
+**Opción D — Mantener wrapper + prohibir side-effects en helpers**. Equivale a B aplicada selectivamente + enforcement (lint/test). Sin enforcement, regresión.
+
+**Opción E — Revertir parcialmente Task 8.5**. Helpers NO aceptan `con`. Cross-helper atomicity vía SQL inline. Duplica SQL. Pierde reutilización de ownership/IDOR.
+
+### D) Coupling con otros issues
+
+| Issue | A | B | C | D | E |
+|---|---|---|---|---|---|
+| #447 (named operator) | No lo crea | No lo crea | **Es la opción** | No lo crea | No lo crea |
+| #448 (con validation) | Persiste | Persiste | **Disuelto** | Persiste | **Disuelto** |
+| #449 (health trigger) | Persiste | Persiste y distribuye | Nombrable, no auto-resuelto | Persiste | Persiste |
+| #450 (capital best-effort) | Persiste | Persiste | Nombrable, no auto-resuelto | Persiste | Persiste |
+| #451 (test atomicity) | Test ad-hoc | Test ad-hoc | **Test natural** | Test ad-hoc | Test ad-hoc |
+
+### E) Lo que NINGUNA opción resuelve
+
+1. Compensación de fallas en side-effects post-commit — no hay outbox/dead-letter.
+2. `apply_pnl_to_capital` best-effort silencioso (issue #450) — política, no estructura sintáctica.
+3. Asimetría de rollback bajo `con=<provisto>` — persiste salvo en C completa.
+4. Re-implementación inline del wrapper en `health.py:588-592` — drift no auditado.
+5. Ausencia de test de invariante completo cross-helper (issue #451) — solo C lo facilita estructuralmente.
+6. Multi-tenancy y `con` — `tenant_id` se threadea ortogonal al `con`; validación pre-tx o intra-tx no definida.
+
+### G) Hallazgos clínicos numerados
+
+1. **[BLOCKER, CONTRA/AMB]** El símbolo `_tx_or_use` enmascara dos contratos operacionales incompatibles.
+2. **[BLOCKER, STATE/OPS]** El cuerpo de `db_close_position` interroga su propio contrato vía `_caller_owned_con`.
+3. **[BLOCKER, GAP/OPS]** No hay compensación garantizada para side-effects post-commit fallidos.
+4. **[BLOCKER, GAP/OPS/SCOPE]** `apply_pnl_to_capital` se ejecuta best-effort sin contrato de compensación.
+5. **[HIGH, CONTRA]** El patrón `if conn is None` se reimplementa inline en `health.py:588-592` en el mismo archivo que usa `_tx_or_use` 3 veces.
+6. **[HIGH, STATE/OPS]** La asimetría de rollback no está documentada en la firma de los helpers.
+7. **[HIGH, SEC]** El parámetro `con` no se valida.
+8. **[HIGH, GAP]** No existe test que ejerza el invariante completo cross-helper.
+9. **[HIGH, AMB/SCOPE]** Los helpers con `con: Optional` no documentan si son seguros de llamar desde threads concurrentes.
+10. **[MEDIUM, OPS]** El docstring de `_tx_or_use` justifica su existencia pero no advierte sobre la divergencia semántica.
+11. **[MEDIUM, SCOPE]** `_tx_or_use` está marcado privado (`_` prefix) pero se usa en 16 módulos cross-package.
+12. **[MEDIUM, STATE]** `apply_pnl_to_capital` se llama a sí mismo con `con=inner_con`, anidando wrappers sin que sea evidente.
+13. **[LOW, AMB]** El nombre `_tx_or_use` no comunica que el "use" tiene contrato distinto al "tx".
+
+### H) Preguntas explícitas handoff a Voronov
+
+1. ¿La unidad atómica correcta es "una operación SQL multi-tabla" o "una unidad de negocio completa incluyendo side-effects compensables"?
+2. ¿Side-effects post-commit son parte del cierre o consumidores asíncronos de un evento de cierre?
+3. ¿Es aceptable que el ledger de capital quede silenciosamente desincronizado en caso de falla?
+4. Si named operator para cierre, ¿debe haber paralelos para apertura/edición/cancelación? Costo de proliferación.
+5. ¿Validación de `con` (#448) es responsabilidad del wrapper, helper, o caller?
+6. ¿"Helpers no hacen side-effects" debe ser arquitectural enforced o convencional?
+7. ¿Test de atomicidad cross-helper (#451) antes o después de elegir opción?
+8. ¿`_tx_or_use` debe sobrevivir bajo cualquier opción, o su existencia es síntoma terminal?
+9. ¿Asimetría rollback bajo `con=<provisto>` es bug o feature documentable?
+10. ¿`_tx_or_use` está mal abstraída o mal adoptada?
+
+---
+
+## Parte II — Dirección ontológica (Voronov)
+
+### La constante invisible
+
+`_tx_or_use` no es un wrapper. No es un dispatcher. Es un **artefacto de indecisión ontológica**: el sistema no ha decidido si los helpers de `db/` son **operaciones SQL** o **operaciones de negocio**. Mientras esa decisión no exista, cualquier opción elegida es local; cualquier refactor es cosmético.
+
+Las cinco opciones de Serrano operan dentro del mismo error de categoría:
+
+> **Tratan el problema como sintáctico (forma del helper) cuando es semántico (qué cosa es un helper).**
+
+PR #445 no introdujo el bug. Reveló el bug que ya existía: **`db/` nunca fue una capa; era una colección.**
+
+### La ley de orquestación
+
+Toda función que persiste estado en un sistema transaccional pertenece a **exactamente una** de estas tres categorías ontológicas:
+
+1. **Operador SQL puro** — recibe `con`, no lo abre, no lo cierra, no dispara side-effects, no compone lógica de negocio. Su unidad es la sentencia.
+2. **Operador de negocio** — abre `con` (o lo recibe explícitamente con semántica documentada), orquesta side-effects, compone múltiples operadores SQL, posee la atomicidad. Su unidad es la transición de estado del dominio.
+3. **Side-effect compensable** — no participa de la atomicidad SQL; vive después del commit; tiene su propia política de retry/dead-letter. Su unidad es el evento.
+
+Una función no puede ser dos de estas a la vez. Si lo intenta, el caller debe interrogarla para razonar — exactamente lo que `_caller_owned_con` ya hace. Esa variable es la confesión del sistema: aquí hay dos contratos viviendo en un símbolo.
+
+### La opción: C, con cualificaciones
+
+C es la única opción que **nombra las tres categorías** y las separa estructuralmente. A, B, D, E reorganizan dentro de la confusión.
+
+Pero C no es suficiente como Serrano la enuncia. La forma correcta de C es más estricta:
+
+> **C no introduce operators. C introduce la distinción de capas. Los operators son la consecuencia, no la causa.**
+
+La decisión no es "crear `PositionClosure`". La decisión es "**`db/` se vuelve operador SQL puro; los operadores de negocio viven en una capa nueva**". `PositionClosure` aparece porque el cierre es un operador de negocio. Aparece `PositionOpening` cuando la apertura lo requiera. No antes.
+
+Esto disuelve el riesgo de proliferación: **no se crean operators preventivamente; se crean cuando un caller actualmente compone múltiples helpers + side-effects.**
+
+### Forma del operador
+
+**Context manager con estado.** No clase con métodos múltiples (eso invita god-object). No función pura (eso pierde el lifecycle). No dataclass (eso es datos sin comportamiento). El operador de cierre posee un lifecycle: pre-validación → transacción → side-effects post-commit → compensación.
+
+```python
+with PositionClosure(position_id, ...) as closure:
+    closure.execute()
+# post-commit side-effects fired in __exit__
+```
+
+El operador es el único lugar donde la atomicidad y los side-effects post-commit coexisten. El caller no orquesta; declara intención.
+
+### Operators que emergen hoy
+
+Hoy, dos:
+- **Cierre de posición** (evidencia: `_caller_owned_con` + compensación post-commit en `check_position_stops`)
+- **Apertura de posición** (evidencia: composición de capital + signal + posición en `api/positions.py`)
+
+No crear preventivamente otros. Cada operador aparece cuando se identifique un caller actual que orqueste >1 helper + side-effect. **Regla de creación: evidencial, no especulativa.**
+
+### Relación con `transaction()`
+
+El operador **posee** `transaction()`. Es el único caller legítimo de `transaction()` para su unidad de negocio. Los helpers SQL puros (`db/`) reciben `con` y nunca lo abren. `transaction()` desaparece de la API pública de `db/`; solo operadores la invocan.
+
+Esto resuelve #448 estructuralmente: la validación de `con` deja de existir porque los helpers ya no pueden recibirlo de un caller externo — solo del operador, que es confiable por construcción.
+
+### Respuestas a las 10 preguntas
+
+1. **Unidad atómica:** unidad de negocio. SQL multi-tabla es mecanismo, no unidad.
+2. **Side-effects post-commit:** estructuralmente consumidores de evento; pragmáticamente hoy el operador los absorbe. La forma del operador (`__exit__` post-commit) debe ser compatible con migración futura a publicación de evento.
+3. **Capital desincronizado:** no aceptable. Pero ortogonal a la elección de opción — es política de compensación (#450). C hace visible la pregunta; las otras la dejan dispersa.
+4. **Operators paralelos:** evidencial, no especulativa. Hoy cierre + apertura. Resto cuando aparezca.
+5. **Validación de `con`:** disuelta. Bajo C, los helpers no reciben `con` de callers externos.
+6. **Enforcement:** arquitectural. El mecanismo es **tipo del parámetro `con`** — helpers SQL puros reciben `Connection` no-opcional; operadores no reciben `con`.
+7. **Test de atomicidad:** después de C, antes de implementar C. Secuencia: elegir C → especificar contrato del operador → escribir test contra contrato → implementar → migrar callers.
+8. **`_tx_or_use`:** terminal. Bajo C, los contratos se separan; el dispatcher condicional deja de tener trabajo.
+9. **Asimetría rollback:** bug bajo helpers actuales; no aplicable bajo C.
+10. **`_tx_or_use` abstraída vs adoptada:** mal concebida. La herramienta materializa una categoría que no debe existir.
+
+### Lo que se queda sin respuesta
+
+Tres asuntos requieren evidencia que Voronov no tiene:
+
+**a. Costo real de migración de los 44 call sites.** La distribución sugiere que la mayoría de helpers (especialmente `auth/`, `notifier/`) son operadores SQL puros que solo necesitan firma cambiada. Pero `health.py`, `kill_switch_v2_*`, `dispatch_per_user.py` necesitan auditoría individual. Esta auditoría debe preceder al plan ejecutable.
+
+**b. Si la apertura de posición necesita operator hoy o más tarde.** La decisión depende de si la composición actual exhibe los síntomas que motivan C (interrogación de contrato, side-effects condicionales). Si no, esperar.
+
+**c. Invariantes de multi-tenancy que el operador debe garantizar.** Mapear dónde hoy se valida tenant y qué pasa si no se valida.
+
+### Cierre
+
+El debate entre las cinco opciones es real pero está mal enmarcado. Las cinco preguntan "¿cómo organizamos `_tx_or_use`?". La pregunta correcta es "¿qué es un helper en `db/`?".
+
+C no es "la opción que crea `PositionClosure`". C es **la opción que decide que `db/` es una capa con un contrato único, y que las transiciones de negocio viven en otra capa con su propio contrato**. `PositionClosure` es el primer habitante de esa segunda capa. Otros emergerán cuando la evidencia lo exija.
+
+> `_tx_or_use` no es un bug a corregir. Es la **huella fósil** de una capa que nunca se nombró. El refactor correcto no la elimina; **la hace innecesaria.**
+
+---
+
+## Pre-condiciones del plan ejecutable
+
+Antes de escribir el plan implementable:
+
+1. **Auditoría per-archivo** de los 44 call sites — clasificar cada helper como (1) operador SQL puro, (2) operador de negocio escondido como helper, o (3) caso límite que requiere juicio.
+2. **Lectura end-to-end** de `api/positions.py` flujo de apertura — confirmar si `PositionOpening` debe crearse en este PR o se difiere.
+3. **Mapeo de invariantes multi-tenancy** — dónde se valida `tenant_id` hoy y qué pasa si no se valida.
+4. **Especificación del contrato del operador `PositionClosure`** — qué pre-validaciones, qué SQL helpers compone, qué side-effects post-commit ejecuta, qué política de compensación. Esto ancla el test #451.
+
+Solo entonces se escribe el plan ejecutable que migra `db/` a capa SQL pura, introduce `PositionClosure` (y `PositionOpening` si la auditoría lo exige), y desinstala `_tx_or_use`.

--- a/docs/superpowers/plans/2026-05-25-446-position-closure-operator.md
+++ b/docs/superpowers/plans/2026-05-25-446-position-closure-operator.md
@@ -1,0 +1,1637 @@
+# PositionClosure Operator + Helper Layer Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve issues #446, #447, #448, #449, #450 (with explicit trade-off), and #451. Introduce `PositionClosure` business operator as the single legal entry point for closing a position. Demote `db/*` helpers (and related modules) to a pure SQL layer where `con: Connection` is mandatory. Delete `_tx_or_use`.
+
+**Architecture:** Three-layer separation per Voronov's ontology: (1) pure SQL operators in `db/`, `auth/`, `notifier/`, etc. — receive `con`, no side-effects, no `_tx_or_use`; (2) business operators in new `operators/` package — own `transaction()`, orchestrate side-effects, declare atomicity; (3) callers (endpoints, scanner, scripts) — instantiate operators OR wrap helpers in explicit `with transaction()` blocks. The first inhabitant of layer 2 is `PositionClosure`. Other operators (`PositionOpening`, etc.) emerge only when caller composition demands them.
+
+**Tech Stack:** Python 3, `sqlite3` stdlib, `contextlib`, `pytest`.
+
+---
+
+## Context (read this before starting)
+
+This plan executes the dirección Voronov articulated in `docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md` and the contract specified in `docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md`. Both files committed at `de70052` and `261e5ef` on this branch. **Read both before executing any task.**
+
+Locked decisions:
+- **Option C strict:** `db/` is the pure SQL layer; business transitions live in `operators/`.
+- **PositionClosure only** in this PR. `PositionOpening` deferred (precondition 2 verdict: no symptoms present).
+- **`apply_pnl_to_capital` runs IN-TX** (resolves #450 in favor of atomicity; trade-off: capital failure aborts close).
+- **All 34 Cat. 1 helpers** become `con: Connection` mandatory in this PR. Caller-side wrapping in `with transaction()` where needed.
+- **5 Cat. 2 hidden operators** (`save_scan`, `init_db`, `log_auth_event`, `dispatch_signal_to_users`, `db_close_position` standalone path) — fix `_tx_or_use` removal but defer operator-extraction to separate tickets. They use `transaction()` directly after migration.
+- **Issues #446/#447/#448/#449 dissolve by construction.** #450 closed with documented trade-off. #451 closed via test fix in Task 14.
+
+---
+
+## File Structure
+
+### New files
+
+- `operators/__init__.py` — empty marker for the new business-operator package.
+- `operators/position_closure.py` — `PositionClosure` context manager + `CloseOutcome` dataclass.
+- `tests/operators/__init__.py` — empty.
+- `tests/operators/test_position_closure.py` — 9 invariant tests (anchors #451).
+
+### Modified files (close-flow specific)
+
+- `db/positions.py`:
+  - Add `db_get_position_by_id(con, pos_id) -> Optional[dict]`.
+  - Add `db_close_position_sql(con, pos_id, exit_price, exit_reason, exit_ts, pnl_usd, pnl_pct) -> dict`.
+  - Delete old `db_close_position` (dual-contract function with health-trigger branch).
+  - Migrate other close-flow callers as needed.
+- `db/capital.py`:
+  - `apply_pnl_to_capital(con: Connection, tenant_id, pnl_usd)` — `con` mandatory.
+  - `db_get_capital(con: Connection, tenant_id)` — `con` mandatory.
+  - `db_upsert_capital(con: Connection, tenant_id, **kwargs)` — `con` mandatory.
+  - `db_list_active_tenant_ids(con: Connection)` — `con` mandatory.
+- `api/positions.py`:
+  - `close_position` endpoint: use `PositionClosure(mode="USER")`.
+  - `check_position_stops` scanner: use `PositionClosure(mode="SYSTEM")` in close loop after trailing-SL tx.
+  - Delete `_apply_close_to_capital` shim (logic absorbed into operator).
+  - Delete `post_tx_actions` machinery (operator handles ordering).
+
+### Modified files (mechanical Cat. 1 sweep)
+
+For each, change `_tx_or_use(con)` → direct `con.execute(...)` and signature `con: Optional[Connection] = None` → `con: Connection`. Then audit callsites and add `with transaction() as con:` wrappers where callers don't already pass `con`:
+
+- `db/positions.py` — `db_create_position`, `db_last_exit_ts`, `db_get_positions`, `db_update_position`.
+- `db/signals.py` — `get_scans`, `get_latest_scan_per_symbol`, `get_latest_signal`, `get_latest_scan`, `get_signals_summary`. (`save_scan` stays as Cat. 2 — use `transaction()` directly inside it, not `_tx_or_use`.)
+- `db/schema.py` — `backfill_tenant`, `_migrate_multi_tenant_b1`, `_migrate_agent_audit`, `_migrate_agent_history`. (`init_db` stays as Cat. 2 hidden operator — use `transaction()` directly inside it.)
+- `db/auth_schema.py` — `init_auth_db`, `has_any_user`, `init_system_state`, `is_setup_completed`, `mark_setup_completed`.
+- `db/user_preferences.py` — `db_get_user_preferences`, `db_upsert_user_preferences`.
+- `auth/tokens.py` — `create_refresh_token`, `lookup_refresh`, `revoke_refresh`, `revoke_family`, `revoke_all_for_user`.
+- `auth/audit.py` — `log_auth_event`. (Cat. 2 hidden operator — use `transaction()` directly inside it.)
+- `notifier/_storage.py` — `record_delivery`, `list_unread`, `mark_read`, `mark_all_read`.
+- `notifier/dedupe.py` — `should_send`.
+- `notifier/dispatch_per_user.py` — `_list_active_users`. (`dispatch_signal_to_users` stays as Cat. 2 — use `transaction()` directly inside it.)
+- `health.py` — `_get_symbol_health_row`, `record_portfolio_transition`, `recent_portfolio_transitions`.
+- `strategy/kill_switch_v2_shadow.py` — `_load_closed_trades`, `_load_open_positions`.
+- `db/transaction.py` — **delete `_tx_or_use`** in the final task.
+
+### Modified files (tests)
+
+- `tests/api/test_check_position_stops_atomicity.py` — fix fixture to actually trigger trailing-SL (#451).
+- `tests/db/test_transaction.py` — no changes needed (the wrapper itself is unchanged).
+- Other test files that called helpers without passing `con` — wrap in `with transaction()` blocks.
+
+### Modified files (docs)
+
+- `CLAUDE.md` — update "Database access" section to describe operators layer + pure SQL helpers.
+
+---
+
+## Tasks
+
+### Task 1: Verify branch and baseline
+
+**Files:** none modified.
+
+- [ ] **Step 1: Confirm branch and HEAD**
+
+Run: `git rev-parse --abbrev-ref HEAD && git rev-parse HEAD`
+Expected: `feat/fix-tx-or-use-dual-contract-446` and `261e5ef` (the preconditions commit).
+
+- [ ] **Step 2: Confirm clean working tree**
+
+Run: `git status --short`
+Expected: empty.
+
+- [ ] **Step 3: Baseline test count**
+
+Run: `pytest --collect-only -q 2>&1 | tail -3`
+Expected: around 2502 tests collected. Note the exact number.
+
+- [ ] **Step 4: Smoke check that all 9 wrapper contract tests still pass**
+
+Run: `pytest tests/db/test_transaction.py -v 2>&1 | tail -15`
+Expected: 9/9 passing.
+
+---
+
+### Task 2: TDD — write the 9 failing invariant tests for PositionClosure
+
+**Files:**
+- Create: `tests/operators/__init__.py`
+- Create: `tests/operators/test_position_closure.py`
+
+- [ ] **Step 1: Create the empty package marker**
+
+Create `tests/operators/__init__.py` as an empty file (matches project convention from `tests/db/__init__.py` and `tests/api/__init__.py`).
+
+- [ ] **Step 2: Write the test file with all 9 invariants**
+
+```python
+"""Invariant tests for operators.position_closure.PositionClosure.
+
+Anchors the 9 testable invariants declared in
+docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md
+Section 'PositionClosure operator contract spec'.
+
+Also resolves issue #451: this is the regression test for the trading
+invariant ('every mutation derived from one tick of price decision
+belongs to one serializable transaction') — done against the operator,
+not against ad-hoc helper composition.
+"""
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from db.transaction import transaction
+from db.schema import init_db
+
+
+@pytest.fixture
+def fresh_db_with_two_tenants(tmp_path, monkeypatch):
+    """Initialize a fresh DB with two tenants, each with an open position."""
+    db_path = tmp_path / "test.db"
+    import btc_api
+    monkeypatch.setattr(btc_api, "DB_FILE", str(db_path))
+    init_db()
+
+    with transaction() as con:
+        # Two tenants with capital seeded.
+        con.execute(
+            "INSERT INTO capital (tenant_id, balance, peak_balance, max_drawdown_pct, updated_ts) "
+            "VALUES (1, 10000.0, 10000.0, 0.0, ?)",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+        con.execute(
+            "INSERT INTO capital (tenant_id, balance, peak_balance, max_drawdown_pct, updated_ts) "
+            "VALUES (2, 5000.0, 5000.0, 0.0, ?)",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+        # Two open positions: one per tenant.
+        con.execute(
+            """INSERT INTO positions
+               (id, symbol, direction, entry_price, qty, sl_price, tp_price,
+                status, entry_ts, tenant_id, atr_entry, be_mult)
+               VALUES (1, 'BTCUSDT', 'long', 100.0, 1.0, 95.0, 110.0,
+                       'open', ?, 1, 2.0, 1.5)""",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+        con.execute(
+            """INSERT INTO positions
+               (id, symbol, direction, entry_price, qty, sl_price, tp_price,
+                status, entry_ts, tenant_id, atr_entry, be_mult)
+               VALUES (2, 'ETHUSDT', 'long', 200.0, 0.5, 195.0, 220.0,
+                       'open', ?, 2, 3.0, 1.5)""",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+    return str(db_path)
+
+
+# ---- Invariant 1: atomicity of close + capital ----
+
+def test_atomicity_close_and_capital_succeed_together(fresh_db_with_two_tenants):
+    """Successful close commits both UPDATE positions and UPDATE capital."""
+    from operators.position_closure import PositionClosure
+
+    with PositionClosure(
+        pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+        mode="USER", caller_tenant_id=1,
+    ) as closure:
+        outcome = closure.execute()
+
+    assert outcome.status == "closed"
+    with transaction() as con:
+        pos = con.execute("SELECT status FROM positions WHERE id=1").fetchone()
+        cap = con.execute("SELECT balance FROM capital WHERE tenant_id=1").fetchone()
+    assert pos["status"] == "closed"
+    assert cap["balance"] != 10000.0  # P&L applied
+
+
+def test_atomicity_capital_failure_aborts_close(fresh_db_with_two_tenants):
+    """If apply_pnl_to_capital raises, the position close is rolled back."""
+    from operators.position_closure import PositionClosure
+    from db import capital as capital_module
+
+    original = capital_module.apply_pnl_to_capital
+
+    def boom(con, tenant_id, pnl_usd):
+        raise sqlite3.OperationalError("simulated capital failure")
+
+    with patch.object(capital_module, "apply_pnl_to_capital", boom):
+        with pytest.raises(sqlite3.OperationalError, match="simulated capital failure"):
+            with PositionClosure(
+                pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+                mode="USER", caller_tenant_id=1,
+            ) as closure:
+                closure.execute()
+
+    with transaction() as con:
+        pos = con.execute("SELECT status FROM positions WHERE id=1").fetchone()
+        cap = con.execute("SELECT balance FROM capital WHERE tenant_id=1").fetchone()
+    assert pos["status"] == "open"
+    assert cap["balance"] == 10000.0
+
+
+# ---- Invariant 2: ownership-before-lock ----
+
+def test_ownership_check_skips_begin_immediate(fresh_db_with_two_tenants):
+    """USER-mode ownership mismatch must NOT open a write transaction."""
+    from operators.position_closure import PositionClosure
+    from db import transaction as tx_module
+
+    begin_count = {"n": 0}
+    original_transaction = tx_module.transaction
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def counting_transaction():
+        begin_count["n"] += 1
+        with original_transaction() as con:
+            yield con
+
+    with patch.object(tx_module, "transaction", counting_transaction):
+        with PositionClosure(
+            pos_id=2, exit_price=220.0, exit_reason="MANUAL",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            outcome = closure.execute()
+
+    assert outcome.status == "not_found"
+    assert begin_count["n"] == 0
+
+
+# ---- Invariant 3: IDOR-equivalence in USER mode ----
+
+def test_idor_equivalent_not_found_for_missing_and_other_tenant(fresh_db_with_two_tenants):
+    """USER mode: missing row and other-tenant row both return identical NOT_FOUND."""
+    from operators.position_closure import PositionClosure
+
+    with PositionClosure(
+        pos_id=9999, exit_price=100.0, exit_reason="MANUAL",
+        mode="USER", caller_tenant_id=1,
+    ) as closure:
+        missing = closure.execute()
+
+    with PositionClosure(
+        pos_id=2, exit_price=220.0, exit_reason="MANUAL",
+        mode="USER", caller_tenant_id=1,
+    ) as closure:
+        other_tenant = closure.execute()
+
+    assert missing.status == "not_found"
+    assert other_tenant.status == "not_found"
+    assert missing.position is None
+    assert other_tenant.position is None
+
+
+# ---- Invariant 4: SYSTEM mode no-IDOR-leak ----
+
+def test_system_mode_closes_correct_tenants_capital(fresh_db_with_two_tenants):
+    """SYSTEM mode applies P&L to the position's owning tenant, not cross-leaked."""
+    from operators.position_closure import PositionClosure
+
+    with PositionClosure(
+        pos_id=2, exit_price=220.0, exit_reason="TP_HIT",
+        mode="SYSTEM",
+    ) as closure:
+        outcome = closure.execute()
+
+    assert outcome.status == "closed"
+    with transaction() as con:
+        cap1 = con.execute("SELECT balance FROM capital WHERE tenant_id=1").fetchone()
+        cap2 = con.execute("SELECT balance FROM capital WHERE tenant_id=2").fetchone()
+    assert cap1["balance"] == 10000.0
+    assert cap2["balance"] != 5000.0
+
+
+# ---- Invariant 5: no post-commit side-effect on exception ----
+
+def test_no_post_commit_side_effects_on_exception(fresh_db_with_two_tenants):
+    """If execute() raises, none of the 4 post-commit side-effects fire."""
+    from operators.position_closure import PositionClosure
+    from db import capital as capital_module
+
+    with patch.object(capital_module, "apply_pnl_to_capital",
+                      side_effect=sqlite3.OperationalError("boom")):
+        with patch("operators.position_closure._write_position_event_log") as ev, \
+             patch("operators.position_closure.trigger_health_evaluation") as he, \
+             patch("operators.position_closure.notify") as nf, \
+             patch("operators.position_closure.update_positions_json") as up:
+            with pytest.raises(sqlite3.OperationalError):
+                with PositionClosure(
+                    pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+                    mode="USER", caller_tenant_id=1,
+                ) as closure:
+                    closure.execute()
+
+    assert ev.call_count == 0
+    assert he.call_count == 0
+    assert nf.call_count == 0
+    assert up.call_count == 0
+
+
+# ---- Invariant 6: single side-effect firing on success ----
+
+def test_each_side_effect_fires_exactly_once_on_success(fresh_db_with_two_tenants):
+    """Each of the 4 post-commit side-effects is invoked exactly once."""
+    from operators.position_closure import PositionClosure
+
+    with patch("operators.position_closure._write_position_event_log") as ev, \
+         patch("operators.position_closure.trigger_health_evaluation") as he, \
+         patch("operators.position_closure.notify") as nf, \
+         patch("operators.position_closure.update_positions_json") as up:
+        with PositionClosure(
+            pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            closure.execute()
+
+    assert ev.call_count == 1
+    assert he.call_count == 1
+    assert nf.call_count == 1
+    assert up.call_count == 1
+
+
+# ---- Invariant 7: idempotent re-close ----
+
+def test_idempotent_reclose_returns_already_closed(fresh_db_with_two_tenants):
+    """Closing an already-closed position returns ALREADY_CLOSED, no re-fire."""
+    from operators.position_closure import PositionClosure
+
+    with PositionClosure(
+        pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+        mode="USER", caller_tenant_id=1,
+    ) as closure:
+        closure.execute()
+
+    with transaction() as con:
+        cap_after_first = con.execute(
+            "SELECT balance FROM capital WHERE tenant_id=1"
+        ).fetchone()["balance"]
+
+    with patch("operators.position_closure.notify") as nf:
+        with PositionClosure(
+            pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            second_outcome = closure.execute()
+
+    assert second_outcome.status == "already_closed"
+    assert nf.call_count == 0
+    with transaction() as con:
+        cap_after_second = con.execute(
+            "SELECT balance FROM capital WHERE tenant_id=1"
+        ).fetchone()["balance"]
+    assert cap_after_first == cap_after_second
+
+
+# ---- Invariant 8: no writer-lock held across I/O ----
+
+def test_no_writer_lock_held_across_post_commit_side_effects(fresh_db_with_two_tenants):
+    """Post-commit side-effects fire strictly after transaction() exits."""
+    from operators.position_closure import PositionClosure
+    from db import transaction as tx_module
+
+    tx_exit_time = {"t": None}
+    side_effect_times = {"ev": None, "he": None, "nf": None, "up": None}
+
+    original_transaction = tx_module.transaction
+    from contextlib import contextmanager
+
+    @contextmanager
+    def timed_transaction():
+        with original_transaction() as con:
+            yield con
+        import time
+        tx_exit_time["t"] = time.perf_counter()
+
+    def record_time(name):
+        def _fn(*args, **kwargs):
+            import time
+            side_effect_times[name] = time.perf_counter()
+        return _fn
+
+    with patch.object(tx_module, "transaction", timed_transaction), \
+         patch("operators.position_closure._write_position_event_log", record_time("ev")), \
+         patch("operators.position_closure.trigger_health_evaluation", record_time("he")), \
+         patch("operators.position_closure.notify", record_time("nf")), \
+         patch("operators.position_closure.update_positions_json", record_time("up")):
+        with PositionClosure(
+            pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            closure.execute()
+
+    assert tx_exit_time["t"] is not None
+    for name, t in side_effect_times.items():
+        assert t is not None, f"side-effect {name} was not called"
+        assert t >= tx_exit_time["t"], f"side-effect {name} fired during tx"
+
+
+# ---- Invariant 9: no-tenant capital skip ----
+
+def test_legacy_null_tenant_position_close_skips_capital(fresh_db_with_two_tenants):
+    """Closing a tenant_id=NULL legacy row commits but skips capital UPSERT."""
+    from operators.position_closure import PositionClosure
+
+    with transaction() as con:
+        con.execute(
+            """INSERT INTO positions
+               (id, symbol, direction, entry_price, qty, sl_price, tp_price,
+                status, entry_ts, tenant_id, atr_entry, be_mult)
+               VALUES (99, 'LEGACY', 'long', 100.0, 1.0, 95.0, 110.0,
+                       'open', ?, NULL, 2.0, 1.5)""",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+
+    with PositionClosure(
+        pos_id=99, exit_price=110.0, exit_reason="TP_HIT",
+        mode="SYSTEM",
+    ) as closure:
+        outcome = closure.execute()
+
+    assert outcome.status == "closed"
+    with transaction() as con:
+        pos = con.execute("SELECT status FROM positions WHERE id=99").fetchone()
+        # No capital row should exist for tenant=NULL.
+        cap_null = con.execute("SELECT * FROM capital WHERE tenant_id IS NULL").fetchall()
+    assert pos["status"] == "closed"
+    assert cap_null == []
+```
+
+- [ ] **Step 3: Verify all 9 tests fail with ModuleNotFoundError**
+
+Run: `pytest tests/operators/test_position_closure.py -v 2>&1 | tail -20`
+Expected: `ModuleNotFoundError: No module named 'operators'` (collection error).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/operators/
+git commit -m "test(operators): add 9 invariant tests for PositionClosure (anchors #451)"
+```
+
+---
+
+### Task 3: Create the operators package + CloseOutcome dataclass
+
+**Files:**
+- Create: `operators/__init__.py`
+- Create: `operators/position_closure.py` (skeleton only — full implementation in Task 4)
+
+- [ ] **Step 1: Create empty package marker**
+
+Create `operators/__init__.py` as an empty file.
+
+- [ ] **Step 2: Create `operators/position_closure.py` with `CloseOutcome` dataclass and class skeleton**
+
+```python
+"""PositionClosure — business operator for closing a position.
+
+Implements the contract specified in
+docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md
+Section 'PositionClosure operator contract spec'.
+
+Single legal entry point for closing a position. The only caller of
+transaction() in the close-flow. db/* helpers are pure SQL and receive
+con from this operator.
+"""
+from __future__ import annotations
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+import sqlite3
+from typing import Literal, Optional
+
+from db.transaction import transaction
+from db.connection import _open_configured_connection
+
+log = logging.getLogger("operators.position_closure")
+
+_VALID_EXIT_REASONS = frozenset({"MANUAL", "SL_HIT", "TP_HIT", "TIME_LIMIT_HIT"})
+
+
+@dataclass(frozen=True)
+class CloseOutcome:
+    status: Literal["closed", "not_found", "already_closed"]
+    position: Optional[dict]
+    pnl_usd: Optional[float]
+    pnl_pct: Optional[float]
+
+
+class PositionClosure:
+    """See module docstring."""
+
+    def __init__(
+        self,
+        pos_id: int,
+        exit_price: float,
+        exit_reason: str,
+        *,
+        mode: Literal["USER", "SYSTEM"],
+        caller_tenant_id: Optional[int] = None,
+        cfg: Optional[dict] = None,
+        now: Optional[datetime] = None,
+    ) -> None:
+        if mode not in ("USER", "SYSTEM"):
+            raise ValueError(f"mode must be 'USER' or 'SYSTEM', got {mode!r}")
+        if mode == "USER":
+            if caller_tenant_id is None or caller_tenant_id <= 0:
+                raise ValueError("USER mode requires caller_tenant_id > 0")
+        if mode == "SYSTEM" and caller_tenant_id is not None:
+            raise ValueError("SYSTEM mode forbids caller_tenant_id (got %r)" % caller_tenant_id)
+        if exit_price <= 0:
+            raise ValueError(f"exit_price must be > 0, got {exit_price}")
+        if exit_reason not in _VALID_EXIT_REASONS:
+            raise ValueError(
+                f"exit_reason must be one of {sorted(_VALID_EXIT_REASONS)}, got {exit_reason!r}"
+            )
+
+        self._pos_id = pos_id
+        self._exit_price = exit_price
+        self._exit_reason = exit_reason
+        self._mode = mode
+        self._caller_tenant_id = caller_tenant_id
+        self._cfg = cfg
+        self._now = now or datetime.now(timezone.utc)
+
+        self._state: Literal["INIT", "NOT_FOUND", "ALREADY_CLOSED", "OK_TO_PROCEED"] = "INIT"
+        self._pre_row: Optional[dict] = None
+        self._result_row: Optional[dict] = None
+        self._consumed = False
+
+    def __enter__(self) -> "PositionClosure":
+        raise NotImplementedError  # Filled in Task 4
+
+    def execute(self) -> CloseOutcome:
+        raise NotImplementedError  # Filled in Task 4
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        raise NotImplementedError  # Filled in Task 4
+```
+
+- [ ] **Step 3: Verify import works (tests should still fail but with a different error now)**
+
+Run: `python -c "from operators.position_closure import PositionClosure, CloseOutcome; print('ok')"`
+Expected: `ok`.
+
+Run: `pytest tests/operators/test_position_closure.py -v 2>&1 | tail -10`
+Expected: tests collect, fail with `NotImplementedError` instead of `ModuleNotFoundError`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add operators/
+git commit -m "feat(operators): skeleton for PositionClosure + CloseOutcome dataclass"
+```
+
+---
+
+### Task 4: Implement PositionClosure lifecycle + add db_get_position_by_id + db_close_position_sql
+
+**Files:**
+- Modify: `operators/position_closure.py`
+- Modify: `db/positions.py`
+
+This task does three things together because they form one logical unit (the operator + the two pure helpers it needs that don't exist yet).
+
+- [ ] **Step 1: Add `db_get_position_by_id` to `db/positions.py`**
+
+Open `db/positions.py`. After the existing `db_get_positions` function (or wherever helpers are grouped), add:
+
+```python
+def db_get_position_by_id(con: sqlite3.Connection, pos_id: int) -> Optional[dict]:
+    """Read a single position by id. Pure SQL — no tenant filter.
+
+    Caller is responsible for tenant ownership check (per Task 8.5 design
+    where helpers are pure SQL operators; ownership lives in the business
+    operator).
+    """
+    row = con.execute("SELECT * FROM positions WHERE id = ?", (pos_id,)).fetchone()
+    return dict(row) if row else None
+```
+
+If `sqlite3` and `Optional` are not yet imported at module top, ensure they are:
+
+```python
+import sqlite3
+from typing import Optional
+```
+
+- [ ] **Step 2: Add `db_close_position_sql` to `db/positions.py`**
+
+In `db/positions.py`, add (typically after `db_close_position` so the diff stays local):
+
+```python
+def db_close_position_sql(
+    con: sqlite3.Connection,
+    pos_id: int,
+    exit_price: float,
+    exit_reason: str,
+    exit_ts: str,
+    pnl_usd: float,
+    pnl_pct: float,
+) -> dict:
+    """Pure SQL: UPDATE the position to closed. Returns the updated row.
+
+    No health trigger, no notify, no logging beyond ERROR. Caller (operator)
+    owns lifecycle, transaction, and side-effects.
+    """
+    con.execute(
+        """UPDATE positions
+           SET status = 'closed',
+               exit_price = ?,
+               exit_ts = ?,
+               exit_reason = ?,
+               pnl_usd = ?,
+               pnl_pct = ?
+           WHERE id = ?""",
+        (exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, pos_id),
+    )
+    row = con.execute("SELECT * FROM positions WHERE id = ?", (pos_id,)).fetchone()
+    return dict(row)
+```
+
+- [ ] **Step 3: Implement `__enter__`, `execute()`, and `__exit__` in `operators/position_closure.py`**
+
+Replace the three `NotImplementedError` stubs with real implementations. Add the required imports to the top of the file:
+
+```python
+from db.positions import db_get_position_by_id, db_close_position_sql, _calc_pnl
+from db.capital import apply_pnl_to_capital
+from api.positions import _write_position_event_log, update_positions_json
+from health import trigger_health_evaluation
+from notifier import notify
+from api.config import load_config
+```
+
+Then the three methods:
+
+```python
+    def __enter__(self) -> "PositionClosure":
+        if self._consumed:
+            raise RuntimeError("PositionClosure is single-use; construct a new one")
+        # Open a short-lived read-only connection outside any write transaction.
+        with closing(_open_configured_connection()) as con:
+            self._pre_row = db_get_position_by_id(con, self._pos_id)
+        if self._pre_row is None:
+            self._state = "NOT_FOUND"
+            return self
+        if self._mode == "USER":
+            if self._pre_row.get("tenant_id") != self._caller_tenant_id:
+                self._state = "NOT_FOUND"  # IDOR-safe collapse
+                return self
+        if self._pre_row.get("status") != "open":
+            self._state = "ALREADY_CLOSED"
+            return self
+        self._state = "OK_TO_PROCEED"
+        return self
+
+    def execute(self) -> CloseOutcome:
+        if self._consumed:
+            raise RuntimeError("PositionClosure already executed; single-use")
+        self._consumed = True
+
+        if self._state == "NOT_FOUND":
+            return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
+        if self._state == "ALREADY_CLOSED":
+            return CloseOutcome(
+                status="already_closed",
+                position=self._pre_row,
+                pnl_usd=None,
+                pnl_pct=None,
+            )
+        # OK_TO_PROCEED
+        with transaction() as con:
+            # Re-select inside the write tx to cover the race window.
+            row = db_get_position_by_id(con, self._pos_id)
+            if row is None:
+                return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
+            if row.get("status") != "open":
+                self._result_row = row
+                return CloseOutcome(
+                    status="already_closed", position=row, pnl_usd=None, pnl_pct=None,
+                )
+
+            pnl_usd, pnl_pct = _calc_pnl(
+                row["direction"], row["entry_price"], self._exit_price, row["qty"],
+            )
+            exit_ts = self._now.isoformat()
+            closed_row = db_close_position_sql(
+                con, self._pos_id, self._exit_price, self._exit_reason,
+                exit_ts, pnl_usd, pnl_pct,
+            )
+            tenant_id = closed_row.get("tenant_id")
+            if tenant_id is not None and pnl_usd is not None:
+                apply_pnl_to_capital(con, tenant_id, pnl_usd)
+            elif tenant_id is None:
+                log.warning(
+                    "PositionClosure: skipping capital roll-in for legacy tenant_id=NULL pos_id=%s",
+                    self._pos_id,
+                )
+            self._result_row = closed_row
+            self._result_pnl = (pnl_usd, pnl_pct)
+        # Transaction committed here.
+        return CloseOutcome(
+            status="closed",
+            position=self._result_row,
+            pnl_usd=self._result_pnl[0],
+            pnl_pct=self._result_pnl[1],
+        )
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if exc_type is not None:
+            log.error(
+                "PositionClosure failed: pos_id=%s mode=%s caller_tenant_id=%s "
+                "exit_reason=%s exit_price=%s exception=%s",
+                self._pos_id, self._mode, self._caller_tenant_id,
+                self._exit_reason, self._exit_price, exc_type.__name__,
+            )
+            return False  # propagate
+
+        if self._result_row is None:
+            # NOT_FOUND or ALREADY_CLOSED path — no side-effects to fire.
+            return False
+
+        cfg = self._cfg or load_config()
+        # 1) event log
+        try:
+            _write_position_event_log(
+                self._result_row, self._exit_reason, self._exit_price,
+            )
+        except Exception as e:  # pragma: no cover - best-effort
+            log.warning("PositionClosure: event log failed: %s", e)
+        # 2) health trigger
+        try:
+            trigger_health_evaluation(self._result_row["symbol"], cfg)
+        except Exception as e:  # pragma: no cover
+            log.warning("PositionClosure: health trigger failed: %s", e)
+        # 3) notify
+        try:
+            from notifier import PositionExitEvent  # local import: notifier import is slow
+            notify(
+                PositionExitEvent(
+                    position=self._result_row,
+                    exit_reason=self._exit_reason,
+                    exit_price=self._exit_price,
+                    pnl_usd=self._result_pnl[0],
+                ),
+                cfg=cfg,
+            )
+        except Exception as e:  # pragma: no cover
+            log.warning("PositionClosure: notify failed: %s", e)
+        # 4) positions snapshot
+        try:
+            update_positions_json()
+        except Exception as e:  # pragma: no cover
+            log.warning("PositionClosure: positions snapshot failed: %s", e)
+        return False
+```
+
+**Note:** the local import `from notifier import PositionExitEvent` may need adjustment depending on the actual notifier API. If `notify()` accepts a dict instead of an event object, adapt. Check `notifier/__init__.py` for the public API before finalizing this code.
+
+- [ ] **Step 4: Run the 9 invariant tests**
+
+Run: `pytest tests/operators/test_position_closure.py -v 2>&1 | tail -30`
+Expected: all 9 tests pass. If any fail, investigate before committing.
+
+If `notify()` signature doesn't match the assumed API, you'll see test failures. Adjust the operator's `__exit__` to match the real signature; do NOT change the notifier itself in this task.
+
+- [ ] **Step 5: Smoke check that existing tests didn't regress**
+
+Run: `pytest tests/api/ tests/db/ -q --tb=no 2>&1 | tail -10`
+Expected: no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/positions.py operators/position_closure.py
+git commit -m "feat(operators): implement PositionClosure lifecycle + pure SQL helpers (db_get_position_by_id, db_close_position_sql)
+
+The 9 invariant tests now pass. db_close_position dual-contract function
+still exists; it's removed in Task 6 after callers migrate."
+```
+
+---
+
+### Task 5: Make apply_pnl_to_capital + db_get_capital + db_upsert_capital take con mandatory
+
+**Files:**
+- Modify: `db/capital.py`
+- Modify: any callers that currently call these without `con`.
+
+These three helpers are called by `PositionClosure` (Task 4) and by other callers in the codebase. We're making the contract explicit: helpers don't open transactions.
+
+- [ ] **Step 1: Grep all callers of these three functions**
+
+```bash
+grep -rn "apply_pnl_to_capital\|db_get_capital\|db_upsert_capital" --include="*.py" .
+```
+
+Note every callsite. Classify each: (a) already passes `con`, (b) doesn't pass `con` and relies on helper opening tx.
+
+- [ ] **Step 2: Change signatures in `db/capital.py`**
+
+For each of `apply_pnl_to_capital`, `db_get_capital`, `db_upsert_capital`, `db_list_active_tenant_ids`:
+
+Before:
+```python
+def db_get_capital(tenant_id: int, con: Optional[sqlite3.Connection] = None) -> Optional[dict]:
+    with _tx_or_use(con) as con:
+        ...
+```
+
+After:
+```python
+def db_get_capital(con: sqlite3.Connection, tenant_id: int) -> Optional[dict]:
+    row = con.execute("SELECT * FROM capital WHERE tenant_id = ?", (tenant_id,)).fetchone()
+    return dict(row) if row else None
+```
+
+Notes:
+- `con` becomes positional first arg.
+- `_tx_or_use(con)` block removed; SQL executes directly on `con`.
+- Type hint: `sqlite3.Connection` (no Optional).
+- `apply_pnl_to_capital` previously called itself via auto-recursion with `inner_con` — flatten: with mandatory `con`, the function just reads + writes inline (no `_tx_or_use(None)` recursive call).
+
+- [ ] **Step 3: Update every caller identified in Step 1**
+
+For each callsite (a) that already passes `con`: change call to positional, e.g., `db_get_capital(con, tenant_id)`. For each (b) that doesn't: wrap in `with transaction() as con:` block, then call `db_get_capital(con, tenant_id)`. Update keyword arg style to positional throughout.
+
+- [ ] **Step 4: Run capital and positions tests**
+
+Run: `pytest tests/ -k "capital or positions" --tb=short 2>&1 | tail -30`
+Expected: pass.
+
+Run the 9 invariant tests too:
+Run: `pytest tests/operators/test_position_closure.py -v 2>&1 | tail -15`
+Expected: still 9/9 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/capital.py api/ db/ scripts/ tests/ scanner/ strategy/ health.py
+git commit -m "refactor(capital): apply_pnl_to_capital + db_get/upsert_capital require con mandatory
+
+Helpers are pure Cat. 1 SQL operators. _tx_or_use is removed from these
+helpers (still present elsewhere; full removal in Task 13)."
+```
+
+---
+
+### Task 6: Migrate api/positions.py callers to PositionClosure
+
+**Files:**
+- Modify: `api/positions.py`
+
+Two callers migrate: the user-facing endpoint and the scanner.
+
+- [ ] **Step 1: Migrate `close_position` endpoint (USER mode)**
+
+Find the existing `close_position` endpoint function in `api/positions.py` (around lines 390-413). Replace its body with:
+
+```python
+@router.post("/positions/{pos_id}/close")
+async def close_position(
+    pos_id: int,
+    request: Request,
+    tenant_id: int = Depends(get_current_tenant_id),
+):
+    """Close a position. USER-mode PositionClosure handles all the
+    choreography (atomicity, ownership, post-commit side-effects)."""
+    from operators.position_closure import PositionClosure
+
+    body = await request.json() if request.headers.get("content-length") else {}
+    exit_price = body.get("exit_price")
+    exit_reason = body.get("exit_reason", "MANUAL")
+
+    if exit_price is None:
+        raise HTTPException(422, "exit_price required")
+
+    with PositionClosure(
+        pos_id=pos_id,
+        exit_price=float(exit_price),
+        exit_reason=exit_reason,
+        mode="USER",
+        caller_tenant_id=tenant_id,
+    ) as closure:
+        outcome = closure.execute()
+
+    if outcome.status == "not_found":
+        raise HTTPException(404, "position not found")
+    if outcome.status == "already_closed":
+        return {"ok": True, "position": outcome.position, "already_closed": True}
+    return {"ok": True, "position": outcome.position}
+```
+
+Adjust to match the real endpoint signature (path params, body schema, response model) in your codebase. The key change is: the body is one `with PositionClosure(...)` block; the four old calls (`db_close_position`, `_write_position_event_log`, `_apply_close_to_capital`, `update_positions_json`) all disappear from here.
+
+- [ ] **Step 2: Migrate `check_position_stops` scanner (SYSTEM mode)**
+
+Find `check_position_stops` in `api/positions.py` (around lines 135-335). The current shape has:
+- Outer `with transaction() as con:` for SELECT open positions + trailing-SL UPDATEs + inline `db_close_position(con=con)` + `_apply_close_to_capital(closed, con=con)`.
+- Post-tx `post_tx_actions` accumulator that fires event log + health + notify in a loop outside the tx.
+
+New shape (preserve all existing logic — this is structural):
+
+```python
+def check_position_stops(symbol, price, now=None, *, symbol_price_overrides=None):
+    """Per-tick decision: read open positions for this symbol, apply trailing-SL,
+    and close positions that hit SL/TP/TIME_LIMIT. Uses PositionClosure for the
+    close-flow so atomicity and side-effects are handled correctly.
+    """
+    # ... existing kwarg validation, batch-mode dispatch (symbol_price_overrides
+    # path), config loading — all unchanged ...
+
+    cfg = load_config()
+    now = now or datetime.now(timezone.utc)
+
+    # Phase 1: read open positions + apply trailing-SL writes in one tx.
+    # (Trailing-SL is per-tick mutation; not part of the close-flow.)
+    pos_list_to_close = []
+    with transaction() as con:
+        rows = con.execute(
+            "SELECT * FROM positions WHERE symbol = ? AND status = 'open'",
+            (symbol,),
+        ).fetchall()
+        pos_list = [dict(r) for r in rows]
+        for pos in pos_list:
+            # Existing trailing-SL ratchet logic — unchanged
+            new_sl = _compute_trailing_sl(pos, price)  # or whatever the existing helper is
+            if new_sl is not None and new_sl > pos["sl_price"]:
+                con.execute(
+                    "UPDATE positions SET sl_price = ? WHERE id = ?",
+                    (new_sl, pos["id"]),
+                )
+                pos["sl_price"] = new_sl
+
+            # Decision: should this position close?
+            reason, exit_price = _decide_exit(pos, price, now, cfg)  # or equivalent
+            if reason:
+                pos_list_to_close.append((pos["id"], exit_price, reason))
+    # Trailing-SL writes are now durable.
+
+    # Phase 2: close each marked position via PositionClosure in SYSTEM mode.
+    # Each closure is its own atomic close + capital tx + post-commit side-effects.
+    from operators.position_closure import PositionClosure
+    for pos_id, exit_price, reason in pos_list_to_close:
+        try:
+            with PositionClosure(
+                pos_id=pos_id,
+                exit_price=exit_price,
+                exit_reason=reason,
+                mode="SYSTEM",
+                cfg=cfg,
+                now=now,
+            ) as closure:
+                closure.execute()
+        except Exception:
+            log.exception("PositionClosure failed for pos_id=%s", pos_id)
+            continue
+```
+
+Delete:
+- `_apply_close_to_capital` shim function (lines ~52-80). The operator now owns capital roll-in.
+- `post_tx_actions` accumulator and the post-tx loop that drains it.
+- Any local imports of `trigger_health_evaluation`, `notify`, etc. that existed only for the post-tx loop.
+
+If your codebase has helpers named differently than `_compute_trailing_sl` or `_decide_exit`, use the real names. Do not invent — preserve the existing decision logic.
+
+- [ ] **Step 3: Run the regression test for the trading invariant**
+
+Run: `pytest tests/api/test_check_position_stops_atomicity.py -v 2>&1 | tail -20`
+Expected: PASS.
+
+Run: `pytest tests/api/ tests/operators/ --tb=short 2>&1 | tail -30`
+Expected: no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/positions.py
+git commit -m "feat(positions): migrate close_position endpoint + check_position_stops to PositionClosure operator
+
+Resolves #446 for the close-flow specifically. Both callers now use the
+operator; _apply_close_to_capital shim deleted; post_tx_actions loop
+deleted. The trailing-SL writes still live in their own per-tick tx
+(intentional separation: trailing is price-tick, close is business
+transition)."
+```
+
+---
+
+### Task 7: Delete the old db_close_position function
+
+**Files:**
+- Modify: `db/positions.py`
+- Modify: any test files that called the old function.
+
+- [ ] **Step 1: Grep for remaining callers**
+
+```bash
+grep -rn "db_close_position\b" --include="*.py" .
+```
+
+Should show no callers other than `db_close_position_sql` (added in Task 4) and the old `db_close_position` definition. If any production caller remains, it was missed — migrate it to `PositionClosure` before deleting.
+
+If tests directly call the old `db_close_position`, decide per test: (a) does the test verify the close-flow semantics? → migrate to use `PositionClosure`. (b) Does it verify the pure SQL UPDATE? → migrate to use `db_close_position_sql`. (c) Was it testing the `_caller_owned_con` branch? → delete as patology (per Voronov's "tests that resist migration are testing the patology").
+
+- [ ] **Step 2: Delete the old `db_close_position` function from `db/positions.py`**
+
+Remove the entire `def db_close_position(...)` block including the `_caller_owned_con` logic, the `_tx_or_use(con)` wrapper, the standalone-mode health trigger import, and the docstring.
+
+- [ ] **Step 3: Verify production grep is clean**
+
+```bash
+grep -rn "db_close_position\b" --include="*.py" . | grep -v "db_close_position_sql"
+```
+Expected: empty.
+
+```bash
+grep -rn "_caller_owned_con" --include="*.py" .
+```
+Expected: empty.
+
+- [ ] **Step 4: Run full test suite, note pass/fail counts**
+
+Run: `pytest tests/ --tb=no -q 2>&1 | tail -5`
+Note the numbers. Compare to baseline (2502 collected). Expect some test fixes needed in Task 8 if callsites changed signature.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/positions.py tests/
+git commit -m "refactor(positions): delete db_close_position dual-contract function
+
+All callers migrated to PositionClosure (production) or
+db_close_position_sql (pure SQL tests). The _caller_owned_con pattern
+and the standalone-mode health trigger are gone from db/."
+```
+
+---
+
+### Task 8: Mechanical sweep — db/ helpers (Cat. 1) to con mandatory
+
+**Files:**
+- Modify: `db/positions.py` (remaining helpers), `db/signals.py`, `db/schema.py`, `db/auth_schema.py`, `db/user_preferences.py`.
+- Modify: all callers of those helpers that don't already pass `con`.
+
+This is the biggest mechanical task. Apply the same pattern uniformly.
+
+- [ ] **Step 1: For each helper in scope, change the signature**
+
+For each of:
+
+`db/positions.py`: `db_create_position`, `db_last_exit_ts`, `db_get_positions`, `db_update_position`
+`db/signals.py`: `get_scans`, `get_latest_scan_per_symbol`, `get_latest_signal`, `get_latest_scan`, `get_signals_summary`
+`db/schema.py`: `backfill_tenant`, `_migrate_multi_tenant_b1`, `_migrate_agent_audit`, `_migrate_agent_history`
+`db/auth_schema.py`: `init_auth_db`, `has_any_user`, `init_system_state`, `is_setup_completed`, `mark_setup_completed`
+`db/user_preferences.py`: `db_get_user_preferences`, `db_upsert_user_preferences`
+
+Pattern:
+
+Before:
+```python
+def db_X(arg1, arg2, con: Optional[sqlite3.Connection] = None) -> ReturnType:
+    with _tx_or_use(con) as con:
+        # SQL body
+```
+
+After:
+```python
+def db_X(con: sqlite3.Connection, arg1, arg2) -> ReturnType:
+    # SQL body (one less indent)
+```
+
+- [ ] **Step 2: For each helper, audit and fix callsites**
+
+For each helper above, run:
+```bash
+grep -rn "helper_name(" --include="*.py" .
+```
+
+For each callsite:
+- If caller already passes `con` as kwarg: change to positional first arg.
+- If caller doesn't pass `con`: wrap the call in `with transaction() as con:` and pass `con` positionally.
+
+Caller categories typically seen:
+- Endpoints in `api/*.py` → wrap in `with transaction()` block.
+- Scripts in `scripts/*.py` → wrap.
+- Tests in `tests/*.py` → wrap.
+- Other helpers (e.g., `init_db` calling `_migrate_*`) → already inside a `transaction()`, just pass `con`.
+
+- [ ] **Step 3: Smoke test after each module migration**
+
+After finishing each module (`db/positions.py`, then `db/signals.py`, etc.), run:
+```bash
+pytest tests/ -k "<module_keyword>" --tb=short 2>&1 | tail -20
+```
+
+E.g. after `db/signals.py`: `pytest tests/ -k "signal or scan" --tb=short 2>&1 | tail -20`.
+
+Fix any failures before moving to the next module.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `pytest tests/ --tb=no -q 2>&1 | tail -5`
+Expected: pass count restored to baseline (2502) or better.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/ api/ scripts/ scanner/ strategy/ tests/ health.py auth/ notifier/
+git commit -m "refactor(db): Cat. 1 helpers in db/ require con mandatory
+
+db_create_position, db_get_positions, db_last_exit_ts, db_update_position,
+get_scans, get_latest_*, get_signals_summary, backfill_tenant, _migrate_*,
+init_auth_db, has_any_user, init_system_state, is_setup_completed,
+mark_setup_completed, db_get_user_preferences, db_upsert_user_preferences
+— all now take con: sqlite3.Connection (no Optional).
+
+Callers wrap in 'with transaction() as con:' where they did not before."
+```
+
+---
+
+### Task 9: Mechanical sweep — auth/, notifier/, health/, strategy/ helpers
+
+**Files:**
+- Modify: `auth/tokens.py`, `auth/audit.py`, `notifier/_storage.py`, `notifier/dedupe.py`, `notifier/dispatch_per_user.py`, `health.py`, `strategy/kill_switch_v2_shadow.py`.
+- Modify: all callers of those helpers that don't already pass `con`.
+
+Same pattern as Task 8.
+
+- [ ] **Step 1: Apply the signature pattern to each helper**
+
+For each of:
+
+`auth/tokens.py`: `create_refresh_token`, `lookup_refresh`, `revoke_refresh`, `revoke_family`, `revoke_all_for_user`
+`notifier/_storage.py`: `record_delivery`, `list_unread`, `mark_read`, `mark_all_read`
+`notifier/dedupe.py`: `should_send`
+`notifier/dispatch_per_user.py`: `_list_active_users`
+`health.py`: `_get_symbol_health_row`, `record_portfolio_transition`, `recent_portfolio_transitions`
+`strategy/kill_switch_v2_shadow.py`: `_load_closed_trades`, `_load_open_positions`
+
+Apply same Before/After pattern as Task 8.
+
+- [ ] **Step 2: For each, audit and fix callsites**
+
+Same as Task 8 Step 2.
+
+- [ ] **Step 3: Smoke test each module**
+
+After `auth/`: `pytest tests/ -k "auth" --tb=short 2>&1 | tail -20`
+After `notifier/`: `pytest tests/ -k "notifier or dedupe or dispatch" --tb=short 2>&1 | tail -20`
+After `health.py` + `strategy/`: `pytest tests/ -k "health or kill_switch" --tb=short 2>&1 | tail -20`
+
+- [ ] **Step 4: Full suite**
+
+Run: `pytest tests/ --tb=no -q 2>&1 | tail -5`
+Expected: pass count restored.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add auth/ notifier/ health.py strategy/ api/ scripts/ tests/
+git commit -m "refactor: Cat. 1 helpers in auth/, notifier/, health/, strategy/ require con mandatory
+
+create_refresh_token, lookup_refresh, revoke_*, record_delivery, list_unread,
+mark_read, mark_all_read, should_send, _list_active_users,
+_get_symbol_health_row, record_portfolio_transition, recent_portfolio_transitions,
+_load_closed_trades, _load_open_positions — all now take con: sqlite3.Connection.
+
+Callers wrap in 'with transaction() as con:' where they did not before."
+```
+
+---
+
+### Task 10: Migrate Cat. 2 hidden operators from _tx_or_use to direct transaction()
+
+**Files:**
+- Modify: `db/signals.py` (`save_scan`), `db/schema.py` (`init_db`), `auth/audit.py` (`log_auth_event`), `notifier/dispatch_per_user.py` (`dispatch_signal_to_users`).
+
+These 4 functions stay structurally where they are (operator-extraction is a separate ticket per the preconditions synthesis), but they cannot continue using `_tx_or_use` after it's deleted in Task 13. Migrate them to `transaction()` directly.
+
+- [ ] **Step 1: For each Cat. 2 hidden operator, replace `_tx_or_use(...)` with `transaction()`**
+
+Pattern: inside the function body, where `_tx_or_use(con)` appears (typically with `con=None` since these are top-level orchestrators), replace with `transaction()`:
+
+Before:
+```python
+def save_scan(scan_data):
+    with _tx_or_use(None) as con:
+        con.execute("INSERT INTO scans ...", ...)
+        scan_id = con.lastrowid
+    # Second tx for outcomes
+    with _tx_or_use(None) as con:
+        ...
+```
+
+After:
+```python
+def save_scan(scan_data):
+    with transaction() as con:
+        con.execute("INSERT INTO scans ...", ...)
+        scan_id = con.lastrowid
+    # Second tx for outcomes
+    with transaction() as con:
+        ...
+```
+
+- [ ] **Step 2: Verify each Cat. 2 function still works**
+
+Run targeted tests:
+```bash
+pytest tests/ -k "save_scan or init_db or log_auth_event or dispatch_signal" --tb=short 2>&1 | tail -20
+```
+Expected: pass.
+
+- [ ] **Step 3: Grep that the 4 functions no longer reference `_tx_or_use`**
+
+```bash
+grep -n "_tx_or_use" db/signals.py db/schema.py auth/audit.py notifier/dispatch_per_user.py
+```
+Expected: empty.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add db/signals.py db/schema.py auth/audit.py notifier/dispatch_per_user.py
+git commit -m "refactor: Cat. 2 hidden operators use transaction() directly, not _tx_or_use
+
+save_scan, init_db, log_auth_event, dispatch_signal_to_users — these
+remain hidden business operators (operator-extraction deferred to
+separate tickets) but no longer depend on _tx_or_use. Prepares for
+_tx_or_use deletion."
+```
+
+---
+
+### Task 11: Verify _tx_or_use has no remaining callers and delete it
+
+**Files:**
+- Modify: `db/transaction.py`
+
+- [ ] **Step 1: Grep for any remaining `_tx_or_use` callers**
+
+```bash
+grep -rn "_tx_or_use" --include="*.py" .
+```
+Expected: only the definition in `db/transaction.py` and possibly references in docstrings/comments.
+
+If any caller remains in production code, return to Task 8/9/10 and migrate it. Do not delete `_tx_or_use` until grep is clean.
+
+- [ ] **Step 2: Delete `_tx_or_use` from `db/transaction.py`**
+
+Open `db/transaction.py`. Delete:
+- The `_tx_or_use` function definition (lines ~60-83).
+- Any reference to `_tx_or_use` in module docstring or other comments.
+
+`transaction()` itself remains untouched.
+
+- [ ] **Step 3: Confirm `db/transaction.py` still imports cleanly**
+
+```bash
+python -c "from db.transaction import transaction; print('ok')"
+```
+Expected: `ok`.
+
+- [ ] **Step 4: Run the 9 wrapper contract tests for `transaction()`**
+
+```bash
+pytest tests/db/test_transaction.py -v 2>&1 | tail -15
+```
+Expected: 9/9 pass (no regression).
+
+- [ ] **Step 5: Run the 9 PositionClosure invariant tests**
+
+```bash
+pytest tests/operators/test_position_closure.py -v 2>&1 | tail -15
+```
+Expected: 9/9 pass.
+
+- [ ] **Step 6: Run full suite**
+
+```bash
+pytest tests/ --tb=no -q 2>&1 | tail -5
+```
+Expected: pass count at or near baseline. If any new failures, fix before commit.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add db/transaction.py
+git commit -m "refactor(db): delete _tx_or_use — issues #446, #447, #448 closed by construction
+
+All helpers now require con explicitly. PositionClosure is the only
+caller of transaction() in the close-flow. _tx_or_use was the fossil
+trace of an unnamed layer (Voronov, 2026-05-25); the layer is now
+named (operators/) and the fossil is gone."
+```
+
+---
+
+### Task 12: Fix the trailing-ratchet atomicity test fixture (#451)
+
+**Files:**
+- Modify: `tests/api/test_check_position_stops_atomicity.py`
+
+The existing test was flagged by Serrano (F-13): the fixture's math means the trailing-SL logic doesn't actually fire under the test scenario. The assertion accepts 4 valid outcomes when only 2 are valid. Fix.
+
+- [ ] **Step 1: Read the current test and its fixture**
+
+Run: `cat tests/api/test_check_position_stops_atomicity.py`
+
+Identify:
+- The position fixture parameters (entry_price, sl_price, atr_entry, be_mult).
+- The price used in the test (108.0 currently).
+- The assertion (`row["sl_price"] in {105.0, 100.0, 104.0, 108.0}`).
+
+- [ ] **Step 2: Adjust fixture so the scanner actually competes**
+
+Per Serrano's F-13 analysis: set `entry_price=98, sl_price=97` so `be_threshold = 98 + 3 = 101` and `108 >= 101 AND sl_price(97) < entry(98)` both True → trailing fires.
+
+Update the fixture seed:
+
+```python
+with transaction() as con:
+    con.execute(
+        """INSERT INTO positions
+           (id, symbol, direction, entry_price, qty, sl_price, tp_price,
+            status, entry_ts, tenant_id, atr_entry, be_mult)
+           VALUES (1, 'BTCUSDT', 'long', 98.0, 1.0, 97.0, 110.0,
+                   'open', ?, 1, 2.0, 1.5)""",
+        (0,),
+    )
+```
+
+- [ ] **Step 3: Tighten the assertion**
+
+Replace the loose set with exactly two valid outcomes (operator wins → 105.0; scanner wins → the computed trailing-SL value, which under these inputs is `98 + round(2.0 * 1.5, 2) = 101.0`).
+
+```python
+assert row["sl_price"] in {105.0, 101.0}, row["sl_price"]
+```
+
+Update the comment to reflect that exactly two winners are valid.
+
+- [ ] **Step 4: Run the regression test**
+
+Run: `pytest tests/api/test_check_position_stops_atomicity.py -v 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/api/test_check_position_stops_atomicity.py
+git commit -m "test(positions): fix trailing-ratchet atomicity fixture to actually trigger SL move (#451)
+
+Previous fixture had be_threshold=103 vs entry=100 with price=108; the
+trailing logic was a no-op for the scanner, making the assertion vacuous.
+New fixture (entry=98, sl=97) makes both branches of the race
+observable: scanner writes 101.0 (computed trailing) or operator writes
+105.0 (manual). Atomicity invariant is now actually tested."
+```
+
+---
+
+### Task 13: Update CLAUDE.md "Database access" section
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Read the current section**
+
+The "Database access" section was added in the previous PR. It currently describes `transaction()` as the entry point for callers. Replace with the new three-layer model.
+
+- [ ] **Step 2: Rewrite the section**
+
+Replace the existing "Database access" subsection with:
+
+```markdown
+## Database access
+
+Three-layer separation:
+
+### 1. Pure SQL helpers (`db/*.py`, `auth/*.py`, etc.)
+
+Receive `con: sqlite3.Connection` as a mandatory first argument. They run SQL and return data. No `transaction()` calls. No side-effects (no HTTP, no file I/O, no logging beyond DEBUG). Examples: `db_close_position_sql`, `db_get_capital`, `apply_pnl_to_capital`, `db_create_position`.
+
+### 2. Business operators (`operators/*.py`)
+
+Own `transaction()` for one named business transition. Orchestrate side-effects. Declare atomicity. The only legal entry point for the transitions they represent. Currently: `PositionClosure` (closing a position with atomic capital roll-in + post-commit health/notify/event-log/snapshot).
+
+Pattern:
+\`\`\`python
+from operators.position_closure import PositionClosure
+
+with PositionClosure(
+    pos_id=42, exit_price=110.0, exit_reason="TP_HIT",
+    mode="USER", caller_tenant_id=tenant_id,
+) as closure:
+    outcome = closure.execute()
+\`\`\`
+
+### 3. Direct `with transaction()` for ad-hoc unit-of-work
+
+When the caller needs a transactional scope around one or more pure SQL helpers but the operation isn't a named business transition, wrap the helpers in `with transaction() as con:` directly:
+
+\`\`\`python
+from db.transaction import transaction
+from db.signals import get_latest_signal
+
+with transaction() as con:
+    sig = get_latest_signal(con, "BTCUSDT")
+\`\`\`
+
+New business operators emerge from evidence (caller composes >1 helper + side-effect with conditional behavior), not preemptively. See `docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md` for the rationale (Voronov, 2026-05-25).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: rewrite Database access section for three-layer model (helpers / operators / direct tx)"
+```
+
+---
+
+### Task 14: Final verification
+
+**Files:** none modified (unless smoke fixes needed).
+
+- [ ] **Step 1: No `_tx_or_use` anywhere**
+
+```bash
+grep -rnE "_tx_or_use|_caller_owned_con" --include="*.py" --include="*.md" --exclude-dir=docs/superpowers/plans --exclude-dir=docs/superpowers/analysis --exclude-dir=.claude .
+```
+Expected: empty.
+
+- [ ] **Step 2: Full test suite**
+
+```bash
+pytest tests/ -q --tb=no 2>&1 | tail -5
+```
+Expected: 0 failed. Same skip count as baseline (~22, all network). Pass count at or near baseline (~2502).
+
+- [ ] **Step 3: Smoke imports for all migrated modules**
+
+```bash
+python -c "
+import importlib
+modules = [
+    'operators.position_closure',
+    'db.transaction', 'db.connection', 'db.positions', 'db.capital',
+    'db.signals', 'db.schema', 'db.auth_schema', 'db.user_preferences',
+    'auth.tokens', 'auth.audit',
+    'notifier._storage', 'notifier.dedupe', 'notifier.dispatch_per_user',
+    'health', 'strategy.kill_switch_v2_shadow',
+    'api.positions',
+]
+for m in modules:
+    importlib.import_module(m)
+print('all', len(modules), 'modules import cleanly')
+"
+```
+Expected: `all 17 modules import cleanly`.
+
+- [ ] **Step 4: Confirm PositionClosure tests pass**
+
+```bash
+pytest tests/operators/test_position_closure.py -v 2>&1 | tail -15
+```
+Expected: 9/9 pass.
+
+- [ ] **Step 5: Confirm wrapper contract tests still pass**
+
+```bash
+pytest tests/db/test_transaction.py -v 2>&1 | tail -15
+```
+Expected: 9/9 pass.
+
+- [ ] **Step 6: Confirm trailing-ratchet test passes with the corrected fixture**
+
+```bash
+pytest tests/api/test_check_position_stops_atomicity.py -v 2>&1 | tail -10
+```
+Expected: PASS.
+
+---
+
+### Task 15: Push, close issues, open PR
+
+**Files:** none modified.
+
+**REQUIRES USER CONFIRMATION** — pushes to dad's repo + opens externally-visible PR.
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/fix-tx-or-use-dual-contract-446
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --repo sssimon/trading-spacial \
+  --title "feat: introduce PositionClosure operator + demote db/ to pure SQL layer (closes #446, #447, #448, #449)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Implements the architectural direction articulated by Voronov on 2026-05-25 (see analysis docs in `docs/superpowers/analysis/`). `db/` becomes a pure SQL layer where helpers receive `con: sqlite3.Connection` mandatory. Business transitions live in the new `operators/` package; the first inhabitant is `PositionClosure`.
+
+`_tx_or_use` is deleted. All 34 Cat. 1 helpers migrate to `con` mandatory. The 5 Cat. 2 hidden business operators (save_scan, init_db, log_auth_event, dispatch_signal_to_users, ex-db_close_position) use `transaction()` directly; operator-extraction for the remaining 4 is deferred to separate tickets.
+
+## Resolves
+
+- **#446** (`_tx_or_use` dual-contract) — closed by construction; the dispatcher and its symbol both gone.
+- **#447** (named operator) — `PositionClosure` is the operator; pattern for future operators established.
+- **#448** (`con` validation) — disuelto; helpers no longer receive `con` from external callers without passing through the operator layer or an explicit `with transaction()` block.
+- **#449** (health trigger non-enforceable) — health trigger lives in `PositionClosure.__exit__`; called exactly once per successful close; tested by invariant #6.
+- **#451** (test laxness) — fixture corrected to actually trigger trailing-SL; assertion tightened to exactly two valid outcomes.
+
+## Resolves with explicit trade-off
+
+- **#450** (`apply_pnl_to_capital` best-effort silencioso) — capital roll-in now runs IN-TX inside the operator's transaction. Trade-off accepted: capital UPSERT failure aborts the close (position stays open). This is strictly safer than the inverse (close commits, capital silently desynced). Documented in `docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md` Section 'Post-commit side-effects'.
+
+## Deferred to separate tickets
+
+- Operator-extraction for the 4 remaining Cat. 2 hidden operators: `save_scan`, `init_db`, `log_auth_event`, `dispatch_signal_to_users`. They function correctly with `transaction()` directly; operator-naming is a separate exercise per Voronov's evidential rule.
+- `PositionOpening` operator: precondition 2 confirmed no current symptoms (no contract interrogation, no conditional side-effects, minimal composition). Create when evidence emerges.
+- Outbox infrastructure for true compensable post-commit delivery: v1 is best-effort log-and-continue. Separate epic.
+
+## Test plan
+
+- [x] 9 PositionClosure invariant tests (`tests/operators/test_position_closure.py`) — atomicity, ownership-before-lock, IDOR-equivalence (USER), no-IDOR-leak (SYSTEM), no-side-effects-on-exception, single-firing, idempotent re-close, no-lock-during-I/O, no-tenant capital skip.
+- [x] 9 `transaction()` wrapper contract tests still pass (no regression).
+- [x] `check_position_stops` atomicity regression test passes with corrected fixture.
+- [x] Full test suite: same baseline as before (no regressions).
+- [ ] Manual smoke in prod after merge: close a position via API, verify health + notify + event log + snapshot all fire. Run scanner cycle, verify position closes correctly on SL/TP hit.
+
+## Migration scope
+
+| Layer | Files | Notes |
+|---|---|---|
+| New | 4 | `operators/__init__.py`, `operators/position_closure.py`, `tests/operators/__init__.py`, `tests/operators/test_position_closure.py` |
+| Production helpers migrated | 13 | db/*, auth/*, notifier/*, health.py, strategy/* |
+| Production callers updated | several | wrapped in `with transaction()` where they relied on helper-opened tx |
+| Total commits | 15 | one per logical phase |
+
+## Architecture notes
+
+The two analysis documents are the source of truth for the design:
+- `docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md` — Serrano's clinical analysis (13 findings, 5 options) + Voronov's ontological reframe + direction.
+- `docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md` — audit results, opening-flow decision, multi-tenancy invariants, full `PositionClosure` contract spec.
+
+Read those before reviewing implementation details.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Close issues with cross-link to PR**
+
+```bash
+NEW_PR=$(gh pr view --json number --jq .number)
+for issue in 446 447 448 449; do
+  gh issue comment $issue --repo sssimon/trading-spacial --body "Closed structurally by #$NEW_PR (PositionClosure operator + db/ as pure SQL layer)."
+  gh issue close $issue --repo sssimon/trading-spacial
+done
+
+gh issue comment 450 --repo sssimon/trading-spacial --body "Closed by #$NEW_PR with explicit trade-off: apply_pnl_to_capital now runs IN-TX inside PositionClosure; capital UPSERT failure aborts the close (position stays open). This is the deliberate design — see PR description and \`docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md\` Section 'Post-commit side-effects' for the trade-off reasoning."
+gh issue close 450 --repo sssimon/trading-spacial
+
+gh issue comment 451 --repo sssimon/trading-spacial --body "Closed by #$NEW_PR: fixture corrected (entry=98, sl=97) so trailing-SL actually fires; assertion tightened to exactly two valid outcomes (105.0 operator-wins or 101.0 scanner-wins)."
+gh issue close 451 --repo sssimon/trading-spacial
+```
+
+- [ ] **Step 4: Done**
+
+The plan is fully executed when this step completes. Manual smoke in prod is the only remaining item, which is the user's call.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- All 5 BLOCKERS + 5 HIGHs from Serrano: tracked via tasks (PositionClosure, helper migration, deletion, fixture fix, docs).
+- Voronov's direction C strict: implemented in Tasks 3-4 (operator + pure helpers in db/), Tasks 8-9 (sweep), Task 11 (deletion).
+- All 9 invariants from preconditions synthesis: Task 2 (write tests) + Task 4 (implement to pass).
+- Multi-tenancy invariants (precondition 3): tested by invariants 2/3/4/9 + implemented in operator's `__enter__` ownership check.
+- `apply_pnl_to_capital` IN-TX trade-off: Task 5 (signature change) + Task 4 (operator calls it inside tx) + tested by invariant 1.
+- `_tx_or_use` deletion: Task 11.
+- Preconditions docs referenced in plan header and self-review.
+
+**Placeholder scan:** None of the disallowed patterns present. All code blocks complete. Migration patterns explicit (Before/After examples in Tasks 8/9).
+
+**Type consistency:**
+- `PositionClosure(...)`: constructor signature consistent across tasks.
+- `CloseOutcome`: dataclass fields (`status`, `position`, `pnl_usd`, `pnl_pct`) consistent.
+- `db_close_position_sql(con, pos_id, exit_price, exit_reason, exit_ts, pnl_usd, pnl_pct)`: same signature used in Task 4 implementation and operator.
+- `apply_pnl_to_capital(con: sqlite3.Connection, tenant_id, pnl_usd)`: same in Task 5 and operator.
+- `db_get_position_by_id(con: sqlite3.Connection, pos_id: int) -> Optional[dict]`: same in Task 4 and operator.
+
+**Caveats:**
+- The exact shape of `notify()`, `notifier.PositionExitEvent`, `_compute_trailing_sl`, and `_decide_exit` in the existing codebase may differ from the names assumed in Task 4 and Task 6. Implementer must read existing code and adapt — these are NOT placeholders; the implementer is told explicitly to "use the real names" in both tasks.
+- The `close_position` endpoint's exact signature (Body schema, async/sync, response model) varies; Task 6 says explicitly "adjust to match the real endpoint signature".
+- Number of helpers per module in Tasks 8-9 reflects the audit (Cat. 1 count = 34); if the audit missed any, implementer must add them to the sweep before Task 11's grep check.

--- a/docs/superpowers/plans/2026-05-25-446-position-closure-operator.md
+++ b/docs/superpowers/plans/2026-05-25-446-position-closure-operator.md
@@ -6,6 +6,8 @@
 
 **Architecture:** Three-layer separation per Voronov's ontology: (1) pure SQL operators in `db/`, `auth/`, `notifier/`, etc. — receive `con`, no side-effects, no `_tx_or_use`; (2) business operators in new `operators/` package — own `transaction()`, orchestrate side-effects, declare atomicity; (3) callers (endpoints, scanner, scripts) — instantiate operators OR wrap helpers in explicit `with transaction()` blocks. The first inhabitant of layer 2 is `PositionClosure`. Other operators (`PositionOpening`, etc.) emerge only when caller composition demands them.
 
+**Access primitives in `db/transaction.py`:** `transaction()` for read-write unit-of-work (BEGIN IMMEDIATE / COMMIT / ROLLBACK / close), `read_only_connection()` for pre-validation reads outside any transaction (no BEGIN; close on exit). Operators may use both; pure SQL helpers receive `con` and use neither.
+
 **Tech Stack:** Python 3, `sqlite3` stdlib, `contextlib`, `pytest`.
 
 ---
@@ -31,7 +33,7 @@ Locked decisions:
 - `operators/__init__.py` — empty marker for the new business-operator package.
 - `operators/position_closure.py` — `PositionClosure` context manager + `CloseOutcome` dataclass.
 - `tests/operators/__init__.py` — empty.
-- `tests/operators/test_position_closure.py` — 9 invariant tests (anchors #451).
+- `tests/operators/test_position_closure.py` — 10 invariant tests (anchors #451; invariant 10 encodes the "best-effort post-commit" commitment).
 
 ### Modified files (close-flow specific)
 
@@ -455,9 +457,46 @@ def test_legacy_null_tenant_position_close_skips_capital(fresh_db_with_two_tenan
         cap_null = con.execute("SELECT * FROM capital WHERE tenant_id IS NULL").fetchall()
     assert pos["status"] == "closed"
     assert cap_null == []
+
+
+# ---- Invariant 10: post-commit side-effect failure does NOT rollback close ----
+
+def test_side_effect_failure_does_not_rollback_close(fresh_db_with_two_tenants):
+    """Best-effort post-commit contract: if any of the 4 __exit__ side-effects
+    raises, the close + capital remain durably committed. Encodes the
+    Voronov AMBER F2 finding — the 'best-effort' commitment must live in
+    the test suite, not only in prose. A future contributor who 'fixes' the
+    try/except in __exit__ to raise will fail this test."""
+    from operators.position_closure import PositionClosure
+
+    # Force each of the 4 post-commit side-effects to raise. None of them
+    # should rollback the close (impossible — already committed) and none
+    # should propagate to the caller.
+    with patch("operators.position_closure._write_position_event_log",
+               side_effect=IOError("event log down")), \
+         patch("operators.position_closure.trigger_health_evaluation",
+               side_effect=RuntimeError("health module crashed")), \
+         patch("operators.position_closure.notify",
+               side_effect=ConnectionError("telegram unreachable")), \
+         patch("operators.position_closure.update_positions_json",
+               side_effect=OSError("disk full")):
+        with PositionClosure(
+            pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            outcome = closure.execute()
+
+    # Caller observes a clean close. All four side-effect failures were
+    # swallowed and logged as WARN by __exit__.
+    assert outcome.status == "closed"
+    with transaction() as con:
+        pos = con.execute("SELECT status FROM positions WHERE id=1").fetchone()
+        cap = con.execute("SELECT balance FROM capital WHERE tenant_id=1").fetchone()
+    assert pos["status"] == "closed"
+    assert cap["balance"] != 10000.0  # P&L was applied in the in-tx step
 ```
 
-- [ ] **Step 3: Verify all 9 tests fail with ModuleNotFoundError**
+- [ ] **Step 3: Verify all 10 tests fail with ModuleNotFoundError**
 
 Run: `pytest tests/operators/test_position_closure.py -v 2>&1 | tail -20`
 Expected: `ModuleNotFoundError: No module named 'operators'` (collection error).
@@ -466,22 +505,53 @@ Expected: `ModuleNotFoundError: No module named 'operators'` (collection error).
 
 ```bash
 git add tests/operators/
-git commit -m "test(operators): add 9 invariant tests for PositionClosure (anchors #451)"
-```
+git commit -m "test(operators): add 10 invariant tests for PositionClosure (anchors #451)
+
+Invariant 10 encodes Voronov AMBER F2: post-commit side-effect failure
+does NOT rollback the close. Locks the 'best-effort log-and-continue'
+contract in the test suite so a future 'fix' that turns the try/except
+into raise fails loudly."
 
 ---
 
-### Task 3: Create the operators package + CloseOutcome dataclass
+### Task 3: Create the operators package + CloseOutcome dataclass + read_only_connection helper
 
 **Files:**
 - Create: `operators/__init__.py`
 - Create: `operators/position_closure.py` (skeleton only — full implementation in Task 4)
+- Modify: `db/transaction.py` (add `read_only_connection()` context manager — names the 4th access pattern per Voronov AMBER F6)
 
 - [ ] **Step 1: Create empty package marker**
 
 Create `operators/__init__.py` as an empty file.
 
-- [ ] **Step 2: Create `operators/position_closure.py` with `CloseOutcome` dataclass and class skeleton**
+- [ ] **Step 2: Add `read_only_connection()` to `db/transaction.py`**
+
+Append to `db/transaction.py` (after `transaction()`):
+
+```python
+@contextmanager
+def read_only_connection() -> Iterator[sqlite3.Connection]:
+    """Open a configured connection for read-only work outside any transaction.
+
+    Use when an operator needs pre-validation reads (ownership check,
+    existence check) that must NOT hold a writer lock. The connection
+    closes on exit; no BEGIN/COMMIT is issued.
+
+    Caller contract:
+    - MAY use con.execute for SELECT.
+    - MUST NOT issue INSERT/UPDATE/DELETE — if SQLite's autocommit triggers,
+      the write happens without the operator's atomicity guarantee.
+    - MUST NOT escape the connection past the `with` block.
+    """
+    con = _open_configured_connection()
+    try:
+        yield con
+    finally:
+        con.close()
+```
+
+- [ ] **Step 3: Create `operators/position_closure.py` with `CloseOutcome` dataclass and class skeleton**
 
 ```python
 """PositionClosure — business operator for closing a position.
@@ -493,6 +563,15 @@ Section 'PositionClosure operator contract spec'.
 Single legal entry point for closing a position. The only caller of
 transaction() in the close-flow. db/* helpers are pure SQL and receive
 con from this operator.
+
+NOTE on `mode` parameter (Voronov AMBER F1): `mode` is a Literal flag
+that bifurcates ownership-check behavior (USER enforces, SYSTEM skips).
+This works for the two modes present today. If a third mode ever emerges
+(BATCH, RECONCILIATION, etc.), the flag-based dispatcher becomes a
+homograph of the _tx_or_use pattern this PR closed. Resolve at that
+point by splitting into subclasses (`UserPositionClosure`,
+`SystemPositionClosure`) sharing an abstract base where the ownership
+contract lives in the type, not in a runtime branch.
 """
 from __future__ import annotations
 from contextlib import closing
@@ -569,19 +648,23 @@ class PositionClosure:
         raise NotImplementedError  # Filled in Task 4
 ```
 
-- [ ] **Step 3: Verify import works (tests should still fail but with a different error now)**
+- [ ] **Step 4: Verify imports work**
 
-Run: `python -c "from operators.position_closure import PositionClosure, CloseOutcome; print('ok')"`
+Run: `python -c "from operators.position_closure import PositionClosure, CloseOutcome; from db.transaction import read_only_connection, transaction; print('ok')"`
 Expected: `ok`.
 
 Run: `pytest tests/operators/test_position_closure.py -v 2>&1 | tail -10`
 Expected: tests collect, fail with `NotImplementedError` instead of `ModuleNotFoundError`.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add operators/
-git commit -m "feat(operators): skeleton for PositionClosure + CloseOutcome dataclass"
+git add operators/ db/transaction.py
+git commit -m "feat(operators): skeleton for PositionClosure + CloseOutcome dataclass + read_only_connection helper
+
+read_only_connection() names the 4th DB access pattern (read outside
+any tx, no BEGIN, close on exit). PositionClosure.__enter__ will use
+it for pre-validation reads (Voronov AMBER F6)."
 ```
 
 ---
@@ -653,9 +736,10 @@ def db_close_position_sql(
 
 - [ ] **Step 3: Implement `__enter__`, `execute()`, and `__exit__` in `operators/position_closure.py`**
 
-Replace the three `NotImplementedError` stubs with real implementations. Add the required imports to the top of the file:
+Replace the three `NotImplementedError` stubs with real implementations. Update imports at the top of the file (drop `_open_configured_connection` direct import; add `read_only_connection` instead):
 
 ```python
+from db.transaction import transaction, read_only_connection
 from db.positions import db_get_position_by_id, db_close_position_sql, _calc_pnl
 from db.capital import apply_pnl_to_capital
 from api.positions import _write_position_event_log, update_positions_json
@@ -664,14 +748,16 @@ from notifier import notify
 from api.config import load_config
 ```
 
+Remove the `from contextlib import closing` and `from db.connection import _open_configured_connection` lines that were in the skeleton (Task 3) — they're no longer needed.
+
 Then the three methods:
 
 ```python
     def __enter__(self) -> "PositionClosure":
         if self._consumed:
             raise RuntimeError("PositionClosure is single-use; construct a new one")
-        # Open a short-lived read-only connection outside any write transaction.
-        with closing(_open_configured_connection()) as con:
+        # Pre-validation read outside any write transaction (no lock contention).
+        with read_only_connection() as con:
             self._pre_row = db_get_position_by_id(con, self._pos_id)
         if self._pre_row is None:
             self._state = "NOT_FOUND"
@@ -1416,6 +1502,15 @@ Three-layer separation:
 
 Receive `con: sqlite3.Connection` as a mandatory first argument. They run SQL and return data. No `transaction()` calls. No side-effects (no HTTP, no file I/O, no logging beyond DEBUG). Examples: `db_close_position_sql`, `db_get_capital`, `apply_pnl_to_capital`, `db_create_position`.
 
+**Documented exceptions** (Cat. 2 hidden business operators living in helper directories — operator-extraction deferred to separate tickets per the rationale in `docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md`):
+
+- `db/schema.py::init_db` — bootstrap orchestrator; opens its own `transaction()` and calls migration helpers.
+- `db/signals.py::save_scan` — dual-transaction pattern (scan write + outcomes write); calls `transaction()` directly twice.
+- `auth/audit.py::log_auth_event` — fallback to stderr if DB write fails; calls `transaction()` directly.
+- `notifier/dispatch_per_user.py::dispatch_signal_to_users` — fan-out orchestrator; calls `transaction()` directly and fires `notify()` side-effect.
+
+These four are recognized exceptions today. When their operator-extraction lands, they migrate to `operators/` and this list shrinks.
+
 ### 2. Business operators (`operators/*.py`)
 
 Own `transaction()` for one named business transition. Orchestrate side-effects. Declare atomicity. The only legal entry point for the transitions they represent. Currently: `PositionClosure` (closing a position with atomic capital roll-in + post-commit health/notify/event-log/snapshot).
@@ -1442,6 +1537,20 @@ from db.signals import get_latest_signal
 with transaction() as con:
     sig = get_latest_signal(con, "BTCUSDT")
 \`\`\`
+
+### 4. Read-only pre-validation outside any transaction (`read_only_connection()`)
+
+When an operator needs to read state BEFORE deciding whether to open a write transaction (e.g., ownership check that should not acquire a writer lock), use `read_only_connection()` from `db.transaction`:
+
+\`\`\`python
+from db.transaction import read_only_connection
+
+with read_only_connection() as con:
+    row = db_get_position_by_id(con, pos_id)
+# no transaction was opened; no lock held.
+\`\`\`
+
+Only used by operators today (`PositionClosure.__enter__`). Pure SQL helpers never call this — they receive `con` from their caller.
 
 New business operators emerge from evidence (caller composes >1 helper + side-effect with conditional behavior), not preemptively. See `docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md` for the rationale (Voronov, 2026-05-25).
 ```
@@ -1558,6 +1667,8 @@ Implements the architectural direction articulated by Voronov on 2026-05-25 (see
 - Operator-extraction for the 4 remaining Cat. 2 hidden operators: `save_scan`, `init_db`, `log_auth_event`, `dispatch_signal_to_users`. They function correctly with `transaction()` directly; operator-naming is a separate exercise per Voronov's evidential rule.
 - `PositionOpening` operator: precondition 2 confirmed no current symptoms (no contract interrogation, no conditional side-effects, minimal composition). Create when evidence emerges.
 - Outbox infrastructure for true compensable post-commit delivery: v1 is best-effort log-and-continue. Separate epic.
+- **Retry policy for capital lock contention** (Voronov AMBER F4): under SQLite `BEGIN IMMEDIATE`, `apply_pnl_to_capital` failures will most commonly be `sqlite3.OperationalError: database is locked` rather than logic errors. Current operator surfaces these as exception → close aborted → user clicks Close again → likely same lock. No retry, no backoff, no metric for "how often does capital-lock abort closes in prod". Acceptable for v1; needs explicit retry policy + observability before high-concurrency multi-tenant scenarios.
+- **`mode="USER"|"SYSTEM"` flag → subclass migration** (Voronov AMBER F1): the Literal flag works for 2 modes today. A third mode (BATCH, RECONCILIATION) reintroduces the dual-contract shape this PR closed. Resolve by splitting into `UserPositionClosure` / `SystemPositionClosure` sharing an abstract base when that third mode emerges. Documented in operator's module docstring.
 
 ## Test plan
 
@@ -1616,10 +1727,13 @@ The plan is fully executed when this step completes. Manual smoke in prod is the
 **Spec coverage:**
 - All 5 BLOCKERS + 5 HIGHs from Serrano: tracked via tasks (PositionClosure, helper migration, deletion, fixture fix, docs).
 - Voronov's direction C strict: implemented in Tasks 3-4 (operator + pure helpers in db/), Tasks 8-9 (sweep), Task 11 (deletion).
-- All 9 invariants from preconditions synthesis: Task 2 (write tests) + Task 4 (implement to pass).
+- All 10 invariants from preconditions synthesis + Voronov AMBER F2: Task 2 (write tests) + Task 4 (implement to pass). Invariant 10 specifically encodes the "best-effort post-commit" commitment so a future contributor cannot silently change it.
 - Multi-tenancy invariants (precondition 3): tested by invariants 2/3/4/9 + implemented in operator's `__enter__` ownership check.
-- `apply_pnl_to_capital` IN-TX trade-off: Task 5 (signature change) + Task 4 (operator calls it inside tx) + tested by invariant 1.
+- `apply_pnl_to_capital` IN-TX trade-off: Task 5 (signature change) + Task 4 (operator calls it inside tx) + tested by invariant 1. Retry policy hole (Voronov F4) named in deferred list.
 - `_tx_or_use` deletion: Task 11.
+- `read_only_connection()` named primitive (Voronov F6): added to `db/transaction.py` in Task 3 step 2; used by operator's `__enter__` in Task 4; documented in CLAUDE.md Task 13 §4.
+- 4 Cat. 2 hidden operators acknowledged in CLAUDE.md (Voronov F3): Task 13 step 2 enumerates them as documented exceptions, eliminating the doc-vs-code dual-contract Voronov flagged.
+- Operator `mode` flag → subclass migration (Voronov F1): documented in operator module docstring (Task 3 step 3) and deferred list (Task 15 PR body).
 - Preconditions docs referenced in plan header and self-review.
 
 **Placeholder scan:** None of the disallowed patterns present. All code blocks complete. Migration patterns explicit (Before/After examples in Tasks 8/9).

--- a/health.py
+++ b/health.py
@@ -451,7 +451,8 @@ def _maybe_auto_reactivate(
       - paused-duration < threshold_days
       - portfolio aggregate tier ≠ NORMAL
     """
-    row = _get_symbol_health_row(symbol)
+    with transaction() as conn:
+        row = _get_symbol_health_row(conn, symbol)
     if row is None or row["state"] != "PAUSED":
         return
 
@@ -678,28 +679,21 @@ def apply_transition(
 
 
 def _get_symbol_health_row(
+    conn,
     symbol: str,
-    *,
-    conn=None,
 ) -> dict[str, Any] | None:
     """Return the symbol_health row for `symbol`, or None if absent.
 
     Selected columns: state, state_since, manual_override,
     probation_trades_remaining, probation_started_at, paused_days_at_entry.
-
-    Per Task 8.5: optional `conn` lets a caller (e.g. get_dashboard_state)
-    reuse its outer transaction instead of opening a nested one that would
-    deadlock on BEGIN IMMEDIATE.
     """
-    from db.transaction import _tx_or_use  # local import to avoid module-init churn
-    with _tx_or_use(conn) as conn:
-        row = conn.execute(
-            """SELECT state, state_since, manual_override,
-                      probation_trades_remaining, probation_started_at,
-                      paused_days_at_entry
-               FROM symbol_health WHERE symbol=?""",
-            (symbol,),
-        ).fetchone()
+    row = conn.execute(
+        """SELECT state, state_since, manual_override,
+                  probation_trades_remaining, probation_started_at,
+                  paused_days_at_entry
+           FROM symbol_health WHERE symbol=?""",
+        (symbol,),
+    ).fetchone()
     if row is None:
         return None
     return {
@@ -726,7 +720,8 @@ def reactivate_symbol(
 
     No-ops with a warning when the symbol is not currently PAUSED.
     """
-    row = _get_symbol_health_row(symbol)
+    with transaction() as conn:
+        row = _get_symbol_health_row(conn, symbol)
     current = row["state"] if row else "NORMAL"
 
     if current != "PAUSED":
@@ -831,7 +826,8 @@ def evaluate_and_record(symbol: str, cfg: dict[str, Any], now: datetime | None =
 
     # B5: inject current probation_trades_remaining into metrics so evaluate_state
     # can apply the PROBATION branch. Read from the symbol_health row.
-    row = _get_symbol_health_row(symbol)
+    with transaction() as conn:
+        row = _get_symbol_health_row(conn, symbol)
     current = row["state"] if row else "NORMAL"
     override = bool(row["manual_override"]) if row else False
     if row is not None:
@@ -979,50 +975,39 @@ def health_monitor_loop(cfg_fn, stop_event=None) -> None:
 
 
 def record_portfolio_transition(
+    conn,
     from_tier: str,
     to_tier: str,
     reason: str,
     dd_pct: float = 0.0,
     concurrent: int = 0,
-    *,
-    conn=None,
 ) -> None:
     """B6: Append a portfolio-tier transition row.
 
     Idempotency / dedup is the caller's responsibility — fires only when a
     transition actually happens (from_tier != to_tier).
-
-    Per Task 8.5: optional `conn` for caller-controlled transaction composition.
     """
     if from_tier == to_tier:
         return
-    from db.transaction import _tx_or_use  # local import
-    with _tx_or_use(conn) as conn:
-        conn.execute(
-            """INSERT INTO portfolio_health_events
-               (from_tier, to_tier, reason, dd_pct, concurrent, ts)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (from_tier, to_tier, reason, float(dd_pct), int(concurrent), _now_iso()),
-        )
+    conn.execute(
+        """INSERT INTO portfolio_health_events
+           (from_tier, to_tier, reason, dd_pct, concurrent, ts)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (from_tier, to_tier, reason, float(dd_pct), int(concurrent), _now_iso()),
+    )
 
 
 def recent_portfolio_transitions(
+    conn,
     limit: int = 5,
-    *,
-    conn=None,
 ) -> list[dict[str, Any]]:
-    """B6: Last N portfolio-tier transitions, newest first.
-
-    Per Task 8.5: optional `conn` for caller-controlled transaction composition.
-    """
-    from db.transaction import _tx_or_use  # local import
-    with _tx_or_use(conn) as conn:
-        rows = conn.execute(
-            """SELECT from_tier, to_tier, reason, dd_pct, concurrent, ts
-               FROM portfolio_health_events
-               ORDER BY ts DESC LIMIT ?""",
-            (limit,),
-        ).fetchall()
+    """B6: Last N portfolio-tier transitions, newest first."""
+    rows = conn.execute(
+        """SELECT from_tier, to_tier, reason, dd_pct, concurrent, ts
+           FROM portfolio_health_events
+           ORDER BY ts DESC LIMIT ?""",
+        (limit,),
+    ).fetchall()
     return [
         {
             "from_tier": r[0], "to_tier": r[1], "reason": r[2],
@@ -1080,7 +1065,7 @@ def get_dashboard_state(
         # Symbols
         symbols_out: list[dict[str, Any]] = []
         for sym in symbols_iter:
-            row = _get_symbol_health_row(sym, conn=conn)  # Task 8.5: share outer tx
+            row = _get_symbol_health_row(conn, sym)  # Task 8.5: share outer tx
             if row is None:
                 # No row → NORMAL placeholder, empty metrics
                 state = "NORMAL"
@@ -1178,7 +1163,7 @@ def get_dashboard_state(
                 from strategy.kill_switch_v2_shadow import (
                     _load_open_positions, _snapshot_prices,
                 )
-                open_positions = _load_open_positions(tenant_id=tenant_id, conn=conn)
+                open_positions = _load_open_positions(conn, tenant_id=tenant_id)
                 prices = _snapshot_prices()
                 open_mtm = 0.0
                 for pos in open_positions:
@@ -1248,7 +1233,7 @@ def get_dashboard_state(
             "peak_equity": peak_equity,
             "current_equity": current_equity,
             "concurrent_failures": int(n_failures),
-            "recent_transitions": recent_portfolio_transitions(limit=5, conn=conn),
+            "recent_transitions": recent_portfolio_transitions(conn, limit=5),
         }
 
         # Alerts (24h window) — append portfolio_dd item if non-NORMAL

--- a/health.py
+++ b/health.py
@@ -414,14 +414,15 @@ def _is_portfolio_normal(cfg: dict[str, Any]) -> bool:
         from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
         from db.capital import db_list_active_tenant_ids
 
-        tenant_ids = db_list_active_tenant_ids()
-        if not tenant_ids:
-            # No onboarded tenants yet — treat as NORMAL (no portfolio to gate).
-            return True
-
         # Concurrent failures: a property of symbol_health (system-wide), so
         # we read it once and reuse it across the per-tenant loop.
+        # Task 5 (#446): `db_list_active_tenant_ids` now takes mandatory
+        # `con` — fold the read into the same transaction.
         with transaction() as conn:
+            tenant_ids = db_list_active_tenant_ids(conn)
+            if not tenant_ids:
+                # No onboarded tenants yet — treat as NORMAL (no portfolio to gate).
+                return True
             n_failures = conn.execute(
                 """SELECT COUNT(*) FROM symbol_health
                    WHERE state IN ('ALERT', 'REDUCED', 'PAUSED', 'PROBATION')"""
@@ -1060,7 +1061,7 @@ def get_dashboard_state(
     # serializes against any concurrent capital write.
     with transaction() as conn:
         from db.capital import db_get_capital
-        capital = db_get_capital(tenant_id, con=conn)
+        capital = db_get_capital(conn, tenant_id)
         # Build symbol list: union of DEFAULT_SYMBOLS + any DB rows. This way
         # the dashboard always shows the curated 10 (as NORMAL placeholders if
         # not yet evaluated) AND any historical/legacy rows in symbol_health.

--- a/notifier/__init__.py
+++ b/notifier/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from db.transaction import transaction
 from notifier import dedupe, ratelimit
 from notifier._storage import record_delivery
 from notifier._templates import render
@@ -91,9 +92,13 @@ def notify(
         if tenant_id is not None else event.dedupe_key
     )
     window_seconds = _resolve_dedupe_window(event, cfg)
-    if not dedupe.should_send(event.event_type, dedupe_key,
-                                window_seconds=window_seconds,
-                                priority=event.priority):
+    with transaction() as con:
+        _should_send = dedupe.should_send(
+            con, event.event_type, dedupe_key,
+            window_seconds=window_seconds,
+            priority=event.priority,
+        )
+    if not _should_send:
         log.debug("notify deduped: %s %s", event.event_type, dedupe_key)
         return []
 
@@ -160,16 +165,18 @@ def notify(
         delivery_status = "partial"
 
     try:
-        record_delivery(
-            event_type=event.event_type,
-            event_key=event.dedupe_key,
-            priority=event.priority,
-            payload=event.to_dict(),
-            channels_sent=channels_sent or ["none"],
-            delivery_status=delivery_status,
-            error_log=any_error,
-            tenant_id=tenant_id,  # B.4: NULL for broadcasts, int for per-user fan-out
-        )
+        with transaction() as con:
+            record_delivery(
+                con,
+                event_type=event.event_type,
+                event_key=event.dedupe_key,
+                priority=event.priority,
+                payload=event.to_dict(),
+                channels_sent=channels_sent or ["none"],
+                delivery_status=delivery_status,
+                error_log=any_error,
+                tenant_id=tenant_id,  # B.4: NULL for broadcasts, int for per-user fan-out
+            )
     except Exception:
         log.exception("notifier failed to persist delivery record")
 

--- a/notifier/_storage.py
+++ b/notifier/_storage.py
@@ -23,14 +23,13 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from db.transaction import _tx_or_use
-
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
 def record_delivery(
+    con: sqlite3.Connection,
     event_type: str,
     event_key: str,
     priority: str,
@@ -39,99 +38,90 @@ def record_delivery(
     delivery_status: str,
     error_log: str | None = None,
     tenant_id: Optional[int] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> int:
-    with _tx_or_use(con) as conn:
-        cur = conn.execute(
-            """INSERT INTO notifications_sent
-               (event_type, event_key, priority, payload_json,
-                channels_sent, delivery_status, sent_at, error_log, tenant_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-            (
-                event_type, event_key, priority,
-                json.dumps(payload, default=str),
-                ",".join(channels_sent), delivery_status,
-                _now_iso(), error_log, tenant_id,
-            ),
-        )
-        return cur.lastrowid
+    cur = con.execute(
+        """INSERT INTO notifications_sent
+           (event_type, event_key, priority, payload_json,
+            channels_sent, delivery_status, sent_at, error_log, tenant_id)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            event_type, event_key, priority,
+            json.dumps(payload, default=str),
+            ",".join(channels_sent), delivery_status,
+            _now_iso(), error_log, tenant_id,
+        ),
+    )
+    return cur.lastrowid
 
 
 def list_unread(
+    con: sqlite3.Connection,
     limit: int = 50,
     tenant_id: Optional[int] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> list[dict[str, Any]]:
-    with _tx_or_use(con) as conn:
-        if tenant_id is None:
-            rows = conn.execute(
-                """SELECT id, event_type, event_key, priority, payload_json,
-                          channels_sent, delivery_status, sent_at, read_at, error_log
-                   FROM notifications_sent
-                   WHERE read_at IS NULL
-                   ORDER BY sent_at DESC
-                   LIMIT ?""",
-                (limit,),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                """SELECT id, event_type, event_key, priority, payload_json,
-                          channels_sent, delivery_status, sent_at, read_at, error_log
-                   FROM notifications_sent
-                   WHERE read_at IS NULL AND tenant_id = ?
-                   ORDER BY sent_at DESC
-                   LIMIT ?""",
-                (tenant_id, limit),
-            ).fetchall()
+    if tenant_id is None:
+        rows = con.execute(
+            """SELECT id, event_type, event_key, priority, payload_json,
+                      channels_sent, delivery_status, sent_at, read_at, error_log
+               FROM notifications_sent
+               WHERE read_at IS NULL
+               ORDER BY sent_at DESC
+               LIMIT ?""",
+            (limit,),
+        ).fetchall()
+    else:
+        rows = con.execute(
+            """SELECT id, event_type, event_key, priority, payload_json,
+                      channels_sent, delivery_status, sent_at, read_at, error_log
+               FROM notifications_sent
+               WHERE read_at IS NULL AND tenant_id = ?
+               ORDER BY sent_at DESC
+               LIMIT ?""",
+            (tenant_id, limit),
+        ).fetchall()
     cols = ["id", "event_type", "event_key", "priority", "payload_json",
             "channels_sent", "delivery_status", "sent_at", "read_at", "error_log"]
     return [dict(zip(cols, r)) for r in rows]
 
 
 def mark_read(
+    con: sqlite3.Connection,
     notification_id: int,
     tenant_id: Optional[int] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> bool:
     """Mark notification as read. Ownership-enforced when tenant_id provided.
 
     Returns True if a row was updated, False if not (e.g., IDOR: trying to
     mark another user's notification).
     """
-    with _tx_or_use(con) as conn:
-        if tenant_id is None:
-            cur = conn.execute(
-                "UPDATE notifications_sent SET read_at = ? WHERE id = ?",
-                (_now_iso(), notification_id),
-            )
-        else:
-            cur = conn.execute(
-                "UPDATE notifications_sent SET read_at = ? "
-                "WHERE id = ? AND tenant_id = ?",
-                (_now_iso(), notification_id, tenant_id),
-            )
-        return cur.rowcount > 0
+    if tenant_id is None:
+        cur = con.execute(
+            "UPDATE notifications_sent SET read_at = ? WHERE id = ?",
+            (_now_iso(), notification_id),
+        )
+    else:
+        cur = con.execute(
+            "UPDATE notifications_sent SET read_at = ? "
+            "WHERE id = ? AND tenant_id = ?",
+            (_now_iso(), notification_id, tenant_id),
+        )
+    return cur.rowcount > 0
 
 
 def mark_all_read(
+    con: sqlite3.Connection,
     tenant_id: Optional[int] = None,
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> int:
     """Mark all unread as read. Scope-limited by tenant_id when provided."""
-    with _tx_or_use(con) as conn:
-        if tenant_id is None:
-            cur = conn.execute(
-                "UPDATE notifications_sent SET read_at = ? WHERE read_at IS NULL",
-                (_now_iso(),),
-            )
-        else:
-            cur = conn.execute(
-                "UPDATE notifications_sent SET read_at = ? "
-                "WHERE read_at IS NULL AND tenant_id = ?",
-                (_now_iso(), tenant_id),
-            )
-        return cur.rowcount
+    if tenant_id is None:
+        cur = con.execute(
+            "UPDATE notifications_sent SET read_at = ? WHERE read_at IS NULL",
+            (_now_iso(),),
+        )
+    else:
+        cur = con.execute(
+            "UPDATE notifications_sent SET read_at = ? "
+            "WHERE read_at IS NULL AND tenant_id = ?",
+            (_now_iso(), tenant_id),
+        )
+    return cur.rowcount

--- a/notifier/dedupe.py
+++ b/notifier/dedupe.py
@@ -13,18 +13,14 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import datetime, timedelta, timezone
-from typing import Optional
-
-from db.transaction import _tx_or_use
 
 
 def should_send(
+    con: sqlite3.Connection,
     event_type: str,
     event_key: str,
     window_seconds: int,
     priority: str = "info",
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> bool:
     """Return True if this event should be sent (no recent duplicate found).
 
@@ -42,11 +38,10 @@ def should_send(
         return True
 
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=window_seconds)
-    with _tx_or_use(con) as conn:
-        row = conn.execute(
-            """SELECT 1 FROM notifications_sent
-               WHERE event_type = ? AND event_key = ? AND sent_at >= ?
-               LIMIT 1""",
-            (event_type, event_key, cutoff.isoformat()),
-        ).fetchone()
+    row = con.execute(
+        """SELECT 1 FROM notifications_sent
+           WHERE event_type = ? AND event_key = ? AND sent_at >= ?
+           LIMIT 1""",
+        (event_type, event_key, cutoff.isoformat()),
+    ).fetchone()
     return row is None

--- a/notifier/dispatch_per_user.py
+++ b/notifier/dispatch_per_user.py
@@ -29,10 +29,7 @@ _DEFAULT_MIN_SCORE = 4
 _DEFAULT_SYMBOL_FILTER: list[str] | None = None  # None = all symbols allowed
 
 
-def _list_active_users(
-    *,
-    con: Optional[sqlite3.Connection] = None,
-) -> list[dict]:
+def _list_active_users(con: sqlite3.Connection) -> list[dict]:
     """Return active users (id + email) for fan-out.
 
     Pre-bootstrap case: if the `users` table doesn't exist yet (auth schema
@@ -40,10 +37,9 @@ def _list_active_users(
     so callers fall back to the legacy broadcast path.
     """
     try:
-        with _tx_or_use(con) as con:
-            rows = con.execute(
-                "SELECT id, email FROM users WHERE is_active = 1 ORDER BY id"
-            ).fetchall()
+        rows = con.execute(
+            "SELECT id, email FROM users WHERE is_active = 1 ORDER BY id"
+        ).fetchall()
     except sqlite3.OperationalError as e:
         if "no such table" in str(e).lower():
             return []
@@ -83,7 +79,8 @@ def dispatch_signal_to_users(
     and `db_get_user_preferences`. The downstream `notify()` call still owns
     its own transactions (file/network I/O — must not extend the DB lock).
     """
-    users = _list_active_users(con=con)
+    with _tx_or_use(con) as _users_con:
+        users = _list_active_users(_users_con)
     if not users:
         log.debug("dispatch_signal_to_users: no active users — broadcast skipped")
         return {}

--- a/notifier/dispatch_per_user.py
+++ b/notifier/dispatch_per_user.py
@@ -91,7 +91,8 @@ def dispatch_signal_to_users(
     out: dict[int, list[DeliveryReceipt]] = {}
 
     for user in users:
-        prefs = db_get_user_preferences(user["id"], con=con)
+        with _tx_or_use(con) as inner_con:
+            prefs = db_get_user_preferences(inner_con, user["id"])
         if prefs is None:
             symbol_filter = _DEFAULT_SYMBOL_FILTER
             min_score = _DEFAULT_MIN_SCORE

--- a/notifier/dispatch_per_user.py
+++ b/notifier/dispatch_per_user.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from typing import Any, Optional
+from typing import Any
 
-from db.transaction import _tx_or_use
+from db.transaction import transaction
 from db.user_preferences import db_get_user_preferences
 from notifier import notify
 from notifier.channels.base import DeliveryReceipt
@@ -65,8 +65,6 @@ def _user_passes_filter(
 def dispatch_signal_to_users(
     event: SignalEvent,
     base_cfg: dict[str, Any],
-    *,
-    con: Optional[sqlite3.Connection] = None,
 ) -> dict[int, list[DeliveryReceipt]]:
     """Fan a SignalEvent out to each active user, honoring their preferences.
 
@@ -75,11 +73,11 @@ def dispatch_signal_to_users(
     Users who pass the filter but have no channels configured still appear
     (with empty receipts) — useful for observability.
 
-    Per Task 8.5: optional `con` is threaded through to `_list_active_users`
-    and `db_get_user_preferences`. The downstream `notify()` call still owns
-    its own transactions (file/network I/O — must not extend the DB lock).
+    Cat. 2 hidden operator: owns its own transaction() calls directly.
+    The downstream `notify()` call still owns its own transactions
+    (file/network I/O — must not extend the DB lock).
     """
-    with _tx_or_use(con) as _users_con:
+    with transaction() as _users_con:
         users = _list_active_users(_users_con)
     if not users:
         log.debug("dispatch_signal_to_users: no active users — broadcast skipped")
@@ -88,7 +86,7 @@ def dispatch_signal_to_users(
     out: dict[int, list[DeliveryReceipt]] = {}
 
     for user in users:
-        with _tx_or_use(con) as inner_con:
+        with transaction() as inner_con:
             prefs = db_get_user_preferences(inner_con, user["id"])
         if prefs is None:
             symbol_filter = _DEFAULT_SYMBOL_FILTER

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -1,0 +1,92 @@
+"""PositionClosure — business operator for closing a position.
+
+Implements the contract specified in
+docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md
+Section 'PositionClosure operator contract spec'.
+
+Single legal entry point for closing a position. The only caller of
+transaction() in the close-flow. db/* helpers are pure SQL and receive
+con from this operator.
+
+NOTE on `mode` parameter (Voronov AMBER F1): `mode` is a Literal flag
+that bifurcates ownership-check behavior (USER enforces, SYSTEM skips).
+This works for the two modes present today. If a third mode ever emerges
+(BATCH, RECONCILIATION, etc.), the flag-based dispatcher becomes a
+homograph of the _tx_or_use pattern this PR closed. Resolve at that
+point by splitting into subclasses (`UserPositionClosure`,
+`SystemPositionClosure`) sharing an abstract base where the ownership
+contract lives in the type, not in a runtime branch.
+"""
+from __future__ import annotations
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+import sqlite3
+from typing import Literal, Optional
+
+from db.transaction import transaction
+from db.connection import _open_configured_connection
+
+log = logging.getLogger("operators.position_closure")
+
+_VALID_EXIT_REASONS = frozenset({"MANUAL", "SL_HIT", "TP_HIT", "TIME_LIMIT_HIT"})
+
+
+@dataclass(frozen=True)
+class CloseOutcome:
+    status: Literal["closed", "not_found", "already_closed"]
+    position: Optional[dict]
+    pnl_usd: Optional[float]
+    pnl_pct: Optional[float]
+
+
+class PositionClosure:
+    """See module docstring."""
+
+    def __init__(
+        self,
+        pos_id: int,
+        exit_price: float,
+        exit_reason: str,
+        *,
+        mode: Literal["USER", "SYSTEM"],
+        caller_tenant_id: Optional[int] = None,
+        cfg: Optional[dict] = None,
+        now: Optional[datetime] = None,
+    ) -> None:
+        if mode not in ("USER", "SYSTEM"):
+            raise ValueError(f"mode must be 'USER' or 'SYSTEM', got {mode!r}")
+        if mode == "USER":
+            if caller_tenant_id is None or caller_tenant_id <= 0:
+                raise ValueError("USER mode requires caller_tenant_id > 0")
+        if mode == "SYSTEM" and caller_tenant_id is not None:
+            raise ValueError("SYSTEM mode forbids caller_tenant_id (got %r)" % caller_tenant_id)
+        if exit_price <= 0:
+            raise ValueError(f"exit_price must be > 0, got {exit_price}")
+        if exit_reason not in _VALID_EXIT_REASONS:
+            raise ValueError(
+                f"exit_reason must be one of {sorted(_VALID_EXIT_REASONS)}, got {exit_reason!r}"
+            )
+
+        self._pos_id = pos_id
+        self._exit_price = exit_price
+        self._exit_reason = exit_reason
+        self._mode = mode
+        self._caller_tenant_id = caller_tenant_id
+        self._cfg = cfg
+        self._now = now or datetime.now(timezone.utc)
+
+        self._state: Literal["INIT", "NOT_FOUND", "ALREADY_CLOSED", "OK_TO_PROCEED"] = "INIT"
+        self._pre_row: Optional[dict] = None
+        self._result_row: Optional[dict] = None
+        self._consumed = False
+
+    def __enter__(self) -> "PositionClosure":
+        raise NotImplementedError  # Filled in Task 4
+
+    def execute(self) -> CloseOutcome:
+        raise NotImplementedError  # Filled in Task 4
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        raise NotImplementedError  # Filled in Task 4

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -231,10 +231,16 @@ class PositionClosure:
 
         # 3) notify
         try:
+            # Preserve pre-migration external event semantics: scanner
+            # used to map SL_HIT→SL, TP_HIT→TP, TIME_LIMIT_HIT→TIME_LIMIT
+            # before constructing PositionExitEvent. Internal
+            # self._exit_reason stays as the DB-canonical *_HIT form;
+            # only the event payload carries the stripped tier code.
+            event_reason = self._exit_reason.replace("_HIT", "")
             event = PositionExitEvent(
                 symbol=pos_row.get("symbol", ""),
                 direction=str(pos_row.get("direction", "LONG")).upper(),
-                exit_reason=self._exit_reason,
+                exit_reason=event_reason,
                 entry_price=float(pos_row.get("entry_price") or 0.0),
                 exit_price=float(self._exit_price),
                 pnl_usd=float(pnl_usd) if pnl_usd is not None else 0.0,

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -18,15 +18,21 @@ point by splitting into subclasses (`UserPositionClosure`,
 contract lives in the type, not in a runtime branch.
 """
 from __future__ import annotations
-from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import logging
-import sqlite3
 from typing import Literal, Optional
 
-from db.transaction import transaction
-from db.connection import _open_configured_connection
+from db import transaction as _tx_module  # imported as module so tests can
+                                            # patch `transaction` on it
+from db.transaction import read_only_connection
+from db.positions import db_get_position_by_id, db_close_position_sql, _calc_pnl
+from db import capital as _capital_module  # imported as module so tests can
+                                            # patch `apply_pnl_to_capital` on it
+from api.positions import _write_position_event_log, update_positions_json
+from api.config import load_config
+from health import trigger_health_evaluation
+from notifier import notify, PositionExitEvent
 
 log = logging.getLogger("operators.position_closure")
 
@@ -80,13 +86,168 @@ class PositionClosure:
         self._state: Literal["INIT", "NOT_FOUND", "ALREADY_CLOSED", "OK_TO_PROCEED"] = "INIT"
         self._pre_row: Optional[dict] = None
         self._result_row: Optional[dict] = None
+        self._result_pnl: tuple[Optional[float], Optional[float]] = (None, None)
         self._consumed = False
 
     def __enter__(self) -> "PositionClosure":
-        raise NotImplementedError  # Filled in Task 4
+        if self._consumed:
+            raise RuntimeError("PositionClosure is single-use; construct a new one")
+        # Pre-validation read outside any write transaction (no lock contention).
+        # Invariant 2: USER-mode ownership mismatch must NOT open a write tx.
+        with read_only_connection() as con:
+            self._pre_row = db_get_position_by_id(con, self._pos_id)
+        if self._pre_row is None:
+            self._state = "NOT_FOUND"
+            return self
+        if self._mode == "USER":
+            if self._pre_row.get("tenant_id") != self._caller_tenant_id:
+                # IDOR-safe collapse: report identical to NOT_FOUND.
+                self._state = "NOT_FOUND"
+                return self
+        if self._pre_row.get("status") != "open":
+            self._state = "ALREADY_CLOSED"
+            return self
+        self._state = "OK_TO_PROCEED"
+        return self
 
     def execute(self) -> CloseOutcome:
-        raise NotImplementedError  # Filled in Task 4
+        if self._consumed:
+            raise RuntimeError("PositionClosure already executed; single-use")
+        self._consumed = True
+
+        if self._state == "NOT_FOUND":
+            return CloseOutcome(
+                status="not_found", position=None, pnl_usd=None, pnl_pct=None,
+            )
+        if self._state == "ALREADY_CLOSED":
+            return CloseOutcome(
+                status="already_closed",
+                position=self._pre_row,
+                pnl_usd=None,
+                pnl_pct=None,
+            )
+        # OK_TO_PROCEED — one transaction wraps the read + close + capital
+        # roll-in. Raises (e.g. capital UPSERT failure) trigger ROLLBACK,
+        # which is the atomicity guarantee invariant 1 / 2 anchor.
+        with _tx_module.transaction() as con:
+            # Re-select inside the write tx to cover the race window between
+            # pre-validation and BEGIN IMMEDIATE.
+            row = db_get_position_by_id(con, self._pos_id)
+            if row is None:
+                return CloseOutcome(
+                    status="not_found", position=None, pnl_usd=None, pnl_pct=None,
+                )
+            if row.get("status") != "open":
+                self._result_row = None  # suppress post-commit side-effects
+                return CloseOutcome(
+                    status="already_closed",
+                    position=row,
+                    pnl_usd=None,
+                    pnl_pct=None,
+                )
+
+            qty = row.get("qty") or 0
+            pnl_usd, pnl_pct = _calc_pnl(
+                row["direction"], row["entry_price"], self._exit_price, qty,
+            )
+            exit_ts = self._now.isoformat()
+            closed_row = db_close_position_sql(
+                con,
+                self._pos_id,
+                self._exit_price,
+                self._exit_reason,
+                exit_ts,
+                pnl_usd,
+                pnl_pct,
+            )
+            tenant_id = closed_row.get("tenant_id")
+            if tenant_id is not None and pnl_usd is not None:
+                # Invariant 1 / 2: capital roll-in joins the same tx. Any
+                # raise inside aborts the close via context-manager rollback.
+                # Pass all args as kwargs — the real signature is
+                # (tenant_id, pnl_usd, *, con=None), but tests mock with a
+                # 3-positional `boom(con, tenant_id, pnl_usd)`. Using kwargs
+                # satisfies both bindings.
+                _capital_module.apply_pnl_to_capital(
+                    tenant_id=int(tenant_id),
+                    pnl_usd=float(pnl_usd),
+                    con=con,
+                )
+            elif tenant_id is None:
+                log.warning(
+                    "PositionClosure: skipping capital roll-in for legacy "
+                    "tenant_id=NULL pos_id=%s",
+                    self._pos_id,
+                )
+            self._result_row = closed_row
+            self._result_pnl = (pnl_usd, pnl_pct)
+        # Transaction committed here.
+        return CloseOutcome(
+            status="closed",
+            position=self._result_row,
+            pnl_usd=self._result_pnl[0],
+            pnl_pct=self._result_pnl[1],
+        )
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
-        raise NotImplementedError  # Filled in Task 4
+        if exc_type is not None:
+            # Invariant 5: on exception inside the block (including from
+            # execute()), no post-commit side-effects fire. Propagate.
+            log.error(
+                "PositionClosure failed: pos_id=%s mode=%s caller_tenant_id=%s "
+                "exit_reason=%s exit_price=%s exception=%s",
+                self._pos_id,
+                self._mode,
+                self._caller_tenant_id,
+                self._exit_reason,
+                self._exit_price,
+                exc_type.__name__,
+            )
+            return False  # propagate
+
+        if self._result_row is None:
+            # NOT_FOUND or ALREADY_CLOSED path — no side-effects to fire.
+            return False
+
+        cfg = self._cfg or load_config()
+        pos_row = self._result_row
+        pnl_usd, pnl_pct = self._result_pnl
+
+        # Invariant 6: each side-effect fires exactly once on success.
+        # Invariant 10 (AMBER F2): best-effort — failures are logged and
+        # swallowed so the committed close is not "undone" by a notify glitch.
+
+        # 1) event log
+        try:
+            _write_position_event_log(pos_row, self._exit_reason, self._exit_price)
+        except Exception as e:
+            log.warning("PositionClosure: event log failed: %s", e)
+
+        # 2) health trigger
+        try:
+            trigger_health_evaluation(pos_row["symbol"], cfg)
+        except Exception as e:
+            log.warning("PositionClosure: health trigger failed: %s", e)
+
+        # 3) notify
+        try:
+            event = PositionExitEvent(
+                symbol=pos_row.get("symbol", ""),
+                direction=str(pos_row.get("direction", "LONG")).upper(),
+                exit_reason=self._exit_reason,
+                entry_price=float(pos_row.get("entry_price") or 0.0),
+                exit_price=float(self._exit_price),
+                pnl_usd=float(pnl_usd) if pnl_usd is not None else 0.0,
+                pnl_pct=float(pnl_pct) if pnl_pct is not None else 0.0,
+            )
+            notify(event, cfg, tenant_id=pos_row.get("tenant_id"))
+        except Exception as e:
+            log.warning("PositionClosure: notify failed: %s", e)
+
+        # 4) positions snapshot
+        try:
+            update_positions_json()
+        except Exception as e:
+            log.warning("PositionClosure: positions snapshot failed: %s", e)
+
+        return False

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -36,7 +36,7 @@ from notifier import notify, PositionExitEvent
 
 log = logging.getLogger("operators.position_closure")
 
-_VALID_EXIT_REASONS = frozenset({"MANUAL", "SL_HIT", "TP_HIT", "TIME_LIMIT_HIT"})
+_VALID_EXIT_REASONS = frozenset({"MANUAL", "MANUAL_AGENT", "SL_HIT", "TP_HIT", "TIME_LIMIT_HIT"})
 
 
 @dataclass(frozen=True)

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -164,14 +164,14 @@ class PositionClosure:
             if tenant_id is not None and pnl_usd is not None:
                 # Invariant 1 / 2: capital roll-in joins the same tx. Any
                 # raise inside aborts the close via context-manager rollback.
-                # Pass all args as kwargs — the real signature is
-                # (tenant_id, pnl_usd, *, con=None), but tests mock with a
-                # 3-positional `boom(con, tenant_id, pnl_usd)`. Using kwargs
-                # satisfies both bindings.
+                # Task 5 (#446): `apply_pnl_to_capital` now has
+                # `con` as mandatory positional first arg — matches the
+                # 3-positional mock `boom(con, tenant_id, pnl_usd)` used in
+                # tests.
                 _capital_module.apply_pnl_to_capital(
-                    tenant_id=int(tenant_id),
-                    pnl_usd=float(pnl_usd),
-                    con=con,
+                    con,
+                    int(tenant_id),
+                    float(pnl_usd),
                 )
             elif tenant_id is None:
                 log.warning(

--- a/scanner/runtime.py
+++ b/scanner/runtime.py
@@ -329,7 +329,9 @@ def scanner_loop():
 
         # Actualizar data/symbols_status.json al final de cada ciclo
         try:
-            rows = get_signals_summary()
+            from db.transaction import transaction  # noqa: PLC0415
+            with transaction() as con:
+                rows = get_signals_summary(con)
             update_symbols_json(rows)
         except Exception as e:
             log.warning(f"update_symbols_json error en ciclo: {e}")

--- a/scripts/backfill_capital_for_user.py
+++ b/scripts/backfill_capital_for_user.py
@@ -25,6 +25,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from db.capital import db_get_capital, db_upsert_capital  # noqa: E402
+from db.transaction import transaction  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 log = logging.getLogger("backfill_capital")
@@ -44,7 +45,9 @@ def main() -> int:
         log.error("--initial-balance must be >= 0 (got %s)", args.initial_balance)
         return 2
 
-    existing = db_get_capital(args.user_id)
+    # Task 5 (#446): both helpers require `con` positional.
+    with transaction() as con:
+        existing = db_get_capital(con, args.user_id)
     if existing is not None and not args.force:
         log.error(
             "Capital row already exists for user_id=%s (balance=%s, peak=%s). "
@@ -53,12 +56,14 @@ def main() -> int:
         )
         return 1
 
-    row = db_upsert_capital(
-        args.user_id,
-        balance=args.initial_balance,
-        peak_balance=args.initial_balance,
-        max_drawdown_pct=None,
-    )
+    with transaction() as con:
+        row = db_upsert_capital(
+            con,
+            args.user_id,
+            balance=args.initial_balance,
+            peak_balance=args.initial_balance,
+            max_drawdown_pct=None,
+        )
     log.info(
         "Backfilled capital for user_id=%s: balance=%s, peak=%s (force=%s)",
         args.user_id, row["balance"], row["peak_balance"], args.force,

--- a/scripts/create_user.py
+++ b/scripts/create_user.py
@@ -111,7 +111,9 @@ def main() -> None:
             file=sys.stderr,
         )
 
-    init_auth_db()
+    from db.transaction import transaction  # noqa: PLC0415
+    with transaction() as con:
+        init_auth_db(con)
 
     email = _prompt_email(args.email)
     if _email_exists(email):

--- a/scripts/migrate_to_multitenant.py
+++ b/scripts/migrate_to_multitenant.py
@@ -162,7 +162,8 @@ def run(args: argparse.Namespace) -> int:
 
     # 4. Real migration
     log.info("Running backfill_tenant(user_id=%s)…", args.user_id)
-    affected = backfill_tenant(args.user_id)
+    with transaction() as con_bf:
+        affected = backfill_tenant(con_bf, args.user_id)
     log.info(
         "backfill_tenant results: %s",
         ", ".join(f"{t}={n}" for t, n in affected.items()),

--- a/scripts/migrate_to_multitenant.py
+++ b/scripts/migrate_to_multitenant.py
@@ -125,7 +125,9 @@ def run(args: argparse.Namespace) -> int:
     # 2. Pre-snapshot
     pre = _snapshot_counts()
     log.info("Pre-migration row counts:\n%s", _format_snapshot(pre))
-    pre_capital = db_get_capital(args.user_id)
+    # Task 5 (#446): db_get_capital requires `con` positional.
+    with transaction() as con:
+        pre_capital = db_get_capital(con, args.user_id)
     log.info(
         "Pre-migration capital row: %s",
         "EXISTS" if pre_capital else "absent",
@@ -167,12 +169,15 @@ def run(args: argparse.Namespace) -> int:
     )
 
     log.info("Upserting capital row…")
-    capital_row = db_upsert_capital(
-        args.user_id,
-        balance=args.initial_balance,
-        peak_balance=args.initial_balance,
-        max_drawdown_pct=None,
-    )
+    # Task 5 (#446): db_upsert_capital requires `con` positional.
+    with transaction() as con:
+        capital_row = db_upsert_capital(
+            con,
+            args.user_id,
+            balance=args.initial_balance,
+            peak_balance=args.initial_balance,
+            max_drawdown_pct=None,
+        )
     log.info(
         "Capital row: balance=%s, peak=%s",
         capital_row["balance"], capital_row["peak_balance"],

--- a/scripts/reset_password.py
+++ b/scripts/reset_password.py
@@ -90,7 +90,9 @@ def main() -> None:
     parser.add_argument("--email", default=None, help="User email")
     args = parser.parse_args()
 
-    init_auth_db()
+    from db.transaction import transaction  # noqa: PLC0415
+    with transaction() as con:
+        init_auth_db(con)
     email = _prompt_email(args.email)
     found = _find_user(email)
     if found is None:

--- a/scripts/reset_password.py
+++ b/scripts/reset_password.py
@@ -105,7 +105,8 @@ def main() -> None:
     new_pwd = _prompt_new_password()
     pwd_hash = hash_password(new_pwd)
     _update_password(user_id, pwd_hash)
-    revoked = revoke_all_for_user(user_id)
+    with transaction() as con:
+        revoked = revoke_all_for_user(con, user_id)
 
     log_auth_event(
         event_type="password_reset_via_cli",

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -443,7 +443,10 @@ def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
             # when ANY tenant breaches them, not when the (meaningless) cross-
             # tenant aggregate does.
             from db.capital import db_list_active_tenant_ids
-            tenant_ids = db_list_active_tenant_ids()
+            from db.transaction import transaction as _tx_for_tenants
+            # Task 5 (#446): `db_list_active_tenant_ids` now requires `con`.
+            with _tx_for_tenants() as _tenants_con:
+                tenant_ids = db_list_active_tenant_ids(_tenants_con)
             if tenant_ids:
                 per_tenant_dd = [
                     _compute_current_portfolio_dd(cfg, tenant_id=tid)
@@ -577,7 +580,14 @@ def _compute_current_portfolio_dd(
             _load_closed_trades, _load_open_positions, _snapshot_prices,
         )
         from db.capital import db_get_capital
-        cap_row = db_get_capital(tenant_id, con=conn)
+        # Task 5 (#446): `db_get_capital` now requires `con` positional.
+        # When the caller did not pass `conn`, open a short read-only tx.
+        if conn is not None:
+            cap_row = db_get_capital(conn, tenant_id)
+        else:
+            from db.transaction import transaction as _tx_for_cap
+            with _tx_for_cap() as _cap_con:
+                cap_row = db_get_capital(_cap_con, tenant_id)
         if cap_row and cap_row.get("balance") is not None:
             capital_base = float(cap_row["balance"])
         else:

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -592,9 +592,17 @@ def _compute_current_portfolio_dd(
             capital_base = float(cap_row["balance"])
         else:
             capital_base = float(cfg.get("capital_usd", 1000.0))
+        if conn is not None:
+            _closed = _load_closed_trades(conn, tenant_id=tenant_id)
+            _opens = _load_open_positions(conn, tenant_id=tenant_id)
+        else:
+            from db.transaction import transaction as _tx_for_loads
+            with _tx_for_loads() as _loads_con:
+                _closed = _load_closed_trades(_loads_con, tenant_id=tenant_id)
+                _opens = _load_open_positions(_loads_con, tenant_id=tenant_id)
         equity_curve = compute_portfolio_equity_curve(
-            closed_trades=_load_closed_trades(tenant_id=tenant_id, conn=conn),
-            open_positions=_load_open_positions(tenant_id=tenant_id, conn=conn),
+            closed_trades=_closed,
+            open_positions=_opens,
             capital_base=capital_base,
             now_price_by_symbol=_snapshot_prices(),
         )

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -433,7 +433,10 @@ def emit_shadow_decision(
         # but emit_shadow is a write-side observer and historical curve
         # consumers expect the same shape across the run.)
         from db.capital import db_get_capital
-        _capital_row = db_get_capital(tenant_id)
+        from db.transaction import transaction as _tx_for_cap
+        # Task 5 (#446): `db_get_capital` now requires `con` positional.
+        with _tx_for_cap() as _cap_con:
+            _capital_row = db_get_capital(_cap_con, tenant_id)
         if _capital_row and _capital_row.get("balance") is not None:
             capital_base = float(_capital_row["balance"])
         else:

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -40,48 +40,39 @@ def _snapshot_prices() -> dict[str, float]:
     return dict(_PRICE_CACHE)
 
 
-def _load_closed_trades(*, tenant_id: int, conn=None) -> list[dict[str, Any]]:
+def _load_closed_trades(conn, *, tenant_id: int) -> list[dict[str, Any]]:
     """Load closed positions for `tenant_id` from DB for portfolio equity computation.
 
     Per the multi-tenant policy (epic B #253), `tenant_id` is required:
     background processes that don't have a user context must iterate via
     `db.capital.db_list_active_tenant_ids()` and call this loader once per
     tenant. Aggregating across tenants implicitly is not allowed.
-
-    Per Task 8.5: optional `conn` for caller-controlled transaction composition.
     """
-    from db.transaction import _tx_or_use
-    with _tx_or_use(conn) as conn:
-        rows = conn.execute(
-            """SELECT symbol, exit_ts, pnl_usd
-               FROM positions
-               WHERE status = 'closed' AND exit_ts IS NOT NULL
-                 AND tenant_id = ?
-               ORDER BY exit_ts""",
-            (tenant_id,),
-        ).fetchall()
+    rows = conn.execute(
+        """SELECT symbol, exit_ts, pnl_usd
+           FROM positions
+           WHERE status = 'closed' AND exit_ts IS NOT NULL
+             AND tenant_id = ?
+           ORDER BY exit_ts""",
+        (tenant_id,),
+    ).fetchall()
     return [
         {"symbol": r[0], "exit_ts": r[1], "pnl_usd": r[2] or 0.0}
         for r in rows
     ]
 
 
-def _load_open_positions(*, tenant_id: int, conn=None) -> list[dict[str, Any]]:
+def _load_open_positions(conn, *, tenant_id: int) -> list[dict[str, Any]]:
     """Load open positions for `tenant_id` from DB for MTM.
 
     See `_load_closed_trades` for the multi-tenant policy rationale.
-
-    Per Task 8.5: optional `conn` for caller-controlled transaction composition
-    (e.g. get_dashboard_state).
     """
-    from db.transaction import _tx_or_use
-    with _tx_or_use(conn) as conn:
-        rows = conn.execute(
-            """SELECT symbol, entry_price, qty, direction
-               FROM positions
-               WHERE status = 'open' AND tenant_id = ?""",
-            (tenant_id,),
-        ).fetchall()
+    rows = conn.execute(
+        """SELECT symbol, entry_price, qty, direction
+           FROM positions
+           WHERE status = 'open' AND tenant_id = ?""",
+        (tenant_id,),
+    ).fetchall()
     return [
         {
             "symbol": r[0],
@@ -442,8 +433,10 @@ def emit_shadow_decision(
         else:
             capital_base = float(cfg.get("capital_usd", _DEFAULT_CAPITAL_USD))
 
-        closed = _load_closed_trades(tenant_id=tenant_id)
-        opens = _load_open_positions(tenant_id=tenant_id)
+        from db.transaction import transaction as _tx_for_loads
+        with _tx_for_loads() as _loads_con:
+            closed = _load_closed_trades(_loads_con, tenant_id=tenant_id)
+            opens = _load_open_positions(_loads_con, tenant_id=tenant_id)
         prices = _snapshot_prices()
         if now_price_by_symbol:
             prices.update(now_price_by_symbol)
@@ -466,16 +459,20 @@ def emit_shadow_decision(
         # B6: record portfolio-tier transitions for the dashboard
         try:
             from health import recent_portfolio_transitions, record_portfolio_transition
-            recent = recent_portfolio_transitions(limit=1)
+            from db.transaction import transaction as _tx_for_pt
+            with _tx_for_pt() as _pt_con:
+                recent = recent_portfolio_transitions(_pt_con, limit=1)
             prev_tier = recent[0]["to_tier"] if recent else "NORMAL"
             if prev_tier != portfolio["tier"]:
-                record_portfolio_transition(
-                    from_tier=prev_tier,
-                    to_tier=portfolio["tier"],
-                    reason=f"shadow_eval_dd_{portfolio_dd:.4f}",
-                    dd_pct=float(portfolio_dd),
-                    concurrent=int(concurrent),
-                )
+                with _tx_for_pt() as _pt_con:
+                    record_portfolio_transition(
+                        _pt_con,
+                        from_tier=prev_tier,
+                        to_tier=portfolio["tier"],
+                        reason=f"shadow_eval_dd_{portfolio_dd:.4f}",
+                        dd_pct=float(portfolio_dd),
+                        concurrent=int(concurrent),
+                    )
         except Exception:
             log.warning("record_portfolio_transition (shadow) failed", exc_info=True)
 

--- a/tests/_baselines/positions.json
+++ b/tests/_baselines/positions.json
@@ -21,7 +21,7 @@
           "sl_price": 49000.0,
           "status": "open",
           "symbol": "BTCUSDT",
-          "tenant_id": 0,
+          "tenant_id": 99,
           "tp_price": 54000.0
         }
       ],
@@ -58,7 +58,7 @@
           "sl_price": 49000.0,
           "status": "open",
           "symbol": "BTCUSDT",
-          "tenant_id": 0,
+          "tenant_id": 99,
           "tp_price": 54000.0
         }
       ],
@@ -88,7 +88,7 @@
         "sl_price": 2900.0,
         "status": "open",
         "symbol": "ETHUSDT",
-        "tenant_id": 0,
+        "tenant_id": 99,
         "tp_price": 3300.0
       }
     },
@@ -122,7 +122,7 @@
         "sl_price": 49000.0,
         "status": "open",
         "symbol": "BTCUSDT",
-        "tenant_id": 0,
+        "tenant_id": 99,
         "tp_price": 54000.0
       }
     },

--- a/tests/_fixtures/scanner_frozen.py
+++ b/tests/_fixtures/scanner_frozen.py
@@ -121,7 +121,7 @@ def frozen_scan(monkeypatch, tmp_path):
     # exits" so snapshot doesn't drift with whatever the runner's signals.db
     # happens to contain. The defensive assert catches future regressions
     # where the helper is called without a symbol argument.
-    def _no_prior_exits(symbol, *args, **kwargs):
+    def _no_prior_exits(con, symbol, *args, **kwargs):
         assert isinstance(symbol, str) and symbol, (
             f"db_last_exit_ts called with bad symbol: {symbol!r}"
         )

--- a/tests/api/test_check_position_stops_atomicity.py
+++ b/tests/api/test_check_position_stops_atomicity.py
@@ -21,15 +21,20 @@ def db_with_position(tmp_path, monkeypatch):
     import btc_api
     monkeypatch.setattr(btc_api, "DB_FILE", str(db_path))
     init_db()
-    # Seed an open position with sl_price = 100. The real schema requires
-    # entry_ts (TEXT NOT NULL) and uses status='open' (lowercase) per
-    # db/schema.py::positions table.
+    # Seed an open position so the trailing-SL ratchet actually fires under
+    # price=108. Math: be_threshold = entry + round(atr * be_mult, 2)
+    #                              = 98 + round(2.0 * 1.5, 2) = 101.
+    # Trailing fires when price >= be_threshold AND sl_price < entry:
+    #   108 >= 101 (True) AND 97 < 98 (True) → scanner writes new_sl = 101.
+    # Previous fixture (entry=100, sl=100) had be_threshold=103 and
+    # sl_price<entry was False (100<100 = False), so trailing was a no-op
+    # for the scanner and the test was vacuous (Serrano F-13).
     with transaction() as con:
         con.execute(
             """INSERT INTO positions
                (id, symbol, direction, entry_price, qty, sl_price, tp_price,
                 status, entry_ts, atr_entry, be_mult)
-               VALUES (1, 'BTCUSDT', 'LONG', 100.0, 1.0, 100.0, 110.0,
+               VALUES (1, 'BTCUSDT', 'LONG', 98.0, 1.0, 97.0, 120.0,
                        'open', '2026-05-24T00:00:00+00:00', 2.0, 1.5)"""
         )
     return str(db_path)
@@ -74,11 +79,11 @@ def test_trailing_ratchet_atomic_under_concurrent_operator_edit(db_with_position
     assert "error" not in operator_result, operator_result["error"]
     assert operator_result.get("ok") is True
 
-    # Final state must reflect exactly one of the two writers; never an
-    # interleaved partial state.
+    # Final state must be exactly one of the two writers' values; never an
+    # interleaved partial state. The atomicity invariant predicts winner-
+    # takes-all: either the operator wrote last (105.0) OR the scanner wrote
+    # last (computed trailing-SL = 101.0). Any other value indicates a torn
+    # write or a stale read (would mean the invariant is broken).
     with transaction() as con:
         row = con.execute("SELECT sl_price FROM positions WHERE id = 1").fetchone()
-    assert row["sl_price"] in {105.0, 100.0, 104.0, 108.0}, row["sl_price"]
-    # Acceptable values: 105.0 (operator wrote last), or any trailing-SL
-    # value produced by the scanner. The point is that there is no half-
-    # applied combination.
+    assert row["sl_price"] in {105.0, 101.0}, row["sl_price"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,8 +206,10 @@ def unauthed_client(monkeypatch, tmp_path):
     # Initialize schemas in the isolated DB
     from db.schema import init_db
     from db.auth_schema import init_auth_db
+    from db.transaction import transaction
     init_db()
-    init_auth_db()
+    with transaction() as con:
+        init_auth_db(con)
 
     return TestClient(btc_api.app)
 
@@ -228,8 +230,10 @@ def viewer_client(monkeypatch, tmp_path):
 
     from db.schema import init_db
     from db.auth_schema import init_auth_db
+    from db.transaction import transaction
     init_db()
-    init_auth_db()
+    with transaction() as con:
+        init_auth_db(con)
 
     return TestClient(btc_api.app)
 

--- a/tests/operators/test_position_closure.py
+++ b/tests/operators/test_position_closure.py
@@ -1,0 +1,375 @@
+"""Invariant tests for operators.position_closure.PositionClosure.
+
+Anchors the 10 testable invariants declared in
+docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md
+Section 'PositionClosure operator contract spec'.
+
+Also resolves issue #451: this is the regression test for the trading
+invariant ('every mutation derived from one tick of price decision
+belongs to one serializable transaction') — done against the operator,
+not against ad-hoc helper composition.
+
+Invariant 10 encodes Voronov AMBER F2: the 'best-effort post-commit'
+commitment must live in the test suite, not only in prose. A future
+contributor who 'fixes' the try/except in __exit__ to raise fails
+test_side_effect_failure_does_not_rollback_close.
+"""
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from db.transaction import transaction
+from db.schema import init_db
+
+
+@pytest.fixture
+def fresh_db_with_two_tenants(tmp_path, monkeypatch):
+    """Initialize a fresh DB with two tenants, each with an open position."""
+    db_path = tmp_path / "test.db"
+    import btc_api
+    monkeypatch.setattr(btc_api, "DB_FILE", str(db_path))
+    init_db()
+
+    with transaction() as con:
+        # Two tenants with capital seeded.
+        con.execute(
+            "INSERT INTO capital (tenant_id, balance, peak_balance, max_drawdown_pct, updated_at) "
+            "VALUES (1, 10000.0, 10000.0, 0.0, ?)",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+        con.execute(
+            "INSERT INTO capital (tenant_id, balance, peak_balance, max_drawdown_pct, updated_at) "
+            "VALUES (2, 5000.0, 5000.0, 0.0, ?)",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+        # Two open positions: one per tenant.
+        con.execute(
+            """INSERT INTO positions
+               (id, symbol, direction, entry_price, qty, sl_price, tp_price,
+                status, entry_ts, tenant_id, atr_entry, be_mult)
+               VALUES (1, 'BTCUSDT', 'long', 100.0, 1.0, 95.0, 110.0,
+                       'open', ?, 1, 2.0, 1.5)""",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+        con.execute(
+            """INSERT INTO positions
+               (id, symbol, direction, entry_price, qty, sl_price, tp_price,
+                status, entry_ts, tenant_id, atr_entry, be_mult)
+               VALUES (2, 'ETHUSDT', 'long', 200.0, 0.5, 195.0, 220.0,
+                       'open', ?, 2, 3.0, 1.5)""",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+    return str(db_path)
+
+
+# ---- Invariant 1: atomicity of close + capital ----
+
+def test_atomicity_close_and_capital_succeed_together(fresh_db_with_two_tenants):
+    """Successful close commits both UPDATE positions and UPDATE capital."""
+    from operators.position_closure import PositionClosure
+
+    with PositionClosure(
+        pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+        mode="USER", caller_tenant_id=1,
+    ) as closure:
+        outcome = closure.execute()
+
+    assert outcome.status == "closed"
+    with transaction() as con:
+        pos = con.execute("SELECT status FROM positions WHERE id=1").fetchone()
+        cap = con.execute("SELECT balance FROM capital WHERE tenant_id=1").fetchone()
+    assert pos["status"] == "closed"
+    assert cap["balance"] != 10000.0  # P&L applied
+
+
+def test_atomicity_capital_failure_aborts_close(fresh_db_with_two_tenants):
+    """If apply_pnl_to_capital raises, the position close is rolled back."""
+    from operators.position_closure import PositionClosure
+    from db import capital as capital_module
+
+    original = capital_module.apply_pnl_to_capital
+
+    def boom(con, tenant_id, pnl_usd):
+        raise sqlite3.OperationalError("simulated capital failure")
+
+    with patch.object(capital_module, "apply_pnl_to_capital", boom):
+        with pytest.raises(sqlite3.OperationalError, match="simulated capital failure"):
+            with PositionClosure(
+                pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+                mode="USER", caller_tenant_id=1,
+            ) as closure:
+                closure.execute()
+
+    with transaction() as con:
+        pos = con.execute("SELECT status FROM positions WHERE id=1").fetchone()
+        cap = con.execute("SELECT balance FROM capital WHERE tenant_id=1").fetchone()
+    assert pos["status"] == "open"
+    assert cap["balance"] == 10000.0
+
+
+# ---- Invariant 2: ownership-before-lock ----
+
+def test_ownership_check_skips_begin_immediate(fresh_db_with_two_tenants):
+    """USER-mode ownership mismatch must NOT open a write transaction."""
+    from operators.position_closure import PositionClosure
+    from db import transaction as tx_module
+
+    begin_count = {"n": 0}
+    original_transaction = tx_module.transaction
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def counting_transaction():
+        begin_count["n"] += 1
+        with original_transaction() as con:
+            yield con
+
+    with patch.object(tx_module, "transaction", counting_transaction):
+        with PositionClosure(
+            pos_id=2, exit_price=220.0, exit_reason="MANUAL",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            outcome = closure.execute()
+
+    assert outcome.status == "not_found"
+    assert begin_count["n"] == 0
+
+
+# ---- Invariant 3: IDOR-equivalence in USER mode ----
+
+def test_idor_equivalent_not_found_for_missing_and_other_tenant(fresh_db_with_two_tenants):
+    """USER mode: missing row and other-tenant row both return identical NOT_FOUND."""
+    from operators.position_closure import PositionClosure
+
+    with PositionClosure(
+        pos_id=9999, exit_price=100.0, exit_reason="MANUAL",
+        mode="USER", caller_tenant_id=1,
+    ) as closure:
+        missing = closure.execute()
+
+    with PositionClosure(
+        pos_id=2, exit_price=220.0, exit_reason="MANUAL",
+        mode="USER", caller_tenant_id=1,
+    ) as closure:
+        other_tenant = closure.execute()
+
+    assert missing.status == "not_found"
+    assert other_tenant.status == "not_found"
+    assert missing.position is None
+    assert other_tenant.position is None
+
+
+# ---- Invariant 4: SYSTEM mode no-IDOR-leak ----
+
+def test_system_mode_closes_correct_tenants_capital(fresh_db_with_two_tenants):
+    """SYSTEM mode applies P&L to the position's owning tenant, not cross-leaked."""
+    from operators.position_closure import PositionClosure
+
+    with PositionClosure(
+        pos_id=2, exit_price=220.0, exit_reason="TP_HIT",
+        mode="SYSTEM",
+    ) as closure:
+        outcome = closure.execute()
+
+    assert outcome.status == "closed"
+    with transaction() as con:
+        cap1 = con.execute("SELECT balance FROM capital WHERE tenant_id=1").fetchone()
+        cap2 = con.execute("SELECT balance FROM capital WHERE tenant_id=2").fetchone()
+    assert cap1["balance"] == 10000.0
+    assert cap2["balance"] != 5000.0
+
+
+# ---- Invariant 5: no post-commit side-effect on exception ----
+
+def test_no_post_commit_side_effects_on_exception(fresh_db_with_two_tenants):
+    """If execute() raises, none of the 4 post-commit side-effects fire."""
+    from operators.position_closure import PositionClosure
+    from db import capital as capital_module
+
+    with patch.object(capital_module, "apply_pnl_to_capital",
+                      side_effect=sqlite3.OperationalError("boom")):
+        with patch("operators.position_closure._write_position_event_log") as ev, \
+             patch("operators.position_closure.trigger_health_evaluation") as he, \
+             patch("operators.position_closure.notify") as nf, \
+             patch("operators.position_closure.update_positions_json") as up:
+            with pytest.raises(sqlite3.OperationalError):
+                with PositionClosure(
+                    pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+                    mode="USER", caller_tenant_id=1,
+                ) as closure:
+                    closure.execute()
+
+    assert ev.call_count == 0
+    assert he.call_count == 0
+    assert nf.call_count == 0
+    assert up.call_count == 0
+
+
+# ---- Invariant 6: single side-effect firing on success ----
+
+def test_each_side_effect_fires_exactly_once_on_success(fresh_db_with_two_tenants):
+    """Each of the 4 post-commit side-effects is invoked exactly once."""
+    from operators.position_closure import PositionClosure
+
+    with patch("operators.position_closure._write_position_event_log") as ev, \
+         patch("operators.position_closure.trigger_health_evaluation") as he, \
+         patch("operators.position_closure.notify") as nf, \
+         patch("operators.position_closure.update_positions_json") as up:
+        with PositionClosure(
+            pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            closure.execute()
+
+    assert ev.call_count == 1
+    assert he.call_count == 1
+    assert nf.call_count == 1
+    assert up.call_count == 1
+
+
+# ---- Invariant 7: idempotent re-close ----
+
+def test_idempotent_reclose_returns_already_closed(fresh_db_with_two_tenants):
+    """Closing an already-closed position returns ALREADY_CLOSED, no re-fire."""
+    from operators.position_closure import PositionClosure
+
+    with PositionClosure(
+        pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+        mode="USER", caller_tenant_id=1,
+    ) as closure:
+        closure.execute()
+
+    with transaction() as con:
+        cap_after_first = con.execute(
+            "SELECT balance FROM capital WHERE tenant_id=1"
+        ).fetchone()["balance"]
+
+    with patch("operators.position_closure.notify") as nf:
+        with PositionClosure(
+            pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            second_outcome = closure.execute()
+
+    assert second_outcome.status == "already_closed"
+    assert nf.call_count == 0
+    with transaction() as con:
+        cap_after_second = con.execute(
+            "SELECT balance FROM capital WHERE tenant_id=1"
+        ).fetchone()["balance"]
+    assert cap_after_first == cap_after_second
+
+
+# ---- Invariant 8: no writer-lock held across I/O ----
+
+def test_no_writer_lock_held_across_post_commit_side_effects(fresh_db_with_two_tenants):
+    """Post-commit side-effects fire strictly after transaction() exits."""
+    from operators.position_closure import PositionClosure
+    from db import transaction as tx_module
+
+    tx_exit_time = {"t": None}
+    side_effect_times = {"ev": None, "he": None, "nf": None, "up": None}
+
+    original_transaction = tx_module.transaction
+    from contextlib import contextmanager
+
+    @contextmanager
+    def timed_transaction():
+        with original_transaction() as con:
+            yield con
+        import time
+        tx_exit_time["t"] = time.perf_counter()
+
+    def record_time(name):
+        def _fn(*args, **kwargs):
+            import time
+            side_effect_times[name] = time.perf_counter()
+        return _fn
+
+    with patch.object(tx_module, "transaction", timed_transaction), \
+         patch("operators.position_closure._write_position_event_log", record_time("ev")), \
+         patch("operators.position_closure.trigger_health_evaluation", record_time("he")), \
+         patch("operators.position_closure.notify", record_time("nf")), \
+         patch("operators.position_closure.update_positions_json", record_time("up")):
+        with PositionClosure(
+            pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            closure.execute()
+
+    assert tx_exit_time["t"] is not None
+    for name, t in side_effect_times.items():
+        assert t is not None, f"side-effect {name} was not called"
+        assert t >= tx_exit_time["t"], f"side-effect {name} fired during tx"
+
+
+# ---- Invariant 9: no-tenant capital skip ----
+
+def test_legacy_null_tenant_position_close_skips_capital(fresh_db_with_two_tenants):
+    """Closing a tenant_id=NULL legacy row commits but skips capital UPSERT."""
+    from operators.position_closure import PositionClosure
+
+    with transaction() as con:
+        con.execute(
+            """INSERT INTO positions
+               (id, symbol, direction, entry_price, qty, sl_price, tp_price,
+                status, entry_ts, tenant_id, atr_entry, be_mult)
+               VALUES (99, 'LEGACY', 'long', 100.0, 1.0, 95.0, 110.0,
+                       'open', ?, NULL, 2.0, 1.5)""",
+            (datetime.now(timezone.utc).isoformat(),),
+        )
+
+    with PositionClosure(
+        pos_id=99, exit_price=110.0, exit_reason="TP_HIT",
+        mode="SYSTEM",
+    ) as closure:
+        outcome = closure.execute()
+
+    assert outcome.status == "closed"
+    with transaction() as con:
+        pos = con.execute("SELECT status FROM positions WHERE id=99").fetchone()
+        # No capital row should exist for tenant=NULL.
+        cap_null = con.execute("SELECT * FROM capital WHERE tenant_id IS NULL").fetchall()
+    assert pos["status"] == "closed"
+    assert cap_null == []
+
+
+# ---- Invariant 10: post-commit side-effect failure does NOT rollback close ----
+
+def test_side_effect_failure_does_not_rollback_close(fresh_db_with_two_tenants):
+    """Best-effort post-commit contract: if any of the 4 __exit__ side-effects
+    raises, the close + capital remain durably committed. Encodes the
+    Voronov AMBER F2 finding — the 'best-effort' commitment must live in
+    the test suite, not only in prose. A future contributor who 'fixes' the
+    try/except in __exit__ to raise will fail this test."""
+    from operators.position_closure import PositionClosure
+
+    # Force each of the 4 post-commit side-effects to raise. None of them
+    # should rollback the close (impossible — already committed) and none
+    # should propagate to the caller.
+    with patch("operators.position_closure._write_position_event_log",
+               side_effect=IOError("event log down")), \
+         patch("operators.position_closure.trigger_health_evaluation",
+               side_effect=RuntimeError("health module crashed")), \
+         patch("operators.position_closure.notify",
+               side_effect=ConnectionError("telegram unreachable")), \
+         patch("operators.position_closure.update_positions_json",
+               side_effect=OSError("disk full")):
+        with PositionClosure(
+            pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+            mode="USER", caller_tenant_id=1,
+        ) as closure:
+            outcome = closure.execute()
+
+    # Caller observes a clean close. All four side-effect failures were
+    # swallowed and logged as WARN by __exit__.
+    assert outcome.status == "closed"
+    with transaction() as con:
+        pos = con.execute("SELECT status FROM positions WHERE id=1").fetchone()
+        cap = con.execute("SELECT balance FROM capital WHERE tenant_id=1").fetchone()
+    assert pos["status"] == "closed"
+    assert cap["balance"] != 10000.0  # P&L was applied in the in-tx step

--- a/tests/test_agent_history_api.py
+++ b/tests/test_agent_history_api.py
@@ -19,7 +19,8 @@ from fastapi.testclient import TestClient
 @pytest.fixture
 def client(tmp_path, monkeypatch):
     """TestClient with fresh DB + bypass-auth. Mirror of the B.7 fixture
-    so the TestClient operates as the synthetic test user (id=0)."""
+    so the TestClient operates as the synthetic test user (id=99
+    post-#446 Task 6; was id=0 pre-fix)."""
     import btc_api
     db_path = str(tmp_path / "test.db")
     monkeypatch.setattr(btc_api, "DB_FILE", db_path)
@@ -81,7 +82,7 @@ class TestListConversations:
         assert body == {"conversations": [], "total": 0, "limit": 20, "offset": 0}
 
     def test_returns_own_conversations_only(self, client):
-        _seed(0, "conv-mine", "mi pregunta")
+        _seed(99, "conv-mine", "mi pregunta")
         resp = client.get("/agent/conversations")
         assert resp.status_code == 200
         body = resp.json()
@@ -92,9 +93,9 @@ class TestListConversations:
         assert body["conversations"][0]["message_count"] == 2
 
     def test_pinned_floats_to_top(self, client):
-        _seed(0, "old", "viejo", surface="dock")
+        _seed(99, "old", "viejo", surface="dock")
         time.sleep(0.01)
-        _seed(0, "new", "nuevo", surface="dock")
+        _seed(99, "new", "nuevo", surface="dock")
         # Pin the OLD one
         from db.transaction import transaction
         with transaction() as con:
@@ -108,8 +109,8 @@ class TestListConversations:
         assert ids == ["old", "new"]
 
     def test_excludes_expired_conversations(self, client):
-        _seed(0, "expired", "expirado")
-        _seed(0, "fresh", "vigente")
+        _seed(99, "expired", "expirado")
+        _seed(99, "fresh", "vigente")
         _expire_meta("expired")
 
         resp = client.get("/agent/conversations")
@@ -118,16 +119,16 @@ class TestListConversations:
         assert resp.json()["total"] == 1
 
     def test_filter_by_surface(self, client):
-        _seed(0, "from-dock", "del dock", surface="dock")
-        _seed(0, "from-detail", "del symbol detail", surface="symbol_detail")
+        _seed(99, "from-dock", "del dock", surface="dock")
+        _seed(99, "from-detail", "del symbol detail", surface="symbol_detail")
 
         resp = client.get("/agent/conversations?surface=symbol_detail")
         ids = [c["conversation_id"] for c in resp.json()["conversations"]]
         assert ids == ["from-detail"]
 
     def test_search_q_matches_title(self, client):
-        _seed(0, "a", "que opinas de PENDLE?")
-        _seed(0, "b", "que tal BTC?")
+        _seed(99, "a", "que opinas de PENDLE?")
+        _seed(99, "b", "que tal BTC?")
 
         resp = client.get("/agent/conversations?q=PENDLE")
         ids = [c["conversation_id"] for c in resp.json()["conversations"]]
@@ -136,8 +137,8 @@ class TestListConversations:
     def test_search_q_matches_message_content(self, client):
         """The user message includes 'BTC' in its title (and content), but
         the SEARCH key 'ZONA LRC' lives only in the assistant body."""
-        _seed(0, "a", "que opinas?", assistant_text="BTC está en ZONA LRC baja")
-        _seed(0, "b", "otra cosa", assistant_text="respuesta cualquiera")
+        _seed(99, "a", "que opinas?", assistant_text="BTC está en ZONA LRC baja")
+        _seed(99, "b", "otra cosa", assistant_text="respuesta cualquiera")
 
         resp = client.get("/agent/conversations?q=ZONA LRC")
         ids = [c["conversation_id"] for c in resp.json()["conversations"]]
@@ -145,8 +146,8 @@ class TestListConversations:
 
     def test_search_escapes_like_wildcards(self, client):
         """A user searching for '%' must match literal '%', not 'anything'."""
-        _seed(0, "a", "100% rentable")
-        _seed(0, "b", "perdida total")
+        _seed(99, "a", "100% rentable")
+        _seed(99, "b", "perdida total")
 
         resp = client.get("/agent/conversations?q=%25")  # URL-encoded %
         ids = [c["conversation_id"] for c in resp.json()["conversations"]]
@@ -154,7 +155,7 @@ class TestListConversations:
 
     def test_pagination_limit_offset(self, client):
         for i in range(5):
-            _seed(0, f"c{i}", f"msg {i}")
+            _seed(99, f"c{i}", f"msg {i}")
             time.sleep(0.005)
         resp = client.get("/agent/conversations?limit=2&offset=1")
         body = resp.json()
@@ -175,9 +176,9 @@ class TestListConversations:
 
 class TestGetMessages:
     def test_returns_ordered_transcript(self, client):
-        _seed(0, "conv-X", "primera", assistant_text="A1")
+        _seed(99, "conv-X", "primera", assistant_text="A1")
         time.sleep(0.01)
-        _seed(0, "conv-X", "segunda", assistant_text="A2")
+        _seed(99, "conv-X", "segunda", assistant_text="A2")
 
         resp = client.get("/agent/conversations/conv-X/messages")
         assert resp.status_code == 200
@@ -191,7 +192,7 @@ class TestGetMessages:
 
     def test_includes_reasoning_and_chips(self, client):
         _seed(
-            0, "conv-Y", "usa tools",
+            99, "conv-Y", "usa tools",
             assistant_text="respuesta",
             reasoning="<think>razonamiento</think>",
             tool_chips=[{"tool": "get_positions", "status": "ok"}],
@@ -209,7 +210,7 @@ class TestGetMessages:
         review issue #6."""
         future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
         _seed(
-            0, "conv-P1", "cerra mi BTC",
+            99, "conv-P1", "cerra mi BTC",
             assistant_text="propongo cerrar",
             proposals=[{
                 "proposal_id": "prop-p1",
@@ -228,7 +229,7 @@ class TestGetMessages:
     def test_proposal_state_expired_when_ttl_passed(self, client):
         past = "2020-01-01T00:00:00+00:00"
         _seed(
-            0, "conv-P2", "cerra ya",
+            99, "conv-P2", "cerra ya",
             proposals=[{
                 "proposal_id": "prop-p2",
                 "action":      "close_position",
@@ -246,7 +247,7 @@ class TestGetMessages:
         from db.transaction import transaction
         future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
         _seed(
-            0, "conv-Perr", "cerra",
+            99, "conv-Perr", "cerra",
             proposals=[{
                 "proposal_id": "prop-perr",
                 "action":      "close_position",
@@ -261,7 +262,7 @@ class TestGetMessages:
                    (tenant_id, conversation_id, ts, action, args_json,
                     idempotency_key, result, http_status, expires_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (0, "conv-Perr", "2026-05-22T10:00:00Z", "close_position",
+                (99, "conv-Perr", "2026-05-22T10:00:00Z", "close_position",
                  "{}", "prop-perr", "error", 500, future),
             )
 
@@ -274,7 +275,7 @@ class TestGetMessages:
         from db.transaction import transaction
         future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
         _seed(
-            0, "conv-Pconf", "cerra",
+            99, "conv-Pconf", "cerra",
             proposals=[{
                 "proposal_id": "prop-pconf",
                 "action":      "close_position",
@@ -289,7 +290,7 @@ class TestGetMessages:
                    (tenant_id, conversation_id, ts, action, args_json,
                     idempotency_key, result, http_status, expires_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (0, "conv-Pconf", "2026-05-22T10:00:00Z", "close_position",
+                (99, "conv-Pconf", "2026-05-22T10:00:00Z", "close_position",
                  "{}", "prop-pconf", "conflict", 409, future),
             )
 
@@ -305,7 +306,7 @@ class TestGetMessages:
         result — defense in depth.
 
         Simulate: tenant 999 has a side_effect row for 'prop-shared'
-        marked 'ok'. Tenant 0 (TestClient) has a message with the
+        marked 'ok'. Tenant 99 (TestClient) has a message with the
         same proposal_id but no side_effect of their own. The state
         derivation MUST return 'stale' (no row found for this tenant)
         — NOT 'ok' (which would leak the other tenant's outcome).
@@ -313,7 +314,7 @@ class TestGetMessages:
         from db.transaction import transaction
         future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
         _seed(
-            0, "conv-Pscope", "x",
+            99, "conv-Pscope", "x",
             proposals=[{
                 "proposal_id": "prop-shared",
                 "action":      "close_position",
@@ -351,7 +352,7 @@ class TestGetMessages:
         empty chips. PR #434 review issue #2."""
         import logging
         from db.transaction import transaction
-        _seed(0, "conv-Mal", "hola", assistant_text="ok")
+        _seed(99, "conv-Mal", "hola", assistant_text="ok")
         # Corrupt the assistant row's tool_chips_json directly
         with transaction() as con:
             con.execute(
@@ -372,7 +373,7 @@ class TestGetMessages:
     def test_malformed_proposals_json_falls_back_gracefully(self, client, caplog):
         import logging
         from db.transaction import transaction
-        _seed(0, "conv-MalP", "hola", assistant_text="ok")
+        _seed(99, "conv-MalP", "hola", assistant_text="ok")
         with transaction() as con:
             con.execute(
                 "UPDATE agent_messages SET proposals_json = ? "
@@ -395,7 +396,7 @@ class TestGetMessages:
         from db.transaction import transaction
         future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
         _seed(
-            0, "conv-P3", "cerra",
+            99, "conv-P3", "cerra",
             proposals=[{
                 "proposal_id": "prop-p3",
                 "action":      "close_position",
@@ -411,7 +412,7 @@ class TestGetMessages:
                    (tenant_id, conversation_id, ts, action, args_json,
                     idempotency_key, result, http_status, expires_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (0, "conv-P3", "2026-05-22T10:00:00Z", "close_position",
+                (99, "conv-P3", "2026-05-22T10:00:00Z", "close_position",
                  "{}", "prop-p3", "ok", 200, future),
             )
 
@@ -424,7 +425,7 @@ class TestGetMessages:
         assert resp.status_code == 404
 
     def test_404_for_expired_conversation(self, client):
-        _seed(0, "conv-expired", "viejo")
+        _seed(99, "conv-expired", "viejo")
         _expire_meta("conv-expired")
         resp = client.get("/agent/conversations/conv-expired/messages")
         assert resp.status_code == 404
@@ -443,7 +444,7 @@ class TestGetMessages:
 
 class TestDeleteConversation:
     def test_soft_delete_removes_from_list_and_messages(self, client):
-        _seed(0, "conv-D1", "borrame")
+        _seed(99, "conv-D1", "borrame")
         # Sanity: visible before delete
         assert len(client.get("/agent/conversations").json()["conversations"]) == 1
 
@@ -467,7 +468,7 @@ class TestDeleteConversation:
         assert resp.status_code == 404
 
     def test_404_for_already_deleted_conversation(self, client):
-        _seed(0, "conv-D2", "hola")
+        _seed(99, "conv-D2", "hola")
         client.delete("/agent/conversations/conv-D2",
                       headers={"X-API-Key": "test-key"})
         # Second delete on the same conversation
@@ -483,7 +484,7 @@ class TestDeleteConversation:
 
 class TestTogglePin:
     def test_pin_then_unpin(self, client):
-        _seed(0, "conv-PN1", "fijame")
+        _seed(99, "conv-PN1", "fijame")
 
         # Pin
         resp1 = client.post(
@@ -513,7 +514,7 @@ class TestTogglePin:
         assert resp.status_code == 404
 
     def test_404_on_expired(self, client):
-        _seed(0, "conv-PN2", "viejo")
+        _seed(99, "conv-PN2", "viejo")
         _expire_meta("conv-PN2")
         resp = client.post(
             "/agent/conversations/conv-PN2/pin",

--- a/tests/test_agent_history_idor.py
+++ b/tests/test_agent_history_idor.py
@@ -1,7 +1,8 @@
 """IDOR suite for #428 H.3 conversation-history endpoints.
 
 Mirrors the B.7 #260 pattern. TestClient operates as synthetic user
-(id=0). Cross-tenant data is seeded for OTHER_USER_ID via the
+(id=99 post-#446 Task 6; was id=0 pre-fix). Cross-tenant data is
+seeded for OTHER_USER_ID via the
 production write path. Every endpoint must:
 
 - Hide other users' conversations from the list.
@@ -20,7 +21,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-OTHER_USER_ID = 999  # synthetic "other tenant" — distinct from TestClient (id=0)
+OTHER_USER_ID = 999  # synthetic "other tenant" — distinct from TestClient (id=99)
 
 
 @pytest.fixture
@@ -61,7 +62,7 @@ def _seed(tenant_id: int, conversation_id: str, user_msg: str = "msg",
 class TestListIDOR:
     def test_list_excludes_other_tenants(self, client):
         _seed(OTHER_USER_ID, "victim-conv", "secreto de la victima")
-        _seed(0, "my-conv", "mi pregunta")
+        _seed(99, "my-conv", "mi pregunta")
 
         body = client.get("/agent/conversations").json()
         ids = [c["conversation_id"] for c in body["conversations"]]
@@ -83,7 +84,7 @@ class TestListIDOR:
         _seed(OTHER_USER_ID, "v-conv",
               user_msg="contraseña super secreta xyz",
               assistant_text="otro secreto")
-        _seed(0, "my-conv", user_msg="hola", assistant_text="qué tal")
+        _seed(99, "my-conv", user_msg="hola", assistant_text="qué tal")
 
         body = client.get("/agent/conversations?q=secreta").json()
         ids = [c["conversation_id"] for c in body["conversations"]]
@@ -107,7 +108,7 @@ class TestGetMessagesIDOR:
 
     def test_own_conversation_visible_other_invisible(self, client):
         _seed(OTHER_USER_ID, "victim-id", "secret")
-        _seed(0, "mine", "hola")
+        _seed(99, "mine", "hola")
 
         ok = client.get("/agent/conversations/mine/messages")
         assert ok.status_code == 200
@@ -245,18 +246,18 @@ class TestSameConversationIdAcrossTenants:
         # Victim creates the conversation legitimately
         _seed(OTHER_USER_ID, "shared-id", "secreto de la victima")
 
-        # Simulate pre-fix orphan rows: attacker's tenant_id=0 rows
+        # Simulate pre-fix orphan rows: attacker's tenant_id=99 rows
         # exist under the same conversation_id.
         with transaction() as con:
             con.execute(
                 """INSERT INTO agent_messages
                    (tenant_id, conversation_id, ts, role, content, expires_at)
                    VALUES (?, ?, ?, 'user', ?, ?)""",
-                (0, "shared-id", "2026-05-22T08:00:00Z",
+                (99, "shared-id", "2026-05-22T08:00:00Z",
                  "attacker injected", "2099-01-01T00:00:00Z"),
             )
 
-        # Attacker (id=0) probing the conversation: meta row is owned by
+        # Attacker (id=99) probing the conversation: meta row is owned by
         # OTHER_USER_ID, so the 404 fires before any message read can
         # happen.
         resp = client.get("/agent/conversations/shared-id/messages")
@@ -274,7 +275,7 @@ class TestSameConversationIdAcrossTenants:
                 """INSERT INTO agent_messages
                    (tenant_id, conversation_id, ts, role, content, expires_at)
                    VALUES (?, ?, ?, 'user', ?, ?)""",
-                (0, "shared-id", "2026-05-22T08:00:00Z",
+                (99, "shared-id", "2026-05-22T08:00:00Z",
                  "match-this-keyword", "2099-01-01T00:00:00Z"),
             )
 

--- a/tests/test_agent_history_schema.py
+++ b/tests/test_agent_history_schema.py
@@ -299,8 +299,11 @@ class TestIdempotency:
 
     def test_migrate_agent_history_directly_twice(self, initialized_db):
         from db.schema import _migrate_agent_history
-        _migrate_agent_history()
-        _migrate_agent_history()  # must not raise
+        from db.transaction import transaction
+        with transaction() as con:
+            _migrate_agent_history(con)
+        with transaction() as con:
+            _migrate_agent_history(con)  # must not raise
         cols = _get_columns(initialized_db, "agent_conversation_meta")
         assert "conversation_id" in cols
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -179,6 +179,28 @@ class TestBuildTelegramMessage:
 #  TESTS — Base de datos (init_db, save_scan, get_scans, etc.)
 # ─────────────────────────────────────────────────────────────────────────────
 
+
+def _tx_get_scans(**kwargs):
+    import btc_api
+    from db.transaction import transaction
+    with transaction() as con:
+        return btc_api.get_scans(con, **kwargs)
+
+
+def _tx_get_latest_signal(symbol=None):
+    import btc_api
+    from db.transaction import transaction
+    with transaction() as con:
+        return btc_api.get_latest_signal(con, symbol)
+
+
+def _tx_get_latest_scan(symbol=None):
+    import btc_api
+    from db.transaction import transaction
+    with transaction() as con:
+        return btc_api.get_latest_scan(con, symbol)
+
+
 class TestDatabase:
     @pytest.fixture(autouse=True)
     def patch_db(self, tmp_db, monkeypatch):
@@ -206,7 +228,7 @@ class TestDatabase:
     def test_get_scans_retorna_lista(self, sample_report):
         import btc_api
         btc_api.save_scan(sample_report)
-        rows = btc_api.get_scans(limit=10)
+        rows = _tx_get_scans(limit=10)
         assert isinstance(rows, list)
         assert len(rows) == 1
 
@@ -214,7 +236,7 @@ class TestDatabase:
         import btc_api
         btc_api.save_scan(sample_report)   # señal completa
         btc_api.save_scan(setup_report)    # setup sin gatillo
-        rows = btc_api.get_scans(only_signals=True)
+        rows = _tx_get_scans(only_signals=True)
         assert len(rows) == 1
         assert rows[0]["señal"] == 1
 
@@ -222,27 +244,27 @@ class TestDatabase:
         import btc_api
         btc_api.save_scan(sample_report)
         btc_api.save_scan(setup_report)
-        rows = btc_api.get_scans(only_setups=True)
+        rows = _tx_get_scans(only_setups=True)
         # Debe incluir señales Y setups
         assert len(rows) == 2
 
     def test_get_latest_signal(self, sample_report):
         import btc_api
         btc_api.save_scan(sample_report)
-        latest = btc_api.get_latest_signal()
+        latest = _tx_get_latest_signal()
         assert latest is not None
         assert latest["señal"] == 1
 
     def test_get_latest_signal_sin_datos(self):
         import btc_api
-        latest = btc_api.get_latest_signal()
+        latest = _tx_get_latest_signal()
         assert latest is None
 
     def test_get_latest_scan(self, sample_report, setup_report):
         import btc_api
         btc_api.save_scan(setup_report)
         btc_api.save_scan(sample_report)  # último
-        latest = btc_api.get_latest_scan()
+        latest = _tx_get_latest_scan()
         assert latest["señal"] == 1
 
     def test_save_scan_guarda_payload_json(self, sample_report):
@@ -268,7 +290,7 @@ class TestDatabase:
         import btc_api
         for _ in range(5):
             btc_api.save_scan(sample_report)
-        rows = btc_api.get_scans(limit=3)
+        rows = _tx_get_scans(limit=3)
         assert len(rows) == 3
 
 
@@ -701,7 +723,7 @@ class TestExecuteScanForSymbol:
 
         cfg = btc_api.load_config()
         btc_api.execute_scan_for_symbol("ETHUSDT", cfg)
-        scans = btc_api.get_scans()
+        scans = _tx_get_scans()
         assert len(scans) >= 1
         assert scans[0]["symbol"] == "ETHUSDT"
 
@@ -809,6 +831,30 @@ class TestExecuteScanForSymbol:
 #  TESTS — Posiciones CRUD (funciones de DB)
 # ─────────────────────────────────────────────────────────────────────────────
 
+def _tx_create_position(data: dict):
+    """Test helper: wrap db_create_position in a transaction."""
+    import btc_api
+    from db.transaction import transaction
+    with transaction() as con:
+        return btc_api.db_create_position(con, data)
+
+
+def _tx_get_positions(status=None, tenant_id=None):
+    """Test helper: wrap db_get_positions in a transaction."""
+    import btc_api
+    from db.transaction import transaction
+    with transaction() as con:
+        return btc_api.db_get_positions(con, status=status, tenant_id=tenant_id)
+
+
+def _tx_update_position(pos_id: int, data: dict):
+    """Test helper: wrap db_update_position in a transaction."""
+    import btc_api
+    from db.transaction import transaction
+    with transaction() as con:
+        return btc_api.db_update_position(con, pos_id, data)
+
+
 class TestPositionsCRUD:
     """Tests for the position management system (DB-level functions)."""
 
@@ -825,7 +871,7 @@ class TestPositionsCRUD:
     def test_create_position_basic(self):
         """Create a position with minimal data (symbol + entry_price)."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
         })
@@ -839,7 +885,7 @@ class TestPositionsCRUD:
     def test_create_position_full(self):
         """Create a position with all fields."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "ethusdt",
             "entry_price": 3500.0,
             "sl_price": 3200.0,
@@ -861,7 +907,7 @@ class TestPositionsCRUD:
     def test_create_position_short_direction(self):
         """Create a SHORT position."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 68000.0,
             "direction": "short",
@@ -871,7 +917,7 @@ class TestPositionsCRUD:
     def test_create_position_with_scan_id(self):
         """Position linked to a scan_id."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "scan_id": 42,
@@ -881,7 +927,7 @@ class TestPositionsCRUD:
     def test_create_position_qty_from_size_usd(self):
         """When qty is not given, it is derived from size_usd / entry_price."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 50000.0,
             "size_usd": 1000.0,
@@ -894,29 +940,29 @@ class TestPositionsCRUD:
     def test_get_positions_empty(self):
         """No positions returns empty list."""
         import btc_api
-        positions = btc_api.db_get_positions()
+        positions = _tx_get_positions()
         assert positions == []
 
     def test_get_positions_returns_all(self):
         """Get all positions regardless of status."""
         import btc_api
-        btc_api.db_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
-        btc_api.db_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
-        positions = btc_api.db_get_positions()
+        _tx_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
+        _tx_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
+        positions = _tx_get_positions()
         assert len(positions) == 2
 
     def test_get_positions_filter_status(self):
         """Filter positions by status."""
         import btc_api
         from operators.position_closure import PositionClosure
-        btc_api.db_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
-        pos2 = btc_api.db_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
+        _tx_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
+        pos2 = _tx_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
         with PositionClosure(pos2["id"], 3800.0, "TP_HIT", mode="SYSTEM") as c:
             c.execute()
 
-        open_pos = btc_api.db_get_positions(status="open")
-        closed_pos = btc_api.db_get_positions(status="closed")
-        all_pos = btc_api.db_get_positions()
+        open_pos = _tx_get_positions(status="open")
+        closed_pos = _tx_get_positions(status="closed")
+        all_pos = _tx_get_positions()
 
         assert len(open_pos) == 1
         assert open_pos[0]["symbol"] == "BTCUSDT"
@@ -928,20 +974,20 @@ class TestPositionsCRUD:
         """status='all' behaves same as no filter."""
         import btc_api
         from operators.position_closure import PositionClosure
-        btc_api.db_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
-        pos2 = btc_api.db_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
+        _tx_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
+        pos2 = _tx_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
         with PositionClosure(pos2["id"], 3800.0, "MANUAL", mode="SYSTEM") as c:
             c.execute()
 
-        all_pos = btc_api.db_get_positions(status="all")
+        all_pos = _tx_get_positions(status="all")
         assert len(all_pos) == 2
 
     def test_get_positions_ordered_desc(self):
         """Positions are returned in descending id order (newest first)."""
         import btc_api
-        p1 = btc_api.db_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
-        p2 = btc_api.db_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
-        positions = btc_api.db_get_positions()
+        p1 = _tx_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
+        p2 = _tx_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
+        positions = _tx_get_positions()
         assert positions[0]["id"] == p2["id"]
         assert positions[1]["id"] == p1["id"]
 
@@ -951,7 +997,7 @@ class TestPositionsCRUD:
         """Close a position and verify exit data."""
         import btc_api
         from operators.position_closure import PositionClosure
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "qty": 0.1,
@@ -970,7 +1016,7 @@ class TestPositionsCRUD:
         """P&L calculation correct for LONG position."""
         import btc_api
         from operators.position_closure import PositionClosure
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "qty": 0.1,
@@ -986,7 +1032,7 @@ class TestPositionsCRUD:
         """Negative P&L for LONG position that drops."""
         import btc_api
         from operators.position_closure import PositionClosure
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "qty": 0.1,
@@ -1002,7 +1048,7 @@ class TestPositionsCRUD:
         """P&L calculation correct for SHORT position."""
         import btc_api
         from operators.position_closure import PositionClosure
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 68000.0,
             "qty": 0.1,
@@ -1018,7 +1064,7 @@ class TestPositionsCRUD:
         """Negative P&L for SHORT position that rises."""
         import btc_api
         from operators.position_closure import PositionClosure
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "qty": 0.1,
@@ -1043,13 +1089,13 @@ class TestPositionsCRUD:
     def test_update_position_sl_tp(self):
         """Update SL/TP of an open position."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
             "tp_price": 70000.0,
         })
-        updated = btc_api.db_update_position(pos["id"], {
+        updated = _tx_update_position(pos["id"], {
             "sl_price": 64000.0,
             "tp_price": 72000.0,
         })
@@ -1062,34 +1108,34 @@ class TestPositionsCRUD:
     def test_update_position_notes(self):
         """Update notes field."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
         })
-        updated = btc_api.db_update_position(pos["id"], {"notes": "Updated note"})
+        updated = _tx_update_position(pos["id"], {"notes": "Updated note"})
         assert updated["notes"] == "Updated note"
 
     def test_update_position_rejects_invalid_fields(self):
         """Only allowed fields can be updated; invalid fields return None."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
         })
         # db_update_position uses an 'allowed' set whitelist;
         # passing only invalid fields returns None (no updates)
-        result = btc_api.db_update_position(pos["id"], {"malicious_field": "hacked"})
+        result = _tx_update_position(pos["id"], {"malicious_field": "hacked"})
         assert result is None
 
     def test_update_position_mixed_valid_invalid_fields(self):
         """Mixed valid and invalid fields: only valid ones are applied."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
         })
-        updated = btc_api.db_update_position(pos["id"], {
+        updated = _tx_update_position(pos["id"], {
             "sl_price": 64000.0,
             "evil_field": "drop table",
         })
@@ -1099,11 +1145,11 @@ class TestPositionsCRUD:
     def test_update_position_allowed_fields(self):
         """All allowed fields can be updated."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
         })
-        updated = btc_api.db_update_position(pos["id"], {
+        updated = _tx_update_position(pos["id"], {
             "sl_price": 63000.0,
             "tp_price": 70000.0,
             "size_usd": 1000.0,
@@ -1123,7 +1169,7 @@ class TestPositionsCRUD:
     def test_check_stops_sl_hit_long(self):
         """SL hit on LONG position auto-closes it."""
         import btc_api
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
@@ -1131,7 +1177,7 @@ class TestPositionsCRUD:
             "direction": "LONG",
         })
         btc_api.check_position_stops("BTCUSDT", 62000.0)  # below SL
-        positions = btc_api.db_get_positions(status="closed")
+        positions = _tx_get_positions(status="closed")
         assert len(positions) == 1
         assert positions[0]["exit_reason"] == "SL_HIT"
         assert positions[0]["exit_price"] == 63000.0  # closes at SL price
@@ -1139,7 +1185,7 @@ class TestPositionsCRUD:
     def test_check_stops_tp_hit_long(self):
         """TP hit on LONG position auto-closes it."""
         import btc_api
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
@@ -1147,7 +1193,7 @@ class TestPositionsCRUD:
             "direction": "LONG",
         })
         btc_api.check_position_stops("BTCUSDT", 71000.0)  # above TP
-        positions = btc_api.db_get_positions(status="closed")
+        positions = _tx_get_positions(status="closed")
         assert len(positions) == 1
         assert positions[0]["exit_reason"] == "TP_HIT"
         assert positions[0]["exit_price"] == 70000.0  # closes at TP price
@@ -1155,7 +1201,7 @@ class TestPositionsCRUD:
     def test_check_stops_price_between_sl_tp(self):
         """Price between SL and TP does not close the position."""
         import btc_api
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
@@ -1163,40 +1209,40 @@ class TestPositionsCRUD:
             "direction": "LONG",
         })
         btc_api.check_position_stops("BTCUSDT", 66000.0)
-        open_pos = btc_api.db_get_positions(status="open")
-        closed_pos = btc_api.db_get_positions(status="closed")
+        open_pos = _tx_get_positions(status="open")
+        closed_pos = _tx_get_positions(status="closed")
         assert len(open_pos) == 1
         assert len(closed_pos) == 0
 
     def test_check_stops_no_sl_tp(self):
         """Position without SL/TP is never auto-closed."""
         import btc_api
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "direction": "LONG",
         })
         btc_api.check_position_stops("BTCUSDT", 50000.0)  # huge drop
-        open_pos = btc_api.db_get_positions(status="open")
+        open_pos = _tx_get_positions(status="open")
         assert len(open_pos) == 1  # still open
 
     def test_check_stops_different_symbol(self):
         """Only positions matching the symbol are checked."""
         import btc_api
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
             "direction": "LONG",
         })
         btc_api.check_position_stops("ETHUSDT", 1000.0)  # different symbol
-        open_pos = btc_api.db_get_positions(status="open")
+        open_pos = _tx_get_positions(status="open")
         assert len(open_pos) == 1  # BTC position still open
 
     def test_check_stops_sl_at_exact_price(self):
         """SL triggered when price equals SL exactly."""
         import btc_api
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
@@ -1204,14 +1250,14 @@ class TestPositionsCRUD:
             "direction": "LONG",
         })
         btc_api.check_position_stops("BTCUSDT", 63000.0)  # exactly at SL
-        closed_pos = btc_api.db_get_positions(status="closed")
+        closed_pos = _tx_get_positions(status="closed")
         assert len(closed_pos) == 1
         assert closed_pos[0]["exit_reason"] == "SL_HIT"
 
     def test_check_stops_tp_at_exact_price(self):
         """TP triggered when price equals TP exactly."""
         import btc_api
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
@@ -1219,21 +1265,21 @@ class TestPositionsCRUD:
             "direction": "LONG",
         })
         btc_api.check_position_stops("BTCUSDT", 70000.0)  # exactly at TP
-        closed_pos = btc_api.db_get_positions(status="closed")
+        closed_pos = _tx_get_positions(status="closed")
         assert len(closed_pos) == 1
         assert closed_pos[0]["exit_reason"] == "TP_HIT"
 
     def test_check_stops_multiple_positions(self):
         """Multiple open positions for same symbol are all checked."""
         import btc_api
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
             "tp_price": 70000.0,
             "direction": "LONG",
         })
-        btc_api.db_create_position({
+        _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 60000.0,
             "sl_price": 58000.0,
@@ -1242,8 +1288,8 @@ class TestPositionsCRUD:
         })
         # Price triggers TP on second position (>=68000) but not first (needs >=70000)
         btc_api.check_position_stops("BTCUSDT", 69000.0)
-        open_pos = btc_api.db_get_positions(status="open")
-        closed_pos = btc_api.db_get_positions(status="closed")
+        open_pos = _tx_get_positions(status="open")
+        closed_pos = _tx_get_positions(status="closed")
         assert len(open_pos) == 1
         assert len(closed_pos) == 1
         assert closed_pos[0]["entry_price"] == 60000.0  # second one hit TP
@@ -1251,7 +1297,7 @@ class TestPositionsCRUD:
     def test_check_stops_already_closed_not_affected(self):
         """Already-closed positions are not re-checked."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "sl_price": 63000.0,
@@ -1263,14 +1309,14 @@ class TestPositionsCRUD:
             c.execute()
         # Now check stops with price below SL -- should NOT re-close
         btc_api.check_position_stops("BTCUSDT", 60000.0)
-        closed_pos = btc_api.db_get_positions(status="closed")
+        closed_pos = _tx_get_positions(status="closed")
         assert len(closed_pos) == 1
         assert closed_pos[0]["exit_reason"] == "MANUAL"  # original reason
 
     def test_trailing_ratchet_moves_sl_to_breakeven(self):
         """When price rises >= 1.5x ATR above entry, SL moves to entry (breakeven)."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 60000.0,
             "sl_price": 59000.0,
@@ -1280,14 +1326,14 @@ class TestPositionsCRUD:
         })
         # Price rises to entry + 1.5*ATR = 60000 + 1000 = 61000
         btc_api.check_position_stops("BTCUSDT", 61000.0)
-        updated = btc_api.db_get_positions(status="open")
+        updated = _tx_get_positions(status="open")
         assert len(updated) == 1
         assert updated[0]["sl_price"] == 60000.0  # moved to entry price
 
     def test_trailing_ratchet_never_lowers_sl(self):
         """SL should only go up (tighten), never down."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 60000.0,
             "sl_price": 60000.0,  # already at breakeven
@@ -1296,14 +1342,14 @@ class TestPositionsCRUD:
             "atr_entry": 666.67,
         })
         btc_api.check_position_stops("BTCUSDT", 60500.0)
-        updated = btc_api.db_get_positions(status="open")
+        updated = _tx_get_positions(status="open")
         assert len(updated) == 1
         assert updated[0]["sl_price"] == 60000.0  # unchanged
 
     def test_trailing_ratchet_uses_custom_be_mult(self):
         """be_mult from position overrides the default 1.5."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "DOGEUSDT",
             "entry_price": 0.10,
             "sl_price": 0.09,
@@ -1314,20 +1360,20 @@ class TestPositionsCRUD:
         })
         # Price at 0.108 — above 1.5x ATR (0.1075) but below 2.0x ATR (0.11)
         btc_api.check_position_stops("DOGEUSDT", 0.108)
-        updated = btc_api.db_get_positions(status="open")
+        updated = _tx_get_positions(status="open")
         assert len(updated) == 1
         assert updated[0]["sl_price"] == 0.09  # NOT at breakeven yet (be_mult=2.0)
 
         # Price at 0.111 — above 2.0x ATR threshold
         btc_api.check_position_stops("DOGEUSDT", 0.111)
-        updated = btc_api.db_get_positions(status="open")
+        updated = _tx_get_positions(status="open")
         assert len(updated) == 1
         assert updated[0]["sl_price"] == 0.10  # NOW at breakeven
 
     def test_position_without_atr_skips_trailing(self):
         """Legacy positions without atr_entry skip trailing logic."""
         import btc_api
-        pos = btc_api.db_create_position({
+        pos = _tx_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 60000.0,
             "sl_price": 58800.0,
@@ -1335,7 +1381,7 @@ class TestPositionsCRUD:
             "direction": "LONG",
         })
         btc_api.check_position_stops("BTCUSDT", 61500.0)
-        updated = btc_api.db_get_positions(status="open")
+        updated = _tx_get_positions(status="open")
         assert len(updated) == 1
         assert updated[0]["sl_price"] == 58800.0  # unchanged, no trailing
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -908,9 +908,11 @@ class TestPositionsCRUD:
     def test_get_positions_filter_status(self):
         """Filter positions by status."""
         import btc_api
+        from operators.position_closure import PositionClosure
         btc_api.db_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
         pos2 = btc_api.db_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
-        btc_api.db_close_position(pos2["id"], 3800.0, "TP_HIT")
+        with PositionClosure(pos2["id"], 3800.0, "TP_HIT", mode="SYSTEM") as c:
+            c.execute()
 
         open_pos = btc_api.db_get_positions(status="open")
         closed_pos = btc_api.db_get_positions(status="closed")
@@ -925,9 +927,11 @@ class TestPositionsCRUD:
     def test_get_positions_status_all_returns_everything(self):
         """status='all' behaves same as no filter."""
         import btc_api
+        from operators.position_closure import PositionClosure
         btc_api.db_create_position({"symbol": "BTCUSDT", "entry_price": 65000})
         pos2 = btc_api.db_create_position({"symbol": "ETHUSDT", "entry_price": 3500})
-        btc_api.db_close_position(pos2["id"], 3800.0, "MANUAL")
+        with PositionClosure(pos2["id"], 3800.0, "MANUAL", mode="SYSTEM") as c:
+            c.execute()
 
         all_pos = btc_api.db_get_positions(status="all")
         assert len(all_pos) == 2
@@ -941,18 +945,21 @@ class TestPositionsCRUD:
         assert positions[0]["id"] == p2["id"]
         assert positions[1]["id"] == p1["id"]
 
-    # --- db_close_position ---
+    # --- PositionClosure (migrated from db_close_position, Task 7) ---
 
     def test_close_position(self):
         """Close a position and verify exit data."""
         import btc_api
+        from operators.position_closure import PositionClosure
         pos = btc_api.db_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "qty": 0.1,
             "direction": "LONG",
         })
-        closed = btc_api.db_close_position(pos["id"], 68000.0, "TP_HIT")
+        with PositionClosure(pos["id"], 68000.0, "TP_HIT", mode="SYSTEM") as c:
+            outcome = c.execute()
+        closed = outcome.position
         assert closed is not None
         assert closed["exit_price"] == 68000.0
         assert closed["exit_reason"] == "TP_HIT"
@@ -962,64 +969,74 @@ class TestPositionsCRUD:
     def test_close_position_pnl_long(self):
         """P&L calculation correct for LONG position."""
         import btc_api
+        from operators.position_closure import PositionClosure
         pos = btc_api.db_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "qty": 0.1,
             "direction": "LONG",
         })
-        closed = btc_api.db_close_position(pos["id"], 68000.0, "TP_HIT")
+        with PositionClosure(pos["id"], 68000.0, "TP_HIT", mode="SYSTEM") as c:
+            outcome = c.execute()
         # PnL = (68000 - 65000) * 0.1 = 300
-        assert closed["pnl_usd"] == pytest.approx(300.0, abs=0.01)
-        assert closed["pnl_pct"] > 0
+        assert outcome.pnl_usd == pytest.approx(300.0, abs=0.01)
+        assert outcome.pnl_pct > 0
 
     def test_close_position_pnl_long_loss(self):
         """Negative P&L for LONG position that drops."""
         import btc_api
+        from operators.position_closure import PositionClosure
         pos = btc_api.db_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "qty": 0.1,
             "direction": "LONG",
         })
-        closed = btc_api.db_close_position(pos["id"], 63000.0, "SL_HIT")
+        with PositionClosure(pos["id"], 63000.0, "SL_HIT", mode="SYSTEM") as c:
+            outcome = c.execute()
         # PnL = (63000 - 65000) * 0.1 = -200
-        assert closed["pnl_usd"] == pytest.approx(-200.0, abs=0.01)
-        assert closed["pnl_pct"] < 0
+        assert outcome.pnl_usd == pytest.approx(-200.0, abs=0.01)
+        assert outcome.pnl_pct < 0
 
     def test_close_position_pnl_short(self):
         """P&L calculation correct for SHORT position."""
         import btc_api
+        from operators.position_closure import PositionClosure
         pos = btc_api.db_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 68000.0,
             "qty": 0.1,
             "direction": "SHORT",
         })
-        closed = btc_api.db_close_position(pos["id"], 65000.0, "TP_HIT")
+        with PositionClosure(pos["id"], 65000.0, "TP_HIT", mode="SYSTEM") as c:
+            outcome = c.execute()
         # PnL for SHORT = (entry - exit) * qty = (68000 - 65000) * 0.1 = 300
-        assert closed["pnl_usd"] == pytest.approx(300.0, abs=0.01)
-        assert closed["pnl_pct"] > 0
+        assert outcome.pnl_usd == pytest.approx(300.0, abs=0.01)
+        assert outcome.pnl_pct > 0
 
     def test_close_position_pnl_short_loss(self):
         """Negative P&L for SHORT position that rises."""
         import btc_api
+        from operators.position_closure import PositionClosure
         pos = btc_api.db_create_position({
             "symbol": "BTCUSDT",
             "entry_price": 65000.0,
             "qty": 0.1,
             "direction": "SHORT",
         })
-        closed = btc_api.db_close_position(pos["id"], 68000.0, "SL_HIT")
+        with PositionClosure(pos["id"], 68000.0, "SL_HIT", mode="SYSTEM") as c:
+            outcome = c.execute()
         # PnL = (65000 - 68000) * 0.1 = -300
-        assert closed["pnl_usd"] == pytest.approx(-300.0, abs=0.01)
-        assert closed["pnl_pct"] < 0
+        assert outcome.pnl_usd == pytest.approx(-300.0, abs=0.01)
+        assert outcome.pnl_pct < 0
 
     def test_close_nonexistent_position_returns_none(self):
-        """Closing a position that does not exist returns None."""
-        import btc_api
-        result = btc_api.db_close_position(9999, 68000.0, "MANUAL")
-        assert result is None
+        """Closing a position that does not exist returns not_found."""
+        from operators.position_closure import PositionClosure
+        with PositionClosure(9999, 68000.0, "MANUAL", mode="SYSTEM") as c:
+            outcome = c.execute()
+        assert outcome.status == "not_found"
+        assert outcome.position is None
 
     # --- db_update_position ---
 
@@ -1241,7 +1258,9 @@ class TestPositionsCRUD:
             "tp_price": 70000.0,
             "direction": "LONG",
         })
-        btc_api.db_close_position(pos["id"], 68000.0, "MANUAL")
+        from operators.position_closure import PositionClosure
+        with PositionClosure(pos["id"], 68000.0, "MANUAL", mode="SYSTEM") as c:
+            c.execute()
         # Now check stops with price below SL -- should NOT re-close
         btc_api.check_position_stops("BTCUSDT", 60000.0)
         closed_pos = btc_api.db_get_positions(status="closed")

--- a/tests/test_api_positions_parity.py
+++ b/tests/test_api_positions_parity.py
@@ -35,12 +35,13 @@ def client(monkeypatch, tmp_path):
             "INSERT INTO scans (id, ts, symbol, estado, señal, setup, price, lrc_pct, rsi_1h, score, score_label, macro_ok, gatillo, payload) "
             "VALUES (2, '2026-01-15T10:05:00Z', 'BTCUSDT', 'LONG', 1, 0, 50000.0, 20.0, 40.0, 5, 'premium', 1, 1, '{}')"
         )
-        # B.5 #258: include tenant_id matching synthetic test user (id=0 per
-        # auth.middleware._synthetic_test_user). Without this, the post-B.5
+        # B.5 #258: include tenant_id matching synthetic test user (id=99 per
+        # auth.middleware._synthetic_test_user; bumped from 0 → 99 by #446
+        # Task 6 fix). Without this, the post-B.5
         # tenant filter on GET /positions excludes NULL-tenant rows.
         con.execute(
             "INSERT INTO positions (id, scan_id, symbol, direction, status, entry_price, entry_ts, sl_price, tp_price, size_usd, qty, tenant_id) "
-            "VALUES (1, 2, 'BTCUSDT', 'LONG', 'open', 50000.0, '2026-01-15T10:05:00Z', 49000.0, 54000.0, 100.0, 0.002, 0)"
+            "VALUES (1, 2, 'BTCUSDT', 'LONG', 'open', 50000.0, '2026-01-15T10:05:00Z', 49000.0, 54000.0, 100.0, 0.002, 99)"
         )
 
     # Test config (api_key="test-key")

--- a/tests/test_api_user_preferences.py
+++ b/tests/test_api_user_preferences.py
@@ -45,12 +45,14 @@ def test_mask_token_short_input_returns_empty():
 
 @pytest.fixture
 def seeded_user_with_telegram(tmp_path, monkeypatch):
-    """Fresh DB with notify_channels seeded for the test-bypass tenant (id=0).
+    """Fresh DB with notify_channels seeded for the test-bypass tenant (id=99).
 
     The autouse _auth_bypass_default fixture (conftest.py) activates
     AUTH_TEST_BYPASS_ROLE=admin, which makes AuthMiddleware inject a
-    synthetic User(id=0). We therefore seed preferences for tenant_id=0 so
-    GET /preferences returns the row we expect.
+    synthetic User(id=99). We therefore seed preferences for tenant_id=99 so
+    GET /preferences returns the row we expect. (Bumped from 0 → 99 by
+    #446 Task 6 fix — PositionClosure USER mode requires
+    caller_tenant_id > 0.)
 
     No real users table row is needed — the bypass user is never DB-hydrated.
     """
@@ -64,7 +66,7 @@ def seeded_user_with_telegram(tmp_path, monkeypatch):
     init_db()
 
     db_upsert_user_preferences(
-        0,
+        99,
         notify_channels={
             "telegram_bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12",
             "telegram_chat_id":   "987654321",
@@ -110,7 +112,7 @@ def test_put_preserves_token_when_value_contains_mask_marker(seeded_user_with_te
 
     # Re-fetch raw from DB (bypass masking) to verify token preserved
     from db.user_preferences import db_get_user_preferences
-    row = db_get_user_preferences(0)
+    row = db_get_user_preferences(99)
     nc = row["notify_channels"]
     assert nc["telegram_bot_token"] == "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12"
     assert nc["telegram_chat_id"] == "111222333"
@@ -133,7 +135,7 @@ def test_put_replaces_token_when_value_unmasked(seeded_user_with_telegram):
     assert r.status_code == 200
 
     from db.user_preferences import db_get_user_preferences
-    row = db_get_user_preferences(0)
+    row = db_get_user_preferences(99)
     assert row["notify_channels"]["telegram_bot_token"] == "111111111:NEWXYZabcDEFghiJKLmnoPQRstuVWXyzABCDE"
 
     # Response body should reflect the new token, masked.
@@ -157,7 +159,7 @@ def test_test_endpoint_no_channels_returns_no_telegram_configured(tmp_path, monk
     monkeypatch.setattr(btc_api, "DB_FILE", db_path)
     init_db()
     init_auth_db()
-    # No user row needed: conftest auth bypass uses synthetic User(id=0).
+    # No user row needed: conftest auth bypass uses synthetic User(id=99).
 
     client = TestClient(btc_api.app)
     r = client.post("/preferences/test")
@@ -170,7 +172,7 @@ def test_test_endpoint_only_token_returns_no_telegram_configured(seeded_user_wit
     """Token set but chat_id missing → still no_telegram_configured."""
     from db.user_preferences import db_upsert_user_preferences
     # Overwrite the fixture's prefs to remove chat_id
-    db_upsert_user_preferences(0, notify_channels={"telegram_bot_token": "xxx:yyy"})
+    db_upsert_user_preferences(99, notify_channels={"telegram_bot_token": "xxx:yyy"})
 
     client = seeded_user_with_telegram
     r = client.post("/preferences/test")

--- a/tests/test_api_user_preferences.py
+++ b/tests/test_api_user_preferences.py
@@ -59,19 +59,22 @@ def seeded_user_with_telegram(tmp_path, monkeypatch):
     import btc_api
     from fastapi.testclient import TestClient
     from db.schema import init_db
+    from db.transaction import transaction
     from db.user_preferences import db_upsert_user_preferences
 
     db_path = str(tmp_path / "test_prefs.db")
     monkeypatch.setattr(btc_api, "DB_FILE", db_path)
     init_db()
 
-    db_upsert_user_preferences(
-        99,
-        notify_channels={
-            "telegram_bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12",
-            "telegram_chat_id":   "987654321",
-        },
-    )
+    with transaction() as con:
+        db_upsert_user_preferences(
+            con,
+            99,
+            notify_channels={
+                "telegram_bot_token": "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12",
+                "telegram_chat_id":   "987654321",
+            },
+        )
 
     return TestClient(btc_api.app)
 
@@ -111,8 +114,10 @@ def test_put_preserves_token_when_value_contains_mask_marker(seeded_user_with_te
     assert r.status_code == 200
 
     # Re-fetch raw from DB (bypass masking) to verify token preserved
+    from db.transaction import transaction
     from db.user_preferences import db_get_user_preferences
-    row = db_get_user_preferences(99)
+    with transaction() as con:
+        row = db_get_user_preferences(con, 99)
     nc = row["notify_channels"]
     assert nc["telegram_bot_token"] == "123456789:ABCdefGHIjklMNOpqrsTUVwxyz_aBcDeFgH12"
     assert nc["telegram_chat_id"] == "111222333"
@@ -134,8 +139,10 @@ def test_put_replaces_token_when_value_unmasked(seeded_user_with_telegram):
     })
     assert r.status_code == 200
 
+    from db.transaction import transaction
     from db.user_preferences import db_get_user_preferences
-    row = db_get_user_preferences(99)
+    with transaction() as con:
+        row = db_get_user_preferences(con, 99)
     assert row["notify_channels"]["telegram_bot_token"] == "111111111:NEWXYZabcDEFghiJKLmnoPQRstuVWXyzABCDE"
 
     # Response body should reflect the new token, masked.
@@ -158,7 +165,8 @@ def test_test_endpoint_no_channels_returns_no_telegram_configured(tmp_path, monk
     db_path = str(tmp_path / "test_prefs_no_channels.db")
     monkeypatch.setattr(btc_api, "DB_FILE", db_path)
     init_db()
-    init_auth_db()
+    with transaction() as con:
+        init_auth_db(con)
     # No user row needed: conftest auth bypass uses synthetic User(id=99).
 
     client = TestClient(btc_api.app)
@@ -170,9 +178,11 @@ def test_test_endpoint_no_channels_returns_no_telegram_configured(tmp_path, monk
 
 def test_test_endpoint_only_token_returns_no_telegram_configured(seeded_user_with_telegram, monkeypatch):
     """Token set but chat_id missing → still no_telegram_configured."""
+    from db.transaction import transaction
     from db.user_preferences import db_upsert_user_preferences
     # Overwrite the fixture's prefs to remove chat_id
-    db_upsert_user_preferences(99, notify_channels={"telegram_bot_token": "xxx:yyy"})
+    with transaction() as con:
+        db_upsert_user_preferences(con, 99, notify_channels={"telegram_bot_token": "xxx:yyy"})
 
     client = seeded_user_with_telegram
     r = client.post("/preferences/test")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -415,20 +415,20 @@ def test_audit_failure_does_not_break_login(unauthed_client, monkeypatch, capsys
     """The auth.audit module is failure-tolerant — even if the DB INSERT
     raises, log_auth_event must NOT propagate the error.
 
-    We simulate this by patching _tx_or_use inside auth.audit so its
+    We simulate this by patching transaction inside auth.audit so its
     connection blows up. Login still has to return 200 and the error must
     surface on stderr (so an operator can later notice the audit gap).
 
-    (Task 8.5 rename: auth.audit now uses `_tx_or_use(con)` instead of
-    `transaction()` so it can be composed into a caller-owned tx.)
+    (Task 10 migration: auth.audit is a Cat. 2 hidden operator and now
+    calls transaction() directly instead of _tx_or_use.)
     """
     _create_user_directly(unauthed_client, "jane@example.com", "long_pass_phrase_j", role="viewer")
 
-    def _broken_transaction(_con=None):
+    def _broken_transaction():
         raise RuntimeError("simulated audit DB failure")
 
     import auth.audit as audit_mod
-    monkeypatch.setattr(audit_mod, "_tx_or_use", _broken_transaction)
+    monkeypatch.setattr(audit_mod, "transaction", _broken_transaction)
 
     resp = _login(unauthed_client, "jane@example.com", "long_pass_phrase_j")
     assert resp.status_code == 200, (

--- a/tests/test_check_position_stops_time_limit.py
+++ b/tests/test_check_position_stops_time_limit.py
@@ -53,9 +53,22 @@ def setup_db_and_cfg(tmp_path, monkeypatch):
     yield set_cfg
 
 
-def _open_btc_position(entry_ts_iso: str, *, sl: float = 50000.0, tp: float = 80000.0):
+def _tx_create_position(data: dict):
     import btc_api
-    return btc_api.db_create_position({
+    from db.transaction import transaction
+    with transaction() as con:
+        return btc_api.db_create_position(con, data)
+
+
+def _tx_get_positions(status=None):
+    import btc_api
+    from db.transaction import transaction
+    with transaction() as con:
+        return btc_api.db_get_positions(con, status=status)
+
+
+def _open_btc_position(entry_ts_iso: str, *, sl: float = 50000.0, tp: float = 80000.0):
+    return _tx_create_position({
         "symbol": "BTCUSDT",
         "entry_price": 65000.0,
         "sl_price": sl,
@@ -84,7 +97,7 @@ def test_check_position_stops_time_limit_fires(setup_db_and_cfg):
     now = entry_dt + timedelta(hours=14)
     btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    closed = btc_api.db_get_positions(status="closed")
+    closed = _tx_get_positions(status="closed")
     assert len(closed) == 1
     assert closed[0]["exit_reason"] == "TIME_LIMIT_HIT"
     assert closed[0]["exit_price"] == 65500.0
@@ -104,7 +117,7 @@ def test_check_position_stops_time_limit_does_not_fire_before(setup_db_and_cfg):
     now = entry_dt + timedelta(hours=13, minutes=59)
     btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1
 
 
@@ -122,7 +135,7 @@ def test_check_position_stops_sl_wins_over_time_limit(setup_db_and_cfg):
     now = entry_dt + timedelta(hours=20)  # well past TL
     btc_api.check_position_stops("BTCUSDT", 62000.0, now=now)  # below SL
 
-    closed = btc_api.db_get_positions(status="closed")
+    closed = _tx_get_positions(status="closed")
     assert len(closed) == 1
     assert closed[0]["exit_reason"] == "SL_HIT"
 
@@ -139,7 +152,7 @@ def test_check_position_stops_no_time_limit_in_config(setup_db_and_cfg):
     now = entry_dt + timedelta(hours=100)
     btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1
 
 
@@ -167,7 +180,7 @@ def test_check_position_stops_retroactive_trigger_logs_warning(
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    closed = btc_api.db_get_positions(status="closed")
+    closed = _tx_get_positions(status="closed")
     assert len(closed) == 1
     assert closed[0]["exit_reason"] == "TIME_LIMIT_HIT"
 
@@ -207,7 +220,7 @@ def test_check_position_stops_no_now_arg_uses_utcnow(setup_db_and_cfg):
 
     btc_api.check_position_stops("BTCUSDT", 65500.0)
 
-    closed = btc_api.db_get_positions(status="closed")
+    closed = _tx_get_positions(status="closed")
     assert len(closed) == 1
     assert closed[0]["exit_reason"] == "TIME_LIMIT_HIT"
 
@@ -227,13 +240,13 @@ def test_check_position_stops_non_aligned_entry_ts_boundary(setup_db_and_cfg):
 
     now_just_before = datetime(2025, 1, 1, 17, 0, 0, 0, tzinfo=timezone.utc)
     btc_api.check_position_stops("BTCUSDT", 65500.0, now=now_just_before)
-    assert len(btc_api.db_get_positions(status="open")) == 1, (
+    assert len(_tx_get_positions(status="open")) == 1, (
         "hours_open=4.9999...h must not trigger TL=5h"
     )
 
     now_just_after = datetime(2025, 1, 1, 17, 0, 0, 600_000, tzinfo=timezone.utc)
     btc_api.check_position_stops("BTCUSDT", 65500.0, now=now_just_after)
-    closed = btc_api.db_get_positions(status="closed")
+    closed = _tx_get_positions(status="closed")
     assert len(closed) == 1
     assert closed[0]["exit_reason"] == "TIME_LIMIT_HIT"
 
@@ -286,7 +299,7 @@ def test_check_position_stops_malformed_entry_ts_skips_position(
     # Position 1: malformed entry_ts, SL/TP set far from price so neither
     # fires (forces the call to reach the time-limit block where the bad
     # entry_ts will be parsed).
-    btc_api.db_create_position({
+    _tx_create_position({
         "symbol": "BTCUSDT",
         "entry_price": 65000.0,
         "sl_price": 50000.0,
@@ -295,7 +308,7 @@ def test_check_position_stops_malformed_entry_ts_skips_position(
         "entry_ts": "not-an-iso-timestamp",
     })
     # Position 2: valid entry_ts, far SL/TP, 30h old (beyond TL=14h).
-    btc_api.db_create_position({
+    _tx_create_position({
         "symbol": "BTCUSDT",
         "entry_price": 65000.0,
         "sl_price": 50000.0,
@@ -307,12 +320,12 @@ def test_check_position_stops_malformed_entry_ts_skips_position(
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0)  # neither SL nor TP
 
-    closed = btc_api.db_get_positions(status="closed")
+    closed = _tx_get_positions(status="closed")
     assert len(closed) == 1
     assert closed[0]["exit_reason"] == "TIME_LIMIT_HIT"
     assert closed[0]["entry_ts"] != "not-an-iso-timestamp"
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1
     assert open_pos[0]["entry_ts"] == "not-an-iso-timestamp"
 
@@ -337,7 +350,7 @@ def test_check_position_stops_invalid_type_rejected(setup_db_and_cfg, caplog):
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1
     assert any("time_limit_hours" in r.getMessage() for r in caplog.records)
 
@@ -357,7 +370,7 @@ def test_check_position_stops_negative_value_rejected(setup_db_and_cfg, caplog):
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1
     assert any("time_limit_hours" in r.getMessage() for r in caplog.records)
 
@@ -377,7 +390,7 @@ def test_check_position_stops_zero_value_rejected(setup_db_and_cfg, caplog):
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1
     assert any("time_limit_hours" in r.getMessage() for r in caplog.records)
 
@@ -434,7 +447,7 @@ def test_check_position_stops_time_limit_bool_rejected(setup_db_and_cfg, caplog)
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1, "bool value must not collapse to 1.0 and close every position"
     assert any("time_limit_hours" in r.getMessage() for r in caplog.records)
 
@@ -455,7 +468,7 @@ def test_check_position_stops_time_limit_nan_rejected(setup_db_and_cfg, caplog):
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1
     assert any("time_limit_hours" in r.getMessage() for r in caplog.records)
 
@@ -475,7 +488,7 @@ def test_check_position_stops_time_limit_inf_rejected(setup_db_and_cfg, caplog):
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    open_pos = btc_api.db_get_positions(status="open")
+    open_pos = _tx_get_positions(status="open")
     assert len(open_pos) == 1
     assert any("time_limit_hours" in r.getMessage() for r in caplog.records)
 
@@ -505,7 +518,7 @@ def test_check_position_stops_invalid_scan_interval_falls_back(
     with caplog.at_level(logging.WARNING, logger="api.positions"):
         btc_api.check_position_stops("BTCUSDT", 65500.0, now=now)
 
-    closed = btc_api.db_get_positions(status="closed")
+    closed = _tx_get_positions(status="closed")
     assert len(closed) == 1
     assert closed[0]["exit_reason"] == "TIME_LIMIT_HIT", (
         "string scan_interval must fall back to 300, not crash the close"

--- a/tests/test_check_position_stops_time_limit.py
+++ b/tests/test_check_position_stops_time_limit.py
@@ -249,9 +249,14 @@ def test_check_position_stops_time_limit_notifier_event_payload(
     })
 
     captured = []
+    # Mock signature must accept tenant_id kwarg — PositionClosure
+    # (post-#446 Task 6) calls notify(event, cfg, tenant_id=...).
+    # Patch operator's notify reference (it's `from notifier import
+    # notify` at module-load, so patching `notifier.notify` won't
+    # intercept the operator's local binding).
     monkeypatch.setattr(
-        "notifier.notify",
-        lambda event, cfg: captured.append(event),
+        "operators.position_closure.notify",
+        lambda event, cfg, *, tenant_id=None: captured.append(event),
     )
 
     entry_dt = datetime.now(timezone.utc) - timedelta(hours=20)

--- a/tests/test_db_positions_last_exit.py
+++ b/tests/test_db_positions_last_exit.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import pytest
 
 from db.positions import db_last_exit_ts
+from db.transaction import transaction
 
 
 @pytest.fixture
@@ -29,14 +30,14 @@ def _insert_position(
     direction: str = "LONG",
 ):
     """Insert a position row directly via db helper."""
-    pos = btc_api.db_create_position({
-        "symbol": symbol,
-        "entry_price": entry_price,
-        "direction": direction,
-        "entry_ts": entry_ts,
-    })
+    with transaction() as con:
+        pos = btc_api.db_create_position(con, {
+            "symbol": symbol,
+            "entry_price": entry_price,
+            "direction": direction,
+            "entry_ts": entry_ts,
+        })
     if status == "closed":
-        from db.transaction import transaction
         with transaction() as con:
             con.execute(
                 "UPDATE positions SET status=?, exit_ts=? WHERE id=?",
@@ -45,18 +46,23 @@ def _insert_position(
     return pos
 
 
+def _last_exit(symbol: str):
+    with transaction() as con:
+        return db_last_exit_ts(con, symbol)
+
+
 # ── Path A: empty DB / no closed positions ─────────────────────────────────
 
 
 def test_no_positions_returns_none(tmp_db):
     """Fresh DB → None (cooldown free for first signal of every symbol)."""
-    assert db_last_exit_ts("BTCUSDT") is None
+    assert _last_exit("BTCUSDT") is None
 
 
 def test_only_open_position_returns_none(tmp_db):
     """Open positions don't count — cooldown only respects closed exits."""
     _insert_position(tmp_db, status="open", exit_ts=None)
-    assert db_last_exit_ts("BTCUSDT") is None
+    assert _last_exit("BTCUSDT") is None
 
 
 # ── Path B: single closed position ─────────────────────────────────────────
@@ -65,7 +71,7 @@ def test_only_open_position_returns_none(tmp_db):
 def test_single_closed_returns_its_exit_ts(tmp_db):
     """Returns tz-aware UTC datetime."""
     _insert_position(tmp_db, exit_ts="2026-01-02T15:30:00+00:00")
-    result = db_last_exit_ts("BTCUSDT")
+    result = _last_exit("BTCUSDT")
     assert isinstance(result, datetime)
     assert result == datetime(2026, 1, 2, 15, 30, 0, tzinfo=timezone.utc)
     assert result.tzinfo is not None
@@ -79,7 +85,7 @@ def test_multiple_closed_returns_most_recent(tmp_db):
     _insert_position(tmp_db, exit_ts="2026-01-01T10:00:00+00:00")
     _insert_position(tmp_db, exit_ts="2026-01-03T10:00:00+00:00")  # most recent
     _insert_position(tmp_db, exit_ts="2026-01-02T10:00:00+00:00")
-    result = db_last_exit_ts("BTCUSDT")
+    result = _last_exit("BTCUSDT")
     assert result == datetime(2026, 1, 3, 10, 0, 0, tzinfo=timezone.utc)
 
 
@@ -89,7 +95,7 @@ def test_multiple_closed_returns_most_recent(tmp_db):
 def test_closed_with_null_exit_ts_returns_none(tmp_db):
     """NULL exit_ts on a 'closed' row is malformed — treat as no exit."""
     _insert_position(tmp_db, exit_ts=None)  # status will still get set to closed
-    assert db_last_exit_ts("BTCUSDT") is None
+    assert _last_exit("BTCUSDT") is None
 
 
 # ── Path E: symbol case ────────────────────────────────────────────────────
@@ -98,8 +104,8 @@ def test_closed_with_null_exit_ts_returns_none(tmp_db):
 def test_lowercase_symbol_normalized_to_upper(tmp_db):
     """`symbol.upper()` so 'btc' / 'BtcUsdT' all hit 'BTCUSDT' rows."""
     _insert_position(tmp_db, symbol="BTCUSDT", exit_ts="2026-01-02T00:00:00+00:00")
-    assert db_last_exit_ts("btcusdt") == datetime(2026, 1, 2, tzinfo=timezone.utc)
-    assert db_last_exit_ts("BtcUsdT") == datetime(2026, 1, 2, tzinfo=timezone.utc)
+    assert _last_exit("btcusdt") == datetime(2026, 1, 2, tzinfo=timezone.utc)
+    assert _last_exit("BtcUsdT") == datetime(2026, 1, 2, tzinfo=timezone.utc)
 
 
 # ── Path F: tz-naive ISO strings ───────────────────────────────────────────
@@ -108,7 +114,7 @@ def test_lowercase_symbol_normalized_to_upper(tmp_db):
 def test_naive_iso_promoted_to_utc(tmp_db):
     """Legacy naive ISO rows get tz=UTC attached for safe arithmetic."""
     _insert_position(tmp_db, exit_ts="2026-01-02T15:30:00")  # NO tz
-    result = db_last_exit_ts("BTCUSDT")
+    result = _last_exit("BTCUSDT")
     assert isinstance(result, datetime)
     assert result.tzinfo is not None
     # Check value preserved (tz attached, not converted from another zone)
@@ -121,4 +127,4 @@ def test_naive_iso_promoted_to_utc(tmp_db):
 def test_malformed_exit_ts_returns_none(tmp_db):
     """ValueError from datetime.fromisoformat must be caught — no crash."""
     _insert_position(tmp_db, exit_ts="not-a-real-iso-string")
-    assert db_last_exit_ts("BTCUSDT") is None
+    assert _last_exit("BTCUSDT") is None

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -378,7 +378,8 @@ def test_get_health_dashboard_uses_tenant_capital_when_present(client):
     """
     from db.capital import db_upsert_capital
     # tenant_id=1 matches the override in the client fixture above.
-    db_upsert_capital(1, balance=10_000.0, peak_balance=12_000.0)
+    with transaction() as con:
+        db_upsert_capital(con, 1, balance=10_000.0, peak_balance=12_000.0)
     resp = client.get("/health/dashboard")
     assert resp.status_code == 200
     portfolio = resp.json()["portfolio"]
@@ -416,7 +417,8 @@ def test_get_health_dashboard_no_double_count_on_realized_pnl_history(client):
     pnl_sequence = [200.0, 200.0, -300.0, 200.0, -100.0]
     # Stamp each trade into the capital ledger.
     for pnl in pnl_sequence:
-        apply_pnl_to_capital(1, pnl)
+        with transaction() as _cap_con:
+            apply_pnl_to_capital(_cap_con, 1, pnl)
 
     # Also insert the closed positions so the (now-removed) equity-curve
     # path would see them — if regression returns, the curve would double-
@@ -470,10 +472,12 @@ def test_get_health_dashboard_isolates_tenants(client):
     import btc_api
 
     # Tenant 1 (active in fixture): balance $10K, no closed trades.
-    db_upsert_capital(1, balance=10_000.0, peak_balance=10_000.0)
+    with transaction() as _cap_con:
+        db_upsert_capital(_cap_con, 1, balance=10_000.0, peak_balance=10_000.0)
 
     # Tenant 2 (NOT the request tenant): seed a -$1000 loss → balance $9K, peak $10K.
-    apply_pnl_to_capital(2, -1_000.0)
+    with transaction() as _cap_con:
+        apply_pnl_to_capital(_cap_con, 2, -1_000.0)
     with transaction() as conn:
         # (a) Tenant 2 has a closed losing trade for ETH.
         conn.execute(

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -217,10 +217,12 @@ def test_init_db_creates_portfolio_health_events_table(tmp_db):
 def test_record_portfolio_transition_inserts_row(tmp_db):
     import btc_api
     from health import record_portfolio_transition
-    record_portfolio_transition(
-        from_tier="NORMAL", to_tier="WARNED",
-        reason="3_concurrent_failures", dd_pct=-0.02, concurrent=3,
-    )
+    with transaction() as conn:
+        record_portfolio_transition(
+            conn,
+            from_tier="NORMAL", to_tier="WARNED",
+            reason="3_concurrent_failures", dd_pct=-0.02, concurrent=3,
+        )
     with transaction() as conn:
         row = conn.execute(
             """SELECT from_tier, to_tier, reason, dd_pct, concurrent
@@ -237,13 +239,16 @@ def test_recent_portfolio_transitions_returns_last_5(tmp_db):
     """Helper to fetch last 5 transitions for the dashboard panel."""
     import btc_api
     from health import record_portfolio_transition, recent_portfolio_transitions
-    for i in range(7):
-        record_portfolio_transition(
-            from_tier="NORMAL" if i % 2 else "WARNED",
-            to_tier="WARNED" if i % 2 else "NORMAL",
-            reason=f"reason_{i}", dd_pct=0.0, concurrent=i,
-        )
-    transitions = recent_portfolio_transitions(limit=5)
+    with transaction() as conn:
+        for i in range(7):
+            record_portfolio_transition(
+                conn,
+                from_tier="NORMAL" if i % 2 else "WARNED",
+                to_tier="WARNED" if i % 2 else "NORMAL",
+                reason=f"reason_{i}", dd_pct=0.0, concurrent=i,
+            )
+    with transaction() as conn:
+        transitions = recent_portfolio_transitions(conn, limit=5)
     assert len(transitions) == 5
     # Newest first
     assert transitions[0]["reason"] == "reason_6"
@@ -531,12 +536,15 @@ def test_portfolio_tier_change_records_transition(tmp_db, monkeypatch):
     # shadow path. We invoke the helper directly (the integration via
     # kill_switch_v2_shadow is wired in step 4 below).
     from health import record_portfolio_transition
-    record_portfolio_transition("NORMAL", "WARNED", reason="3_concurrent",
-                                 dd_pct=-0.01, concurrent=3)
-    record_portfolio_transition("WARNED", "REDUCED", reason="dd_threshold",
-                                 dd_pct=-0.04, concurrent=3)
+    with transaction() as conn:
+        record_portfolio_transition(conn, "NORMAL", "WARNED", reason="3_concurrent",
+                                     dd_pct=-0.01, concurrent=3)
+    with transaction() as conn:
+        record_portfolio_transition(conn, "WARNED", "REDUCED", reason="dd_threshold",
+                                     dd_pct=-0.04, concurrent=3)
 
-    transitions = recent_portfolio_transitions(limit=5)
+    with transaction() as conn:
+        transitions = recent_portfolio_transitions(conn, limit=5)
     assert len(transitions) == 2
     assert transitions[0]["to_tier"] == "REDUCED"
     assert transitions[1]["to_tier"] == "WARNED"

--- a/tests/test_health_shim_integration.py
+++ b/tests/test_health_shim_integration.py
@@ -4,6 +4,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from db.transaction import transaction
+
 
 @pytest.fixture
 def tmp_db(tmp_path, monkeypatch):
@@ -94,7 +96,8 @@ def test_shim_propagates_lrc_pct_from_rep_to_signal_event(tmp_db):
         btc_api.push_telegram_direct(rep, _cfg())
 
     # The notifier persists the SignalEvent payload to notifications_sent.
-    rows = storage.list_unread(tenant_id=None)
+    with transaction() as con:
+        rows = storage.list_unread(con, tenant_id=None)
     signal_rows = [r for r in rows if r["event_type"] == "signal"]
     assert signal_rows, "no signal notification persisted"
     payload = json.loads(signal_rows[0]["payload_json"])
@@ -123,7 +126,8 @@ def test_shim_handles_missing_lrc_gracefully(tmp_db):
     with patch("notifier.channels.telegram.requests.post", return_value=fake_resp):
         btc_api.push_telegram_direct(rep, _cfg())
 
-    rows = storage.list_unread(tenant_id=None)
+    with transaction() as con:
+        rows = storage.list_unread(con, tenant_id=None)
     signal_rows = [r for r in rows if r["event_type"] == "signal"]
     assert signal_rows, "no signal notification persisted"
     payload = json.loads(signal_rows[0]["payload_json"])

--- a/tests/test_multi_tenant_b1_schema.py
+++ b/tests/test_multi_tenant_b1_schema.py
@@ -263,7 +263,9 @@ class TestBackfillTenant:
         con.commit()
         con.close()
 
-        affected = backfill_tenant(user_id=99)
+        from db.transaction import transaction
+        with transaction() as _con:
+            affected = backfill_tenant(_con, user_id=99)
         assert affected["positions"] == 3
         # Other tables had 0 NULL rows
         assert affected["signal_outcomes"] == 0
@@ -289,9 +291,12 @@ class TestBackfillTenant:
         con.commit()
         con.close()
 
-        first = backfill_tenant(user_id=42)
+        from db.transaction import transaction
+        with transaction() as _con:
+            first = backfill_tenant(_con, user_id=42)
         assert first["positions"] == 1
-        second = backfill_tenant(user_id=42)
+        with transaction() as _con:
+            second = backfill_tenant(_con, user_id=42)
         assert second["positions"] == 0  # idempotent
 
     def test_backfill_preserves_existing_tenant_ids(self, initialized_db):
@@ -311,7 +316,9 @@ class TestBackfillTenant:
         con.commit()
         con.close()
 
-        affected = backfill_tenant(user_id=99)
+        from db.transaction import transaction
+        with transaction() as _con:
+            affected = backfill_tenant(_con, user_id=99)
         assert affected["positions"] == 1  # only the NULL one updated
 
         con = sqlite3.connect(initialized_db)

--- a/tests/test_multi_tenant_b2_capital_tracker.py
+++ b/tests/test_multi_tenant_b2_capital_tracker.py
@@ -119,12 +119,15 @@ class TestCloseHookIntegration:
         from api.positions import close_position
         from db.capital import db_get_capital, INITIAL_CAPITAL_DEFAULT
         from db.positions import db_create_position
+        from db.transaction import transaction
 
-        pos = db_create_position(
-            {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 10.0,
-             "direction": "LONG"},
-            tenant_id=1,
-        )
+        with transaction() as con:
+            pos = db_create_position(
+                con,
+                {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 10.0,
+                 "direction": "LONG"},
+                tenant_id=1,
+            )
         close_position(
             pos_id=pos["id"],
             body={"exit_price": 125.0, "exit_reason": "MANUAL"},
@@ -140,12 +143,15 @@ class TestCloseHookIntegration:
         from api.positions import close_position
         from db.capital import db_get_capital, INITIAL_CAPITAL_DEFAULT
         from db.positions import db_create_position
+        from db.transaction import transaction
 
-        pos = db_create_position(
-            {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 10.0,
-             "direction": "LONG"},
-            tenant_id=1,
-        )
+        with transaction() as con:
+            pos = db_create_position(
+                con,
+                {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 10.0,
+                 "direction": "LONG"},
+                tenant_id=1,
+            )
         close_position(
             pos_id=pos["id"],
             body={"exit_price": 90.0, "exit_reason": "MANUAL"},
@@ -169,11 +175,14 @@ class TestCloseHookIntegration:
         monkeypatch.setattr(_pos, "load_config", lambda: {"symbol_overrides": {}})
         monkeypatch.setattr(_pos, "update_positions_json", lambda: None)
 
-        db_create_position(
-            {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 10.0,
-             "direction": "LONG", "sl_price": 95.0, "tp_price": 120.0},
-            tenant_id=3,
-        )
+        from db.transaction import transaction
+        with transaction() as con:
+            db_create_position(
+                con,
+                {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 10.0,
+                 "direction": "LONG", "sl_price": 95.0, "tp_price": 120.0},
+                tenant_id=3,
+            )
         # Price tags SL → SL_HIT triggers db_close_position + capital hook
         check_position_stops("BTCUSDT", 94.0, now=datetime.now(timezone.utc))
         from db.transaction import transaction
@@ -198,14 +207,18 @@ class TestCloseHookIntegration:
         from db.capital import db_get_capital
         from db.positions import db_create_position
 
-        db_create_position(
-            {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 10.0,
-             "direction": "LONG"},
-            tenant_id=9,
-        )
+        from db.transaction import transaction
+        with transaction() as con:
+            db_create_position(
+                con,
+                {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 10.0,
+                 "direction": "LONG"},
+                tenant_id=9,
+            )
         # Pull pos_id (we just created it)
         from db.positions import db_get_positions
-        pos = db_get_positions(tenant_id=9)[0]
+        with transaction() as con:
+            pos = db_get_positions(con, tenant_id=9)[0]
         # Stub update_positions_json
         import api.positions as _pos
         _orig = _pos.update_positions_json

--- a/tests/test_multi_tenant_b2_capital_tracker.py
+++ b/tests/test_multi_tenant_b2_capital_tracker.py
@@ -9,7 +9,11 @@ Locked test list (§4):
 - test_auto_close_via_check_position_stops
 - test_two_users_independent
 - test_cancel_does_not_touch_capital
-- test_legacy_tenant_null_skipped
+- test_legacy_tenant_null_skipped (DELETED post-#446 Task 6 — the
+  `_apply_close_to_capital` shim it tested was removed; the
+  "tenant_id=NULL → skip capital" semantic is covered at the operator
+  level by tests/operators/test_position_closure.py invariant 9
+  `test_legacy_null_tenant_position_close_skips_capital`)
 - test_first_close_auto_inits_capital
 - test_drawdown_undefined_when_peak_zero
 """
@@ -178,28 +182,15 @@ class TestCloseHookIntegration:
         # SL_HIT exit_price = sl_price (95.0) → pnl = (95-100)*10 = -50
         assert row["balance"] == pytest.approx(INITIAL_CAPITAL_DEFAULT - 50.0, abs=0.01)
 
-    def test_legacy_tenant_null_skipped(self, initialized_db):
-        """Position with tenant_id=NULL closes → no capital row created."""
-        from api.positions import close_position
-        from db.capital import db_get_capital
-        from db.positions import db_create_position
-
-        # tenant_id NOT passed → NULL on row
-        pos = db_create_position(
-            {"symbol": "BTCUSDT", "entry_price": 100.0, "qty": 5.0,
-             "direction": "LONG"},
-        )
-        assert pos["tenant_id"] is None
-        # Close without tenant_id (matches scanner-style internal close)
-        from db.positions import db_close_position
-        from api.positions import _apply_close_to_capital
-        from db.transaction import transaction
-        closed = db_close_position(pos["id"], 110.0, "MANUAL")
-        with transaction() as con:
-            _apply_close_to_capital(closed, con=con)
-        # No capital row created for tenant 1 (or anyone)
-        with transaction() as con:
-            assert db_get_capital(con, 1) is None
+    # test_legacy_tenant_null_skipped — DELETED post-#446 Task 6.
+    # The `api.positions._apply_close_to_capital` shim it imported was
+    # removed when `close_position` migrated to PositionClosure. The
+    # "tenant_id=NULL → skip capital" semantic is now covered at the
+    # operator level by
+    # tests/operators/test_position_closure.py::test_legacy_null_tenant_position_close_skips_capital
+    # (invariant 9). Retaining this test here would duplicate the
+    # operator invariant and require re-implementing the shim purely to
+    # back the test.
 
     def test_cancel_does_not_touch_capital(self, initialized_db):
         """DELETE /positions/{id} (cancel) leaves capital untouched."""

--- a/tests/test_multi_tenant_b2_capital_tracker.py
+++ b/tests/test_multi_tenant_b2_capital_tracker.py
@@ -45,19 +45,26 @@ class TestApplyPnlToCapital:
     def test_first_close_auto_inits_capital(self, initialized_db):
         """Pre-reg §2.3: first close with no prior row auto-inits from INITIAL_CAPITAL_DEFAULT."""
         from db.capital import apply_pnl_to_capital, db_get_capital, INITIAL_CAPITAL_DEFAULT
-        row = apply_pnl_to_capital(tenant_id=42, pnl_usd=250.0)
+        from db.transaction import transaction
+        with transaction() as con:
+            row = apply_pnl_to_capital(con, 42, 250.0)
         assert row["balance"] == INITIAL_CAPITAL_DEFAULT + 250.0
         assert row["peak_balance"] == INITIAL_CAPITAL_DEFAULT + 250.0
         # Persistence check
-        persisted = db_get_capital(42)
+        with transaction() as con:
+            persisted = db_get_capital(con, 42)
         assert persisted["balance"] == INITIAL_CAPITAL_DEFAULT + 250.0
 
     def test_peak_is_monotonic_after_loss_streak(self, initialized_db):
         """Pre-reg §2.3: peak never decreases across +300, -200, -50 sequence."""
         from db.capital import apply_pnl_to_capital, INITIAL_CAPITAL_DEFAULT
-        apply_pnl_to_capital(tenant_id=1, pnl_usd=300.0)   # bal 10300, peak 10300
-        apply_pnl_to_capital(tenant_id=1, pnl_usd=-200.0)  # bal 10100, peak 10300
-        row = apply_pnl_to_capital(tenant_id=1, pnl_usd=-50.0)  # bal 10050, peak 10300
+        from db.transaction import transaction
+        with transaction() as con:
+            apply_pnl_to_capital(con, 1, 300.0)   # bal 10300, peak 10300
+        with transaction() as con:
+            apply_pnl_to_capital(con, 1, -200.0)  # bal 10100, peak 10300
+        with transaction() as con:
+            row = apply_pnl_to_capital(con, 1, -50.0)  # bal 10050, peak 10300
         assert row["balance"] == INITIAL_CAPITAL_DEFAULT + 50.0
         assert row["peak_balance"] == INITIAL_CAPITAL_DEFAULT + 300.0
         # dd_pct = (10300 - 10050) / 10300 * 100
@@ -67,25 +74,34 @@ class TestApplyPnlToCapital:
     def test_drawdown_undefined_when_peak_zero(self, initialized_db):
         """Pre-reg §2.3: peak <= 0 leaves max_drawdown_pct as None (no div-by-zero)."""
         from db.capital import apply_pnl_to_capital, db_upsert_capital
+        from db.transaction import transaction
         # Synthetic seed: peak forced to 0
-        db_upsert_capital(7, balance=0.0, peak_balance=0.0, max_drawdown_pct=None)
-        row = apply_pnl_to_capital(tenant_id=7, pnl_usd=-10.0)  # balance -10, peak max(0, -10)=0
+        with transaction() as con:
+            db_upsert_capital(con, 7, balance=0.0, peak_balance=0.0, max_drawdown_pct=None)
+        with transaction() as con:
+            row = apply_pnl_to_capital(con, 7, -10.0)  # balance -10, peak max(0, -10)=0
         assert row["peak_balance"] == 0.0
         assert row["max_drawdown_pct"] is None  # peak not > 0 -> None
 
     def test_two_users_independent(self, initialized_db):
         """Pre-reg §4: closing for user A does NOT touch user B."""
         from db.capital import apply_pnl_to_capital, db_get_capital, INITIAL_CAPITAL_DEFAULT
-        apply_pnl_to_capital(tenant_id=1, pnl_usd=100.0)
-        apply_pnl_to_capital(tenant_id=2, pnl_usd=-50.0)
-        a = db_get_capital(1)
-        b = db_get_capital(2)
+        from db.transaction import transaction
+        with transaction() as con:
+            apply_pnl_to_capital(con, 1, 100.0)
+        with transaction() as con:
+            apply_pnl_to_capital(con, 2, -50.0)
+        with transaction() as con:
+            a = db_get_capital(con, 1)
+            b = db_get_capital(con, 2)
         assert a["balance"] == INITIAL_CAPITAL_DEFAULT + 100.0
         assert b["balance"] == INITIAL_CAPITAL_DEFAULT - 50.0
         # Round-trip: another close for A must not touch B
-        apply_pnl_to_capital(tenant_id=1, pnl_usd=25.0)
-        assert db_get_capital(1)["balance"] == INITIAL_CAPITAL_DEFAULT + 125.0
-        assert db_get_capital(2)["balance"] == INITIAL_CAPITAL_DEFAULT - 50.0
+        with transaction() as con:
+            apply_pnl_to_capital(con, 1, 25.0)
+        with transaction() as con:
+            assert db_get_capital(con, 1)["balance"] == INITIAL_CAPITAL_DEFAULT + 125.0
+            assert db_get_capital(con, 2)["balance"] == INITIAL_CAPITAL_DEFAULT - 50.0
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +126,9 @@ class TestCloseHookIntegration:
             body={"exit_price": 125.0, "exit_reason": "MANUAL"},
             tenant_id=1,
         )
-        row = db_get_capital(1)
+        from db.transaction import transaction
+        with transaction() as con:
+            row = db_get_capital(con, 1)
         assert row["balance"] == pytest.approx(INITIAL_CAPITAL_DEFAULT + 250.0, abs=0.01)
 
     def test_manual_close_decrements_balance(self, initialized_db):
@@ -129,7 +147,9 @@ class TestCloseHookIntegration:
             body={"exit_price": 90.0, "exit_reason": "MANUAL"},
             tenant_id=1,
         )
-        row = db_get_capital(1)
+        from db.transaction import transaction
+        with transaction() as con:
+            row = db_get_capital(con, 1)
         assert row["balance"] == pytest.approx(INITIAL_CAPITAL_DEFAULT - 100.0, abs=0.01)
         assert row["peak_balance"] == INITIAL_CAPITAL_DEFAULT  # auto-init peak preserved
         assert row["max_drawdown_pct"] > 0  # current drawdown from peak
@@ -152,7 +172,9 @@ class TestCloseHookIntegration:
         )
         # Price tags SL → SL_HIT triggers db_close_position + capital hook
         check_position_stops("BTCUSDT", 94.0, now=datetime.now(timezone.utc))
-        row = db_get_capital(3)
+        from db.transaction import transaction
+        with transaction() as con:
+            row = db_get_capital(con, 3)
         # SL_HIT exit_price = sl_price (95.0) → pnl = (95-100)*10 = -50
         assert row["balance"] == pytest.approx(INITIAL_CAPITAL_DEFAULT - 50.0, abs=0.01)
 
@@ -171,10 +193,13 @@ class TestCloseHookIntegration:
         # Close without tenant_id (matches scanner-style internal close)
         from db.positions import db_close_position
         from api.positions import _apply_close_to_capital
+        from db.transaction import transaction
         closed = db_close_position(pos["id"], 110.0, "MANUAL")
-        _apply_close_to_capital(closed)
+        with transaction() as con:
+            _apply_close_to_capital(closed, con=con)
         # No capital row created for tenant 1 (or anyone)
-        assert db_get_capital(1) is None
+        with transaction() as con:
+            assert db_get_capital(con, 1) is None
 
     def test_cancel_does_not_touch_capital(self, initialized_db):
         """DELETE /positions/{id} (cancel) leaves capital untouched."""
@@ -198,4 +223,6 @@ class TestCloseHookIntegration:
             delete_position(pos_id=pos["id"], tenant_id=9)
         finally:
             _pos.update_positions_json = _orig
-        assert db_get_capital(9) is None  # never created
+        from db.transaction import transaction
+        with transaction() as con:
+            assert db_get_capital(con, 9) is None  # never created

--- a/tests/test_multi_tenant_b4_signal_routing.py
+++ b/tests/test_multi_tenant_b4_signal_routing.py
@@ -34,7 +34,8 @@ def seeded_db(tmp_path, monkeypatch):
     from db.schema import init_db
     from db.transaction import transaction
     init_db()
-    init_auth_db()
+    with transaction() as con:
+        init_auth_db(con)
     # Note: notifier.dedupe is DB-backed (queries notifications_sent table),
     # so a fresh tmp_path DB per test gives us clean dedupe state automatically.
 
@@ -77,11 +78,13 @@ def _base_cfg():
 
 class TestDispatchPerUser:
     def test_two_users_different_filters(self, seeded_db):
+        from db.transaction import transaction
         from db.user_preferences import db_upsert_user_preferences
         from notifier.dispatch_per_user import dispatch_signal_to_users
 
-        db_upsert_user_preferences(1, symbol_filter=["BTCUSDT"], min_score=5)
-        db_upsert_user_preferences(2, symbol_filter=None, min_score=2)
+        with transaction() as con:
+            db_upsert_user_preferences(con, 1, symbol_filter=["BTCUSDT"], min_score=5)
+            db_upsert_user_preferences(con, 2, symbol_filter=None, min_score=2)
 
         # BTC sc=6 → both
         out = dispatch_signal_to_users(_make_signal("BTCUSDT", 6), _base_cfg())
@@ -123,13 +126,15 @@ class TestDispatchPerUser:
 
     def test_per_user_telegram_chat_routing(self, seeded_db, monkeypatch):
         """User's notify_channels.telegram_chat_id overrides global."""
+        from db.transaction import transaction
         from db.user_preferences import db_upsert_user_preferences
         from notifier.dispatch_per_user import dispatch_signal_to_users
 
-        db_upsert_user_preferences(
-            1, notify_channels={"telegram_chat_id": "USER_A_CHAT"},
-        )
-        db_upsert_user_preferences(2, notify_channels=None)
+        with transaction() as con:
+            db_upsert_user_preferences(
+                con, 1, notify_channels={"telegram_chat_id": "USER_A_CHAT"},
+            )
+            db_upsert_user_preferences(con, 2, notify_channels=None)
 
         # Patch TelegramChannel.__init__ to capture chat_id per-call
         seen_chats: list[str] = []
@@ -200,8 +205,10 @@ class TestDispatchPerUser:
         monkeypatch.setattr(btc_api, "DB_FILE", db_path)
         from db.schema import init_db
         from db.auth_schema import init_auth_db
+        from db.transaction import transaction
         init_db()
-        init_auth_db()
+        with transaction() as con:
+            init_auth_db(con)
 
         from notifier.dispatch_per_user import dispatch_signal_to_users
         out = dispatch_signal_to_users(_make_signal("BTCUSDT", 9), _base_cfg())
@@ -209,10 +216,12 @@ class TestDispatchPerUser:
 
     def test_symbol_filter_empty_list_means_none(self, seeded_db):
         """symbol_filter=[] (explicit empty whitelist) → user skipped."""
+        from db.transaction import transaction
         from db.user_preferences import db_upsert_user_preferences
         from notifier.dispatch_per_user import dispatch_signal_to_users
 
-        db_upsert_user_preferences(1, symbol_filter=[], min_score=0)
+        with transaction() as con:
+            db_upsert_user_preferences(con, 1, symbol_filter=[], min_score=0)
         # User 2 has no prefs → defaults
 
         out = dispatch_signal_to_users(_make_signal("BTCUSDT", 9), _base_cfg())

--- a/tests/test_multi_tenant_b5_capital_prefs.py
+++ b/tests/test_multi_tenant_b5_capital_prefs.py
@@ -118,12 +118,16 @@ class TestCapitalDB:
 
 class TestUserPreferencesDB:
     def test_get_returns_none_when_missing(self, initialized_db):
+        from db.transaction import transaction
         from db.user_preferences import db_get_user_preferences
-        assert db_get_user_preferences(tenant_id=1) is None
+        with transaction() as con:
+            assert db_get_user_preferences(con, tenant_id=1) is None
 
     def test_upsert_creates_with_defaults(self, initialized_db):
+        from db.transaction import transaction
         from db.user_preferences import db_upsert_user_preferences
-        row = db_upsert_user_preferences(tenant_id=1)
+        with transaction() as con:
+            row = db_upsert_user_preferences(con, tenant_id=1)
         assert row["tenant_id"] == 1
         # min_score defaults to 4 per schema
         assert row["min_score"] == 4
@@ -131,25 +135,31 @@ class TestUserPreferencesDB:
         assert row["notify_channels"] is None
 
     def test_upsert_with_all_fields(self, initialized_db):
+        from db.transaction import transaction
         from db.user_preferences import db_upsert_user_preferences
-        row = db_upsert_user_preferences(
-            tenant_id=1,
-            symbol_filter=["BTCUSDT", "ETHUSDT"],
-            min_score=5,
-            notify_channels={"telegram_chat_id": "12345"},
-        )
+        with transaction() as con:
+            row = db_upsert_user_preferences(
+                con,
+                tenant_id=1,
+                symbol_filter=["BTCUSDT", "ETHUSDT"],
+                min_score=5,
+                notify_channels={"telegram_chat_id": "12345"},
+            )
         assert row["symbol_filter"] == ["BTCUSDT", "ETHUSDT"]
         assert row["min_score"] == 5
         assert row["notify_channels"] == {"telegram_chat_id": "12345"}
 
     def test_upsert_preserves_fields_when_none_passed(self, initialized_db):
+        from db.transaction import transaction
         from db.user_preferences import db_upsert_user_preferences
-        db_upsert_user_preferences(
-            tenant_id=1, symbol_filter=["BTC"], min_score=6,
-            notify_channels={"email": "a@b.c"},
-        )
-        # Update only min_score, others preserved
-        updated = db_upsert_user_preferences(tenant_id=1, min_score=7)
+        with transaction() as con:
+            db_upsert_user_preferences(
+                con,
+                tenant_id=1, symbol_filter=["BTC"], min_score=6,
+                notify_channels={"email": "a@b.c"},
+            )
+            # Update only min_score, others preserved
+            updated = db_upsert_user_preferences(con, tenant_id=1, min_score=7)
         assert updated["min_score"] == 7
         assert updated["symbol_filter"] == ["BTC"]
         assert updated["notify_channels"] == {"email": "a@b.c"}

--- a/tests/test_multi_tenant_b5_capital_prefs.py
+++ b/tests/test_multi_tenant_b5_capital_prefs.py
@@ -51,11 +51,15 @@ def client(tmp_path, monkeypatch):
 class TestCapitalDB:
     def test_get_returns_none_when_missing(self, initialized_db):
         from db.capital import db_get_capital
-        assert db_get_capital(tenant_id=1) is None
+        from db.transaction import transaction
+        with transaction() as con:
+            assert db_get_capital(con, 1) is None
 
     def test_upsert_creates_row(self, initialized_db):
         from db.capital import db_upsert_capital, db_get_capital
-        row = db_upsert_capital(tenant_id=1, balance=10000.0)
+        from db.transaction import transaction
+        with transaction() as con:
+            row = db_upsert_capital(con, 1, balance=10000.0)
         assert row["tenant_id"] == 1
         assert row["balance"] == 10000.0
         # peak_balance defaulted to balance when not provided + row new
@@ -63,35 +67,48 @@ class TestCapitalDB:
         # max_drawdown_pct None for new row
         assert row["max_drawdown_pct"] is None
         # Persists
-        assert db_get_capital(tenant_id=1)["balance"] == 10000.0
+        with transaction() as con:
+            assert db_get_capital(con, 1)["balance"] == 10000.0
 
     def test_upsert_replaces_existing(self, initialized_db):
         from db.capital import db_upsert_capital
-        db_upsert_capital(tenant_id=1, balance=10000.0)
-        updated = db_upsert_capital(tenant_id=1, balance=11000.0, peak_balance=12000.0)
+        from db.transaction import transaction
+        with transaction() as con:
+            db_upsert_capital(con, 1, balance=10000.0)
+        with transaction() as con:
+            updated = db_upsert_capital(con, 1, balance=11000.0, peak_balance=12000.0)
         assert updated["balance"] == 11000.0
         assert updated["peak_balance"] == 12000.0
 
     def test_upsert_preserves_peak_when_omitted(self, initialized_db):
         from db.capital import db_upsert_capital
-        db_upsert_capital(tenant_id=1, balance=10000.0, peak_balance=15000.0)
+        from db.transaction import transaction
+        with transaction() as con:
+            db_upsert_capital(con, 1, balance=10000.0, peak_balance=15000.0)
         # Update balance only, peak should stay
-        updated = db_upsert_capital(tenant_id=1, balance=9500.0)
+        with transaction() as con:
+            updated = db_upsert_capital(con, 1, balance=9500.0)
         assert updated["balance"] == 9500.0
         assert updated["peak_balance"] == 15000.0  # preserved
 
     def test_upsert_preserves_max_drawdown_when_omitted(self, initialized_db):
         from db.capital import db_upsert_capital
-        db_upsert_capital(tenant_id=1, balance=10000.0, max_drawdown_pct=-15.0)
-        updated = db_upsert_capital(tenant_id=1, balance=11000.0)
+        from db.transaction import transaction
+        with transaction() as con:
+            db_upsert_capital(con, 1, balance=10000.0, max_drawdown_pct=-15.0)
+        with transaction() as con:
+            updated = db_upsert_capital(con, 1, balance=11000.0)
         assert updated["max_drawdown_pct"] == -15.0  # preserved
 
     def test_tenant_isolation(self, initialized_db):
         from db.capital import db_upsert_capital, db_get_capital
-        db_upsert_capital(tenant_id=1, balance=10000.0)
-        db_upsert_capital(tenant_id=2, balance=20000.0)
-        assert db_get_capital(tenant_id=1)["balance"] == 10000.0
-        assert db_get_capital(tenant_id=2)["balance"] == 20000.0
+        from db.transaction import transaction
+        with transaction() as con:
+            db_upsert_capital(con, 1, balance=10000.0)
+            db_upsert_capital(con, 2, balance=20000.0)
+        with transaction() as con:
+            assert db_get_capital(con, 1)["balance"] == 10000.0
+            assert db_get_capital(con, 2)["balance"] == 20000.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_multi_tenant_b5_enforcement.py
+++ b/tests/test_multi_tenant_b5_enforcement.py
@@ -361,12 +361,15 @@ class TestBackfillRestoresVisibility:
 class TestNotifierStorageTenantEnforcement:
     def test_record_delivery_persists_tenant_id(self, initialized_db):
         from notifier._storage import record_delivery
+        from db.transaction import transaction
         import sqlite3
-        nid = record_delivery(
-            event_type="signal", event_key="signal:BTC", priority="info",
-            payload={"symbol": "BTC"}, channels_sent=["telegram"],
-            delivery_status="ok", tenant_id=42,
-        )
+        with transaction() as con:
+            nid = record_delivery(
+                con,
+                event_type="signal", event_key="signal:BTC", priority="info",
+                payload={"symbol": "BTC"}, channels_sent=["telegram"],
+                delivery_status="ok", tenant_id=42,
+            )
         con = sqlite3.connect(initialized_db)
         row = con.execute(
             "SELECT tenant_id FROM notifications_sent WHERE id=?", (nid,)
@@ -376,18 +379,23 @@ class TestNotifierStorageTenantEnforcement:
 
     def test_list_unread_filters_by_tenant(self, initialized_db):
         from notifier._storage import list_unread, record_delivery
-        record_delivery(
-            event_type="signal", event_key="signal:BTC", priority="info",
-            payload={}, channels_sent=["telegram"], delivery_status="ok",
-            tenant_id=1,
-        )
-        record_delivery(
-            event_type="signal", event_key="signal:ETH", priority="info",
-            payload={}, channels_sent=["telegram"], delivery_status="ok",
-            tenant_id=2,
-        )
-        user1_notifs = list_unread(tenant_id=1)
-        user2_notifs = list_unread(tenant_id=2)
+        from db.transaction import transaction
+        with transaction() as con:
+            record_delivery(
+                con,
+                event_type="signal", event_key="signal:BTC", priority="info",
+                payload={}, channels_sent=["telegram"], delivery_status="ok",
+                tenant_id=1,
+            )
+            record_delivery(
+                con,
+                event_type="signal", event_key="signal:ETH", priority="info",
+                payload={}, channels_sent=["telegram"], delivery_status="ok",
+                tenant_id=2,
+            )
+        with transaction() as con:
+            user1_notifs = list_unread(con, tenant_id=1)
+            user2_notifs = list_unread(con, tenant_id=2)
         assert len(user1_notifs) == 1
         assert user1_notifs[0]["event_key"] == "signal:BTC"
         assert len(user2_notifs) == 1
@@ -396,64 +404,84 @@ class TestNotifierStorageTenantEnforcement:
     def test_mark_read_idor_returns_false(self, initialized_db):
         """User 2 cannot mark user 1's notification as read."""
         from notifier._storage import mark_read, record_delivery, list_unread
-        nid = record_delivery(
-            event_type="signal", event_key="signal:BTC", priority="info",
-            payload={}, channels_sent=["telegram"], delivery_status="ok",
-            tenant_id=1,
-        )
+        from db.transaction import transaction
+        with transaction() as con:
+            nid = record_delivery(
+                con,
+                event_type="signal", event_key="signal:BTC", priority="info",
+                payload={}, channels_sent=["telegram"], delivery_status="ok",
+                tenant_id=1,
+            )
         # User 2 tries to mark user 1's notification
-        ok = mark_read(nid, tenant_id=2)
+        with transaction() as con:
+            ok = mark_read(con, nid, tenant_id=2)
         assert ok is False
         # Verify notif is still unread for user 1
-        user1_unread = list_unread(tenant_id=1)
+        with transaction() as con:
+            user1_unread = list_unread(con, tenant_id=1)
         assert len(user1_unread) == 1
 
     def test_mark_read_owner_succeeds(self, initialized_db):
         from notifier._storage import mark_read, record_delivery
-        nid = record_delivery(
-            event_type="signal", event_key="signal:BTC", priority="info",
-            payload={}, channels_sent=["telegram"], delivery_status="ok",
-            tenant_id=1,
-        )
-        ok = mark_read(nid, tenant_id=1)
+        from db.transaction import transaction
+        with transaction() as con:
+            nid = record_delivery(
+                con,
+                event_type="signal", event_key="signal:BTC", priority="info",
+                payload={}, channels_sent=["telegram"], delivery_status="ok",
+                tenant_id=1,
+            )
+        with transaction() as con:
+            ok = mark_read(con, nid, tenant_id=1)
         assert ok is True
 
     def test_mark_all_read_scope_limited_to_tenant(self, initialized_db):
         """mark_all_read affects only current tenant's notifications."""
         from notifier._storage import mark_all_read, record_delivery, list_unread
+        from db.transaction import transaction
         # 2 unread for user 1
-        for i in range(2):
+        with transaction() as con:
+            for i in range(2):
+                record_delivery(
+                    con,
+                    event_type="signal", event_key=f"signal:U1_{i}", priority="info",
+                    payload={}, channels_sent=["telegram"], delivery_status="ok",
+                    tenant_id=1,
+                )
+            # 1 unread for user 2
             record_delivery(
-                event_type="signal", event_key=f"signal:U1_{i}", priority="info",
+                con,
+                event_type="signal", event_key="signal:U2", priority="info",
                 payload={}, channels_sent=["telegram"], delivery_status="ok",
-                tenant_id=1,
+                tenant_id=2,
             )
-        # 1 unread for user 2
-        record_delivery(
-            event_type="signal", event_key="signal:U2", priority="info",
-            payload={}, channels_sent=["telegram"], delivery_status="ok",
-            tenant_id=2,
-        )
 
-        marked_for_user1 = mark_all_read(tenant_id=1)
+        with transaction() as con:
+            marked_for_user1 = mark_all_read(con, tenant_id=1)
         assert marked_for_user1 == 2
 
         # User 2's notification still unread
-        user2_unread = list_unread(tenant_id=2)
+        with transaction() as con:
+            user2_unread = list_unread(con, tenant_id=2)
         assert len(user2_unread) == 1
         assert user2_unread[0]["event_key"] == "signal:U2"
 
     def test_legacy_null_tenant_invisible_to_filter(self, initialized_db):
         """Notifications without tenant_id (system broadcasts) invisible to per-user filter."""
         from notifier._storage import list_unread, record_delivery
-        record_delivery(
-            event_type="signal", event_key="system:broadcast", priority="info",
-            payload={}, channels_sent=["telegram"], delivery_status="ok",
-            # No tenant_id → NULL
-        )
+        from db.transaction import transaction
+        with transaction() as con:
+            record_delivery(
+                con,
+                event_type="signal", event_key="system:broadcast", priority="info",
+                payload={}, channels_sent=["telegram"], delivery_status="ok",
+                # No tenant_id → NULL
+            )
         # User 1 sees nothing (strict filter)
-        user1_unread = list_unread(tenant_id=1)
+        with transaction() as con:
+            user1_unread = list_unread(con, tenant_id=1)
         assert user1_unread == []
         # Legacy unfiltered listing sees it
-        all_unread = list_unread()
+        with transaction() as con:
+            all_unread = list_unread(con)
         assert len(all_unread) == 1

--- a/tests/test_multi_tenant_b5_enforcement.py
+++ b/tests/test_multi_tenant_b5_enforcement.py
@@ -115,13 +115,15 @@ class TestDbGetPositions:
         assert len(all_positions) == 2
 
     def test_status_and_tenant_combined(self, initialized_db):
-        from db.positions import db_create_position, db_close_position, db_get_positions
+        from db.positions import db_create_position, db_get_positions
+        from operators.position_closure import PositionClosure
         db_create_position({"symbol": "BTC", "entry_price": 80000, "size_usd": 500}, tenant_id=1)
         db_create_position({"symbol": "ETH", "entry_price": 2300, "size_usd": 500}, tenant_id=1)
         # Close one for user 1
         all_pos = db_get_positions(tenant_id=1)
         first_id = all_pos[0]["id"]
-        db_close_position(first_id, 81000, "MANUAL", tenant_id=1)
+        with PositionClosure(first_id, 81000, "MANUAL", mode="USER", caller_tenant_id=1) as c:
+            c.execute()
 
         open_for_1 = db_get_positions(status="open", tenant_id=1)
         closed_for_1 = db_get_positions(status="closed", tenant_id=1)
@@ -140,30 +142,36 @@ class TestDbGetPositions:
 
 
 # ---------------------------------------------------------------------------
-# db_close_position — ownership enforced
+# PositionClosure — ownership enforced (migrated from db_close_position, Task 7)
 # ---------------------------------------------------------------------------
 
 
 class TestDbClosePosition:
     def test_owner_can_close(self, initialized_db):
-        from db.positions import db_create_position, db_close_position
+        from db.positions import db_create_position
+        from operators.position_closure import PositionClosure
         pos = db_create_position(
             {"symbol": "BTC", "entry_price": 80000, "size_usd": 500},
             tenant_id=1,
         )
-        closed = db_close_position(pos["id"], 81000, "MANUAL", tenant_id=1)
-        assert closed is not None
-        assert closed["status"] == "closed"
+        with PositionClosure(pos["id"], 81000, "MANUAL", mode="USER", caller_tenant_id=1) as c:
+            outcome = c.execute()
+        assert outcome.status == "closed"
+        assert outcome.position is not None
+        assert outcome.position["status"] == "closed"
 
     def test_non_owner_returns_none(self, initialized_db):
-        """IDOR protection: user 2 tries to close user 1's position → None."""
-        from db.positions import db_create_position, db_close_position
+        """IDOR protection: user 2 tries to close user 1's position → not_found."""
+        from db.positions import db_create_position
+        from operators.position_closure import PositionClosure
         pos = db_create_position(
             {"symbol": "BTC", "entry_price": 80000, "size_usd": 500},
             tenant_id=1,
         )
-        closed = db_close_position(pos["id"], 81000, "MANUAL", tenant_id=2)
-        assert closed is None
+        with PositionClosure(pos["id"], 81000, "MANUAL", mode="USER", caller_tenant_id=2) as c:
+            outcome = c.execute()
+        assert outcome.status == "not_found"
+        assert outcome.position is None
 
         # Verify position still open
         from db.positions import db_get_positions
@@ -171,14 +179,17 @@ class TestDbClosePosition:
         assert all_pos[0]["status"] == "open"
 
     def test_legacy_no_tenant_works(self, initialized_db):
-        """tenant_id=None preserves legacy: any position closeable."""
-        from db.positions import db_create_position, db_close_position
+        """SYSTEM mode (no tenant_id) can close any position."""
+        from db.positions import db_create_position
+        from operators.position_closure import PositionClosure
         pos = db_create_position(
             {"symbol": "BTC", "entry_price": 80000, "size_usd": 500},
             tenant_id=1,
         )
-        closed = db_close_position(pos["id"], 81000, "MANUAL")  # no tenant_id
-        assert closed is not None
+        with PositionClosure(pos["id"], 81000, "MANUAL", mode="SYSTEM") as c:
+            outcome = c.execute()
+        assert outcome.status == "closed"
+        assert outcome.position is not None
 
 
 # ---------------------------------------------------------------------------
@@ -220,12 +231,14 @@ class TestDbUpdatePosition:
 
 class TestDbLastExitTs:
     def test_filter_by_tenant(self, initialized_db):
-        from db.positions import db_create_position, db_close_position, db_last_exit_ts
+        from db.positions import db_create_position, db_last_exit_ts
+        from operators.position_closure import PositionClosure
         # User 1 closes a BTC position
         pos1 = db_create_position(
             {"symbol": "BTC", "entry_price": 80000, "size_usd": 500}, tenant_id=1,
         )
-        db_close_position(pos1["id"], 81000, "MANUAL", tenant_id=1)
+        with PositionClosure(pos1["id"], 81000, "MANUAL", mode="USER", caller_tenant_id=1) as c:
+            c.execute()
         # User 2 also has a BTC trade, but never closed
         db_create_position(
             {"symbol": "BTC", "entry_price": 79000, "size_usd": 500}, tenant_id=2,

--- a/tests/test_multi_tenant_b5_enforcement.py
+++ b/tests/test_multi_tenant_b5_enforcement.py
@@ -32,6 +32,34 @@ def initialized_db(tmp_path, monkeypatch):
     yield db_path
 
 
+def _tx_create_position(data: dict, tenant_id=None):
+    from db.positions import db_create_position
+    from db.transaction import transaction
+    with transaction() as con:
+        return db_create_position(con, data, tenant_id=tenant_id)
+
+
+def _tx_get_positions(status=None, tenant_id=None):
+    from db.positions import db_get_positions
+    from db.transaction import transaction
+    with transaction() as con:
+        return db_get_positions(con, status=status, tenant_id=tenant_id)
+
+
+def _tx_update_position(pos_id: int, data: dict, tenant_id=None):
+    from db.positions import db_update_position
+    from db.transaction import transaction
+    with transaction() as con:
+        return db_update_position(con, pos_id, data, tenant_id=tenant_id)
+
+
+def _tx_last_exit_ts(symbol: str, tenant_id=None):
+    from db.positions import db_last_exit_ts
+    from db.transaction import transaction
+    with transaction() as con:
+        return db_last_exit_ts(con, symbol, tenant_id=tenant_id)
+
+
 def _make_user(user_id: int, role: str = "admin"):
     """Build a minimal User dataclass instance for dependency tests."""
     from auth.models import User
@@ -70,7 +98,7 @@ class TestGetCurrentTenantId:
 class TestDbCreatePosition:
     def test_with_tenant_id_persists(self, initialized_db):
         from db.positions import db_create_position
-        pos = db_create_position(
+        pos = _tx_create_position(
             {"symbol": "BTCUSDT", "entry_price": 80000, "size_usd": 500},
             tenant_id=42,
         )
@@ -79,7 +107,7 @@ class TestDbCreatePosition:
     def test_without_tenant_id_is_null(self, initialized_db):
         """Legacy callers (no tenant_id) insert NULL — preserves pre-multi-tenant behavior."""
         from db.positions import db_create_position
-        pos = db_create_position(
+        pos = _tx_create_position(
             {"symbol": "BTCUSDT", "entry_price": 80000, "size_usd": 500},
         )
         assert pos["tenant_id"] is None
@@ -93,12 +121,12 @@ class TestDbCreatePosition:
 class TestDbGetPositions:
     def test_filters_by_tenant_id(self, initialized_db):
         from db.positions import db_create_position, db_get_positions
-        db_create_position({"symbol": "BTC", "entry_price": 80000}, tenant_id=1)
-        db_create_position({"symbol": "ETH", "entry_price": 2300}, tenant_id=2)
-        db_create_position({"symbol": "RUNE", "entry_price": 0.5}, tenant_id=1)
+        _tx_create_position({"symbol": "BTC", "entry_price": 80000}, tenant_id=1)
+        _tx_create_position({"symbol": "ETH", "entry_price": 2300}, tenant_id=2)
+        _tx_create_position({"symbol": "RUNE", "entry_price": 0.5}, tenant_id=1)
 
-        user1 = db_get_positions(tenant_id=1)
-        user2 = db_get_positions(tenant_id=2)
+        user1 = _tx_get_positions(tenant_id=1)
+        user2 = _tx_get_positions(tenant_id=2)
 
         assert len(user1) == 2
         assert {p["symbol"] for p in user1} == {"BTC", "RUNE"}
@@ -108,35 +136,35 @@ class TestDbGetPositions:
     def test_legacy_no_tenant_returns_all(self, initialized_db):
         """When tenant_id=None (legacy/internal), returns all rows including NULL."""
         from db.positions import db_create_position, db_get_positions
-        db_create_position({"symbol": "BTC", "entry_price": 80000}, tenant_id=1)
-        db_create_position({"symbol": "ETH", "entry_price": 2300})  # NULL
+        _tx_create_position({"symbol": "BTC", "entry_price": 80000}, tenant_id=1)
+        _tx_create_position({"symbol": "ETH", "entry_price": 2300})  # NULL
 
-        all_positions = db_get_positions()
+        all_positions = _tx_get_positions()
         assert len(all_positions) == 2
 
     def test_status_and_tenant_combined(self, initialized_db):
         from db.positions import db_create_position, db_get_positions
         from operators.position_closure import PositionClosure
-        db_create_position({"symbol": "BTC", "entry_price": 80000, "size_usd": 500}, tenant_id=1)
-        db_create_position({"symbol": "ETH", "entry_price": 2300, "size_usd": 500}, tenant_id=1)
+        _tx_create_position({"symbol": "BTC", "entry_price": 80000, "size_usd": 500}, tenant_id=1)
+        _tx_create_position({"symbol": "ETH", "entry_price": 2300, "size_usd": 500}, tenant_id=1)
         # Close one for user 1
-        all_pos = db_get_positions(tenant_id=1)
+        all_pos = _tx_get_positions(tenant_id=1)
         first_id = all_pos[0]["id"]
         with PositionClosure(first_id, 81000, "MANUAL", mode="USER", caller_tenant_id=1) as c:
             c.execute()
 
-        open_for_1 = db_get_positions(status="open", tenant_id=1)
-        closed_for_1 = db_get_positions(status="closed", tenant_id=1)
+        open_for_1 = _tx_get_positions(status="open", tenant_id=1)
+        closed_for_1 = _tx_get_positions(status="closed", tenant_id=1)
         assert len(open_for_1) == 1
         assert len(closed_for_1) == 1
 
     def test_pre_backfill_data_invisible(self, initialized_db):
         """Existing positions with tenant_id=NULL must NOT show up when filtering by tenant."""
         from db.positions import db_create_position, db_get_positions
-        db_create_position({"symbol": "BTC", "entry_price": 80000})  # NULL tenant
-        db_create_position({"symbol": "ETH", "entry_price": 2300}, tenant_id=1)
+        _tx_create_position({"symbol": "BTC", "entry_price": 80000})  # NULL tenant
+        _tx_create_position({"symbol": "ETH", "entry_price": 2300}, tenant_id=1)
 
-        user1 = db_get_positions(tenant_id=1)
+        user1 = _tx_get_positions(tenant_id=1)
         assert len(user1) == 1
         assert user1[0]["symbol"] == "ETH"
 
@@ -150,7 +178,7 @@ class TestDbClosePosition:
     def test_owner_can_close(self, initialized_db):
         from db.positions import db_create_position
         from operators.position_closure import PositionClosure
-        pos = db_create_position(
+        pos = _tx_create_position(
             {"symbol": "BTC", "entry_price": 80000, "size_usd": 500},
             tenant_id=1,
         )
@@ -164,7 +192,7 @@ class TestDbClosePosition:
         """IDOR protection: user 2 tries to close user 1's position → not_found."""
         from db.positions import db_create_position
         from operators.position_closure import PositionClosure
-        pos = db_create_position(
+        pos = _tx_create_position(
             {"symbol": "BTC", "entry_price": 80000, "size_usd": 500},
             tenant_id=1,
         )
@@ -175,14 +203,14 @@ class TestDbClosePosition:
 
         # Verify position still open
         from db.positions import db_get_positions
-        all_pos = db_get_positions(tenant_id=1)
+        all_pos = _tx_get_positions(tenant_id=1)
         assert all_pos[0]["status"] == "open"
 
     def test_legacy_no_tenant_works(self, initialized_db):
         """SYSTEM mode (no tenant_id) can close any position."""
         from db.positions import db_create_position
         from operators.position_closure import PositionClosure
-        pos = db_create_position(
+        pos = _tx_create_position(
             {"symbol": "BTC", "entry_price": 80000, "size_usd": 500},
             tenant_id=1,
         )
@@ -200,27 +228,27 @@ class TestDbClosePosition:
 class TestDbUpdatePosition:
     def test_owner_can_update(self, initialized_db):
         from db.positions import db_create_position, db_update_position
-        pos = db_create_position(
+        pos = _tx_create_position(
             {"symbol": "BTC", "entry_price": 80000},
             tenant_id=1,
         )
-        updated = db_update_position(pos["id"], {"sl_price": 79000}, tenant_id=1)
+        updated = _tx_update_position(pos["id"], {"sl_price": 79000}, tenant_id=1)
         assert updated is not None
         assert updated["sl_price"] == 79000
 
     def test_non_owner_returns_none(self, initialized_db):
         """IDOR: user 2 can't update user 1's position."""
         from db.positions import db_create_position, db_update_position
-        pos = db_create_position(
+        pos = _tx_create_position(
             {"symbol": "BTC", "entry_price": 80000},
             tenant_id=1,
         )
-        updated = db_update_position(pos["id"], {"sl_price": 79000}, tenant_id=2)
+        updated = _tx_update_position(pos["id"], {"sl_price": 79000}, tenant_id=2)
         assert updated is None
 
         # Verify SL not changed
         from db.positions import db_get_positions
-        all_pos = db_get_positions(tenant_id=1)
+        all_pos = _tx_get_positions(tenant_id=1)
         assert all_pos[0]["sl_price"] is None
 
 
@@ -234,24 +262,24 @@ class TestDbLastExitTs:
         from db.positions import db_create_position, db_last_exit_ts
         from operators.position_closure import PositionClosure
         # User 1 closes a BTC position
-        pos1 = db_create_position(
+        pos1 = _tx_create_position(
             {"symbol": "BTC", "entry_price": 80000, "size_usd": 500}, tenant_id=1,
         )
         with PositionClosure(pos1["id"], 81000, "MANUAL", mode="USER", caller_tenant_id=1) as c:
             c.execute()
         # User 2 also has a BTC trade, but never closed
-        db_create_position(
+        _tx_create_position(
             {"symbol": "BTC", "entry_price": 79000, "size_usd": 500}, tenant_id=2,
         )
 
         # User 1 sees their own exit
-        last_user1 = db_last_exit_ts("BTC", tenant_id=1)
+        last_user1 = _tx_last_exit_ts("BTC", tenant_id=1)
         assert last_user1 is not None
         # User 2 has no exit
-        last_user2 = db_last_exit_ts("BTC", tenant_id=2)
+        last_user2 = _tx_last_exit_ts("BTC", tenant_id=2)
         assert last_user2 is None
         # Legacy (no tenant) sees user 1's exit (most recent)
-        last_legacy = db_last_exit_ts("BTC")
+        last_legacy = _tx_last_exit_ts("BTC")
         assert last_legacy is not None
 
 
@@ -291,7 +319,7 @@ class TestTamperingResistance:
             "symbol": "BTC", "entry_price": 80000, "size_usd": 500,
             "tenant_id": 999,  # attacker tries to set this
         }
-        pos = db_create_position(malicious_body, tenant_id=1)
+        pos = _tx_create_position(malicious_body, tenant_id=1)
         # tenant_id reflects the explicit arg (1), NOT the body value (999)
         assert pos["tenant_id"] == 1
 
@@ -308,17 +336,19 @@ class TestBackfillRestoresVisibility:
         from db.schema import backfill_tenant
 
         # Pre-migration: legacy create (no tenant_id)
-        db_create_position({"symbol": "BTC", "entry_price": 80000})
+        _tx_create_position({"symbol": "BTC", "entry_price": 80000})
 
         # User 1 queries, sees nothing
-        assert db_get_positions(tenant_id=1) == []
+        assert _tx_get_positions(tenant_id=1) == []
 
         # Run backfill assigning everything to user 1
-        affected = backfill_tenant(user_id=1)
+        from db.transaction import transaction
+        with transaction() as con:
+            affected = backfill_tenant(con, user_id=1)
         assert affected["positions"] == 1
 
         # Now user 1 sees the row
-        results = db_get_positions(tenant_id=1)
+        results = _tx_get_positions(tenant_id=1)
         assert len(results) == 1
         assert results[0]["symbol"] == "BTC"
 

--- a/tests/test_multi_tenant_b7_idor.py
+++ b/tests/test_multi_tenant_b7_idor.py
@@ -3,9 +3,11 @@
 Pre-reg: docs/superpowers/specs/es/2026-05-16-multi-tenant-threat-model.md
 
 Strategy:
-- TestClient operates as synthetic test user (id=0 per auth.middleware._synthetic_test_user)
+- TestClient operates as synthetic test user (id=99 per auth.middleware._synthetic_test_user;
+  updated from 0 → 99 by #446 Task 6 fix — PositionClosure USER mode requires
+  caller_tenant_id > 0 to match production semantics)
 - Cross-tenant data is seeded directly via DB (user_id=999 = "other user")
-- Verify TestClient (acting as user 0) cannot see / mutate user 999's data
+- Verify TestClient (acting as user 99) cannot see / mutate user 999's data
 - Verify tampering vectors (query/header/body manipulation) are silently dropped
 
 Coverage:
@@ -25,7 +27,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-OTHER_USER_ID = 999  # synthetic "other user" — not the TestClient's identity (0)
+OTHER_USER_ID = 999  # synthetic "other user" — not the TestClient's identity (99)
 
 
 @pytest.fixture
@@ -59,11 +61,11 @@ def _seed_other_user_position(symbol: str = "BTCUSDT") -> int:
 
 
 def _seed_own_position(symbol: str = "ETHUSDT") -> int:
-    """Insert position owned by TestClient (user_id=0)."""
+    """Insert position owned by TestClient (user_id=99)."""
     from db.positions import db_create_position
     pos = db_create_position(
         {"symbol": symbol, "entry_price": 2300, "size_usd": 300, "direction": "LONG"},
-        tenant_id=0,
+        tenant_id=99,
     )
     return pos["id"]
 
@@ -137,9 +139,9 @@ class TestPositionsIDOR:
             headers={"X-API-Key": "test-key"},
         )
         assert resp.status_code == 200
-        # Verify the position was created under user 0, not 999
+        # Verify the position was created under user 99, not 999
         from db.positions import db_get_positions
-        own_positions = db_get_positions(tenant_id=0)
+        own_positions = db_get_positions(tenant_id=99)
         other_positions = db_get_positions(tenant_id=OTHER_USER_ID)
         assert len(own_positions) == 1
         assert len(other_positions) == 0
@@ -174,7 +176,7 @@ class TestNotificationsIDOR:
 
     def test_list_excludes_other_user_notifications(self, client):
         self._seed_notif(OTHER_USER_ID, "other:1")
-        self._seed_notif(0, "own:1")
+        self._seed_notif(99, "own:1")
         # GET /notifications uses verify_api_key — pass header
         resp = client.get("/notifications", headers={"X-API-Key": "test-key"})
         assert resp.status_code == 200
@@ -194,7 +196,7 @@ class TestNotificationsIDOR:
         # Seed unread for both
         self._seed_notif(OTHER_USER_ID, "other:1")
         self._seed_notif(OTHER_USER_ID, "other:2")
-        own_id = self._seed_notif(0, "own:1")
+        own_id = self._seed_notif(99, "own:1")
 
         resp = client.post(
             "/notifications/read-all",
@@ -234,7 +236,7 @@ class TestSignalsPerformanceIDOR:
         for i in range(10):
             self._seed_signal_outcome(OTHER_USER_ID, score=5, price_24h_higher=True)
         # Own user has 1 losing outcome
-        self._seed_signal_outcome(0, score=3, price_24h_higher=False)
+        self._seed_signal_outcome(99, score=3, price_24h_higher=False)
 
         resp = client.get("/signals/performance")
         assert resp.status_code == 200
@@ -256,7 +258,7 @@ class TestCapitalIDOR:
         with transaction() as con:
             db_upsert_capital(con, OTHER_USER_ID, balance=999999.0)
         resp = client.get("/capital")
-        assert resp.status_code == 404  # current user (id=0) has no capital
+        assert resp.status_code == 404  # current user (id=99) has no capital
 
     def test_put_does_not_overwrite_other_user_capital(self, client):
         from db.capital import db_upsert_capital, db_get_capital

--- a/tests/test_multi_tenant_b7_idor.py
+++ b/tests/test_multi_tenant_b7_idor.py
@@ -53,20 +53,26 @@ def client(tmp_path, monkeypatch):
 def _seed_other_user_position(symbol: str = "BTCUSDT") -> int:
     """Insert position owned by OTHER_USER_ID. Returns pos_id."""
     from db.positions import db_create_position
-    pos = db_create_position(
-        {"symbol": symbol, "entry_price": 80000, "size_usd": 500, "direction": "LONG"},
-        tenant_id=OTHER_USER_ID,
-    )
+    from db.transaction import transaction
+    with transaction() as con:
+        pos = db_create_position(
+            con,
+            {"symbol": symbol, "entry_price": 80000, "size_usd": 500, "direction": "LONG"},
+            tenant_id=OTHER_USER_ID,
+        )
     return pos["id"]
 
 
 def _seed_own_position(symbol: str = "ETHUSDT") -> int:
     """Insert position owned by TestClient (user_id=99)."""
     from db.positions import db_create_position
-    pos = db_create_position(
-        {"symbol": symbol, "entry_price": 2300, "size_usd": 300, "direction": "LONG"},
-        tenant_id=99,
-    )
+    from db.transaction import transaction
+    with transaction() as con:
+        pos = db_create_position(
+            con,
+            {"symbol": symbol, "entry_price": 2300, "size_usd": 300, "direction": "LONG"},
+            tenant_id=99,
+        )
     return pos["id"]
 
 
@@ -141,8 +147,10 @@ class TestPositionsIDOR:
         assert resp.status_code == 200
         # Verify the position was created under user 99, not 999
         from db.positions import db_get_positions
-        own_positions = db_get_positions(tenant_id=99)
-        other_positions = db_get_positions(tenant_id=OTHER_USER_ID)
+        from db.transaction import transaction
+        with transaction() as con:
+            own_positions = db_get_positions(con, tenant_id=99)
+            other_positions = db_get_positions(con, tenant_id=OTHER_USER_ID)
         assert len(own_positions) == 1
         assert len(other_positions) == 0
 
@@ -286,11 +294,14 @@ class TestCapitalIDOR:
 class TestPreferencesIDOR:
     def test_get_other_user_prefs_invisible(self, client):
         """GET /preferences returns DEFAULTS (not other user's prefs)."""
+        from db.transaction import transaction
         from db.user_preferences import db_upsert_user_preferences
-        db_upsert_user_preferences(
-            tenant_id=OTHER_USER_ID, symbol_filter=["XAUTUSDT"], min_score=8,
-            notify_channels={"telegram_chat_id": "OTHER"},
-        )
+        with transaction() as con:
+            db_upsert_user_preferences(
+                con,
+                tenant_id=OTHER_USER_ID, symbol_filter=["XAUTUSDT"], min_score=8,
+                notify_channels={"telegram_chat_id": "OTHER"},
+            )
         resp = client.get("/preferences")
         assert resp.status_code == 200
         body = resp.json()
@@ -300,8 +311,10 @@ class TestPreferencesIDOR:
         assert body["notify_channels"] is None
 
     def test_put_does_not_overwrite_other_user_prefs(self, client):
+        from db.transaction import transaction
         from db.user_preferences import db_upsert_user_preferences, db_get_user_preferences
-        db_upsert_user_preferences(tenant_id=OTHER_USER_ID, min_score=8)
+        with transaction() as con:
+            db_upsert_user_preferences(con, tenant_id=OTHER_USER_ID, min_score=8)
         # Current user PUTs their own
         resp = client.put(
             "/preferences",
@@ -310,7 +323,8 @@ class TestPreferencesIDOR:
         )
         assert resp.status_code == 200
         # Other user's prefs unchanged
-        other = db_get_user_preferences(OTHER_USER_ID)
+        with transaction() as con:
+            other = db_get_user_preferences(con, OTHER_USER_ID)
         assert other["min_score"] == 8
 
 

--- a/tests/test_multi_tenant_b7_idor.py
+++ b/tests/test_multi_tenant_b7_idor.py
@@ -252,13 +252,17 @@ class TestCapitalIDOR:
     def test_get_other_user_capital_invisible(self, client):
         """GET /capital with other user's data seeded must 404 for current user."""
         from db.capital import db_upsert_capital
-        db_upsert_capital(tenant_id=OTHER_USER_ID, balance=999999.0)
+        from db.transaction import transaction
+        with transaction() as con:
+            db_upsert_capital(con, OTHER_USER_ID, balance=999999.0)
         resp = client.get("/capital")
         assert resp.status_code == 404  # current user (id=0) has no capital
 
     def test_put_does_not_overwrite_other_user_capital(self, client):
         from db.capital import db_upsert_capital, db_get_capital
-        db_upsert_capital(tenant_id=OTHER_USER_ID, balance=999999.0)
+        from db.transaction import transaction
+        with transaction() as con:
+            db_upsert_capital(con, OTHER_USER_ID, balance=999999.0)
         # Current user PUTs their own
         resp = client.put(
             "/capital",
@@ -267,7 +271,8 @@ class TestCapitalIDOR:
         )
         assert resp.status_code == 200
         # Other user's capital unchanged
-        other = db_get_capital(OTHER_USER_ID)
+        with transaction() as con:
+            other = db_get_capital(con, OTHER_USER_ID)
         assert other["balance"] == 999999.0
 
 

--- a/tests/test_multi_tenant_b7_idor.py
+++ b/tests/test_multi_tenant_b7_idor.py
@@ -176,11 +176,14 @@ class TestPositionsIDOR:
 class TestNotificationsIDOR:
     def _seed_notif(self, tenant_id: int, event_key: str = "test:1"):
         from notifier._storage import record_delivery
-        return record_delivery(
-            event_type="signal", event_key=event_key, priority="info",
-            payload={"x": 1}, channels_sent=["telegram"], delivery_status="ok",
-            tenant_id=tenant_id,
-        )
+        from db.transaction import transaction
+        with transaction() as con:
+            return record_delivery(
+                con,
+                event_type="signal", event_key=event_key, priority="info",
+                payload={"x": 1}, channels_sent=["telegram"], delivery_status="ok",
+                tenant_id=tenant_id,
+            )
 
     def test_list_excludes_other_user_notifications(self, client):
         self._seed_notif(OTHER_USER_ID, "other:1")
@@ -215,7 +218,9 @@ class TestNotificationsIDOR:
 
         # Verify other user's notifications still unread
         from notifier._storage import list_unread
-        other_still_unread = list_unread(tenant_id=OTHER_USER_ID)
+        from db.transaction import transaction
+        with transaction() as con:
+            other_still_unread = list_unread(con, tenant_id=OTHER_USER_ID)
         assert len(other_still_unread) == 2
 
 

--- a/tests/test_multi_tenant_b8_migration.py
+++ b/tests/test_multi_tenant_b8_migration.py
@@ -44,7 +44,8 @@ def seeded_db(tmp_path, monkeypatch):
     from db.transaction import transaction
 
     init_db()
-    init_auth_db()
+    with transaction() as con:
+        init_auth_db(con)
 
     # Insert a real user (id=1)
     with transaction() as con:

--- a/tests/test_multi_tenant_b8_migration.py
+++ b/tests/test_multi_tenant_b8_migration.py
@@ -132,7 +132,8 @@ class TestMigrationLogic:
                 "SELECT COUNT(*) FROM positions WHERE tenant_id IS NULL"
             ).fetchone()[0]
         assert null_pos == 2
-        assert db_get_capital(1) is None  # no capital row created
+        with transaction() as con:
+            assert db_get_capital(con, 1) is None  # no capital row created
 
     def test_execute_stamps_tenant_id(self, seeded_db):
         """Pre-reg §2.3: --execute backfills tenant_id on NULL rows."""
@@ -175,7 +176,9 @@ class TestMigrationLogic:
         from db.capital import db_get_capital
 
         assert run(self._make_args(execute=True, initial_balance=12500.0)) == 0
-        row = db_get_capital(1)
+        from db.transaction import transaction
+        with transaction() as con:
+            row = db_get_capital(con, 1)
         assert row is not None
         assert row["balance"] == 12500.0
         assert row["peak_balance"] == 12500.0
@@ -185,9 +188,11 @@ class TestMigrationLogic:
         """Pre-reg §2.3 step 4: existing capital row + no --force → exit 1."""
         from scripts.migrate_to_multitenant import run
         from db.capital import db_upsert_capital
+        from db.transaction import transaction
 
         # Pre-create capital row
-        db_upsert_capital(1, balance=5000.0, peak_balance=5000.0)
+        with transaction() as con:
+            db_upsert_capital(con, 1, balance=5000.0, peak_balance=5000.0)
         # Need backfill_tenant to not be a no-op too — let it run normally
         # The script should refuse the capital overwrite specifically.
         exit_code = run(self._make_args(execute=True, force=False))
@@ -197,12 +202,15 @@ class TestMigrationLogic:
         """Pre-reg §2.3 step 4: --force replaces existing capital row."""
         from scripts.migrate_to_multitenant import run
         from db.capital import db_get_capital, db_upsert_capital
+        from db.transaction import transaction
 
-        db_upsert_capital(1, balance=5000.0, peak_balance=5000.0)
+        with transaction() as con:
+            db_upsert_capital(con, 1, balance=5000.0, peak_balance=5000.0)
         exit_code = run(self._make_args(execute=True, force=True,
                                          initial_balance=20_000.0))
         assert exit_code == 0
-        row = db_get_capital(1)
+        with transaction() as con:
+            row = db_get_capital(con, 1)
         assert row["balance"] == 20_000.0
         assert row["peak_balance"] == 20_000.0
 

--- a/tests/test_notifications_endpoints.py
+++ b/tests/test_notifications_endpoints.py
@@ -14,11 +14,13 @@ def client(tmp_path, monkeypatch):
     return TestClient(btc_api.app)
 
 
-def _seed(n_unread=3, n_read=2, tenant_id: int = 0):
+def _seed(n_unread=3, n_read=2, tenant_id: int = 99):
     """Insert notifications directly via the storage helper.
 
-    B.5 follow-up #258: tenant_id=0 matches synthetic test user
-    (auth.middleware._synthetic_test_user). Without explicit tenant_id,
+    B.5 follow-up #258: tenant_id=99 matches synthetic test user
+    (auth.middleware._synthetic_test_user). Updated from 0 → 99 by
+    #446 Task 6 fix (PositionClosure USER mode requires
+    caller_tenant_id > 0). Without explicit tenant_id,
     strict filter excludes rows post-B.5-follow-up.
     """
     from notifier._storage import record_delivery, mark_read

--- a/tests/test_notifications_endpoints.py
+++ b/tests/test_notifications_endpoints.py
@@ -2,6 +2,8 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from db.transaction import transaction
+
 
 @pytest.fixture
 def client(tmp_path, monkeypatch):
@@ -25,21 +27,24 @@ def _seed(n_unread=3, n_read=2, tenant_id: int = 99):
     """
     from notifier._storage import record_delivery, mark_read
     ids = []
-    for i in range(n_unread):
-        ids.append(record_delivery(
-            event_type="signal", event_key=f"signal:SYM{i}", priority="info",
-            payload={"symbol": f"SYM{i}"}, channels_sent=["telegram"],
-            delivery_status="ok",
-            tenant_id=tenant_id,
-        ))
-    for i in range(n_read):
-        nid = record_delivery(
-            event_type="health", event_key=f"health:R{i}", priority="warning",
-            payload={"symbol": f"R{i}"}, channels_sent=["telegram"],
-            delivery_status="ok",
-            tenant_id=tenant_id,
-        )
-        mark_read(nid, tenant_id=tenant_id)
+    with transaction() as con:
+        for i in range(n_unread):
+            ids.append(record_delivery(
+                con,
+                event_type="signal", event_key=f"signal:SYM{i}", priority="info",
+                payload={"symbol": f"SYM{i}"}, channels_sent=["telegram"],
+                delivery_status="ok",
+                tenant_id=tenant_id,
+            ))
+        for i in range(n_read):
+            nid = record_delivery(
+                con,
+                event_type="health", event_key=f"health:R{i}", priority="warning",
+                payload={"symbol": f"R{i}"}, channels_sent=["telegram"],
+                delivery_status="ok",
+                tenant_id=tenant_id,
+            )
+            mark_read(con, nid, tenant_id=tenant_id)
     return ids
 
 

--- a/tests/test_notifier_dedupe.py
+++ b/tests/test_notifier_dedupe.py
@@ -18,25 +18,30 @@ def tmp_db(tmp_path, monkeypatch):
 
 def test_first_send_always_allowed(tmp_db):
     from notifier.dedupe import should_send
-    assert should_send("health", "health:BTC:PAUSED", window_seconds=60) is True
+    with transaction() as con:
+        assert should_send(con, "health", "health:BTC:PAUSED", window_seconds=60) is True
 
 
 def test_repeat_within_window_blocked(tmp_db):
     from notifier.dedupe import should_send
     from notifier._storage import record_delivery
 
-    record_delivery("health", "health:BTC:PAUSED", "warning",
-                    {"symbol": "BTC"}, ["telegram"], "ok")
-    assert should_send("health", "health:BTC:PAUSED", window_seconds=60) is False
+    with transaction() as con:
+        record_delivery(con, "health", "health:BTC:PAUSED", "warning",
+                        {"symbol": "BTC"}, ["telegram"], "ok")
+    with transaction() as con:
+        assert should_send(con, "health", "health:BTC:PAUSED", window_seconds=60) is False
 
 
 def test_zero_window_never_dedupes(tmp_db):
     from notifier.dedupe import should_send
     from notifier._storage import record_delivery
 
-    record_delivery("signal", "signal:BTC", "info",
-                    {"symbol": "BTC"}, ["telegram"], "ok")
-    assert should_send("signal", "signal:BTC", window_seconds=0) is True
+    with transaction() as con:
+        record_delivery(con, "signal", "signal:BTC", "info",
+                        {"symbol": "BTC"}, ["telegram"], "ok")
+    with transaction() as con:
+        assert should_send(con, "signal", "signal:BTC", window_seconds=0) is True
 
 
 def test_critical_priority_bypasses_dedupe(tmp_db):
@@ -44,12 +49,15 @@ def test_critical_priority_bypasses_dedupe(tmp_db):
     from notifier.dedupe import should_send
     from notifier._storage import record_delivery
 
-    record_delivery("infra", "infra:scanner", "critical",
-                    {"component": "scanner"}, ["telegram"], "ok")
-    assert should_send("infra", "infra:scanner", window_seconds=60,
-                        priority="critical") is True
-    assert should_send("infra", "infra:scanner", window_seconds=60,
-                        priority="warning") is False
+    with transaction() as con:
+        record_delivery(con, "infra", "infra:scanner", "critical",
+                        {"component": "scanner"}, ["telegram"], "ok")
+    with transaction() as con:
+        assert should_send(con, "infra", "infra:scanner", window_seconds=60,
+                            priority="critical") is True
+    with transaction() as con:
+        assert should_send(con, "infra", "infra:scanner", window_seconds=60,
+                            priority="warning") is False
 
 
 def test_record_older_than_window_allows_resend(tmp_db):
@@ -69,4 +77,5 @@ def test_record_older_than_window_allows_resend(tmp_db):
             ("health", "health:BTC:PAUSED", "warning", "{}", "telegram", "ok", past, None),
         )
 
-    assert should_send("health", "health:BTC:PAUSED", window_seconds=60) is True
+    with transaction() as con:
+        assert should_send(con, "health", "health:BTC:PAUSED", window_seconds=60) is True

--- a/tests/test_notifier_integration.py
+++ b/tests/test_notifier_integration.py
@@ -3,6 +3,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
+from db.transaction import transaction
+
 
 @pytest.fixture
 def tmp_db_and_reset(tmp_path, monkeypatch):
@@ -49,7 +51,8 @@ def test_notify_signal_sends_to_telegram_and_records(tmp_db_and_reset, ok_telegr
     assert mock_post.call_count == 1
 
     from notifier._storage import list_unread
-    rows = list_unread(limit=5)
+    with transaction() as con:
+        rows = list_unread(con, limit=5)
     assert len(rows) == 1
     assert rows[0]["event_type"] == "signal"
 
@@ -113,7 +116,8 @@ def test_notify_render_failure_produces_failed_receipt(tmp_db_and_reset):
     assert "boom" in receipts[0].error
 
     from notifier._storage import list_unread
-    rows = list_unread(limit=5)
+    with transaction() as con:
+        rows = list_unread(con, limit=5)
     assert len(rows) == 1
     assert rows[0]["delivery_status"] == "failed"
 

--- a/tests/test_notifier_storage.py
+++ b/tests/test_notifier_storage.py
@@ -1,5 +1,6 @@
 """Storage of outbound notifications — insert, list unread, mark-read."""
 import pytest
+from db.transaction import transaction
 
 
 @pytest.fixture
@@ -19,15 +20,18 @@ def tmp_db(tmp_path, monkeypatch):
 
 def test_record_delivery_inserts_row(tmp_db):
     from notifier._storage import record_delivery
-    record_delivery(
-        event_type="signal", event_key="signal:BTCUSDT",
-        priority="info",
-        payload={"symbol": "BTCUSDT", "score": 6},
-        channels_sent=["telegram"],
-        delivery_status="ok",
-    )
+    with transaction() as con:
+        record_delivery(
+            con,
+            event_type="signal", event_key="signal:BTCUSDT",
+            priority="info",
+            payload={"symbol": "BTCUSDT", "score": 6},
+            channels_sent=["telegram"],
+            delivery_status="ok",
+        )
     from notifier._storage import list_unread
-    rows = list_unread(limit=10)
+    with transaction() as con:
+        rows = list_unread(con, limit=10)
     assert len(rows) == 1
     assert rows[0]["event_type"] == "signal"
     assert rows[0]["delivery_status"] == "ok"
@@ -35,17 +39,24 @@ def test_record_delivery_inserts_row(tmp_db):
 
 def test_list_unread_filters_read(tmp_db):
     from notifier._storage import record_delivery, list_unread, mark_read
-    record_delivery("signal", "signal:BTCUSDT", "info",
-                    {"symbol": "BTCUSDT"}, ["telegram"], "ok")
-    (row_id,) = (r["id"] for r in list_unread(limit=10))
-    mark_read(row_id)
-    assert list_unread(limit=10) == []
+    with transaction() as con:
+        record_delivery(con, "signal", "signal:BTCUSDT", "info",
+                        {"symbol": "BTCUSDT"}, ["telegram"], "ok")
+    with transaction() as con:
+        (row_id,) = (r["id"] for r in list_unread(con, limit=10))
+    with transaction() as con:
+        mark_read(con, row_id)
+    with transaction() as con:
+        assert list_unread(con, limit=10) == []
 
 
 def test_list_unread_ordered_by_sent_at_desc(tmp_db):
     from notifier._storage import record_delivery, list_unread
-    record_delivery("signal", "signal:A", "info", {"s": "A"}, ["telegram"], "ok")
-    record_delivery("signal", "signal:B", "info", {"s": "B"}, ["telegram"], "ok")
-    rows = list_unread(limit=10)
+    with transaction() as con:
+        record_delivery(con, "signal", "signal:A", "info", {"s": "A"}, ["telegram"], "ok")
+    with transaction() as con:
+        record_delivery(con, "signal", "signal:B", "info", {"s": "B"}, ["telegram"], "ok")
+    with transaction() as con:
+        rows = list_unread(con, limit=10)
     assert rows[0]["event_key"] == "signal:B"
     assert rows[1]["event_key"] == "signal:A"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1489,6 +1489,7 @@ class TestScanEmitsV2ShadowDecision:
         """scan() writes BOTH engine='v1' AND engine='v2_shadow' rows to the log."""
         import btc_api, btc_scanner, observability
         from db.capital import db_upsert_capital
+        from db.transaction import transaction
         db_path = str(tmp_path / "signals.db")
         monkeypatch.setattr(btc_api, "DB_FILE", db_path)
         if hasattr(btc_api, "_db_conn"):
@@ -1497,7 +1498,8 @@ class TestScanEmitsV2ShadowDecision:
         # Multi-tenant: scanner iterates db_list_active_tenant_ids() to emit
         # shadow decisions; without a capital row the loop is empty and no
         # v2_shadow row is written. Seed a tenant so the assertion can fire.
-        db_upsert_capital(1, balance=10_000.0, peak_balance=10_000.0)
+        with transaction() as con:
+            db_upsert_capital(con, 1, balance=10_000.0, peak_balance=10_000.0)
 
         # Mock market data fetch (Task 3 A6 pattern)
         import pandas as pd

--- a/tests/test_scanner_cooldown.py
+++ b/tests/test_scanner_cooldown.py
@@ -70,7 +70,7 @@ def _make_scan_klines(volume=1000.0, base=100.0):
 
 def test_e5_path_a_no_prior_exits_returns_activo_false_with_null_hours(monkeypatch):
     """Path A: db_last_exit_ts → None. activo=False, hours_since_last_exit=None."""
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: None)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
     assert e5["activo"] is False
@@ -82,7 +82,7 @@ def test_e5_path_a_no_prior_exits_returns_activo_false_with_null_hours(monkeypat
 def test_e5_path_b_hours_since_exceeds_cooldown_returns_activo_false(monkeypatch):
     """Path B: 10h since exit, 6h required → activo=False."""
     last_exit = datetime.now(timezone.utc) - timedelta(hours=10)
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: last_exit)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
     assert e5["activo"] is False
@@ -94,7 +94,7 @@ def test_e5_path_b_hours_since_exceeds_cooldown_returns_activo_false(monkeypatch
 def test_e5_path_c_hours_since_below_cooldown_returns_activo_true(monkeypatch):
     """Path C: 1h since exit, 6h required → activo=True (the core blocking path)."""
     last_exit = datetime.now(timezone.utc) - timedelta(hours=1)
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: last_exit)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
     assert e5["activo"] is True
@@ -105,7 +105,7 @@ def test_e5_path_c_hours_since_below_cooldown_returns_activo_true(monkeypatch):
 def test_e5_path_c_uses_per_symbol_override_not_global(monkeypatch):
     """Per-symbol override binds when global cd would not (8h since exit, cd=14)."""
     last_exit = datetime.now(timezone.utc) - timedelta(hours=8)
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: last_exit)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 14}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
     assert e5["activo"] is True
@@ -114,7 +114,7 @@ def test_e5_path_c_uses_per_symbol_override_not_global(monkeypatch):
 
 def test_e5_path_d_invalid_override_falls_back_to_global_cooldown_h(monkeypatch, caplog):
     """Path D: invalid override → fallback to COOLDOWN_H. Validator emits 1 warn."""
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: None)
     caplog.set_level(logging.WARNING)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": -5}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
@@ -133,7 +133,7 @@ def test_e5_path_d_invalid_override_fallback_USED_in_comparison(monkeypatch, cap
     (missing/None) and let the trade through.
     """
     last_exit = datetime.now(timezone.utc) - timedelta(hours=1)
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: last_exit)
     caplog.set_level(logging.WARNING)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": -5}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
@@ -146,7 +146,7 @@ def test_e5_path_d_invalid_override_fallback_USED_in_comparison(monkeypatch, cap
 
 def test_e5_path_e_db_exception_fail_open_logs_warning(monkeypatch, caplog):
     """DB query raises → activo=False (fail-open), warning logged."""
-    def _boom(sym):
+    def _boom(con, sym):
         raise RuntimeError("DB connection lost")
     monkeypatch.setattr("db.positions.db_last_exit_ts", _boom)
     caplog.set_level(logging.WARNING)
@@ -161,7 +161,7 @@ def test_e5_path_e_db_exception_fail_open_logs_warning(monkeypatch, caplog):
 def test_e5_path_e_sqlite_operational_error_logs_at_error_level(monkeypatch, caplog):
     """SQLite OperationalError escalates to log.error (not warning)."""
     import sqlite3
-    def _boom(sym):
+    def _boom(con, sym):
         raise sqlite3.OperationalError("database is locked")
     monkeypatch.setattr("db.positions.db_last_exit_ts", _boom)
     caplog.set_level(logging.WARNING)
@@ -177,7 +177,7 @@ def test_e5_path_e_sqlite_operational_error_logs_at_error_level(monkeypatch, cap
 
 def test_e5_path_e_oserror_logs_at_error_level(monkeypatch, caplog):
     """OSError (disk-full, permission-denied, missing parent dir) escalates to error."""
-    def _boom(sym):
+    def _boom(con, sym):
         raise OSError("disk full")
     monkeypatch.setattr("db.positions.db_last_exit_ts", _boom)
     caplog.set_level(logging.WARNING)
@@ -196,7 +196,7 @@ def test_e5_path_e_oserror_logs_at_error_level(monkeypatch, caplog):
 
 def test_e5_dict_always_present_keys_match_baseline_shape(monkeypatch):
     """Frontend pin: 4 keys, types correct. Drift here breaks downstream consumers."""
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: None)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
 
@@ -211,7 +211,7 @@ def test_e5_dict_always_present_keys_match_baseline_shape(monkeypatch):
 def test_e5_hours_since_rounded_to_2_decimals(monkeypatch):
     """Round contract: hours_since_last_exit must be limited to 2 decimals."""
     last_exit = datetime.now(timezone.utc) - timedelta(hours=2, minutes=37, seconds=18)
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: last_exit)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
     h = e5["hours_since_last_exit"]
@@ -220,14 +220,14 @@ def test_e5_hours_since_rounded_to_2_decimals(monkeypatch):
 
 
 def test_e5_cooldown_hours_required_reflects_per_symbol_when_present(monkeypatch):
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: None)
     cfg = {"symbol_overrides": {"ETHUSDT": {"cooldown_hours": 14}}}
     e5 = scanner._build_e5_cooldown("ETHUSDT", cfg)
     assert e5["cooldown_hours_required"] == 14.0
 
 
 def test_e5_cooldown_hours_required_reflects_global_when_overrides_missing(monkeypatch):
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: None)
     cfg = {"symbol_overrides": {}}  # no per-symbol entry
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
     assert e5["cooldown_hours_required"] == float(scanner.COOLDOWN_H)
@@ -236,7 +236,7 @@ def test_e5_cooldown_hours_required_reflects_global_when_overrides_missing(monke
 def test_e5_payload_json_serializable(monkeypatch):
     """The dict ends up in scan() report which is JSON-serialized for /symbols."""
     last_exit = datetime.now(timezone.utc) - timedelta(hours=3)
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: last_exit)
     cfg = {"symbol_overrides": {"BTCUSDT": {"cooldown_hours": 6}}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
     # Must not raise.
@@ -249,7 +249,7 @@ def test_e5_payload_json_serializable(monkeypatch):
 
 def test_e5_disabled_symbol_does_not_crash(monkeypatch):
     """cfg.symbol_overrides[BTC] = False → no AttributeError on .get('cooldown_hours')."""
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: None)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: None)
     cfg = {"symbol_overrides": {"BTCUSDT": False}}
     e5 = scanner._build_e5_cooldown("BTCUSDT", cfg)
     assert e5["cooldown_hours_required"] == float(scanner.COOLDOWN_H)
@@ -286,7 +286,7 @@ def test_scan_blocks_signal_when_cooldown_active(fake_cfg, monkeypatch):
 
     # Last exit 1h ago — cooldown 14h NOT elapsed → activo=True
     last_exit = datetime.now(timezone.utc) - timedelta(hours=1)
-    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda sym: last_exit)
+    monkeypatch.setattr("db.positions.db_last_exit_ts", lambda con, sym: last_exit)
 
     fake_decision = _make_long_signal()
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -330,7 +330,8 @@ def test_11_reset_password_cli_revokes_all_refreshes(tmp_path, monkeypatch):
     from auth.tokens import _hash_refresh, revoke_all_for_user
 
     init_db()
-    init_auth_db()
+    with transaction() as con:
+        init_auth_db(con)
     now = datetime.now(timezone.utc).isoformat()
     with transaction() as con:
         cur = con.execute(

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -357,7 +357,8 @@ def test_11_reset_password_cli_revokes_all_refreshes(tmp_path, monkeypatch):
             "WHERE id = ?",
             (new_hash, datetime.now(timezone.utc).isoformat(), uid),
         )
-    revoked = revoke_all_for_user(uid)
+    with transaction() as con:
+        revoked = revoke_all_for_user(con, uid)
     assert revoked == 2
 
     # Verify in DB: hash changed, both refreshes revoked_at IS NOT NULL.


### PR DESCRIPTION
## Summary

Implements the architectural direction articulated by Voronov on 2026-05-25 (analysis docs in `docs/superpowers/analysis/`). `db/` becomes a pure SQL layer where helpers receive `con: sqlite3.Connection` mandatory. Business transitions live in the new `operators/` package; the first inhabitant is `PositionClosure`.

`_tx_or_use` is deleted. All 34 Cat. 1 helpers migrate to `con` mandatory. The 4 Cat. 2 hidden business operators (`save_scan`, `init_db`, `log_auth_event`, `dispatch_signal_to_users`) use `transaction()` directly; operator-extraction for them is deferred to separate tickets.

## Resolves

- **#446** (`_tx_or_use` dual-contract) — closed by construction; the dispatcher and its symbol both gone.
- **#447** (named operator) — `PositionClosure` is the operator; pattern for future operators established.
- **#448** (`con` validation) — disuelto; helpers no longer receive `con` from external callers without passing through the operator layer or an explicit `with transaction()` block.
- **#449** (health trigger non-enforceable) — health trigger lives in `PositionClosure.__exit__`; called exactly once per successful close; tested by invariant #6.
- **#451** (test laxness) — fixture corrected (entry=98, sl=97); assertion tightened to exactly two valid outcomes (105.0 operator-wins or 101.0 scanner-wins).

## Resolves with explicit trade-off

- **#450** (`apply_pnl_to_capital` best-effort silencioso) — capital roll-in now runs IN-TX inside the operator's transaction. Trade-off accepted: capital UPSERT failure aborts the close (position stays open). This is strictly safer than the inverse (close commits, capital silently desynced). Documented in `docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md` Section 'Post-commit side-effects'.

## Voronov AMBER amendments (all applied)

The plan was reviewed AMBER by Voronov; 5 amendments applied before execution:

- **F3** (mandatory): `CLAUDE.md` "Database access" section now enumerates the 4 deferred Cat. 2 hidden operators as named exceptions. Eliminates the doc-vs-code dual-contract.
- **F2** (recommended): Invariant test #10 (`test_side_effect_failure_does_not_rollback_close`) encodes the "best-effort post-commit" commitment in the test suite — a future contributor who "fixes" the try/except in `__exit__` to raise fails this test loudly.
- **F6** (documentation): `read_only_connection()` context manager added to `db/transaction.py` as the named 4th DB access pattern. Documented in `CLAUDE.md` §4.
- **F1** (docstring): Operator module docstring notes that the `mode` Literal flag works for 2 modes today; a 3rd mode forces subclassing.
- **F4** (deferred list): Retry policy hole for capital lock contention under `BEGIN IMMEDIATE` named in deferred list below.

Voronov re-reviewed amendments: **GREEN**. Execution authorized.

## Deferred to separate tickets

- Operator-extraction for the 4 remaining Cat. 2 hidden operators (`save_scan`, `init_db`, `log_auth_event`, `dispatch_signal_to_users`). They function correctly with `transaction()` directly; operator-naming is a separate exercise per Voronov's evidential rule.
- `PositionOpening` operator: precondition 2 confirmed no current symptoms (no contract interrogation, no conditional side-effects, minimal composition). Create when evidence emerges.
- Outbox infrastructure for true compensable post-commit delivery: v1 is best-effort log-and-continue. Separate epic.
- **Retry policy for capital lock contention** (Voronov AMBER F4): under SQLite `BEGIN IMMEDIATE`, `apply_pnl_to_capital` failures will most commonly be `sqlite3.OperationalError: database is locked` rather than logic errors. Current operator surfaces these as exception → close aborted → user clicks Close again → likely same lock. No retry, no backoff, no metric for "how often does capital-lock abort closes in prod". Acceptable for v1; needs explicit retry policy + observability before high-concurrency multi-tenant scenarios.
- **`mode="USER"|"SYSTEM"` flag → subclass migration** (Voronov AMBER F1): the Literal flag works for 2 modes today. A third mode (BATCH, RECONCILIATION) reintroduces the dual-contract shape this PR closed. Resolve by splitting into `UserPositionClosure` / `SystemPositionClosure` sharing an abstract base when that third mode emerges. Documented in operator's module docstring.

## Test plan

- [x] 11 PositionClosure invariant tests (`tests/operators/test_position_closure.py`) — atomicity (success + failure), ownership-before-lock, IDOR-equivalence (USER), no-IDOR-leak (SYSTEM), no-side-effects-on-exception, single-firing, idempotent re-close, no-lock-during-I/O, no-tenant capital skip, side-effect-failure-does-not-rollback.
- [x] 9 `transaction()` wrapper contract tests still pass (no regression).
- [x] Atomicity regression test passes with corrected fixture.
- [x] Full test suite: 2489 passed, 22 skipped, 1 pre-existing flaky failure in `tests/test_setup.py` (daemon thread leak from `kill_switch_calibrator_loop` across tests; not related to this PR — see PR #445 known limitations).
- [ ] Manual smoke in prod after merge: close a position via API, verify health + notify + event log + snapshot all fire. Run scanner cycle, verify position closes correctly on SL/TP hit.

## Migration scope

| Layer | Files | Notes |
|---|---|---|
| New | 4 | `operators/__init__.py`, `operators/position_closure.py`, `tests/operators/__init__.py`, `tests/operators/test_position_closure.py` |
| Production helpers migrated | ~13 | db/*, auth/*, notifier/*, health.py, strategy/* (~34 Cat. 1 helpers) |
| Cat. 2 migrated to `transaction()` directly | 4 | save_scan, init_db, log_auth_event, dispatch_signal_to_users |
| Production callers updated | several | wrapped in `with transaction()` where they relied on helper-opened tx |
| Total commits | 17 | analysis + plan + amendments + execution |

## Architecture notes

The two analysis documents are the source of truth for the design:
- `docs/superpowers/analysis/2026-05-25-446-tx-or-use-analysis-and-direction.md` — Serrano's clinical analysis (13 findings, 5 options) + Voronov's ontological reframe + direction.
- `docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md` — audit results (46 helpers classified), opening-flow decision (DEFER), multi-tenancy invariants, full `PositionClosure` contract spec.

Plan: `docs/superpowers/plans/2026-05-25-446-position-closure-operator.md` (with AMBER amendments).

Read those before reviewing implementation details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope explícito — lo que este PR NO resuelve

Tras review clínico de Serrano + reframe ontológico de Voronov (2026-05-25), nombrar lo que la narrativa de "atomicidad resuelta" podría inducir a inferir incorrectamente:

- **#453** (Plano 1 — Voronov reframe) — `check_position_stops` Phase 2 itera con `try/except: continue`. Atomicidad **per-close** está resuelta; **integridad observacional per-tick** (cuando N posiciones cruzan SL y K<N cierran) NO se restauró. F-05 aplica per-close en Phase 2, no per-tick. Esta deuda **predates** este PR.
- **#454** — Capital lock contention bajo `BEGIN IMMEDIATE` aborta el close. Sin retry/escalación. El trade-off IN-TX (#450) lo nombró parcialmente; este issue lo dimensiona operacionalmente.
- **#455** — Los 4 post-commit side-effects (`__exit__`) tienen criticidad heterogénea pero política uniforme (`log.warning`). Sin métrica por categoría, sin alerta. notify-fail = user no sabe del cierre.
- **#456** — `read_only_connection()` no enforza read-only en runtime. Mismo tipo de ambigüedad que este PR cierra, en escala menor.

## Deuda MEDIUM trackeada

- **#457** — `mode` flag USER/SYSTEM sin trigger condition para subclass refactor (Voronov AMBER F1).
- **#458** — Test de atomicidad no cubre composición multi-campo bajo ticks concurrentes.
- **#459** — Las 4 excepciones Cat. 2 en CLAUDE.md son 4 animales distintos, no una categoría; necesitan tickets de extracción específicos (especialmente `dispatch_signal_to_users` y `save_scan`).
- **#460** — `_consumed` single-use enforcement asimétrico (`__enter__` chequea pero solo `execute` setea).
- **#461** — Re-select en write-tx no re-valida tenant_id (defense-in-depth ausente, hipotético hoy).
- **#462** — `update_positions_json` usa `transaction()` para SELECT; debería usar `read_only_connection()` tras #456.

## Lo que se sostiene de la propuesta original

El PR resuelve estructuralmente #446/#447/#448/#449 (Serrano confirmó); resuelve #450 con trade-off explícito; resuelve #451 con fixture corregido y matemáticamente correcto. La capa `operators/` está nombrada y `db/` tiene contrato único (sujeto a las 4 excepciones documentadas en CLAUDE.md §1).

> Voronov: "Lo que estás debatiendo no es si mergear. Es si dejar que el sistema sepa lo que tú ya sabes." — Esta sección es esa señalización.