### PR TITLE
feat: 'Capas de enforcement de invariantes' registry + 3 moves (qty→schema, precheck/snapshot→tipo, snapshot==row→tipo)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,13 +334,13 @@ Cuatro capas posibles, de más fuerte a más débil:
 | **Test** | Invariant test que falla si la violación ocurre | pytest en CI |
 | **Convención** | Comentario en código / sección de CLAUDE.md / revisión humana | Revisor (si recuerda mirar) |
 
-### Invariantes C2 — estado actual y movimiento de este PR
+### Invariantes C2 — estado tras este PR
 
-| Invariante de dominio | Capa actual | Capa objetivo | Issue | Razón del movimiento |
-|---|---|---|---|---|
-| `qty` siempre tiene valor numérico para positions activas | Convención (`or 0` en 2 sitios) | **Schema** (CHECK con exemption por `status='legacy_unmeasurable'` — ver Finding meta) | #467 | El default silencioso a 0 corrompe `pnl_usd=0` aplicado al capital. La fix vive en schema. |
-| `precheck_connection` y `snapshot_connection` son contratos distintos | Convención (docstrings + CLAUDE.md §4) | **Tipo** (NewType `PrecheckConn` / `SnapshotConn`) | #468 | Hoy ambas retornan `sqlite3.Connection`. mypy no detecta el mis-uso. |
-| Los campos del `PositionSnapshot` consumidos por el write-tx no cambian entre precheck y BEGIN IMMEDIATE | Convención (re-validación parcial de tenant_id + status) | **Tipo** (`OwnershipValidatedSnapshot` con factory privada + re-validación de TODOS los campos mutables) | #469 + F6 | El re-validate actual solo cubre 2 de 6 campos. Schema no enforza inmutabilidad. |
+| Invariante de dominio | Capa enforced | Mecanismo | Issue cerrado |
+|---|---|---|---|
+| `qty` siempre tiene valor numérico para positions activas (o `status='legacy_unmeasurable'`) | **Schema** | `CHECK (qty IS NOT NULL OR status='legacy_unmeasurable')` en `positions` (vía `_migrate_qty_not_null` en `db/schema.py`) | #467 |
+| `precheck_connection` y `snapshot_connection` son contratos distintos | **Tipo** | `NewType("PrecheckConn", sqlite3.Connection)` y `NewType("SnapshotConn", sqlite3.Connection)` en `db/transaction.py` — mypy detecta mis-uso | #468 |
+| Los campos del snapshot consumidos por el write-tx no cambian entre precheck y BEGIN IMMEDIATE | **Tipo + runtime check** | `OwnershipValidatedSnapshot` (factory privada en `operators/precheck.py`) + field-by-field re-validation en `PositionClosure.execute()` cubre los 6 campos del `PositionSnapshot` | #469 + F6 |
 
 ### Patrón nombrado: "invariantes de dominio sin contraparte estructural"
 
@@ -357,6 +357,12 @@ Implicación: hasta que `create_position` exija lo que `close_position` asume, t
 ### Documented status: `legacy_unmeasurable`
 
 Status especial usado por `_migrate_qty_not_null` (#467) para reconocer 670 rows históricas cuya `qty` nunca fue medida y no es derivable. El schema CHECK constraint exempta este status: `CHECK (qty IS NOT NULL OR status='legacy_unmeasurable')`. Convierte 670 mentiras silenciosas en 670 reconocimientos explícitos.
+
+### Known scope gap (Voronov 2026-05-26)
+
+> El sistema enforza invariantes en el momento de cruce (precheck→snapshot, snapshot→write) pero **no enforza invariantes en el momento de origen** (creación de la position). Toda la cadena de defensa de C2 asume que la position fue creada correctamente. Si en `position_open` se crea una row con `tenant_id` mal asignado, los 3 mecanismos de C2 la sostendrán correctamente *con el tenant equivocado*. C2 endurece el ciclo de vida; no endurece el nacimiento.
+
+Esta deuda NO está cubierta por este PR. Tratamiento futuro: auditar `db_create_position` y los endpoints que invocan creación (`POST /positions`, paths del scanner) bajo la misma lente del registro de capas.
 
 ## Known Limitations
 - `watchdog.py` uses Windows-specific commands (`tasklist`, `taskkill`, `wmic`, `netstat`) and won't run on Linux/Mac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,43 @@ New business operators emerge from evidence (caller composes >1 helper + side-ef
 
 `F-05` (trading invariant "every mutation derived from one tick of price decision belongs to one serializable transaction") **applies per-close** in Phase 2 of `check_position_stops`, **not per-tick**. The Phase 2 loop wraps each `PositionClosure(SYSTEM)` in `try/except: continue`, so partial-failure observability across N positions in the same tick is currently absent. See #453 for the issue tracking the integrity-observational debt (Voronov reframe of Serrano F-NEW Plano 1, 2026-05-25).
 
+## Capas de enforcement de invariantes (Voronov 2026-05-26)
+
+El dominio del repo afirma invariantes que el almacenamiento no garantiza por defecto. Cada vez que esa asimetría no se nombra, el código paga la diferencia en **membranas silenciosas**: `or 0`, "código de revisor", re-validaciones parciales. Este registro lista las invariantes de dominio que tocan el cluster C2 (#467/#468/#469) y la capa que las enforza.
+
+Cuatro capas posibles, de más fuerte a más débil:
+
+| Capa | Cómo enforza | Quién detecta violación |
+|---|---|---|
+| **Schema** | DDL constraint (CHECK, NOT NULL, FK, UNIQUE) | El motor SQLite, en write |
+| **Tipo** | Python typing (NewType, frozen dataclass, factory privada) | mypy en CI / `__post_init__` en runtime |
+| **Test** | Invariant test que falla si la violación ocurre | pytest en CI |
+| **Convención** | Comentario en código / sección de CLAUDE.md / revisión humana | Revisor (si recuerda mirar) |
+
+### Invariantes C2 — estado actual y movimiento de este PR
+
+| Invariante de dominio | Capa actual | Capa objetivo | Issue | Razón del movimiento |
+|---|---|---|---|---|
+| `qty` siempre tiene valor numérico para positions activas | Convención (`or 0` en 2 sitios) | **Schema** (CHECK con exemption por `status='legacy_unmeasurable'` — ver Finding meta) | #467 | El default silencioso a 0 corrompe `pnl_usd=0` aplicado al capital. La fix vive en schema. |
+| `precheck_connection` y `snapshot_connection` son contratos distintos | Convención (docstrings + CLAUDE.md §4) | **Tipo** (NewType `PrecheckConn` / `SnapshotConn`) | #468 | Hoy ambas retornan `sqlite3.Connection`. mypy no detecta el mis-uso. |
+| Los campos del `PositionSnapshot` consumidos por el write-tx no cambian entre precheck y BEGIN IMMEDIATE | Convención (re-validación parcial de tenant_id + status) | **Tipo** (`OwnershipValidatedSnapshot` con factory privada + re-validación de TODOS los campos mutables) | #469 + F6 | El re-validate actual solo cubre 2 de 6 campos. Schema no enforza inmutabilidad. |
+
+### Patrón nombrado: "invariantes de dominio sin contraparte estructural"
+
+Cada futuro issue de la familia `or X`, "código de revisor", "trust-and-document" debería compararse contra este registro. Si la invariante pertenece a una capa más fuerte que `convención`, moverla es la fix correcta.
+
+### Finding meta — asimetría contractual create vs close (Voronov post-medición 2026-05-26)
+
+Medición de `signals.db` reveló 670 de 2018 positions con `qty IS NULL` (33%), **ZERO backfillables** desde `size_usd/entry_price`. La asunción del plan original era que `qty NULL` era deuda de cierre (size_usd existió, se perdió). La realidad: deuda de nacimiento (size_usd nunca prometido).
+
+> **El sistema tiene un `close()` que asume invariantes que `open()` nunca prometió.** `qty NULL` no es el problema — es el síntoma. La membrana de cierre asume un contrato que la membrana de apertura nunca firmó.
+
+Implicación: hasta que `create_position` exija lo que `close_position` asume, todo CHECK en la salida es teatro defensivo. Issue separado: asimetría contractual create vs close (open issue antes del PR merge — Task 13.5 del plan 2026-05-26-467-468-469).
+
+### Documented status: `legacy_unmeasurable`
+
+Status especial usado por `_migrate_qty_not_null` (#467) para reconocer 670 rows históricas cuya `qty` nunca fue medida y no es derivable. El schema CHECK constraint exempta este status: `CHECK (qty IS NOT NULL OR status='legacy_unmeasurable')`. Convierte 670 mentiras silenciosas en 670 reconocimientos explícitos.
+
 ## Known Limitations
 - `watchdog.py` uses Windows-specific commands (`tasklist`, `taskkill`, `wmic`, `netstat`) and won't run on Linux/Mac
 - The webhook process itself is not supervised by the watchdog (only btc_api.py is)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,9 +330,18 @@ Cuatro capas posibles, de más fuerte a más débil:
 | Capa | Cómo enforza | Quién detecta violación |
 |---|---|---|
 | **Schema** | DDL constraint (CHECK, NOT NULL, FK, UNIQUE) | El motor SQLite, en write |
-| **Tipo** | Python typing (NewType, frozen dataclass, factory privada) | mypy en CI / `__post_init__` en runtime |
+| **Tipo** | Anotación + **órgano de rechazo en runtime** (`__post_init__` con `isinstance`, factory privada con sentinel, NewType propagado al consumer). En un lenguaje sin type-checker en CI, la anotación sola es convención disfrazada de sintaxis. La rung 'tipo' sólo es real cuando el constructor o el factory rechaza la entrada equivocada con `TypeError`. | mypy estricto en CI **o** runtime check explícito (`__post_init__` / factory sentinel) |
 | **Test** | Invariant test que falla si la violación ocurre | pytest en CI |
 | **Convención** | Comentario en código / sección de CLAUDE.md / revisión humana | Revisor (si recuerda mirar) |
+
+### Regla de coherencia (Voronov post-Serrano 2026-05-26)
+
+> "La fuerza de una garantía está acotada por encima por el órgano más débil que puede rechazarla en la frontera que la garantía dice proteger."
+
+Tres consecuencias para esta codebase:
+1. Las anotaciones forward-ref en dataclasses no son enforcement. Si una clase declara un field con un tipo específico, debe tener `__post_init__` que rechace lo contrario, o el field debe construirse vía factory privada con sentinel. Sin órgano de rechazo, la anotación pertenece a la rung 'convención', no a 'tipo'.
+2. `NewType` solo cuenta como 'tipo' si el consumer también está anotado y el camino completo es estructuralmente coherente. Una `PrecheckConn` definida y luego pasada a una función con anotación `sqlite3.Connection` regresa a 'convención'.
+3. Cerrar un issue (`#NNN`) contra una eliminación parcial de la patología deja la enfermedad en los sitios no tocados. Closure requiere que el predicado del issue sea verdad en todos los call sites, no sólo los listados en el plan.
 
 ### Invariantes C2 — estado tras este PR
 

--- a/api/positions.py
+++ b/api/positions.py
@@ -54,7 +54,7 @@ def _validated_time_limit_hours(value, symbol: str) -> float | None:
 def _write_position_event_log(pos: dict, reason: str, exit_price: float):
     try:
         _ensure_dirs()
-        qty = pos.get("qty") or 0
+        qty = pos["qty"]
         pnl_usd, pnl_pct = _calc_pnl(pos["direction"], pos["entry_price"], exit_price, qty)
         emoji = _EVENT_LOG_LABELS.get(reason, "STOP LOSS")
         ts_now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")

--- a/db/schema.py
+++ b/db/schema.py
@@ -315,6 +315,15 @@ def init_db() -> None:
     with transaction() as con_hist:
         _migrate_agent_history(con_hist)
 
+    # qty NOT NULL enforcement migration — #467 (Voronov amended).
+    # MUST run LAST: depends on positions having atr_entry/be_mult/tenant_id
+    # columns from earlier migrations. Backfills qty where possible, quarantines
+    # the residue as status='legacy_unmeasurable', recreates positions with
+    # CHECK (qty IS NOT NULL OR status='legacy_unmeasurable').
+    # See `Capas de enforcement de invariantes` in CLAUDE.md.
+    with transaction() as con_qty:
+        _migrate_qty_not_null(con_qty)
+
 
 # Per-user tables that need a tenant_id column (Epic B B.1).
 # kill_switch_* tables intentionally NOT in this list — kept global for B.1
@@ -676,3 +685,109 @@ def backfill_tenant(
         )
         affected[table] = cursor.rowcount
     return affected
+
+
+def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
+    """Move 'qty != NULL' from convención to schema (#467, Voronov amended).
+
+    Per Voronov post-Task-1 measurement: original Path D (abort on
+    unbackfillable) was unrealizable in production (670 unbackfillable rows
+    of 2018). Revised policy (C) — quarantine:
+
+    1. Backfill: for rows where qty IS NULL AND size_usd IS NOT NULL AND
+       entry_price > 0, set qty = size_usd / entry_price.
+    2. For remaining NULL rows (legacy bug residue + test fixture debris):
+       UPDATE status = 'legacy_unmeasurable'. Keep qty NULL. Status admits
+       the absence; the schema CHECK below exempts this status.
+    3. Recreate the positions table with:
+       CHECK (qty IS NOT NULL OR status = 'legacy_unmeasurable')
+
+    Idempotent: detects existing CHECK constraint and skips.
+    """
+    # Idempotency check: SQLite stores CREATE TABLE in sqlite_master.
+    schema_row = con.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='positions'"
+    ).fetchone()
+    if schema_row and schema_row[0] and "legacy_unmeasurable" in schema_row[0]:
+        log.info(
+            "_migrate_qty_not_null: positions table already has the quarantine CHECK; skipping."
+        )
+        return
+
+    # 1. Backfill aggressively.
+    con.execute(
+        """UPDATE positions
+           SET qty = size_usd / entry_price
+           WHERE qty IS NULL
+             AND size_usd IS NOT NULL
+             AND entry_price IS NOT NULL
+             AND entry_price > 0"""
+    )
+    backfilled = con.execute("SELECT changes()").fetchone()[0]
+    log.info("_migrate_qty_not_null: backfilled qty for %d rows.", backfilled)
+
+    # 2. Quarantine remaining NULL rows.
+    con.execute(
+        """UPDATE positions
+           SET status = 'legacy_unmeasurable'
+           WHERE qty IS NULL
+             AND status != 'legacy_unmeasurable'"""
+    )
+    quarantined = con.execute("SELECT changes()").fetchone()[0]
+    log.info(
+        "_migrate_qty_not_null: quarantined %d rows as status='legacy_unmeasurable'.",
+        quarantined,
+    )
+
+    # 3. Recreate positions table with CHECK constraint.
+    # SQLite pattern: CREATE TABLE positions_new (...); INSERT ...; DROP; RENAME.
+    # NOTE: use individual con.execute() — executescript() issues an implicit
+    # COMMIT that would close the surrounding transaction(). DDL inside
+    # transaction() is safe in SQLite (DDL participates in the active tx).
+    log.info(
+        "_migrate_qty_not_null: recreating positions table with CHECK constraint "
+        "(qty IS NOT NULL OR status = 'legacy_unmeasurable')."
+    )
+    con.execute(
+        """
+        CREATE TABLE positions_new (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            scan_id     INTEGER REFERENCES scans(id),
+            symbol      TEXT    NOT NULL,
+            direction   TEXT    NOT NULL DEFAULT 'LONG',
+            status      TEXT    NOT NULL DEFAULT 'open',
+            entry_price REAL    NOT NULL,
+            entry_ts    TEXT    NOT NULL,
+            sl_price    REAL,
+            tp_price    REAL,
+            size_usd    REAL,
+            qty         REAL,
+            exit_price  REAL,
+            exit_ts     TEXT,
+            exit_reason TEXT,
+            pnl_usd     REAL,
+            pnl_pct     REAL,
+            notes       TEXT,
+            atr_entry   REAL,
+            be_mult     REAL,
+            tenant_id   INTEGER,
+            CHECK (qty IS NOT NULL OR status = 'legacy_unmeasurable')
+        )
+        """
+    )
+    con.execute(
+        """
+        INSERT INTO positions_new SELECT
+            id, scan_id, symbol, direction, status, entry_price, entry_ts,
+            sl_price, tp_price, size_usd, qty, exit_price, exit_ts, exit_reason,
+            pnl_usd, pnl_pct, notes, atr_entry, be_mult, tenant_id
+        FROM positions
+        """
+    )
+    con.execute("DROP TABLE positions")
+    con.execute("ALTER TABLE positions_new RENAME TO positions")
+    con.execute("CREATE INDEX idx_positions_tenant ON positions(tenant_id)")
+    log.info(
+        "_migrate_qty_not_null: migration complete. "
+        "positions enforces qty IS NOT NULL OR status='legacy_unmeasurable'."
+    )

--- a/db/schema.py
+++ b/db/schema.py
@@ -714,25 +714,56 @@ def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
         )
         return
 
-    # 1. Backfill aggressively.
-    con.execute(
-        """UPDATE positions
-           SET qty = size_usd / entry_price
-           WHERE qty IS NULL
-             AND size_usd IS NOT NULL
-             AND entry_price IS NOT NULL
-             AND entry_price > 0"""
-    )
-    backfilled = con.execute("SELECT changes()").fetchone()[0]
-    log.info("_migrate_qty_not_null: backfilled qty for %d rows.", backfilled)
+    # Column-aware migration: an old/stub positions table may not yet have
+    # size_usd or qty columns (the earlier _migrate_* helpers are tolerant
+    # of missing columns; this one must be too). Query the live schema and
+    # gate each step on which columns actually exist.
+    existing_cols = {
+        row[1] for row in con.execute("PRAGMA table_info(positions)").fetchall()
+    }
+    has_size_usd = "size_usd" in existing_cols
+    has_qty = "qty" in existing_cols
+    has_entry_price = "entry_price" in existing_cols
 
-    # 2. Quarantine remaining NULL rows.
-    con.execute(
-        """UPDATE positions
-           SET status = 'legacy_unmeasurable'
-           WHERE qty IS NULL
-             AND status != 'legacy_unmeasurable'"""
-    )
+    # 1. Backfill aggressively — only when both source and target columns exist.
+    if has_qty and has_size_usd and has_entry_price:
+        con.execute(
+            """UPDATE positions
+               SET qty = size_usd / entry_price
+               WHERE qty IS NULL
+                 AND size_usd IS NOT NULL
+                 AND entry_price IS NOT NULL
+                 AND entry_price > 0"""
+        )
+        backfilled = con.execute("SELECT changes()").fetchone()[0]
+        log.info("_migrate_qty_not_null: backfilled qty for %d rows.", backfilled)
+    else:
+        log.info(
+            "_migrate_qty_not_null: skipping backfill — columns not yet present "
+            "(has_qty=%s, has_size_usd=%s, has_entry_price=%s).",
+            has_qty,
+            has_size_usd,
+            has_entry_price,
+        )
+
+    # 2. Quarantine rows that will fail the CHECK constraint after recreation.
+    if has_qty:
+        # Standard path: only rows whose qty is actually NULL need quarantine.
+        con.execute(
+            """UPDATE positions
+               SET status = 'legacy_unmeasurable'
+               WHERE qty IS NULL
+                 AND status != 'legacy_unmeasurable'"""
+        )
+    else:
+        # No qty column at all — after recreation every existing row will land
+        # with qty=NULL in the new schema, so all of them must be quarantined
+        # up-front or the CHECK constraint would reject the INSERT.
+        con.execute(
+            """UPDATE positions
+               SET status = 'legacy_unmeasurable'
+               WHERE status != 'legacy_unmeasurable'"""
+        )
     quarantined = con.execute("SELECT changes()").fetchone()[0]
     log.info(
         "_migrate_qty_not_null: quarantined %d rows as status='legacy_unmeasurable'.",
@@ -775,15 +806,23 @@ def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
         )
         """
     )
-    con.execute(
-        """
-        INSERT INTO positions_new SELECT
-            id, scan_id, symbol, direction, status, entry_price, entry_ts,
-            sl_price, tp_price, size_usd, qty, exit_price, exit_ts, exit_reason,
-            pnl_usd, pnl_pct, notes, atr_entry, be_mult, tenant_id
-        FROM positions
-        """
+    # Build the SELECT dynamically: missing source columns land as NULL in the
+    # new table. Order MUST mirror TARGET_COLS so positional INSERT lines up.
+    TARGET_COLS = [
+        "id", "scan_id", "symbol", "direction", "status", "entry_price",
+        "entry_ts", "sl_price", "tp_price", "size_usd", "qty",
+        "exit_price", "exit_ts", "exit_reason", "pnl_usd", "pnl_pct",
+        "notes", "atr_entry", "be_mult", "tenant_id",
+    ]
+    select_expressions = [
+        col if col in existing_cols else "NULL"
+        for col in TARGET_COLS
+    ]
+    insert_sql = (
+        f"INSERT INTO positions_new ({', '.join(TARGET_COLS)}) "
+        f"SELECT {', '.join(select_expressions)} FROM positions"
     )
+    con.execute(insert_sql)
     con.execute("DROP TABLE positions")
     con.execute("ALTER TABLE positions_new RENAME TO positions")
     con.execute("CREATE INDEX idx_positions_tenant ON positions(tenant_id)")

--- a/db/transaction.py
+++ b/db/transaction.py
@@ -5,13 +5,32 @@ BEGIN / COMMIT / ROLLBACK and the connection lifecycle. Callers never
 touch commit/rollback/close.
 """
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Iterator, NewType
 import logging
 import sqlite3
 
 from db.connection import _open_configured_connection
 
 log = logging.getLogger("db.transaction")
+
+
+# Move 'precheck != snapshot' from convención to tipo (#468, Voronov 2026-05-26).
+#
+# PrecheckConn is a connection authorized for reads that will FEED a follow-up
+# write transaction. The caller is contractually obligated to extract any field
+# the write-tx will need into an immutable snapshot (see
+# operators.precheck.OwnershipValidatedSnapshot) BEFORE the with block exits.
+#
+# SnapshotConn is a connection authorized for TERMINAL reads — results
+# serialize to an output (JSON file, HTTP response, log) and are NOT used to
+# drive a subsequent mutation. No follow-up re-validation obligation.
+#
+# Both NewTypes wrap sqlite3.Connection. mypy treats them as incompatible;
+# at runtime, both are no-ops (the wrapped object is the original Connection).
+# The mechanism is identical (PRAGMA query_only=1); the contract is in the
+# type, not in the docstring.
+PrecheckConn = NewType("PrecheckConn", sqlite3.Connection)
+SnapshotConn = NewType("SnapshotConn", sqlite3.Connection)
 
 
 @contextmanager
@@ -57,7 +76,7 @@ def transaction() -> Iterator[sqlite3.Connection]:
 
 
 @contextmanager
-def precheck_connection() -> Iterator[sqlite3.Connection]:
+def precheck_connection() -> Iterator[PrecheckConn]:
     """Open a configured connection for a PRECHECK READ that will feed a
     follow-up write transaction.
 
@@ -84,13 +103,13 @@ def precheck_connection() -> Iterator[sqlite3.Connection]:
     con = _open_configured_connection()
     try:
         con.execute("PRAGMA query_only = 1")
-        yield con
+        yield PrecheckConn(con)
     finally:
         con.close()
 
 
 @contextmanager
-def snapshot_connection() -> Iterator[sqlite3.Connection]:
+def snapshot_connection() -> Iterator[SnapshotConn]:
     """Open a configured connection for a TERMINAL READ (no follow-up write).
 
     Use for snapshot generation, dashboard queries, audit reads — operations
@@ -108,6 +127,6 @@ def snapshot_connection() -> Iterator[sqlite3.Connection]:
     con = _open_configured_connection()
     try:
         con.execute("PRAGMA query_only = 1")
-        yield con
+        yield SnapshotConn(con)
     finally:
         con.close()

--- a/docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md
+++ b/docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md
@@ -1,0 +1,1592 @@
+# Enforcement Layers Registry + Three Layer Moves (qty→schema, precheck/snapshot→tipo, snapshot==row→tipo)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close issues #467, #468, #469 by naming the patología they share (invariantes de dominio sin contraparte estructural) and moving the three invariants from convención to either schema or tipo. The plan begins with a written registry in CLAUDE.md ("Capas de enforcement de invariantes") and then executes three movements within that registry.
+
+**Architecture:** Per Voronov's meta-reframe (2026-05-26): the three issues are symptoms of one disease — the system confuses what the domain model promises with what storage guarantees. The code pays the difference in silent translation membranes (`or 0`, "código de revisor", partial re-validations). The plan first registers the four enforcement layers (schema / tipo / test / convención) and then moves three specific invariants from `convención` to the layer that actually enforces them: (1) `qty != NULL` → schema (CHECK constraint via backfill + table recreation); (2) `precheck != snapshot` → tipo (NewType); (3) `snapshot fields == row fields in write-tx` → tipo (OwnershipValidatedSnapshot factory + re-validate ALL mutable fields per F6).
+
+**Tech Stack:** Python 3.12, `sqlite3` stdlib, `dataclasses`, `typing.NewType`, `pytest`.
+
+---
+
+## Context (read before starting)
+
+PR #466 separated semantic from mechanical invariants of `read_only_connection`. C2 is the bill for that separation — it surfaces what the semantic layer asserts that the mechanical layer never promised. Voronov:
+
+> Los tres issues no son deuda de #466. Son la primera generación de un patrón donde el dominio afirma más de lo que el almacenamiento garantiza, y el código paga la diferencia en membranas silenciosas — `or 0`, comentarios de revisor, re-validaciones parciales. Mientras esa asimetría no esté nombrada, cada issue futuro de esta familia se debatirá como si fuera nuevo.
+>
+> No es un problema de implementación. Es un problema de **registro**.
+
+The plan executes Voronov's 4-step structure:
+
+1. Register the enforcement layers (CLAUDE.md section).
+2. Move `qty != NULL` from convención to schema.
+3. Move `precheck != snapshot` from convención to tipo.
+4. Move `snapshot fields == row fields in write-tx` from convención to tipo.
+
+Locked decisions per Voronov:
+
+- **#467: path D first (backfill + CONSTRAINT), then A trivially**. The structural commitment doesn't require measurement of production NULL count; the commitment IS the measurement. If backfill fails for any row, migration aborts and the operator must intervene before merge.
+- **#468: path B (NewType)** with explicit semantic distinction in module docstring. NewType is runtime-trivial but compile-time enforced via mypy.
+- **#469 + F6: path C + E together**. `OwnershipValidatedSnapshot` whose only factory is `_run_precheck`; `execute()` re-validates ALL mutable snapshot fields (not just `tenant_id` and `status` — also `entry_price`, `qty`, `direction`, `symbol`).
+
+The deeper debt Voronov flagged ("ownership validated at lifecycle crossings, not at birth"): NOT addressed in this plan. Flagged as known scope gap in CLAUDE.md update at Task 13.
+
+---
+
+## Scope Check
+
+One cohesive subsystem (DB invariants + their enforcement layer registry + the 3 specific moves). Already a single plan. The three moves are independent of each other (no order dependency between qty/precheck-snapshot/ownership-validated) but share the meta-registry as precondition.
+
+---
+
+## File Structure
+
+### New files
+
+- `operators/precheck.py` (modified) — `OwnershipValidatedSnapshot` class with private factory pattern.
+- `tests/operators/test_ownership_validated_snapshot.py` — type-level + runtime tests for the factory pattern.
+
+### Modified files
+
+- `CLAUDE.md`:
+  - **Pre-work (Task 2):** new section "Capas de enforcement de invariantes" with 4-column registry (schema / tipo / test / convención) listing the C2 invariants.
+  - **Post-moves (Task 13):** update the registry to reflect that the 3 invariants have moved from `convención` to their target layer; add "Known scope gap: invariantes en el momento de creación" pointing to Voronov's deeper deuda.
+
+- `db/schema.py`:
+  - New helper `_migrate_qty_not_null()` — backfill `qty = size_usd / entry_price` where possible; if any row remains NULL after backfill, raise with explicit log naming rows; recreate `positions` table with `CHECK (qty IS NOT NULL)` via the standard SQLite ALTER-by-rename pattern.
+
+- `db/transaction.py`:
+  - Add `from typing import NewType`.
+  - `PrecheckConn = NewType("PrecheckConn", sqlite3.Connection)`.
+  - `SnapshotConn = NewType("SnapshotConn", sqlite3.Connection)`.
+  - `precheck_connection()` return type annotation changes to `Iterator[PrecheckConn]` and yields `PrecheckConn(con)`.
+  - `snapshot_connection()` same with `SnapshotConn`.
+  - Module docstring gains explicit semantic distinction paragraph per Voronov.
+
+- `operators/precheck.py`:
+  - Add `OwnershipValidatedSnapshot` (frozen dataclass wrapping `PositionSnapshot` + an internal sentinel for factory enforcement).
+  - Update `PrecheckOkToProceed.snapshot` field type to `OwnershipValidatedSnapshot`.
+
+- `operators/position_closure.py`:
+  - `_run_precheck()` constructs `OwnershipValidatedSnapshot` via the factory sentinel; this is the ONLY location that may construct it.
+  - `execute()` consumes `OwnershipValidatedSnapshot.inner` (the `PositionSnapshot`) and re-validates ALL of its mutable fields against the fresh re-SELECT (not only `tenant_id` and `status`).
+  - Remove `qty = snapshot.qty or 0` membrane (no longer needed once schema enforces NOT NULL).
+
+- `api/positions.py`:
+  - Remove `qty = pos.get("qty") or 0` membrane in `_write_position_event_log`.
+
+- `tests/operators/test_position_closure.py`:
+  - Update existing invariants to construct `PositionClosure` against the new types (most should pass unchanged; the snapshot-related ones may need minor adjustment).
+  - Add invariant #14: `test_cross_mutation_race_entry_price_rejects_close` — entry_price changes between precheck and write-tx → operator must detect via snapshot field re-validation and return `not_found` or `rejected_unexpected_state`.
+
+- `tests/operators/test_precheck.py`:
+  - Add tests for `OwnershipValidatedSnapshot` factory: cannot be constructed without the factory sentinel; the sentinel is module-private.
+
+---
+
+## Locked API Design
+
+### `db/transaction.py` — NewType additions
+
+```python
+from typing import Iterator, NewType
+import sqlite3
+
+# PrecheckConn: a connection authorized for reads that will FEED a follow-up
+# write transaction. The caller is contractually obligated to extract any
+# field the write-tx will need into an immutable snapshot (see
+# operators.precheck.OwnershipValidatedSnapshot) BEFORE the with block exits.
+PrecheckConn = NewType("PrecheckConn", sqlite3.Connection)
+
+# SnapshotConn: a connection authorized for TERMINAL reads — results serialize
+# to an output (JSON, HTTP response, log) and are NOT used to drive a write-tx.
+# No follow-up re-validation obligation.
+SnapshotConn = NewType("SnapshotConn", sqlite3.Connection)
+
+
+@contextmanager
+def precheck_connection() -> Iterator[PrecheckConn]:
+    """[existing docstring updated to declare the type contract]"""
+    con = _open_configured_connection()
+    try:
+        con.execute("PRAGMA query_only = 1")
+        yield PrecheckConn(con)
+    finally:
+        con.close()
+
+
+@contextmanager
+def snapshot_connection() -> Iterator[SnapshotConn]:
+    """[existing docstring updated to declare the type contract]"""
+    con = _open_configured_connection()
+    try:
+        con.execute("PRAGMA query_only = 1")
+        yield SnapshotConn(con)
+    finally:
+        con.close()
+```
+
+### `operators/precheck.py` — `OwnershipValidatedSnapshot`
+
+```python
+# Module-private sentinel: external callers cannot construct
+# OwnershipValidatedSnapshot directly. The factory check is by value comparison
+# against this sentinel, which is not exported from the module.
+_VALIDATION_SENTINEL = object()
+
+
+@dataclass(frozen=True)
+class OwnershipValidatedSnapshot:
+    """A PositionSnapshot that has been validated for ownership by a precheck
+    (USER mode: caller_tenant_id matched snapshot.tenant_id; SYSTEM mode:
+    accepted unconditionally).
+
+    Construction requires the module-private _VALIDATION_SENTINEL. This means
+    only `operators.position_closure.PositionClosure._run_precheck()` (which
+    has access to the sentinel via a private import) can build instances.
+    A future write-tx that consumes this type is guaranteed (by construction)
+    that ownership was checked. The write-tx must STILL re-validate the
+    snapshot's mutable fields against a fresh re-SELECT (this is enforced
+    by PositionClosure.execute()'s explicit comparisons).
+
+    Closes #469 + F6: the validation guarantee lives in the type, not in a
+    docstring.
+    """
+    inner: PositionSnapshot
+    _sentinel: object  # must equal _VALIDATION_SENTINEL at construction
+
+    def __post_init__(self):
+        if self._sentinel is not _VALIDATION_SENTINEL:
+            raise TypeError(
+                "OwnershipValidatedSnapshot can only be constructed via "
+                "operators.position_closure.PositionClosure._run_precheck "
+                "(which holds the module-private validation sentinel)."
+            )
+
+
+def _build_validated_snapshot(snapshot: PositionSnapshot) -> OwnershipValidatedSnapshot:
+    """Internal factory used by PositionClosure._run_precheck.
+    NOT exported from this module's public surface."""
+    return OwnershipValidatedSnapshot(inner=snapshot, _sentinel=_VALIDATION_SENTINEL)
+```
+
+`PrecheckOkToProceed` updates to use the new type:
+
+```python
+@dataclass(frozen=True)
+class PrecheckOkToProceed:
+    """Position passed precheck. snapshot is OwnershipValidatedSnapshot —
+    construction-time guarantee that ownership was checked."""
+    snapshot: OwnershipValidatedSnapshot
+```
+
+### `operators/position_closure.py` — write-tx re-validates ALL mutable fields
+
+```python
+def execute(self) -> CloseOutcome:
+    # ... [unchanged: dispatch on PrecheckResult variants for NotFound /
+    #      AlreadyClosed / RejectedState] ...
+
+    # PrecheckOkToProceed: write-tx must re-validate ALL snapshot fields.
+    validated = result.snapshot           # OwnershipValidatedSnapshot
+    snap = validated.inner                # the wrapped PositionSnapshot
+
+    with _tx_module.transaction() as con:
+        row = db_get_position_by_id(con, self._pos_id)
+        if row is None:
+            return CloseOutcome(status="not_found", position=None,
+                                pnl_usd=None, pnl_pct=None)
+
+        # #469 + F6: re-validate ALL mutable fields, not only tenant_id+status.
+        # Per CLAUDE.md "Capas de enforcement", the schema does NOT enforce
+        # immutability of entry_price/qty/direction/symbol — so the write-tx
+        # MUST. If any field has drifted between precheck and BEGIN IMMEDIATE,
+        # the snapshot is stale; collapse to NOT_FOUND (IDOR-safe).
+        snapshot_fields = (
+            ("tenant_id", snap.tenant_id),
+            ("status_must_still_be_open", "open"),  # special: row.status must be "open"
+            ("entry_price", snap.entry_price),
+            ("qty", snap.qty),
+            ("direction", snap.direction),
+            ("symbol", snap.symbol),
+        )
+        # Handle status separately because its expected value is the literal
+        # "open" (not a snapshot field), and the not-open paths have distinct
+        # outcomes (closed → already_closed; other → rejected_unexpected_state).
+        if row["status"] == "closed":
+            race_snap = PositionSnapshot(...)  # build from row, as in #466
+            return CloseOutcome(status="already_closed",
+                                position=self._snapshot_to_dict(race_snap),
+                                pnl_usd=None, pnl_pct=None)
+        if row["status"] != "open":
+            race_snap = PositionSnapshot(...)  # build from row
+            return CloseOutcome(status="rejected_unexpected_state",
+                                position=self._snapshot_to_dict(race_snap),
+                                pnl_usd=None, pnl_pct=None)
+
+        # Now compare every other mutable field.
+        for field_name, snapshot_value in snapshot_fields:
+            if field_name == "status_must_still_be_open":
+                continue  # handled above
+            row_value = row[field_name]
+            if row_value != snapshot_value:
+                # Some field changed between precheck and write-tx.
+                # Collapse to NOT_FOUND (IDOR-safe — same shape as
+                # ownership-mismatch).
+                return CloseOutcome(status="not_found", position=None,
+                                    pnl_usd=None, pnl_pct=None)
+
+        # All snapshot fields confirmed. Snapshot is trusted; proceed.
+        # qty no longer needs `or 0` — schema enforces NOT NULL (Task 4).
+        pnl_usd, pnl_pct = _calc_pnl(
+            snap.direction, snap.entry_price, self._exit_price, snap.qty,
+        )
+        # ... [rest unchanged: db_close_position_sql, apply_pnl_to_capital] ...
+```
+
+---
+
+## Tasks
+
+### Task 1: Verify branch + baseline + measure qty NULL population
+
+**Files:** none modified.
+
+- [ ] **Step 1: Confirm branch and HEAD**
+
+Run: `git rev-parse --abbrev-ref HEAD && git rev-parse HEAD`
+Expected: `feat/enforcement-layers-registry-467-468-469` and a commit at or descending from `0ab40b4f`.
+
+- [ ] **Step 2: Confirm clean working tree**
+
+Run: `git status --short`
+Expected: empty.
+
+- [ ] **Step 3: Baseline test count**
+
+Run: `pytest --collect-only -q 2>&1 | tail -3`
+Expected: ~2530 tests collected. Note exact number.
+
+- [ ] **Step 4: Measure qty NULL population (for Task 4 backfill planning)**
+
+This step does NOT decide policy (Voronov's "compromiso, no medición" applies). It informs the backfill SQL's expected scope.
+
+If a production DB is accessible locally:
+```bash
+sqlite3 signals.db "SELECT COUNT(*) AS total, \
+  SUM(CASE WHEN qty IS NULL THEN 1 ELSE 0 END) AS qty_null, \
+  SUM(CASE WHEN qty IS NULL AND size_usd IS NOT NULL AND entry_price > 0 THEN 1 ELSE 0 END) AS backfillable \
+  FROM positions;"
+```
+
+If not, document the query for later execution and proceed. The migration in Task 4 backfills aggressively and aborts if any row remains NULL — so the policy holds either way.
+
+---
+
+### Task 2: Write "Capas de enforcement de invariantes" registry in CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+Per Voronov's pre-condition: the meta-registry MUST be written before the three moves. The registry lists each invariant C2 touches with its current enforcement layer and its target layer after this plan.
+
+- [ ] **Step 1: Locate insertion point**
+
+Run: `grep -n "^## Known Limitations\|^### Known scope gap" CLAUDE.md`
+
+Insert the new section AFTER the "Database access" §4b and BEFORE "Known scope gap" or "Known Limitations" (whichever comes first).
+
+- [ ] **Step 2: Append the registry section**
+
+Add to `CLAUDE.md`:
+
+```markdown
+## Capas de enforcement de invariantes (Voronov 2026-05-26)
+
+El dominio del repo afirma invariantes que el almacenamiento no garantiza por defecto. Cada vez que esa asimetría no se nombra, el código paga la diferencia en **membranas silenciosas**: `or 0`, "código de revisor", re-validaciones parciales. Este registro lista las invariantes de dominio que tocan el cluster C2 (#467/#468/#469) y la capa que las enforza.
+
+Cuatro capas posibles, de más fuerte a más débil:
+
+| Capa | Cómo enforza | Quién detecta violación |
+|---|---|---|
+| **Schema** | DDL constraint (CHECK, NOT NULL, FK, UNIQUE) | El motor SQLite, en write |
+| **Tipo** | Python typing (NewType, frozen dataclass, factory privada) | mypy en CI / `__post_init__` en runtime |
+| **Test** | Invariant test que falla si la violación ocurre | pytest en CI |
+| **Convención** | Comentario en código / sección de CLAUDE.md / revisión humana | Revisor (si recuerda mirar) |
+
+### Invariantes C2 — estado actual y movimiento de este PR
+
+| Invariante de dominio | Capa actual | Capa objetivo | Issue | Razón del movimiento |
+|---|---|---|---|---|
+| `qty` siempre tiene valor numérico para positions activas | Convención (`or 0` en 2 sitios) | **Schema** (CHECK NOT NULL via backfill + recreación de tabla) | #467 | El default silencioso a 0 corrompe `pnl_usd=0` aplicado al capital. El dominio promete numérico; el schema lo permite NULL. La fix vive en schema. |
+| `precheck_connection` y `snapshot_connection` son contratos distintos | Convención (docstrings + CLAUDE.md §4) | **Tipo** (NewType `PrecheckConn` / `SnapshotConn`) | #468 | Hoy ambas retornan `sqlite3.Connection`. mypy no detecta el mis-uso. La distinción es funcional (sin ella, #461 era un bug); por tanto merece tipo, no comentario. |
+| Los campos del `PositionSnapshot` consumidos por el write-tx no cambian entre precheck y BEGIN IMMEDIATE | Convención (re-validación parcial de tenant_id + status) | **Tipo** (`OwnershipValidatedSnapshot` con factory privada + re-validación de TODOS los campos mutables en write-tx) | #469 + F6 | El re-validate actual solo cubre 2 de 6 campos del snapshot. Schema no enforza inmutabilidad de `entry_price`, `qty`, `direction`, `symbol`. Una migración o UPDATE ad-hoc puede mutarlos y el operator usa valores stale. |
+
+### Patrón nombrado: "invariantes de dominio sin contraparte estructural"
+
+Cada futuro issue de la familia `or X`, "código de revisor", "trust-and-document" debería compararse contra este registro. Si la invariante pertenece a una capa más fuerte que `convención`, moverla es la fix correcta. Si verdaderamente pertenece a `convención` (e.g., norma estética que no afecta correctness), declararlo explícitamente con justificación.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): add 'Capas de enforcement de invariantes' registry (Voronov meta-reframe for #467 #468 #469)
+
+Names the patología the three issues share: invariantes de dominio sin
+contraparte estructural. Lists the 3 C2 invariants with current vs target
+enforcement layer. Subsequent tasks move each one from convención to
+schema (#467) or tipo (#468 #469)."
+```
+
+---
+
+### Task 3: TDD — write failing test for qty backfill migration
+
+**Files:**
+- Create: `tests/db/test_migrate_qty_not_null.py`
+
+The migration helper `_migrate_qty_not_null()` doesn't exist yet. This test pins its contract.
+
+- [ ] **Step 1: Create the test file**
+
+```python
+"""Invariant tests for db.schema._migrate_qty_not_null.
+
+Voronov path D for #467: backfill qty for legacy rows where computable
+(qty = size_usd / entry_price), then add CHECK CONSTRAINT NOT NULL via
+table recreation. Aborts loudly if any row remains NULL after backfill —
+the operator must intervene before merge.
+"""
+import sqlite3
+import pytest
+
+
+def _init_minimal_positions_table(con: sqlite3.Connection) -> None:
+    """Create the positions table without the qty NOT NULL constraint
+    (mirrors the schema as it was before this migration)."""
+    con.execute("""
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY,
+            symbol TEXT NOT NULL,
+            direction TEXT,
+            status TEXT NOT NULL DEFAULT 'open',
+            entry_price REAL,
+            entry_ts TEXT NOT NULL DEFAULT (datetime('now')),
+            size_usd REAL,
+            qty REAL,
+            sl_price REAL,
+            tp_price REAL,
+            exit_price REAL,
+            exit_ts TEXT,
+            exit_reason TEXT,
+            pnl_usd REAL,
+            pnl_pct REAL,
+            atr_entry REAL,
+            be_mult REAL,
+            tenant_id INTEGER
+        )
+    """)
+
+
+def test_backfill_qty_from_size_usd_and_entry_price(tmp_path):
+    """Rows with qty IS NULL but size_usd and entry_price set must be
+    backfilled to qty = size_usd / entry_price before the constraint is added."""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, size_usd, qty) "
+        "VALUES (1, 'BTCUSDT', 100.0, 1000.0, NULL)"
+    )
+    con.commit()
+
+    _migrate_qty_not_null(con)
+
+    row = con.execute("SELECT qty FROM positions WHERE id = 1").fetchone()
+    assert row[0] == 10.0  # 1000 / 100
+
+
+def test_migration_aborts_if_any_row_unbackfillable(tmp_path):
+    """If a row has qty IS NULL AND (size_usd IS NULL OR entry_price IS NULL
+    OR entry_price <= 0), the migration must raise with a clear message
+    naming the problematic row ids."""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    # Row 1: backfillable
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, size_usd, qty) "
+        "VALUES (1, 'BTCUSDT', 100.0, 1000.0, NULL)"
+    )
+    # Row 2: unbackfillable (entry_price NULL)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, size_usd, qty) "
+        "VALUES (2, 'ETHUSDT', NULL, 500.0, NULL)"
+    )
+    con.commit()
+
+    with pytest.raises(RuntimeError, match=r"unbackfillable.*\b2\b"):
+        _migrate_qty_not_null(con)
+
+
+def test_post_migration_insert_with_null_qty_is_rejected(tmp_path):
+    """After successful migration, attempting to INSERT a row with qty NULL
+    must raise sqlite3.IntegrityError (CHECK constraint violation)."""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, size_usd, qty) "
+        "VALUES (1, 'BTCUSDT', 100.0, 1000.0, 10.0)"  # has qty
+    )
+    con.commit()
+
+    _migrate_qty_not_null(con)
+
+    with pytest.raises(sqlite3.IntegrityError):
+        con.execute(
+            "INSERT INTO positions (id, symbol, entry_price, qty) "
+            "VALUES (99, 'XYZ', 50.0, NULL)"
+        )
+
+
+def test_idempotent_on_already_migrated_table(tmp_path):
+    """Running _migrate_qty_not_null twice must be a no-op the second time
+    (matching the pattern of other _migrate_* helpers in db/schema.py)."""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, size_usd, qty) "
+        "VALUES (1, 'BTCUSDT', 100.0, 1000.0, 10.0)"
+    )
+    con.commit()
+
+    _migrate_qty_not_null(con)
+    _migrate_qty_not_null(con)  # second run must not raise
+
+    row = con.execute("SELECT qty FROM positions WHERE id = 1").fetchone()
+    assert row[0] == 10.0
+```
+
+- [ ] **Step 2: Verify all 4 tests fail with `ImportError` or `AttributeError`**
+
+Run: `pytest tests/db/test_migrate_qty_not_null.py -v 2>&1 | tail -20`
+Expected: 4 failures, all at the import `from db.schema import _migrate_qty_not_null`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/db/test_migrate_qty_not_null.py
+git commit -m "test(db): add failing invariant tests for _migrate_qty_not_null (advances #467 path D)
+
+Backfill qty=size_usd/entry_price where possible; abort on any remaining
+NULL; post-migration INSERT with NULL qty raises IntegrityError; idempotent
+on re-run."
+```
+
+---
+
+### Task 4: Implement `_migrate_qty_not_null` in db/schema.py
+
+**Files:**
+- Modify: `db/schema.py`
+
+- [ ] **Step 1: Read the existing _migrate_* pattern**
+
+Run: `grep -n "^def _migrate" db/schema.py`
+
+Note the conventions used by `_migrate_multi_tenant_b1`, `_migrate_agent_audit`, `_migrate_agent_history` (idempotency check pattern, log style, etc.). The new helper should match.
+
+- [ ] **Step 2: Add the migration function**
+
+Append to `db/schema.py` (after the existing `_migrate_*` functions):
+
+```python
+def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
+    """Move 'qty != NULL' from convención to schema (#467).
+
+    1. Backfill: for rows where qty IS NULL AND size_usd IS NOT NULL AND
+       entry_price > 0, set qty = size_usd / entry_price.
+    2. If any row still has qty IS NULL after backfill, raise RuntimeError
+       naming the offending row ids — the operator must intervene.
+    3. Recreate the positions table with a CHECK (qty IS NOT NULL) constraint
+       (SQLite does not support ALTER TABLE ADD CONSTRAINT for CHECK).
+
+    Idempotent: detects existing CHECK constraint and skips.
+    """
+    # Idempotency check: SQLite stores the CREATE TABLE statement in sqlite_master.
+    # If the existing schema already contains "CHECK (qty IS NOT NULL)" or
+    # equivalent, this migration is a no-op.
+    schema_row = con.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='positions'"
+    ).fetchone()
+    if schema_row and schema_row[0] and "qty" in schema_row[0]:
+        if "CHECK" in schema_row[0].upper() and "QTY" in schema_row[0].upper().replace(" ", ""):
+            log.info("_migrate_qty_not_null: positions table already has qty CHECK constraint; skipping.")
+            return
+
+    # 1. Backfill aggressively.
+    con.execute(
+        """UPDATE positions
+           SET qty = size_usd / entry_price
+           WHERE qty IS NULL
+             AND size_usd IS NOT NULL
+             AND entry_price IS NOT NULL
+             AND entry_price > 0"""
+    )
+    backfilled = con.execute(
+        "SELECT changes()"
+    ).fetchone()[0]
+    log.info("_migrate_qty_not_null: backfilled qty for %d rows.", backfilled)
+
+    # 2. Check for any remaining NULL qty.
+    unbackfillable_rows = con.execute(
+        "SELECT id FROM positions WHERE qty IS NULL"
+    ).fetchall()
+    if unbackfillable_rows:
+        ids = [r[0] for r in unbackfillable_rows]
+        raise RuntimeError(
+            "_migrate_qty_not_null: cannot complete migration. "
+            f"{len(ids)} row(s) have qty IS NULL and cannot be backfilled "
+            f"from size_usd/entry_price (entry_price NULL or <= 0). "
+            f"Affected row ids: unbackfillable {ids}. "
+            "Operator must investigate and either backfill manually or "
+            "delete these rows before re-running the migration."
+        )
+
+    # 3. Recreate positions table with CHECK constraint.
+    # SQLite pattern: CREATE TABLE positions_new (...) WITH CHECK; INSERT ...;
+    # DROP TABLE positions; ALTER TABLE positions_new RENAME TO positions.
+    log.info("_migrate_qty_not_null: recreating positions table with CHECK (qty IS NOT NULL).")
+    # We capture the existing column order and types from the live schema to
+    # avoid drift. The new constraint is added at the table level.
+    con.executescript(
+        """
+        CREATE TABLE positions_new (
+            id INTEGER PRIMARY KEY,
+            symbol TEXT NOT NULL,
+            direction TEXT,
+            status TEXT NOT NULL DEFAULT 'open',
+            entry_price REAL,
+            entry_ts TEXT NOT NULL DEFAULT (datetime('now')),
+            size_usd REAL,
+            qty REAL CHECK (qty IS NOT NULL),
+            sl_price REAL,
+            tp_price REAL,
+            exit_price REAL,
+            exit_ts TEXT,
+            exit_reason TEXT,
+            pnl_usd REAL,
+            pnl_pct REAL,
+            atr_entry REAL,
+            be_mult REAL,
+            tenant_id INTEGER
+        );
+        INSERT INTO positions_new SELECT
+            id, symbol, direction, status, entry_price, entry_ts, size_usd, qty,
+            sl_price, tp_price, exit_price, exit_ts, exit_reason, pnl_usd,
+            pnl_pct, atr_entry, be_mult, tenant_id
+        FROM positions;
+        DROP TABLE positions;
+        ALTER TABLE positions_new RENAME TO positions;
+        """
+    )
+    # Recreate any indexes that lived on the old table. Inspect the original
+    # schema's CREATE INDEX statements and replay them.
+    # In this codebase the positions table has an index on (symbol, status);
+    # if your live schema has more, add them here.
+    con.execute("CREATE INDEX IF NOT EXISTS idx_positions_symbol_status ON positions(symbol, status)")
+    log.info("_migrate_qty_not_null: migration complete. positions table now enforces qty IS NOT NULL.")
+```
+
+If the actual production `positions` table has columns or indexes this stub doesn't list, the implementer MUST update the CREATE/INSERT/INDEX statements to match. Run `sqlite3 signals.db ".schema positions"` to read the real schema first if a local DB exists.
+
+- [ ] **Step 3: Hook the migration into `init_db`**
+
+In `db/schema.py::init_db`, after the existing `_migrate_*` calls, add:
+
+```python
+_migrate_qty_not_null(con)
+```
+
+Locate the existing migration block (around the end of `init_db`) and append the new call. The order matters: any migration that creates the positions table must run before this one.
+
+- [ ] **Step 4: Verify the 4 tests pass**
+
+Run: `pytest tests/db/test_migrate_qty_not_null.py -v 2>&1 | tail -10`
+Expected: 4/4 pass.
+
+- [ ] **Step 5: Verify init_db is still idempotent on a fresh DB**
+
+```bash
+python -c "
+import os
+os.environ['BTC_DB'] = '/tmp/test_init.db'
+if os.path.exists('/tmp/test_init.db'):
+    os.remove('/tmp/test_init.db')
+from db.schema import init_db
+init_db()
+init_db()  # second call must not raise
+print('init_db idempotent on fresh DB: ok')
+"
+```
+Expected: `init_db idempotent on fresh DB: ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/schema.py
+git commit -m "feat(db): _migrate_qty_not_null moves qty != NULL from convención to schema (closes #467)
+
+Voronov path D: backfill qty=size_usd/entry_price where computable; abort
+loudly on unbackfillable rows; recreate positions table with
+CHECK (qty IS NOT NULL). The schema now enforces what the domain
+promises. The 'or 0' membranes in operator and event_log become dead
+code (removed in Task 5)."
+```
+
+---
+
+### Task 5: Remove `qty = ... or 0` membranes from operator and event_log
+
+**Files:**
+- Modify: `operators/position_closure.py`
+- Modify: `api/positions.py` (the `_write_position_event_log` helper)
+
+The schema now enforces NOT NULL (Task 4). The `or 0` fallbacks are no longer needed and were the visible symptom of the patología.
+
+- [ ] **Step 1: Locate the two membranes**
+
+Run: `grep -n "qty.*or 0\|qty.*qty\b.*0" operators/position_closure.py api/positions.py`
+
+Expected: 2 matches — one in `operators/position_closure.py` (around line 235 inside `execute()`), one in `api/positions.py::_write_position_event_log` (around line 57).
+
+- [ ] **Step 2: Remove the operator's membrane**
+
+In `operators/position_closure.py`, find this block (search for `qty = snapshot.qty or 0`):
+
+```python
+            # Snapshot's immutable fields trusted; consume directly.
+            # qty may be NULL in legacy rows (schema allows; some fixtures set
+            # only size_usd). Match the previous behavior of defaulting to 0.
+            qty = snapshot.qty or 0
+            pnl_usd, pnl_pct = _calc_pnl(
+                snapshot.direction, snapshot.entry_price, self._exit_price, qty,
+            )
+```
+
+Replace with:
+
+```python
+            # Snapshot's immutable fields trusted; consume directly.
+            # Schema now enforces qty NOT NULL (CHECK constraint via
+            # _migrate_qty_not_null) — the previous 'or 0' membrane is gone.
+            pnl_usd, pnl_pct = _calc_pnl(
+                snapshot.direction, snapshot.entry_price, self._exit_price, snapshot.qty,
+            )
+```
+
+- [ ] **Step 3: Remove the event log's membrane**
+
+In `api/positions.py`, find `_write_position_event_log`. Inside it, locate `qty = pos.get("qty") or 0` (line ~57). Replace with `qty = pos["qty"]` (the schema guarantees presence).
+
+If the helper accepts a `dict` (post-snapshot output of `_snapshot_to_dict`) AND legacy callers still pass raw rows, verify both paths still have `qty` populated. If any legacy caller passes a partial dict, that caller should be fixed instead — but for now if `pos.get("qty")` is being defensive against a missing key (not just NULL), keep `pos.get("qty")` and remove only the `or 0`. The key existence is not a schema concern.
+
+Recommended safest replacement:
+```python
+qty = pos["qty"]  # schema enforces NOT NULL post-Task-4
+```
+
+- [ ] **Step 4: Run the existing test suite to surface any caller that doesn't yet have qty**
+
+```bash
+pytest tests/operators/test_position_closure.py tests/api/ -q --tb=short 2>&1 | tail -15
+```
+Expected: all green. If any test fails because a fixture inserts a position without `qty`, that fixture must be updated to set `qty` (the schema demands it).
+
+If fixtures fail: locate them via `grep -n "INSERT INTO positions" tests/`, update each to include `qty` in the column list and `size_usd / entry_price` (or a literal value) in VALUES.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add operators/position_closure.py api/positions.py tests/
+git commit -m "refactor: remove 'qty or 0' membranes — schema now enforces NOT NULL (closes #467)
+
+Two silent translation membranes deleted:
+- operators/position_closure.py::execute (was 'qty = snapshot.qty or 0')
+- api/positions.py::_write_position_event_log (was 'qty = pos.get(\"qty\") or 0')
+
+Test fixtures updated to set qty in INSERT statements (schema requires it).
+
+The 'or 0' was the visible symptom of #467. The fix lives in schema, not in
+the consumer."
+```
+
+---
+
+### Task 6: TDD — write failing tests for NewType PrecheckConn / SnapshotConn
+
+**Files:**
+- Modify: `tests/db/test_transaction.py`
+
+- [ ] **Step 1: Append the NewType tests**
+
+```python
+
+
+# ---- NewType enforcement (closes #468) ----
+
+def test_precheck_connection_yields_PrecheckConn_type():
+    """precheck_connection must yield a value whose type is PrecheckConn."""
+    from db.transaction import precheck_connection, PrecheckConn
+
+    with precheck_connection() as con:
+        # NewType is a runtime no-op (the value is just the wrapped object),
+        # but the type annotation must be importable and the helper must use it.
+        assert con is not None
+        # Verify the helper's annotation declares PrecheckConn (not raw sqlite3.Connection).
+    import inspect
+    from db.transaction import precheck_connection as pc
+    sig = inspect.signature(pc.__wrapped__) if hasattr(pc, "__wrapped__") else inspect.signature(pc)
+    # The contextmanager wrapper might hide signature; we check the module's
+    # type alias is importable instead.
+    assert PrecheckConn is not None
+
+
+def test_snapshot_connection_yields_SnapshotConn_type():
+    """snapshot_connection must yield a value whose type is SnapshotConn."""
+    from db.transaction import snapshot_connection, SnapshotConn
+
+    with snapshot_connection() as con:
+        assert con is not None
+    assert SnapshotConn is not None
+
+
+def test_PrecheckConn_and_SnapshotConn_are_distinct_NewTypes():
+    """PrecheckConn and SnapshotConn must be distinct NewType objects.
+    A NewType-aware type checker (mypy) treats them as incompatible; at
+    runtime they are both callables that return their argument unchanged."""
+    from db.transaction import PrecheckConn, SnapshotConn
+
+    assert PrecheckConn is not SnapshotConn
+    # NewType instances are callables; calling either returns the argument.
+    import sqlite3
+    con = sqlite3.connect(":memory:")
+    try:
+        wrapped_a = PrecheckConn(con)
+        wrapped_b = SnapshotConn(con)
+        # Runtime equality: both wrap the same object.
+        assert wrapped_a is con
+        assert wrapped_b is con
+    finally:
+        con.close()
+```
+
+- [ ] **Step 2: Verify the 3 tests fail with ImportError**
+
+Run: `pytest tests/db/test_transaction.py::test_precheck_connection_yields_PrecheckConn_type tests/db/test_transaction.py::test_snapshot_connection_yields_SnapshotConn_type tests/db/test_transaction.py::test_PrecheckConn_and_SnapshotConn_are_distinct_NewTypes -v 2>&1 | tail -15`
+
+Expected: all 3 fail with `ImportError: cannot import name 'PrecheckConn'` (or similar).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/db/test_transaction.py
+git commit -m "test(db): add failing NewType tests for PrecheckConn / SnapshotConn (advances #468)
+
+Tests verify the NewTypes are importable, distinct, and runtime-trivial
+(call returns argument unchanged). Compile-time enforcement is mypy's
+responsibility (no test can directly assert mypy strictness)."
+```
+
+---
+
+### Task 7: Implement NewType PrecheckConn / SnapshotConn in db/transaction.py
+
+**Files:**
+- Modify: `db/transaction.py`
+
+- [ ] **Step 1: Add NewType definitions**
+
+In `db/transaction.py`, after the existing imports, add:
+
+```python
+from typing import NewType
+
+# Move 'precheck != snapshot' from convención to tipo (#468, Voronov 2026-05-26).
+#
+# PrecheckConn is a connection authorized for reads that will FEED a follow-up
+# write transaction. The caller is contractually obligated to extract any field
+# the write-tx will need into an immutable snapshot (see
+# operators.precheck.OwnershipValidatedSnapshot) BEFORE the with block exits.
+#
+# SnapshotConn is a connection authorized for TERMINAL reads — results
+# serialize to an output (JSON file, HTTP response, log) and are NOT used to
+# drive a subsequent mutation. No follow-up re-validation obligation.
+#
+# Both NewTypes wrap sqlite3.Connection. mypy treats them as incompatible;
+# at runtime, both are no-ops (the wrapped object is the original Connection).
+# The mechanism is identical (PRAGMA query_only=1); the contract is in the
+# type, not in the docstring.
+PrecheckConn = NewType("PrecheckConn", sqlite3.Connection)
+SnapshotConn = NewType("SnapshotConn", sqlite3.Connection)
+```
+
+- [ ] **Step 2: Update return type annotations and yield statements**
+
+Find `precheck_connection`:
+
+```python
+@contextmanager
+def precheck_connection() -> Iterator[sqlite3.Connection]:
+    ...
+    con = _open_configured_connection()
+    try:
+        con.execute("PRAGMA query_only = 1")
+        yield con
+    finally:
+        con.close()
+```
+
+Change to:
+
+```python
+@contextmanager
+def precheck_connection() -> Iterator[PrecheckConn]:
+    ...
+    con = _open_configured_connection()
+    try:
+        con.execute("PRAGMA query_only = 1")
+        yield PrecheckConn(con)
+    finally:
+        con.close()
+```
+
+Same change for `snapshot_connection` with `SnapshotConn`.
+
+- [ ] **Step 3: Update module-level imports order if needed**
+
+Ensure `NewType` is imported alongside the existing `typing` imports (likely `from typing import Iterator`). Consolidate.
+
+- [ ] **Step 4: Verify the 3 tests pass**
+
+Run: `pytest tests/db/test_transaction.py -v 2>&1 | tail -20`
+Expected: all transaction tests pass (the 3 new + the previous 12 = 15).
+
+- [ ] **Step 5: Verify PositionClosure invariants still pass**
+
+Run: `pytest tests/operators/test_position_closure.py -q 2>&1 | tail -3`
+Expected: all pass. The NewType is runtime-invisible; no consumer changes are required.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/transaction.py
+git commit -m "feat(db): NewType PrecheckConn / SnapshotConn — invariant from convención to tipo (closes #468)
+
+precheck_connection now returns Iterator[PrecheckConn]; snapshot_connection
+returns Iterator[SnapshotConn]. Both are NewTypes wrapping sqlite3.Connection.
+Runtime is a no-op; compile-time mypy treats them as incompatible.
+
+Voronov: 'Si precheck y snapshot fueran intercambiables, #461 no habría
+sido un bug. Lo fue. Por lo tanto la separación es funcional, no estética
+— merece tipo, no comentario.'"
+```
+
+---
+
+### Task 8: TDD — write failing test for OwnershipValidatedSnapshot factory pattern
+
+**Files:**
+- Create: `tests/operators/test_ownership_validated_snapshot.py`
+
+- [ ] **Step 1: Create the test file**
+
+```python
+"""Tests for OwnershipValidatedSnapshot factory pattern (#469 + F6).
+
+The class must not be constructible without the module-private sentinel.
+The only legitimate constructor is operators.position_closure._run_precheck.
+"""
+import pytest
+
+
+def test_cannot_construct_without_sentinel():
+    """OwnershipValidatedSnapshot raised TypeError if constructed with a
+    foreign sentinel (i.e., any object other than the module-private
+    _VALIDATION_SENTINEL)."""
+    from operators.precheck import OwnershipValidatedSnapshot, PositionSnapshot
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+
+    # Try with a wrong sentinel (e.g., another object()).
+    with pytest.raises(TypeError, match=r"private validation sentinel"):
+        OwnershipValidatedSnapshot(inner=snap, _sentinel=object())
+
+
+def test_cannot_construct_with_none_sentinel():
+    """OwnershipValidatedSnapshot raises TypeError if _sentinel is None."""
+    from operators.precheck import OwnershipValidatedSnapshot, PositionSnapshot
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+
+    with pytest.raises(TypeError, match=r"private validation sentinel"):
+        OwnershipValidatedSnapshot(inner=snap, _sentinel=None)
+
+
+def test_internal_factory_builds_validated_snapshot():
+    """_build_validated_snapshot is the only legitimate constructor.
+    It is module-private (underscore prefix), not exported from precheck's
+    public surface."""
+    from operators.precheck import (
+        _build_validated_snapshot,
+        OwnershipValidatedSnapshot,
+        PositionSnapshot,
+    )
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+
+    validated = _build_validated_snapshot(snap)
+    assert isinstance(validated, OwnershipValidatedSnapshot)
+    assert validated.inner == snap
+
+
+def test_PrecheckOkToProceed_carries_OwnershipValidatedSnapshot():
+    """PrecheckOkToProceed.snapshot is typed as OwnershipValidatedSnapshot
+    (not PositionSnapshot) — the type-level guarantee that ownership was
+    validated."""
+    from operators.precheck import (
+        PrecheckOkToProceed,
+        OwnershipValidatedSnapshot,
+        _build_validated_snapshot,
+        PositionSnapshot,
+    )
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+    validated = _build_validated_snapshot(snap)
+    ok = PrecheckOkToProceed(snapshot=validated)
+    assert isinstance(ok.snapshot, OwnershipValidatedSnapshot)
+    assert ok.snapshot.inner == snap
+```
+
+- [ ] **Step 2: Verify all 4 tests fail with ImportError**
+
+Run: `pytest tests/operators/test_ownership_validated_snapshot.py -v 2>&1 | tail -15`
+Expected: 4 failures, all at imports.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/operators/test_ownership_validated_snapshot.py
+git commit -m "test(operators): add failing tests for OwnershipValidatedSnapshot factory (advances #469 F6)
+
+The class cannot be constructed without the module-private sentinel.
+The only legitimate constructor is _build_validated_snapshot (used by
+PositionClosure._run_precheck). PrecheckOkToProceed carries the validated
+snapshot, not the raw PositionSnapshot."
+```
+
+---
+
+### Task 9: Implement OwnershipValidatedSnapshot + update PrecheckOkToProceed in operators/precheck.py
+
+**Files:**
+- Modify: `operators/precheck.py`
+
+- [ ] **Step 1: Add the sentinel + class + factory**
+
+Append to `operators/precheck.py` (after existing PositionSnapshot/PrecheckNotFound/etc.):
+
+```python
+# Module-private sentinel — external callers cannot import this name
+# (single underscore is a convention; the factory check is by `is` identity).
+_VALIDATION_SENTINEL = object()
+
+
+@dataclass(frozen=True)
+class OwnershipValidatedSnapshot:
+    """A PositionSnapshot whose ownership has been validated by a precheck.
+
+    USER mode: caller_tenant_id matched snapshot.tenant_id at precheck time.
+    SYSTEM mode: ownership validation does not apply; the snapshot is
+    accepted by construction.
+
+    Construction requires the module-private _VALIDATION_SENTINEL. The only
+    legitimate constructor is `_build_validated_snapshot` (called by
+    `operators.position_closure.PositionClosure._run_precheck`).
+
+    A future write-tx that consumes this type is guaranteed (by construction)
+    that ownership was checked at precheck. The write-tx MUST STILL re-validate
+    the snapshot's mutable fields against a fresh re-SELECT — that is enforced
+    in PositionClosure.execute() by explicit field-by-field comparison.
+
+    Closes #469 + F6 (Voronov path C + E): the validation guarantee lives in
+    the type, not in a docstring.
+    """
+    inner: PositionSnapshot
+    _sentinel: object  # must be _VALIDATION_SENTINEL at construction
+
+    def __post_init__(self):
+        if self._sentinel is not _VALIDATION_SENTINEL:
+            raise TypeError(
+                "OwnershipValidatedSnapshot cannot be constructed directly. "
+                "Use the private validation sentinel via "
+                "operators.precheck._build_validated_snapshot (callable only "
+                "from operators.position_closure._run_precheck)."
+            )
+
+
+def _build_validated_snapshot(snapshot: PositionSnapshot) -> OwnershipValidatedSnapshot:
+    """Internal factory used by PositionClosure._run_precheck.
+
+    NOT exported from this module's public surface (single underscore).
+    Module-private convention: external code should not call this directly.
+    """
+    return OwnershipValidatedSnapshot(inner=snapshot, _sentinel=_VALIDATION_SENTINEL)
+```
+
+- [ ] **Step 2: Update PrecheckOkToProceed.snapshot field type**
+
+Find the existing `PrecheckOkToProceed` dataclass. Change:
+
+```python
+@dataclass(frozen=True)
+class PrecheckOkToProceed:
+    """Position passed all precheck conditions. ..."""
+    snapshot: PositionSnapshot
+```
+
+to:
+
+```python
+@dataclass(frozen=True)
+class PrecheckOkToProceed:
+    """Position passed all precheck conditions. snapshot is an
+    OwnershipValidatedSnapshot — type-level guarantee that ownership was
+    checked at precheck (#469 + F6, Voronov 2026-05-26)."""
+    snapshot: OwnershipValidatedSnapshot
+```
+
+- [ ] **Step 3: Verify the 4 new tests pass**
+
+Run: `pytest tests/operators/test_ownership_validated_snapshot.py -v 2>&1 | tail -10`
+Expected: 4/4 pass.
+
+- [ ] **Step 4: Note: PositionClosure tests will break**
+
+Run: `pytest tests/operators/test_position_closure.py -q 2>&1 | tail -5`
+Expected: failures, because `PositionClosure._run_precheck` currently constructs `PrecheckOkToProceed(snapshot=snapshot)` directly (where snapshot is `PositionSnapshot`, but the field now expects `OwnershipValidatedSnapshot`). Task 10 fixes this.
+
+Do NOT commit Task 9 in isolation if PositionClosure tests fail. Continue to Task 10.
+
+Actually: commit anyway — the test suite is in transition. The next task brings the operator into compliance.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add operators/precheck.py
+git commit -m "feat(operators): OwnershipValidatedSnapshot + _build_validated_snapshot factory (advances #469 F6)
+
+The class cannot be constructed without the module-private validation
+sentinel. PrecheckOkToProceed.snapshot is now typed as
+OwnershipValidatedSnapshot (type-level guarantee that ownership was
+checked at precheck).
+
+Operator (PositionClosure._run_precheck) updated to use the factory in
+Task 10."
+```
+
+---
+
+### Task 10: Migrate PositionClosure to use OwnershipValidatedSnapshot + re-validate ALL mutable fields
+
+**Files:**
+- Modify: `operators/position_closure.py`
+
+This task completes #469+F6. The operator's `_run_precheck` constructs `OwnershipValidatedSnapshot` via the factory; `execute()` re-validates EVERY mutable field of the snapshot against the fresh re-SELECT (not only `tenant_id` and `status`).
+
+- [ ] **Step 1: Update imports**
+
+In `operators/position_closure.py`, update the precheck import:
+
+Before:
+```python
+from operators.precheck import (
+    PositionSnapshot,
+    PrecheckNotFound,
+    PrecheckAlreadyClosed,
+    PrecheckOkToProceed,
+    PrecheckRejectedState,
+    PrecheckResult,
+)
+```
+
+After:
+```python
+from operators.precheck import (
+    PositionSnapshot,
+    OwnershipValidatedSnapshot,
+    _build_validated_snapshot,
+    PrecheckNotFound,
+    PrecheckAlreadyClosed,
+    PrecheckOkToProceed,
+    PrecheckRejectedState,
+    PrecheckResult,
+)
+```
+
+- [ ] **Step 2: Update `_run_precheck` to use the factory**
+
+Find the line `return PrecheckOkToProceed(snapshot=snapshot)`. Replace with:
+
+```python
+        return PrecheckOkToProceed(snapshot=_build_validated_snapshot(snapshot))
+```
+
+- [ ] **Step 3: Update `execute()` to unwrap the validated snapshot and re-validate ALL mutable fields**
+
+Find the block inside `execute()` that handles `PrecheckOkToProceed`:
+
+```python
+        # PrecheckOkToProceed: write-tx must re-validate snapshot's mutable fields.
+        snapshot = result.snapshot
+        with _tx_module.transaction() as con:
+            row = db_get_position_by_id(con, self._pos_id)
+            if row is None:
+                return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
+            # #461 closure: tenant_id re-validation is obligatory by construction.
+            if row["tenant_id"] != snapshot.tenant_id:
+                # Tenant reassigned between precheck and write-tx. IDOR-safe collapse.
+                return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
+            # ... [status handling: closed → already_closed; other → rejected_unexpected_state] ...
+
+            # Snapshot's immutable fields trusted; consume directly.
+            pnl_usd, pnl_pct = _calc_pnl(
+                snapshot.direction, snapshot.entry_price, self._exit_price, snapshot.qty,
+            )
+            # ...
+```
+
+Replace the relevant section with:
+
+```python
+        # PrecheckOkToProceed: write-tx must re-validate ALL snapshot fields.
+        # OwnershipValidatedSnapshot guarantees ownership was checked at precheck;
+        # the snapshot's mutable fields (everything in PositionSnapshot — tenant_id,
+        # status, entry_price, qty, direction, symbol) MUST be re-validated against
+        # the fresh row inside BEGIN IMMEDIATE. Schema does not enforce immutability
+        # of entry_price/qty/direction/symbol (CLAUDE.md "Capas de enforcement"),
+        # so the write-tx is the only place where stale snapshots are caught.
+        validated = result.snapshot   # OwnershipValidatedSnapshot
+        snap = validated.inner         # PositionSnapshot
+        with _tx_module.transaction() as con:
+            row = db_get_position_by_id(con, self._pos_id)
+            if row is None:
+                return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
+
+            # Status handling (3 branches: open / closed / other).
+            if row["status"] == "closed":
+                race_snap = PositionSnapshot(
+                    pos_id=row["id"],
+                    tenant_id=row["tenant_id"],
+                    status=row["status"],
+                    symbol=row["symbol"],
+                    direction=row["direction"],
+                    entry_price=row["entry_price"],
+                    qty=row["qty"],
+                )
+                return CloseOutcome(
+                    status="already_closed",
+                    position=self._snapshot_to_dict(race_snap),
+                    pnl_usd=None, pnl_pct=None,
+                )
+            if row["status"] != "open":
+                race_snap = PositionSnapshot(
+                    pos_id=row["id"],
+                    tenant_id=row["tenant_id"],
+                    status=row["status"],
+                    symbol=row["symbol"],
+                    direction=row["direction"],
+                    entry_price=row["entry_price"],
+                    qty=row["qty"],
+                )
+                return CloseOutcome(
+                    status="rejected_unexpected_state",
+                    position=self._snapshot_to_dict(race_snap),
+                    pnl_usd=None, pnl_pct=None,
+                )
+
+            # Re-validate ALL other mutable fields (#469 + F6).
+            # If any field has drifted, the snapshot is stale; collapse to
+            # NOT_FOUND (IDOR-safe — same shape as ownership mismatch).
+            if (row["tenant_id"] != snap.tenant_id
+                or row["entry_price"] != snap.entry_price
+                or row["qty"] != snap.qty
+                or row["direction"] != snap.direction
+                or row["symbol"] != snap.symbol):
+                return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
+
+            # All snapshot fields confirmed. Snapshot is trusted; proceed.
+            pnl_usd, pnl_pct = _calc_pnl(
+                snap.direction, snap.entry_price, self._exit_price, snap.qty,
+            )
+            exit_ts = self._now.isoformat()
+            closed_row = db_close_position_sql(
+                con, self._pos_id, self._exit_price, self._exit_reason,
+                exit_ts, pnl_usd, pnl_pct,
+            )
+            if snap.tenant_id is not None and pnl_usd is not None:
+                _capital_module.apply_pnl_to_capital(con, snap.tenant_id, pnl_usd)
+            elif snap.tenant_id is None:
+                log.warning(
+                    "PositionClosure: skipping capital roll-in for legacy tenant_id=NULL pos_id=%s",
+                    self._pos_id,
+                )
+            self._result_row = closed_row
+            self._result_pnl = (pnl_usd, pnl_pct)
+```
+
+- [ ] **Step 4: Run the full operator test suite**
+
+```bash
+pytest tests/operators/ -v --tb=short 2>&1 | tail -25
+```
+Expected: all existing invariants pass. If `test_tenant_reassignment_between_precheck_and_write_rejects_close` (the #461 closure proof) still passes, the tenant_id re-validation in the new code is wired correctly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add operators/position_closure.py
+git commit -m "feat(operators): PositionClosure re-validates ALL mutable snapshot fields in write-tx (closes #469 F6)
+
+_run_precheck constructs PrecheckOkToProceed with an OwnershipValidatedSnapshot
+(type-level guarantee that ownership was checked at precheck).
+
+execute() re-validates not only tenant_id and status, but also entry_price,
+qty, direction, and symbol against the freshly re-SELECTed row. Any drift
+collapses to NOT_FOUND (IDOR-safe).
+
+Voronov F6: the schema does not enforce immutability of these fields; the
+write-tx is the only place where stale snapshots are caught. Convention
+becomes type+runtime check."
+```
+
+---
+
+### Task 11: Add invariant test for cross-mutation race (entry_price)
+
+**Files:**
+- Modify: `tests/operators/test_position_closure.py`
+
+- [ ] **Step 1: Append the new invariant test**
+
+```python
+
+
+# ---- Invariant 14: cross-mutation race rejects close when snapshot field drifts ----
+
+def test_cross_mutation_race_entry_price_rejects_close(fresh_db_with_two_tenants):
+    """If a snapshot field that is NOT tenant_id/status changes between precheck
+    and BEGIN IMMEDIATE (e.g., entry_price is updated by a migration or ad-hoc
+    UPDATE), the operator must detect the drift and return not_found.
+
+    Closes #469 + F6: validation lives in the type (OwnershipValidatedSnapshot)
+    and the runtime field-by-field comparison in execute()."""
+    from operators.position_closure import PositionClosure
+
+    closure = PositionClosure(
+        pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+        mode="USER", caller_tenant_id=1,
+    )
+    closure.__enter__()  # precheck reads entry_price (whatever the fixture set)
+
+    # Simulate an entry_price drift between precheck and write-tx.
+    with transaction() as con:
+        con.execute("UPDATE positions SET entry_price = 999.99 WHERE id = 1")
+
+    outcome = closure.execute()
+    closure.__exit__(None, None, None)
+
+    # The snapshot held the old entry_price; the row now has 999.99.
+    # The mismatch must collapse to NOT_FOUND.
+    assert outcome.status == "not_found"
+
+    # The row was not closed.
+    with transaction() as con:
+        pos = con.execute("SELECT status, entry_price FROM positions WHERE id=1").fetchone()
+    assert pos["status"] == "open"
+    assert pos["entry_price"] == 999.99  # our UPDATE remains
+```
+
+- [ ] **Step 2: Verify the test passes**
+
+Run: `pytest tests/operators/test_position_closure.py::test_cross_mutation_race_entry_price_rejects_close -v 2>&1 | tail -10`
+Expected: PASS. The field-by-field comparison added in Task 10 catches the drift.
+
+- [ ] **Step 3: Run all invariants**
+
+Run: `pytest tests/operators/test_position_closure.py -v 2>&1 | tail -25`
+Expected: all 14+ invariants pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/operators/test_position_closure.py
+git commit -m "test(operators): add invariant #14 — cross-mutation race rejects close (#469 F6 closure proof)
+
+If entry_price (or any other snapshot field) drifts between precheck and
+BEGIN IMMEDIATE, the snapshot is stale and the operator returns NOT_FOUND.
+Exercises the field-by-field re-validation added in Task 10."
+```
+
+---
+
+### Task 12: Update CLAUDE.md registry to reflect the moves
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+The registry was written in Task 2 listing the invariants with current vs target layer. After Tasks 4-11, the moves are complete. Update the table to reflect the new actual state.
+
+- [ ] **Step 1: Locate the registry section**
+
+Run: `grep -n "Capas de enforcement de invariantes" CLAUDE.md`
+
+- [ ] **Step 2: Replace the "Invariantes C2" table with the post-merge state**
+
+Find the "Invariantes C2 — estado actual y movimiento de este PR" table from Task 2. Replace with:
+
+```markdown
+### Invariantes C2 — estado tras este PR
+
+| Invariante de dominio | Capa enforced | Mecanismo | Issue cerrado |
+|---|---|---|---|
+| `qty` siempre tiene valor numérico para positions | **Schema** | `CHECK (qty IS NOT NULL)` en `positions` (vía `_migrate_qty_not_null` en `db/schema.py`) | #467 |
+| `precheck_connection` y `snapshot_connection` son contratos distintos | **Tipo** | `NewType("PrecheckConn", sqlite3.Connection)` y `NewType("SnapshotConn", sqlite3.Connection)` en `db/transaction.py` — mypy detecta mis-uso | #468 |
+| Los campos del snapshot consumidos por el write-tx no cambian entre precheck y BEGIN IMMEDIATE | **Tipo + runtime check** | `OwnershipValidatedSnapshot` (factory privada en `operators/precheck.py`) + field-by-field re-validation en `PositionClosure.execute()` cubre los 6 campos del `PositionSnapshot` | #469 + F6 |
+
+### Patrón nombrado: "invariantes de dominio sin contraparte estructural"
+
+(unchanged — still applies)
+
+### Known scope gap (Voronov 2026-05-26)
+
+> El sistema enforza invariantes en el momento de cruce (precheck→snapshot, snapshot→write) pero **no enforza invariantes en el momento de origen** (creación de la position). Toda la cadena de defensa de C2 asume que la position fue creada correctamente. Si en `position_open` se crea una row con `tenant_id` mal asignado, los 3 mecanismos de C2 la sostendrán correctamente *con el tenant equivocado*. C2 endurece el ciclo de vida; no endurece el nacimiento.
+
+Esta deuda NO está cubierta por este PR. Tratamiento futuro: auditar `db_create_position` y los endpoints que invocan creación (`POST /positions`, paths del scanner) bajo la misma lente del registro de capas.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): update enforcement registry — 3 moves complete + name 'birth-time' debt as known scope gap
+
+Registry reflects the actual state: qty NOT NULL in schema; precheck/snapshot
+as distinct NewTypes; OwnershipValidatedSnapshot + write-tx field-by-field
+re-validation for snapshot drift.
+
+Voronov flagged: 'C2 endurece el ciclo de vida; no endurece el nacimiento.'
+Documented as Known scope gap for future audit of position creation paths."
+```
+
+---
+
+### Task 13: Final verification
+
+**Files:** none modified (unless smoke surfaces a fix).
+
+- [ ] **Step 1: Grep for surviving `or 0` patterns related to qty**
+
+Run: `grep -rn "qty.*or 0\|qty.*qty\b.*0" --include="*.py" .`
+Expected: empty. (If anything remains, it's a missed membrane — fix and commit.)
+
+- [ ] **Step 2: Run all transaction tests**
+
+Run: `pytest tests/db/test_transaction.py -v 2>&1 | tail -20`
+Expected: 15+ pass (was 12; added 3 NewType tests in Task 6).
+
+- [ ] **Step 3: Run all PositionClosure invariants**
+
+Run: `pytest tests/operators/test_position_closure.py -v 2>&1 | tail -25`
+Expected: 14+ pass (was 13; added invariant #14 in Task 11).
+
+- [ ] **Step 4: Run precheck type tests**
+
+Run: `pytest tests/operators/test_precheck.py tests/operators/test_ownership_validated_snapshot.py -v 2>&1 | tail -15`
+Expected: existing 5 + new 4 = 9 pass.
+
+- [ ] **Step 5: Run migration tests**
+
+Run: `pytest tests/db/test_migrate_qty_not_null.py -v 2>&1 | tail -10`
+Expected: 4 pass.
+
+- [ ] **Step 6: Atomicity regression**
+
+Run: `pytest tests/api/test_check_position_stops_atomicity.py -v 2>&1 | tail -10`
+Expected: PASS.
+
+- [ ] **Step 7: Full suite**
+
+Run: `pytest tests/ --tb=no -q -p no:cacheprovider 2>/dev/null | tail -5`
+Expected: baseline (~2498 post-#466) + ~11 new tests (4 migration + 3 NewType + 4 ownership-validated) + 1 invariant 14 = ~2514. Skipped count same (~22). The pre-existing `test_setup` daemon flake may or may not appear.
+
+- [ ] **Step 8: Smoke imports for all modified modules**
+
+```bash
+python -c "
+import importlib
+for m in ('db.transaction', 'db.schema', 'operators.precheck', 'operators.position_closure', 'api.positions'):
+    importlib.import_module(m)
+from db.transaction import PrecheckConn, SnapshotConn
+from operators.precheck import OwnershipValidatedSnapshot, _build_validated_snapshot
+print('all 5 modules + 4 new symbols import cleanly')
+"
+```
+Expected: `all 5 modules + 4 new symbols import cleanly`.
+
+---
+
+### Task 14: Push + open PR + close #467 #468 #469 (REQUIRES USER CONFIRMATION)
+
+**Files:** none modified.
+
+This step is externally visible to `sssimon/trading-spacial`. Confirm before executing in an autonomous session.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/enforcement-layers-registry-467-468-469`
+Expected: branch published; URL printed.
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+```bash
+gh pr create --repo sssimon/trading-spacial \
+  --title "feat: 'Capas de enforcement de invariantes' registry + 3 moves (qty→schema, precheck/snapshot→tipo, snapshot==row→tipo) [closes #467 #468 #469]" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Voronov's meta-reframe of Cluster C2. Closes three issues by FIRST naming the patología they share — *"invariantes de dominio sin contraparte estructural"* — and THEN moving three specific invariants from `convención` to either `schema` or `tipo` within a written registry.
+
+The three moves:
+
+- **#467 (qty != NULL): convención → schema.** `_migrate_qty_not_null` backfills `qty = size_usd / entry_price` for legacy rows; aborts loudly if any row remains NULL; recreates the `positions` table with `CHECK (qty IS NOT NULL)`. The two `or 0` membranes (in `position_closure.execute()` and `_write_position_event_log`) are deleted — the schema now guarantees what the code was silently translating.
+
+- **#468 (precheck != snapshot): convención → tipo.** `NewType("PrecheckConn", sqlite3.Connection)` and `NewType("SnapshotConn", sqlite3.Connection)` in `db/transaction.py`. Runtime is a no-op; mypy detects mis-use at the call site. The distinction is no longer enforceable only by code reviewer attention.
+
+- **#469 + F6 (snapshot fields stable between precheck and write-tx): convención → tipo + runtime check.** `OwnershipValidatedSnapshot` with private factory (`_build_validated_snapshot`) callable only from `PositionClosure._run_precheck`. `PrecheckOkToProceed.snapshot` typed as this class. `PositionClosure.execute()` re-validates ALL six mutable snapshot fields (tenant_id, status, entry_price, qty, direction, symbol) against the fresh re-SELECT — not only the two it covered before. Any drift collapses to NOT_FOUND (IDOR-safe).
+
+## Why this PR
+
+Per Voronov's reframe (2026-05-26):
+
+> Los tres issues no son deuda de #466. Son la primera generación de un patrón donde el dominio afirma más de lo que el almacenamiento garantiza, y el código paga la diferencia en membranas silenciosas — `or 0`, comentarios de revisor, re-validaciones parciales. Mientras esa asimetría no esté nombrada, cada issue futuro de esta familia se debatirá como si fuera nuevo. No es un problema de implementación. Es un problema de registro.
+
+The plan begins by writing that registry in CLAUDE.md ("Capas de enforcement de invariantes") with four columns — schema / tipo / test / convención — and lists the three C2 invariants with their current and target layers. The implementation then executes the three layer moves. After merge, the registry reflects the actual state.
+
+## Known scope gap (named, NOT closed by this PR)
+
+> El sistema enforza invariantes en el momento de cruce (precheck→snapshot, snapshot→write) pero NO enforza invariantes en el momento de origen (creación de la position). Si en `position_open` se crea una row con `tenant_id` mal asignado, los 3 mecanismos de C2 la sostendrán correctamente *con el tenant equivocado*. C2 endurece el ciclo de vida; no endurece el nacimiento.
+
+Documented in CLAUDE.md "Capas de enforcement" §Known scope gap. Future audit pending.
+
+## Resolves
+
+- **#467** — qty NULL silent close
+- **#468** — structural enforcement of precheck vs snapshot
+- **#469 + F6** — #461 defense-in-depth + re-validate ALL mutable snapshot fields (not only tenant_id/status)
+
+## Test plan
+
+- [x] 4 migration tests in `tests/db/test_migrate_qty_not_null.py` (backfill, abort on unbackfillable, IntegrityError post-migration, idempotent)
+- [x] 3 NewType tests in `tests/db/test_transaction.py` (PrecheckConn / SnapshotConn yield + distinct)
+- [x] 4 OwnershipValidatedSnapshot tests in `tests/operators/test_ownership_validated_snapshot.py` (cannot construct without sentinel, factory builds, PrecheckOkToProceed carries the validated type)
+- [x] Invariant #14 in `tests/operators/test_position_closure.py` (cross-mutation race on entry_price rejects close)
+- [x] Existing 13 PositionClosure invariants still pass (snapshot pattern is unchanged from the caller's perspective; only the internal type tightens)
+- [x] Existing 12 transaction tests still pass
+- [x] Atomicity regression still passes
+- [x] Full suite ~2514 passed, 22 skipped (Binance network), 1 pre-existing test_setup flake (PR #445 known limitation)
+- [ ] Manual smoke in prod after merge: confirm close-flow works; confirm `_migrate_qty_not_null` ran on prod DB cleanly
+
+## What this PR does NOT do
+
+- Does NOT enforce immutability of `entry_price`/`qty`/`direction`/`symbol` at schema level (CHECK / trigger). The write-tx re-validation catches the drift; schema-level enforcement is a separate future PR (would close the "stale snapshot" detection at write time but would also require redesigning any operation that legitimately needs to mutate these fields, e.g., split positions).
+- Does NOT close the "birth-time invariants" gap — see Known scope gap above.
+- Does NOT introduce a `validated_transaction(precheck_fn)` higher-order helper. The OwnershipValidatedSnapshot type IS the hand-off; an over-helper would obscure it.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Close #467, #468, #469 with cross-link**
+
+Run:
+```bash
+NEW_PR=$(gh pr view --json number --jq .number)
+gh issue comment 467 --repo sssimon/trading-spacial --body "Closed by #$NEW_PR. \`qty != NULL\` is now enforced at schema level via \`CHECK (qty IS NOT NULL)\`. The 'or 0' membranes are deleted. \`_migrate_qty_not_null\` backfills legacy rows from \`size_usd/entry_price\` and aborts loudly if any row remains unbackfillable."
+gh issue close 467 --repo sssimon/trading-spacial
+
+gh issue comment 468 --repo sssimon/trading-spacial --body "Closed by #$NEW_PR via Voronov path B (NewType). \`PrecheckConn\` and \`SnapshotConn\` are now distinct \`NewType\` aliases for \`sqlite3.Connection\`. Runtime is a no-op; mypy detects mis-use at the call site. The distinction lives in the type system, not in code reviewer attention."
+gh issue close 468 --repo sssimon/trading-spacial
+
+gh issue comment 469 --repo sssimon/trading-spacial --body "Closed by #$NEW_PR via Voronov path C+E together. \`OwnershipValidatedSnapshot\` (private factory callable only from \`PositionClosure._run_precheck\`) types the precheck output. \`execute()\` now re-validates ALL six mutable snapshot fields (tenant_id, status, entry_price, qty, direction, symbol) against the fresh re-SELECT — not only two. F6 (the missing re-validations for entry_price/qty/direction/symbol) is closed by the same change."
+gh issue close 469 --repo sssimon/trading-spacial
+```
+
+- [ ] **Step 4: Done**
+
+The plan is fully executed when this step completes.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Voronov's pre-condition (registry in CLAUDE.md): Task 2.
+- Voronov path D for #467 (backfill + CONSTRAINT): Tasks 3-4 (TDD + implementation), Task 5 (remove membranes).
+- Voronov path B for #468 (NewType): Tasks 6-7.
+- Voronov path C+E for #469+F6 (factory + re-validate all mutable fields): Tasks 8-11.
+- Update to registry post-moves: Task 12.
+- Known scope gap (birth-time invariants): Task 12.
+
+**Placeholder scan:** None of the disallowed patterns present. All code blocks complete. Migration table recreation explicitly notes "if the live schema has additional columns or indexes, the implementer must update the CREATE/INSERT statements" — that is a real caveat, not a placeholder, because the live schema is not in this plan's context.
+
+**Type consistency:**
+- `PrecheckConn` / `SnapshotConn` named consistently across Tasks 6, 7.
+- `OwnershipValidatedSnapshot` / `_build_validated_snapshot` / `_VALIDATION_SENTINEL` named consistently across Tasks 8, 9, 10.
+- `PositionSnapshot` field set (pos_id, tenant_id, status, symbol, direction, entry_price, qty) named consistently with #466 (Tasks 10-12 use the same fields).
+
+**Caveats:**
+- Task 4's `CREATE TABLE positions_new` schema is a best-guess from the test fixture; the implementer MUST verify against the live `signals.db` schema before running. If the live schema has columns this plan omits, INSERT will silently lose data. The implementer must inspect `.schema positions` on the live DB first.
+- Task 5's removal of `qty = pos.get("qty") or 0` in `_write_position_event_log` assumes `qty` is always populated in `pos` dicts post-Task-4. If any caller bypasses the new schema constraint (raw SQL elsewhere), that caller must be fixed. The plan does not audit for this; the test suite catches it via failures.
+- Task 10's `execute()` rewrite is the most substantial code change. The implementer should run all `tests/operators/test_position_closure.py` invariants after this task and confirm the existing 13 still pass before adding invariant #14 in Task 11.

--- a/docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md
+++ b/docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md
@@ -10,6 +10,43 @@
 
 ---
 
+## AMENDMENT 2026-05-26 (post-Task-1 measurement + Voronov reframe)
+
+Task 1 medición reveló que la premisa del Path D original (backfill `qty = size_usd / entry_price`) **NO es ejecutable en producción**:
+
+- 2018 total positions; 670 con `qty IS NULL` (33%)
+- **ZERO backfillable** desde `size_usd/entry_price` (la inmensa mayoría tampoco tiene `size_usd`)
+- 668 son closed (arqueología del bug histórico, ya cerradas con `pnl_usd=0`)
+- 2 son open con `entry_ts=2026-06-15` futuro, `tenant_id=NULL` — debris (test fixtures leaked to prod DB)
+
+Voronov reframe completo:
+
+> La medición no eligió la política. Reveló que la política propuesta describía un mundo que no existe.
+>
+> Tu plan asumió **deuda de cierre** (size_usd existió, qty derivable). La medición dice **deuda de nacimiento** (size_usd nunca prometida).
+>
+> **`UPDATE qty=0` es mentira tipográfica**: cero y desconocido no son sinónimos. **`status='legacy_unmeasurable'` convierte 668 mentiras silenciosas en 668 reconocimientos explícitos.**
+
+### Finding meta (precede Task 4)
+
+> **El sistema tiene un `close()` que asume invariantes que `open()` nunca prometió.** `qty NULL` no es el problema. Es el síntoma. La membrana de cierre asume un contrato que la membrana de apertura nunca firmó. Mientras esa asimetría exista, Task 4 es cosmética: estás poniendo CHECK CONSTRAINT en una salida cuya entrada no garantiza nada.
+
+### Tasks amended
+
+- **Task 2 (registry):** ADD a "Finding meta — asimetría contractual create vs close" sub-section documenting the meta finding. ADD `legacy_unmeasurable` as a documented status that the schema CHECK exempts.
+- **Task 3 (TDD tests):** REWRITE — no más `test_migration_aborts_if_any_row_unbackfillable`. Add `test_unbackfillable_rows_get_legacy_unmeasurable_status` + `test_check_constraint_exempts_legacy_unmeasurable`.
+- **Task 4 (impl):** REWRITE policy. Backfill what computable; UPDATE remaining NULL rows to `status='legacy_unmeasurable'` (keep qty NULL — admitir ausencia, no inventar valor); CHECK constraint: `CHECK (qty IS NOT NULL OR status='legacy_unmeasurable')`. **Fija, sin flags.**
+- **NEW Task 13.5 (before push):** Open 2 new issues — (a) test/prod permeability (debris in production DB), (b) `create_position` vs `close_position` contract asymmetry.
+- **Task 14 PR description:** Reference both the original reframe (Cluster C2 meta) AND this amendment.
+
+### Voronov's sharpened principle (replace plan's original)
+
+> "No requiere medir para decidir si comprometerse. Requiere medir para saber a qué comprometerse."
+
+The commitment stands. The shape of the commitment changed.
+
+---
+
 ## Context (read before starting)
 
 PR #466 separated semantic from mechanical invariants of `read_only_connection`. C2 is the bill for that separation — it surfaces what the semantic layer asserts that the mechanical layer never promised. Voronov:

--- a/health.py
+++ b/health.py
@@ -1170,8 +1170,18 @@ def get_dashboard_state(
                     sym = pos.get("symbol")
                     if not sym or sym not in prices:
                         continue
+                    raw_qty = pos.get("qty")
+                    if raw_qty is None:
+                        # Quarantined legacy_unmeasurable position (#467) —
+                        # explicitly excluded from open-MTM. Surfacing rather
+                        # than silently coercing to 0 (Serrano BLOCKER 2).
+                        log.warning(
+                            "get_dashboard_state: skipping legacy_unmeasurable "
+                            "position from open_mtm sym=%s", sym,
+                        )
+                        continue
                     entry = float(pos.get("entry_price") or 0)
-                    qty = float(pos.get("qty") or 0)
+                    qty = float(raw_qty)
                     direction = pos.get("direction", "LONG")
                     price_now = float(prices[sym])
                     if direction == "SHORT":

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -29,6 +29,8 @@ from db.transaction import precheck_connection
 from db.positions import db_get_position_by_id, db_close_position_sql, _calc_pnl
 from operators.precheck import (
     PositionSnapshot,
+    OwnershipValidatedSnapshot,
+    _build_validated_snapshot,
     PrecheckNotFound,
     PrecheckAlreadyClosed,
     PrecheckOkToProceed,
@@ -136,7 +138,7 @@ class PositionClosure:
             # MUST be reported distinctly, not collapsed to already_closed.
             return PrecheckRejectedState(snapshot=snapshot)
 
-        return PrecheckOkToProceed(snapshot=snapshot)
+        return PrecheckOkToProceed(snapshot=_build_validated_snapshot(snapshot))
 
     @staticmethod
     def _snapshot_to_dict(snapshot: PositionSnapshot) -> dict:
@@ -178,23 +180,28 @@ class PositionClosure:
                 pnl_pct=None,
             )
 
-        # PrecheckOkToProceed: write-tx must re-validate snapshot's mutable fields.
-        snapshot = result.snapshot
+        # PrecheckOkToProceed: write-tx must re-validate ALL snapshot fields.
+        # OwnershipValidatedSnapshot guarantees ownership was checked at precheck;
+        # the snapshot's mutable fields (everything in PositionSnapshot — tenant_id,
+        # status, entry_price, qty, direction, symbol) MUST be re-validated against
+        # the fresh row inside BEGIN IMMEDIATE. Schema does not enforce immutability
+        # of entry_price/qty/direction/symbol (CLAUDE.md "Capas de enforcement"),
+        # so the write-tx is the only place where stale snapshots are caught.
+        validated = result.snapshot   # OwnershipValidatedSnapshot
+        snap = validated.inner         # PositionSnapshot
         with _tx_module.transaction() as con:
             row = db_get_position_by_id(con, self._pos_id)
             if row is None:
                 return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
-            # #461 closure: tenant_id re-validation is obligatory by construction.
-            if row["tenant_id"] != snapshot.tenant_id:
-                # Tenant reassigned between precheck and write-tx. IDOR-safe collapse.
-                return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
+
+            # Status handling (3 branches: open / closed / other).
+            # F1 fix per Voronov: closed branch normalizes CloseOutcome.position shape
+            # to snapshot shape (same as precheck-detected already_closed branch).
+            # Consumers needing exit_* fields must read the row directly via a separate query.
+            # F2 fix per Voronov: status != "open" AND != "closed" (e.g., "cancelled")
+            # MUST NOT collapse to already_closed. The consumer needs the real state.
             if row["status"] == "closed":
-                # Race: another caller closed this position between precheck and BEGIN IMMEDIATE.
-                # Do NOT set self._result_row — the other caller already fired side-effects.
-                # F1 fix per Voronov: normalize CloseOutcome.position shape to snapshot
-                # shape (same as precheck-detected already_closed branch). Consumers
-                # needing exit_* fields must read the row directly via a separate query.
-                race_snapshot = PositionSnapshot(
+                race_snap = PositionSnapshot(
                     pos_id=row["id"],
                     tenant_id=row["tenant_id"],
                     status=row["status"],
@@ -205,15 +212,11 @@ class PositionClosure:
                 )
                 return CloseOutcome(
                     status="already_closed",
-                    position=self._snapshot_to_dict(race_snapshot),
-                    pnl_usd=None,
-                    pnl_pct=None,
+                    position=self._snapshot_to_dict(race_snap),
+                    pnl_usd=None, pnl_pct=None,
                 )
             if row["status"] != "open":
-                # F2 fix per Voronov: status != "open" AND != "closed" (e.g., "cancelled")
-                # MUST NOT collapse to already_closed. The consumer needs to know the real
-                # state to decide retry vs notify vs log-skip.
-                rejected_snapshot = PositionSnapshot(
+                race_snap = PositionSnapshot(
                     pos_id=row["id"],
                     tenant_id=row["tenant_id"],
                     status=row["status"],
@@ -224,25 +227,36 @@ class PositionClosure:
                 )
                 return CloseOutcome(
                     status="rejected_unexpected_state",
-                    position=self._snapshot_to_dict(rejected_snapshot),
-                    pnl_usd=None,
-                    pnl_pct=None,
+                    position=self._snapshot_to_dict(race_snap),
+                    pnl_usd=None, pnl_pct=None,
                 )
 
-            # Snapshot's immutable fields trusted; consume directly.
+            # Re-validate ALL other mutable fields (#469 + F6).
+            # tenant_id re-validation is the #461 closure (tenant reassigned between
+            # precheck and write-tx → IDOR-safe collapse to NOT_FOUND).
+            # entry_price/qty/direction/symbol drift means the snapshot is stale;
+            # collapse to NOT_FOUND for the same IDOR-safe shape as ownership mismatch.
+            if (row["tenant_id"] != snap.tenant_id
+                or row["entry_price"] != snap.entry_price
+                or row["qty"] != snap.qty
+                or row["direction"] != snap.direction
+                or row["symbol"] != snap.symbol):
+                return CloseOutcome(status="not_found", position=None, pnl_usd=None, pnl_pct=None)
+
+            # All snapshot fields confirmed. Snapshot is trusted; proceed.
             # Schema now enforces qty NOT NULL (CHECK constraint with
             # exemption for status='legacy_unmeasurable' — see #467).
             pnl_usd, pnl_pct = _calc_pnl(
-                snapshot.direction, snapshot.entry_price, self._exit_price, snapshot.qty,
+                snap.direction, snap.entry_price, self._exit_price, snap.qty,
             )
             exit_ts = self._now.isoformat()
             closed_row = db_close_position_sql(
                 con, self._pos_id, self._exit_price, self._exit_reason,
                 exit_ts, pnl_usd, pnl_pct,
             )
-            if snapshot.tenant_id is not None and pnl_usd is not None:
-                _capital_module.apply_pnl_to_capital(con, snapshot.tenant_id, pnl_usd)
-            elif snapshot.tenant_id is None:
+            if snap.tenant_id is not None and pnl_usd is not None:
+                _capital_module.apply_pnl_to_capital(con, snap.tenant_id, pnl_usd)
+            elif snap.tenant_id is None:
                 log.warning(
                     "PositionClosure: skipping capital roll-in for legacy tenant_id=NULL pos_id=%s",
                     self._pos_id,

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -230,11 +230,10 @@ class PositionClosure:
                 )
 
             # Snapshot's immutable fields trusted; consume directly.
-            # qty may be NULL in legacy rows (schema allows; some fixtures set
-            # only size_usd). Match the previous behavior of defaulting to 0.
-            qty = snapshot.qty or 0
+            # Schema now enforces qty NOT NULL (CHECK constraint with
+            # exemption for status='legacy_unmeasurable' — see #467).
             pnl_usd, pnl_pct = _calc_pnl(
-                snapshot.direction, snapshot.entry_price, self._exit_price, qty,
+                snapshot.direction, snapshot.entry_price, self._exit_price, snapshot.qty,
             )
             exit_ts = self._now.isoformat()
             closed_row = db_close_position_sql(

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -25,7 +25,7 @@ from typing import Literal, Optional
 
 from db import transaction as _tx_module  # imported as module so tests can
                                             # patch `transaction` on it
-from db.transaction import precheck_connection
+from db.transaction import PrecheckConn, precheck_connection
 from db.positions import db_get_position_by_id, db_close_position_sql, _calc_pnl
 from operators.precheck import (
     PositionSnapshot,
@@ -102,17 +102,24 @@ class PositionClosure:
     def __enter__(self) -> "PositionClosure":
         if self._consumed:
             raise RuntimeError("PositionClosure is single-use; construct a new one")
-        self._precheck_result = self._run_precheck()
+        with precheck_connection() as precheck_con:
+            self._precheck_result = self._run_precheck(precheck_con)
         return self
 
-    def _run_precheck(self) -> PrecheckResult:
+    def _run_precheck(self, precheck_con: PrecheckConn) -> PrecheckResult:
         """Read outside any transaction; return one of the 3 PrecheckResult variants.
 
         Implements ownership-before-lock (USER mode): a row whose tenant_id does
         not match caller_tenant_id collapses to PrecheckNotFound (IDOR-safe).
+
+        Signature consumes PrecheckConn (NewType from db.transaction) to declare
+        the KIND of connection this operator expects — Voronov-coherent: the
+        operator names its consumed contract, not just the helpers. Helper
+        signatures (db_get_position_by_id et al.) are intentionally not updated;
+        they accept either NewType via Python's structural subtyping of
+        sqlite3.Connection.
         """
-        with precheck_connection() as con:
-            row = db_get_position_by_id(con, self._pos_id)
+        row = db_get_position_by_id(precheck_con, self._pos_id)
 
         if row is None:
             return PrecheckNotFound()

--- a/operators/precheck.py
+++ b/operators/precheck.py
@@ -55,8 +55,20 @@ class PrecheckOkToProceed:
     OwnershipValidatedSnapshot — a type-level guarantee that ownership was
     checked at precheck time. The write-tx MUST STILL re-validate the
     snapshot's mutable fields against a fresh re-SELECT inside BEGIN
-    IMMEDIATE (immutable fields trusted directly)."""
+    IMMEDIATE (immutable fields trusted directly).
+
+    Runtime organ: __post_init__ rejects construction with a raw
+    PositionSnapshot. The 'tipo' rung in CLAUDE.md is real only because
+    this check exists (mypy is not in CI; annotation alone does not refuse).
+    """
     snapshot: "OwnershipValidatedSnapshot"
+
+    def __post_init__(self):
+        if not isinstance(self.snapshot, OwnershipValidatedSnapshot):
+            raise TypeError(
+                f"PrecheckOkToProceed.snapshot must be an OwnershipValidatedSnapshot, "
+                f"got {type(self.snapshot).__name__}. Use _build_validated_snapshot."
+            )
 
 
 @dataclass(frozen=True)

--- a/operators/precheck.py
+++ b/operators/precheck.py
@@ -51,9 +51,12 @@ class PrecheckAlreadyClosed:
 
 @dataclass(frozen=True)
 class PrecheckOkToProceed:
-    """Position passed all precheck conditions. The snapshot carries the
-    fields the write-tx will need (immutable directly; mutable re-validated)."""
-    snapshot: PositionSnapshot
+    """Position passed all precheck conditions. The snapshot is an
+    OwnershipValidatedSnapshot — a type-level guarantee that ownership was
+    checked at precheck time. The write-tx MUST STILL re-validate the
+    snapshot's mutable fields against a fresh re-SELECT inside BEGIN
+    IMMEDIATE (immutable fields trusted directly)."""
+    snapshot: "OwnershipValidatedSnapshot"
 
 
 @dataclass(frozen=True)
@@ -66,3 +69,50 @@ class PrecheckRejectedState:
 
 
 PrecheckResult = Union[PrecheckNotFound, PrecheckAlreadyClosed, PrecheckOkToProceed, PrecheckRejectedState]
+
+
+# Module-private sentinel — external callers cannot import this name
+# (single underscore is a convention; the factory check is by `is` identity).
+_VALIDATION_SENTINEL = object()
+
+
+@dataclass(frozen=True)
+class OwnershipValidatedSnapshot:
+    """A PositionSnapshot whose ownership has been validated by a precheck.
+
+    USER mode: caller_tenant_id matched snapshot.tenant_id at precheck time.
+    SYSTEM mode: ownership validation does not apply; the snapshot is
+    accepted by construction.
+
+    Construction requires the module-private _VALIDATION_SENTINEL. The only
+    legitimate constructor is `_build_validated_snapshot` (called by
+    `operators.position_closure.PositionClosure._run_precheck`).
+
+    A future write-tx that consumes this type is guaranteed (by construction)
+    that ownership was checked at precheck. The write-tx MUST STILL re-validate
+    the snapshot's mutable fields against a fresh re-SELECT — that is enforced
+    in PositionClosure.execute() by explicit field-by-field comparison.
+
+    Closes #469 + F6 (Voronov path C + E): the validation guarantee lives in
+    the type, not in a docstring.
+    """
+    inner: PositionSnapshot
+    _sentinel: object  # must be _VALIDATION_SENTINEL at construction
+
+    def __post_init__(self):
+        if self._sentinel is not _VALIDATION_SENTINEL:
+            raise TypeError(
+                "OwnershipValidatedSnapshot cannot be constructed directly. "
+                "Use the private validation sentinel via "
+                "operators.precheck._build_validated_snapshot (callable only "
+                "from operators.position_closure._run_precheck)."
+            )
+
+
+def _build_validated_snapshot(snapshot: PositionSnapshot) -> OwnershipValidatedSnapshot:
+    """Internal factory used by PositionClosure._run_precheck.
+
+    NOT exported from this module's public surface (single underscore).
+    Module-private convention: external code should not call this directly.
+    """
+    return OwnershipValidatedSnapshot(inner=snapshot, _sentinel=_VALIDATION_SENTINEL)

--- a/strategy/kill_switch_v2.py
+++ b/strategy/kill_switch_v2.py
@@ -142,8 +142,18 @@ def compute_portfolio_equity_curve(
         sym = pos.get("symbol")
         if sym not in now_price_by_symbol:
             continue
+        raw_qty = pos.get("qty")
+        if raw_qty is None:
+            # Quarantined legacy_unmeasurable position (#467) — skipping rather
+            # than silently coercing to 0 in the MTM/risk-threshold roll-up.
+            # Under-counting exposure on these rows was Serrano BLOCKER 2.
+            log.warning(
+                "kill_switch_v2: skipping legacy_unmeasurable position from "
+                "MTM sym=%s", sym,
+            )
+            continue
         entry = float(pos.get("entry_price") or 0)
-        qty = float(pos.get("qty") or 0)
+        qty = float(raw_qty)
         direction = pos.get("direction", "LONG")
         current_price = now_price_by_symbol[sym]
         if direction == "SHORT":

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -73,11 +73,15 @@ def _load_open_positions(conn, *, tenant_id: int) -> list[dict[str, Any]]:
            WHERE status = 'open' AND tenant_id = ?""",
         (tenant_id,),
     ).fetchall()
+    # NOTE: qty is intentionally NOT coerced to 0.0 here. Legacy unmeasurable
+    # positions (#467) carry qty=None; the membrane that hid this got removed
+    # in the post-Serrano correction. Consumers (health.py, kill_switch_v2)
+    # must skip None explicitly — see CLAUDE.md "Capas de enforcement".
     return [
         {
             "symbol": r[0],
             "entry_price": r[1] or 0.0,
-            "qty": r[2] or 0.0,
+            "qty": r[2],
             "direction": r[3] or "LONG",
         }
         for r in rows

--- a/tests/db/test_migrate_qty_not_null.py
+++ b/tests/db/test_migrate_qty_not_null.py
@@ -143,6 +143,52 @@ def test_check_constraint_rejects_null_qty_for_active_status(tmp_path):
     assert row[1] == "legacy_unmeasurable"
 
 
+def test_migration_tolerates_stub_positions_table(tmp_path):
+    """Migration must not crash when positions table predates size_usd/qty.
+
+    Simulates a very old DB schema (pre-B.1 stub) — earlier _migrate_* helpers
+    add tenant_id incrementally, but _migrate_qty_not_null must not reference
+    size_usd/qty in raw SQL if those columns don't yet exist.
+    """
+    import sqlite3
+    from db.schema import _migrate_qty_not_null
+
+    db = tmp_path / "stub.db"
+    con = sqlite3.connect(db)
+    con.executescript('''
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            symbol TEXT NOT NULL,
+            direction TEXT NOT NULL DEFAULT 'LONG',
+            status TEXT NOT NULL DEFAULT 'open',
+            entry_price REAL NOT NULL,
+            entry_ts TEXT NOT NULL
+        );
+        INSERT INTO positions (symbol, direction, status, entry_price, entry_ts)
+        VALUES ('BTCUSDT', 'LONG', 'open', 50000.0, '2024-01-01T00:00:00');
+    ''')
+    con.commit()
+
+    # Should not raise.
+    _migrate_qty_not_null(con)
+    con.commit()
+
+    # Row preserved.
+    row = con.execute("SELECT symbol, status, qty FROM positions").fetchone()
+    assert row[0] == 'BTCUSDT'
+    # qty column now exists (recreated), value is NULL.
+    assert row[2] is None
+    # Status quarantined since qty is NULL.
+    assert row[1] == 'legacy_unmeasurable'
+
+    # CHECK constraint is in place.
+    schema = con.execute(
+        "SELECT sql FROM sqlite_master WHERE name='positions'"
+    ).fetchone()[0]
+    assert "legacy_unmeasurable" in schema
+    con.close()
+
+
 def test_idempotent_on_already_migrated_table(tmp_path):
     """Running _migrate_qty_not_null twice is a no-op the second time."""
     from db.schema import _migrate_qty_not_null

--- a/tests/db/test_migrate_qty_not_null.py
+++ b/tests/db/test_migrate_qty_not_null.py
@@ -1,0 +1,163 @@
+"""Invariant tests for db.schema._migrate_qty_not_null (amended Voronov policy).
+
+Voronov path (C) for #467 post-Task-1 measurement:
+- Backfill qty = size_usd / entry_price where computable.
+- UNbackfillable rows → status='legacy_unmeasurable' (qty remains NULL).
+- CHECK constraint: qty IS NOT NULL OR status='legacy_unmeasurable'.
+
+The status admite the deuda explicitly instead of inventing values via
+UPDATE qty=0. Voronov: 'convierte mentiras silenciosas en reconocimientos
+explícitos'.
+"""
+import sqlite3
+import pytest
+
+
+def _init_minimal_positions_table(con: sqlite3.Connection) -> None:
+    """Create the positions table matching the live signals.db schema
+    (CREATE TABLE positions ...) WITHOUT the qty CHECK constraint."""
+    con.execute("""
+        CREATE TABLE positions (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            scan_id     INTEGER,
+            symbol      TEXT    NOT NULL,
+            direction   TEXT    NOT NULL DEFAULT 'LONG',
+            status      TEXT    NOT NULL DEFAULT 'open',
+            entry_price REAL    NOT NULL,
+            entry_ts    TEXT    NOT NULL,
+            sl_price    REAL,
+            tp_price    REAL,
+            size_usd    REAL,
+            qty         REAL,
+            exit_price  REAL,
+            exit_ts     TEXT,
+            exit_reason TEXT,
+            pnl_usd     REAL,
+            pnl_pct     REAL,
+            notes       TEXT,
+            atr_entry   REAL,
+            be_mult     REAL,
+            tenant_id   INTEGER
+        )
+    """)
+
+
+def test_backfill_qty_from_size_usd_and_entry_price(tmp_path):
+    """Rows with qty=NULL but size_usd and entry_price set must be backfilled
+    to qty = size_usd / entry_price. Status is unchanged."""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, size_usd, qty) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1000.0, NULL)"
+    )
+    con.commit()
+
+    _migrate_qty_not_null(con)
+
+    row = con.execute("SELECT qty, status FROM positions WHERE id = 1").fetchone()
+    assert row[0] == 10.0  # 1000 / 100
+    assert row[1] == "open"  # status unchanged
+
+
+def test_unbackfillable_closed_rows_get_legacy_unmeasurable_status(tmp_path):
+    """Closed rows with qty=NULL and size_usd=NULL cannot be backfilled.
+    They must get status='legacy_unmeasurable'; qty remains NULL.
+    (Voronov: admite ausencia, no inventar valor.)"""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, size_usd, qty, status) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', NULL, NULL, 'closed')"
+    )
+    con.commit()
+
+    _migrate_qty_not_null(con)
+
+    row = con.execute("SELECT qty, status FROM positions WHERE id = 1").fetchone()
+    assert row[0] is None  # qty admitido como ausente
+    assert row[1] == "legacy_unmeasurable"
+
+
+def test_unbackfillable_open_rows_also_get_legacy_unmeasurable_status(tmp_path):
+    """Open rows with qty=NULL and size_usd=NULL are treated the same as
+    closed+NULL — quarantine status (Voronov: 'tratalas como las
+    closed+NULL en esta migración')."""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, size_usd, qty, status) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', NULL, NULL, 'open')"
+    )
+    con.commit()
+
+    _migrate_qty_not_null(con)
+
+    row = con.execute("SELECT qty, status FROM positions WHERE id = 1").fetchone()
+    assert row[0] is None
+    assert row[1] == "legacy_unmeasurable"
+
+
+def test_check_constraint_rejects_null_qty_for_active_status(tmp_path):
+    """Post-migration, INSERT with qty=NULL and status='open' raises
+    IntegrityError. INSERT with qty=NULL and status='legacy_unmeasurable'
+    succeeds (the schema exempts the quarantine status)."""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    # Seed one valid row so migration runs cleanly.
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, size_usd, qty, status) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1000.0, 10.0, 'closed')"
+    )
+    con.commit()
+
+    _migrate_qty_not_null(con)
+
+    # Active status with NULL qty must be rejected.
+    with pytest.raises(sqlite3.IntegrityError):
+        con.execute(
+            "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, status) "
+            "VALUES (99, 'XYZ', 50.0, '2026-04-20T10:00:00+00:00', NULL, 'open')"
+        )
+
+    # legacy_unmeasurable status with NULL qty must be accepted (exempted).
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, status) "
+        "VALUES (100, 'XYZ', 50.0, '2026-04-20T10:00:00+00:00', NULL, 'legacy_unmeasurable')"
+    )
+    con.commit()
+    row = con.execute("SELECT qty, status FROM positions WHERE id = 100").fetchone()
+    assert row[0] is None
+    assert row[1] == "legacy_unmeasurable"
+
+
+def test_idempotent_on_already_migrated_table(tmp_path):
+    """Running _migrate_qty_not_null twice is a no-op the second time."""
+    from db.schema import _migrate_qty_not_null
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, size_usd, qty) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1000.0, 10.0)"
+    )
+    con.commit()
+
+    _migrate_qty_not_null(con)
+    _migrate_qty_not_null(con)  # second run must not raise
+
+    row = con.execute("SELECT qty FROM positions WHERE id = 1").fetchone()
+    assert row[0] == 10.0

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -199,3 +199,51 @@ def test_precheck_connection_does_not_leak_query_only(fresh_db):
     with transaction() as con:
         rows = con.execute("SELECT x FROM leak_test ORDER BY x").fetchall()
     assert [r["x"] for r in rows] == [42, 99]
+
+
+# ---- NewType enforcement (closes #468) ----
+
+def test_precheck_connection_yields_PrecheckConn_type():
+    """precheck_connection must yield a value whose type is PrecheckConn."""
+    from db.transaction import precheck_connection, PrecheckConn
+
+    with precheck_connection() as con:
+        # NewType is a runtime no-op (the value is just the wrapped object),
+        # but the type annotation must be importable and the helper must use it.
+        assert con is not None
+        # Verify the helper's annotation declares PrecheckConn (not raw sqlite3.Connection).
+    import inspect
+    from db.transaction import precheck_connection as pc
+    sig = inspect.signature(pc.__wrapped__) if hasattr(pc, "__wrapped__") else inspect.signature(pc)
+    # The contextmanager wrapper might hide signature; we check the module's
+    # type alias is importable instead.
+    assert PrecheckConn is not None
+
+
+def test_snapshot_connection_yields_SnapshotConn_type():
+    """snapshot_connection must yield a value whose type is SnapshotConn."""
+    from db.transaction import snapshot_connection, SnapshotConn
+
+    with snapshot_connection() as con:
+        assert con is not None
+    assert SnapshotConn is not None
+
+
+def test_PrecheckConn_and_SnapshotConn_are_distinct_NewTypes():
+    """PrecheckConn and SnapshotConn must be distinct NewType objects.
+    A NewType-aware type checker (mypy) treats them as incompatible; at
+    runtime they are both callables that return their argument unchanged."""
+    from db.transaction import PrecheckConn, SnapshotConn
+
+    assert PrecheckConn is not SnapshotConn
+    # NewType instances are callables; calling either returns the argument.
+    import sqlite3
+    con = sqlite3.connect(":memory:")
+    try:
+        wrapped_a = PrecheckConn(con)
+        wrapped_b = SnapshotConn(con)
+        # Runtime equality: both wrap the same object.
+        assert wrapped_a is con
+        assert wrapped_b is con
+    finally:
+        con.close()

--- a/tests/operators/test_ownership_validated_snapshot.py
+++ b/tests/operators/test_ownership_validated_snapshot.py
@@ -1,0 +1,80 @@
+"""Tests for OwnershipValidatedSnapshot factory pattern (#469 + F6).
+
+The class must not be constructible without the module-private sentinel.
+The only legitimate constructor is operators.position_closure._run_precheck.
+"""
+import pytest
+
+
+def test_cannot_construct_without_sentinel():
+    """OwnershipValidatedSnapshot raised TypeError if constructed with a
+    foreign sentinel (i.e., any object other than the module-private
+    _VALIDATION_SENTINEL)."""
+    from operators.precheck import OwnershipValidatedSnapshot, PositionSnapshot
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+
+    # Try with a wrong sentinel (e.g., another object()).
+    with pytest.raises(TypeError, match=r"private validation sentinel"):
+        OwnershipValidatedSnapshot(inner=snap, _sentinel=object())
+
+
+def test_cannot_construct_with_none_sentinel():
+    """OwnershipValidatedSnapshot raises TypeError if _sentinel is None."""
+    from operators.precheck import OwnershipValidatedSnapshot, PositionSnapshot
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+
+    with pytest.raises(TypeError, match=r"private validation sentinel"):
+        OwnershipValidatedSnapshot(inner=snap, _sentinel=None)
+
+
+def test_internal_factory_builds_validated_snapshot():
+    """_build_validated_snapshot is the only legitimate constructor.
+    It is module-private (underscore prefix), not exported from precheck's
+    public surface."""
+    from operators.precheck import (
+        _build_validated_snapshot,
+        OwnershipValidatedSnapshot,
+        PositionSnapshot,
+    )
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+
+    validated = _build_validated_snapshot(snap)
+    assert isinstance(validated, OwnershipValidatedSnapshot)
+    assert validated.inner == snap
+
+
+def test_PrecheckOkToProceed_carries_OwnershipValidatedSnapshot():
+    """PrecheckOkToProceed.snapshot is typed as OwnershipValidatedSnapshot
+    (not PositionSnapshot) — the type-level guarantee that ownership was
+    validated."""
+    from operators.precheck import (
+        PrecheckOkToProceed,
+        OwnershipValidatedSnapshot,
+        _build_validated_snapshot,
+        PositionSnapshot,
+    )
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+    validated = _build_validated_snapshot(snap)
+    ok = PrecheckOkToProceed(snapshot=validated)
+    assert isinstance(ok.snapshot, OwnershipValidatedSnapshot)
+    assert ok.snapshot.inner == snap

--- a/tests/operators/test_position_closure.py
+++ b/tests/operators/test_position_closure.py
@@ -572,3 +572,38 @@ def test_precheck_rejected_state_distinct_from_already_closed():
     assert isinstance(rs, PrecheckRejectedState)
     assert not isinstance(rs, PrecheckAlreadyClosed)
     assert rs.snapshot.status == "cancelled"
+
+
+# ---- Invariant 14: cross-mutation race rejects close when snapshot field drifts ----
+
+def test_cross_mutation_race_entry_price_rejects_close(fresh_db_with_two_tenants):
+    """If a snapshot field that is NOT tenant_id/status changes between precheck
+    and BEGIN IMMEDIATE (e.g., entry_price is updated by a migration or ad-hoc
+    UPDATE), the operator must detect the drift and return not_found.
+
+    Closes #469 + F6: validation lives in the type (OwnershipValidatedSnapshot)
+    and the runtime field-by-field comparison in execute()."""
+    from operators.position_closure import PositionClosure
+
+    closure = PositionClosure(
+        pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+        mode="USER", caller_tenant_id=1,
+    )
+    closure.__enter__()  # precheck reads entry_price (whatever the fixture set)
+
+    # Simulate an entry_price drift between precheck and write-tx.
+    with transaction() as con:
+        con.execute("UPDATE positions SET entry_price = 999.99 WHERE id = 1")
+
+    outcome = closure.execute()
+    closure.__exit__(None, None, None)
+
+    # The snapshot held the old entry_price; the row now has 999.99.
+    # The mismatch must collapse to NOT_FOUND.
+    assert outcome.status == "not_found"
+
+    # The row was not closed.
+    with transaction() as con:
+        pos = con.execute("SELECT status, entry_price FROM positions WHERE id=1").fetchone()
+    assert pos["status"] == "open"
+    assert pos["entry_price"] == 999.99  # our UPDATE remains

--- a/tests/operators/test_precheck.py
+++ b/tests/operators/test_precheck.py
@@ -41,6 +41,7 @@ def test_precheck_result_variants_distinguishable():
     via isinstance."""
     from operators.precheck import (
         PositionSnapshot, PrecheckNotFound, PrecheckAlreadyClosed, PrecheckOkToProceed,
+        _build_validated_snapshot,
     )
 
     snap = PositionSnapshot(
@@ -51,7 +52,7 @@ def test_precheck_result_variants_distinguishable():
 
     nf = PrecheckNotFound()
     ac = PrecheckAlreadyClosed(snapshot=snap)
-    ok = PrecheckOkToProceed(snapshot=snap)
+    ok = PrecheckOkToProceed(snapshot=_build_validated_snapshot(snap))
 
     assert isinstance(nf, PrecheckNotFound)
     assert not isinstance(nf, PrecheckAlreadyClosed)
@@ -61,7 +62,7 @@ def test_precheck_result_variants_distinguishable():
     assert not isinstance(ac, PrecheckOkToProceed)
 
     assert isinstance(ok, PrecheckOkToProceed)
-    assert ok.snapshot == snap
+    assert ok.snapshot.inner == snap
 
 
 def test_precheck_not_found_carries_no_snapshot():

--- a/tests/test_agent_proposals.py
+++ b/tests/test_agent_proposals.py
@@ -244,8 +244,8 @@ def _seed_position(con, *, tenant_id: int, status: str = "open", id: int | None 
     # outer CM tried to COMMIT.
     cur = con.execute(
         "INSERT INTO positions "
-        "(symbol, direction, status, entry_price, entry_ts, size_usd, tenant_id) "
-        "VALUES ('BTCUSDT', 'LONG', ?, 50000, '2026-04-20T10:00:00+00:00', 1000, ?)",
+        "(symbol, direction, status, entry_price, entry_ts, size_usd, qty, tenant_id) "
+        "VALUES ('BTCUSDT', 'LONG', ?, 50000, '2026-04-20T10:00:00+00:00', 1000, 0.02, ?)",
         (status, tenant_id),
     )
     return cur.lastrowid

--- a/tests/test_agent_safety_regression.py
+++ b/tests/test_agent_safety_regression.py
@@ -181,9 +181,9 @@ async def test_propose_close_path_uses_id_from_tool_result(tmp_db, monkeypatch):
     with transaction() as con:
         con.execute(
             "INSERT INTO positions "
-            "(symbol, direction, status, entry_price, entry_ts, size_usd, tenant_id) "
+            "(symbol, direction, status, entry_price, entry_ts, size_usd, qty, tenant_id) "
             "VALUES ('ETHUSDT', 'LONG', 'open', 3000, '2026-05-19T10:00:00+00:00', "
-            "        1000, 1)",
+            "        1000, 0.333, 1)",
         )
         pos_id = con.execute("SELECT MAX(id) AS id FROM positions").fetchone()["id"]
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -106,9 +106,9 @@ def _seed_two_tenant_positions(con):
         ):
             con.execute(
                 "INSERT INTO positions "
-                "(symbol, direction, status, entry_price, entry_ts, size_usd, "
+                "(symbol, direction, status, entry_price, entry_ts, size_usd, qty, "
                 " exit_price, exit_ts, pnl_usd, tenant_id) "
-                "VALUES ('BTCUSDT', ?, ?, ?, '2026-05-15T10:00:00+00:00', 1000, "
+                "VALUES ('BTCUSDT', ?, ?, ?, '2026-05-15T10:00:00+00:00', 1000, 0.02, "
                 " ?, ?, ?, ?)",
                 (direction, status, base_price, exit_price, exit_ts, pnl, tid),
             )
@@ -167,9 +167,9 @@ def test_get_position_detail_returns_not_found_for_other_tenant(tmp_db):
     with transaction() as con:
         cur = con.execute(
             "INSERT INTO positions "
-            "(symbol, direction, status, entry_price, entry_ts, size_usd, tenant_id) "
+            "(symbol, direction, status, entry_price, entry_ts, size_usd, qty, tenant_id) "
             "VALUES ('BTCUSDT', 'LONG', 'open', 50000, "
-            "'2026-05-15T10:00:00+00:00', 1000, 2)"
+            "'2026-05-15T10:00:00+00:00', 1000, 0.02, 2)"
         )
         other_tenant_pos_id = cur.lastrowid
 
@@ -190,9 +190,9 @@ def test_get_position_detail_returns_row_for_own_tenant(tmp_db):
     with transaction() as con:
         cur = con.execute(
             "INSERT INTO positions "
-            "(symbol, direction, status, entry_price, entry_ts, size_usd, tenant_id) "
+            "(symbol, direction, status, entry_price, entry_ts, size_usd, qty, tenant_id) "
             "VALUES ('ETHUSDT', 'LONG', 'open', 3000, "
-            "'2026-05-15T10:00:00+00:00', 500, 7)"
+            "'2026-05-15T10:00:00+00:00', 500, 0.166, 7)"
         )
         own_pos_id = cur.lastrowid
 

--- a/tests/test_health_alert_notify.py
+++ b/tests/test_health_alert_notify.py
@@ -27,9 +27,9 @@ def _insert_closed(conn, symbol, pnl, exit_ts):
     # would end the active tx and the outer CM's COMMIT would raise.
     conn.execute(
         """INSERT INTO positions
-           (symbol, direction, status, entry_price, entry_ts,
+           (symbol, direction, status, entry_price, entry_ts, qty,
             exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?, 1)""",
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 1.0, 101.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
     )
 

--- a/tests/test_health_dashboard.py
+++ b/tests/test_health_dashboard.py
@@ -98,9 +98,9 @@ def tmp_db(tmp_path, monkeypatch):
 def _insert_closed_position(conn, symbol, pnl, exit_ts):
     conn.execute(
         """INSERT INTO positions
-           (symbol, direction, status, entry_price, entry_ts,
+           (symbol, direction, status, entry_price, entry_ts, qty,
             exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', ?, ?, 1)""",
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 1.0, 110.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
     )
 
@@ -322,9 +322,9 @@ def test_get_health_dashboard_seeded_symbol_returns_full_state(client):
         for i in range(5):
             conn.execute(
                 """INSERT INTO positions
-                   (symbol, direction, status, entry_price, entry_ts,
+                   (symbol, direction, status, entry_price, entry_ts, qty,
                     exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 1.0, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
                 (f"2026-04-2{1+i}T12:00:00+00:00", f"2026-04-2{1+i}T13:00:00+00:00"),
             )
         # Seed an event
@@ -433,10 +433,10 @@ def test_get_health_dashboard_no_double_count_on_realized_pnl_history(client):
             reason = "TP" if pnl > 0 else "SL"
             conn.execute(
                 """INSERT INTO positions
-                   (symbol, direction, status, entry_price, entry_ts,
+                   (symbol, direction, status, entry_price, entry_ts, qty,
                     exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct,
                     tenant_id)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, ?, ?, ?, ?, ?, 1)""",
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 1.0, ?, ?, ?, ?, ?, 1)""",
                 (
                     f"2026-04-2{i + 1}T12:00:00+00:00",
                     100.0 + pnl / 10.0,
@@ -487,9 +487,9 @@ def test_get_health_dashboard_isolates_tenants(client):
         # (a) Tenant 2 has a closed losing trade for ETH.
         conn.execute(
             """INSERT INTO positions
-               (symbol, direction, status, entry_price, entry_ts,
+               (symbol, direction, status, entry_price, entry_ts, qty,
                 exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-               VALUES ('ETH', 'LONG', 'closed', 1000.0, '2026-04-20T12:00:00+00:00',
+               VALUES ('ETH', 'LONG', 'closed', 1000.0, '2026-04-20T12:00:00+00:00', 1.0,
                        900.0, '2026-04-20T15:00:00+00:00', 'SL', -1000.0, -0.10, 2)"""
         )
         # (b) Tenant 2 has an OPEN long BTC position with a large unrealized

--- a/tests/test_health_integration.py
+++ b/tests/test_health_integration.py
@@ -21,9 +21,9 @@ def _insert_closed(conn, symbol, pnl, exit_ts):
     # db.transaction's contract and break the outer CM's COMMIT.
     conn.execute(
         """INSERT INTO positions
-           (symbol, direction, status, entry_price, entry_ts,
+           (symbol, direction, status, entry_price, entry_ts, qty,
             exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?, 1)""",
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 1.0, 101.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
     )
 
@@ -134,9 +134,9 @@ def test_paused_reactivate_to_probation_then_complete_after_n_trades(tmp_db):
             ts = (datetime.now(timezone.utc) - timedelta(days=180 + i)).isoformat()
             conn.execute(
                 """INSERT INTO positions
-                   (symbol, direction, status, entry_price, entry_ts,
+                   (symbol, direction, status, entry_price, entry_ts, qty,
                     exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 95.0, ?, 'SL', -5.0, -0.05, 1)""",
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 1.0, 95.0, ?, 'SL', -5.0, -0.05, 1)""",
                 (ts, ts),
             )
         # Insert PAUSED row for BTC, set 15 days ago
@@ -175,9 +175,9 @@ def test_paused_reactivate_to_probation_then_complete_after_n_trades(tmp_db):
         with transaction() as conn:
             conn.execute(
                 """INSERT INTO positions
-                   (symbol, direction, status, entry_price, entry_ts,
+                   (symbol, direction, status, entry_price, entry_ts, qty,
                     exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 1.0, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
                 (ts, ts),
             )
         trigger_health_evaluation("BTC", cfg)

--- a/tests/test_health_pause_tier.py
+++ b/tests/test_health_pause_tier.py
@@ -26,9 +26,9 @@ def _insert_closed(conn, symbol, pnl, exit_ts):
     # db.transaction's contract and break the outer CM's COMMIT.
     conn.execute(
         """INSERT INTO positions
-           (symbol, direction, status, entry_price, entry_ts,
+           (symbol, direction, status, entry_price, entry_ts, qty,
             exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?, 1)""",
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 1.0, 101.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl, pnl / 100.0),
     )
 

--- a/tests/test_health_probation.py
+++ b/tests/test_health_probation.py
@@ -216,9 +216,9 @@ def test_trigger_health_evaluation_decrements_then_evaluates(tmp_db):
         for i in range(25):
             conn.execute(
                 """INSERT INTO positions
-                   (symbol, direction, status, entry_price, entry_ts,
+                   (symbol, direction, status, entry_price, entry_ts, qty,
                     exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 1.0, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
                 (f"2026-05-{1+i%28:02d}T12:00:00+00:00", f"2026-05-{1+i%28:02d}T13:00:00+00:00"),
             )
 
@@ -250,9 +250,9 @@ def test_daily_cron_eval_does_not_decrement_probation(tmp_db):
         for i in range(25):
             conn.execute(
                 """INSERT INTO positions
-                   (symbol, direction, status, entry_price, entry_ts,
+                   (symbol, direction, status, entry_price, entry_ts, qty,
                     exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
+                   VALUES ('BTC', 'LONG', 'closed', 100.0, ?, 1.0, 110.0, ?, 'TP', 10.0, 0.10, 1)""",
                 (f"2026-05-{1+i%28:02d}T12:00:00+00:00", f"2026-05-{1+i%28:02d}T13:00:00+00:00"),
             )
     cfg = {"kill_switch": {

--- a/tests/test_health_rolling_metrics.py
+++ b/tests/test_health_rolling_metrics.py
@@ -24,9 +24,9 @@ def _insert_closed_position(conn, symbol, pnl_usd, exit_ts):
     """
     conn.execute(
         """INSERT INTO positions
-           (symbol, direction, status, entry_price, entry_ts,
+           (symbol, direction, status, entry_price, entry_ts, qty,
             exit_price, exit_ts, exit_reason, pnl_usd, pnl_pct, tenant_id)
-           VALUES (?, 'LONG', 'closed', 100.0, ?, 101.0, ?, 'TP', ?, ?, 1)""",
+           VALUES (?, 'LONG', 'closed', 100.0, ?, 1.0, 101.0, ?, 'TP', ?, ?, 1)""",
         (symbol, exit_ts, exit_ts, pnl_usd, pnl_usd / 100.0),
     )
 
@@ -52,8 +52,8 @@ def test_open_positions_are_excluded(tmp_db):
     with transaction() as conn:
         conn.execute(
             """INSERT INTO positions
-               (symbol, direction, status, entry_price, entry_ts, pnl_usd, pnl_pct, tenant_id)
-               VALUES ('BTCUSDT', 'LONG', 'open', 100.0, ?, NULL, NULL, 1)""",
+               (symbol, direction, status, entry_price, entry_ts, qty, pnl_usd, pnl_pct, tenant_id)
+               VALUES ('BTCUSDT', 'LONG', 'open', 100.0, ?, 1.0, NULL, NULL, 1)""",
             (NOW.isoformat(),),
         )
         metrics = compute_rolling_metrics("BTCUSDT", conn, now=NOW)

--- a/tests/test_multi_tenant_b1_schema.py
+++ b/tests/test_multi_tenant_b1_schema.py
@@ -230,8 +230,8 @@ class TestNullTenantIdAllowed:
         """B.1 explicitly leaves tenant_id nullable; insert NULL is valid."""
         con = sqlite3.connect(initialized_db)
         con.execute(
-            "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, tenant_id) "
-            "VALUES (?, ?, ?, ?, ?, NULL)",
+            "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, qty, tenant_id) "
+            "VALUES (?, ?, ?, ?, ?, 1.0, NULL)",
             ("BTCUSDT", "LONG", "open", 80000.0, "2026-05-15T12:00:00Z"),
         )
         con.commit()
@@ -256,8 +256,8 @@ class TestBackfillTenant:
         # Insert positions with NULL tenant_id (simulating pre-multi-tenant data)
         for symbol, price in (("BTCUSDT", 80000), ("ETHUSDT", 2300), ("RUNEUSDT", 0.5)):
             con.execute(
-                "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, tenant_id) "
-                "VALUES (?, 'LONG', 'open', ?, '2026-05-15T12:00:00Z', NULL)",
+                "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, qty, tenant_id) "
+                "VALUES (?, 'LONG', 'open', ?, '2026-05-15T12:00:00Z', 1.0, NULL)",
                 (symbol, price),
             )
         con.commit()
@@ -284,8 +284,8 @@ class TestBackfillTenant:
 
         con = sqlite3.connect(initialized_db)
         con.execute(
-            "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, tenant_id) "
-            "VALUES (?, 'LONG', 'open', ?, '2026-05-15T12:00:00Z', NULL)",
+            "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, qty, tenant_id) "
+            "VALUES (?, 'LONG', 'open', ?, '2026-05-15T12:00:00Z', 1.0, NULL)",
             ("BTCUSDT", 80000),
         )
         con.commit()
@@ -306,12 +306,12 @@ class TestBackfillTenant:
         con = sqlite3.connect(initialized_db)
         # One row with explicit tenant_id, one with NULL
         con.execute(
-            "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, tenant_id) "
-            "VALUES ('BTCUSDT', 'LONG', 'open', 80000, '2026-05-15T12:00:00Z', 7)"
+            "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, qty, tenant_id) "
+            "VALUES ('BTCUSDT', 'LONG', 'open', 80000, '2026-05-15T12:00:00Z', 1.0, 7)"
         )
         con.execute(
-            "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, tenant_id) "
-            "VALUES ('ETHUSDT', 'LONG', 'open', 2300, '2026-05-15T12:00:00Z', NULL)"
+            "INSERT INTO positions(symbol, direction, status, entry_price, entry_ts, qty, tenant_id) "
+            "VALUES ('ETHUSDT', 'LONG', 'open', 2300, '2026-05-15T12:00:00Z', 1.0, NULL)"
         )
         con.commit()
         con.close()

--- a/tests/test_multi_tenant_b8_migration.py
+++ b/tests/test_multi_tenant_b8_migration.py
@@ -58,13 +58,13 @@ def seeded_db(tmp_path, monkeypatch):
         # Pre-multi-tenant rows: tenant_id NULL across each per-user table
         con.execute(
             "INSERT INTO positions (symbol, direction, status, entry_price, "
-            "entry_ts) VALUES ('BTCUSDT', 'LONG', 'closed', 65000, "
-            "'2026-04-01T00:00:00')"
+            "entry_ts, qty) VALUES ('BTCUSDT', 'LONG', 'closed', 65000, "
+            "'2026-04-01T00:00:00', 1.0)"
         )
         con.execute(
             "INSERT INTO positions (symbol, direction, status, entry_price, "
-            "entry_ts) VALUES ('ETHUSDT', 'LONG', 'open', 3000, "
-            "'2026-04-02T00:00:00')"
+            "entry_ts, qty) VALUES ('ETHUSDT', 'LONG', 'open', 3000, "
+            "'2026-04-02T00:00:00', 1.0)"
         )
         con.execute(
             "INSERT INTO signal_outcomes (scan_id, symbol, signal_ts, "


### PR DESCRIPTION
## Summary

Voronov meta-reframe of Cluster C2. Closes three issues by FIRST naming the patología they share — *invariantes de dominio sin contraparte estructural* — and THEN moving three specific invariants from \`convención\` to either \`schema\` or \`tipo\` within a written registry (\`CLAUDE.md\` § \"Capas de enforcement de invariantes\").

Voronov's framing:
> Los tres issues no son deuda de #466. Son la primera generación de un patrón donde el dominio afirma más de lo que el almacenamiento garantiza, y el código paga la diferencia en membranas silenciosas — \`or 0\`, comentarios de revisor, re-validaciones parciales. Mientras esa asimetría no esté nombrada, cada issue futuro de esta familia se debatirá como si fuera nuevo.

## The three moves

| Invariante | Capa enforced | Mecanismo | Closes |
|---|---|---|---|
| \`qty\` siempre numérica para positions activas (o \`status='legacy_unmeasurable'\`) | **Schema** | \`CHECK (qty IS NOT NULL OR status='legacy_unmeasurable')\` vía \`_migrate_qty_not_null\` | #467 |
| \`precheck_connection\` ≠ \`snapshot_connection\` | **Tipo** | \`NewType(\"PrecheckConn\", sqlite3.Connection)\` + \`NewType(\"SnapshotConn\", sqlite3.Connection)\` | #468 |
| Los 6 campos del snapshot no cambian entre precheck y BEGIN IMMEDIATE | **Tipo + runtime check** | \`OwnershipValidatedSnapshot\` (factory privada) + field-by-field re-validation en \`PositionClosure.execute()\` | #469 + F6 |

## Amendment — Voronov post-Task-1 measurement (2026-05-26)

Plan amended in-flight: the original Task 4 (\`raise on unbackfillable\`) was unrealizable in production. Task 1 measured \`signals.db\`:

- 2018 total positions; 670 with \`qty IS NULL\` (33%)
- **Zero** backfillable from \`size_usd / entry_price\` (la mayoría tampoco tiene \`size_usd\`)
- 668 closed (arqueología); 2 open con \`entry_ts=2026-06-15\` (debris de test fixtures — ahora rastreado en #470)

Reframe: \`UPDATE qty=0\` sería mentira tipográfica; \`status='legacy_unmeasurable'\` convierte 670 mentiras silenciosas en 670 reconocimientos explícitos. \"Admite ausencia, no inventes valor.\"

Sharpened principle:
> No requiere medir para decidir si comprometerse. Requiere medir para saber a qué comprometerse.

## Finding meta — asimetría contractual create vs close

> El sistema tiene un \`close()\` que asume invariantes que \`open()\` nunca prometió. \`qty NULL\` no es el problema. Es el síntoma. La membrana de cierre asume un contrato que la membrana de apertura nunca firmó.

Documented in CLAUDE.md as \"Known scope gap\"; tracked separately in #471 (birth-time enforcement).

## Test results

- \`tests/db/test_migrate_qty_not_null.py\` — 6/6 pass (backfill, quarantine, CHECK enforcement, idempotency, stub-table tolerance)
- \`tests/db/test_transaction.py\` — 15/15 pass (3 new NewType tests + 12 pre-existing)
- \`tests/operators/test_precheck.py\` + \`test_ownership_validated_snapshot.py\` — 9/9 pass
- \`tests/operators/test_position_closure.py\` — 17/17 pass (incl. new invariant #14: cross-mutation race entry_price rejects close)
- \`tests/api/test_check_position_stops_atomicity.py\` — PASS (regression guard from #463)
- Full suite: 2516 passed, 22 skipped, 1 ordering flake (\`test_emit_shadow_uses_cache_for_multi_symbol_mtm\` — passes in isolation, pre-existing)

## Production data smoke

Migration applied to a copy of \`signals.db\`:
- BEFORE: 2018 rows, 670 qty NULL
- AFTER: 2018 rows preserved, 0 backfilled, 670 quarantined as \`legacy_unmeasurable\`
- Row count exact; zero data loss; CHECK constraint live

## Companion issues opened

- #470 — test/prod permeability (debris from test fixtures in production DB)
- #471 — contract asymmetry between \`create_position\` and \`close_position\` (birth-time gap)

## Test plan for reviewers

- [ ] Targeted suites green: \`pytest tests/db/test_migrate_qty_not_null.py tests/db/test_transaction.py tests/operators/test_precheck.py tests/operators/test_ownership_validated_snapshot.py tests/operators/test_position_closure.py tests/api/test_check_position_stops_atomicity.py\`
- [ ] Smoke against your own \`signals.db\` (recommend backing up first):
      \`\`\`
      cp signals.db /tmp/signals.bak
      python -c \"import btc_api; btc_api.DB_FILE='signals.db'; from db.schema import init_db; init_db()\"
      \`\`\`
- [ ] Verify CHECK constraint:
      \`\`\`
      sqlite3 signals.db \".schema positions\" | grep CHECK
      \`\`\`
- [ ] Read CLAUDE.md § \"Capas de enforcement de invariantes\" — confirms the registry framework is correctly oriented for future cluster work

Closes #467
Closes #468
Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)