### PR TITLE
feat(operators): honest narrowing of OwnershipValidatedSnapshot enforcement claim (closes #481, advances #477)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md
+++ b/docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md
@@ -1055,9 +1055,10 @@ snapshot, not the raw PositionSnapshot."
 
 ### Task 9: Implement OwnershipValidatedSnapshot + update PrecheckOkToProceed in operators/precheck.py
 
-> **Footnote (post-implementation, post-Serrano review of PR #486 — 2026-05-26):** The error message, sentinel comment, and `Closes #469 + F6` framing in the Step 1 code block below were softened/qualified after this plan executed. Specifically:
-> - PR #486 closes **#481** (doc honesty — the `"callable only from operators.position_closure._run_precheck"` wording was a documentation lie) and advances **#477** (registry coherence — Path 3 honest narrowing of the factory's single-call-site rung).
-> - Issue **#487** (post-Serrano F2) tracks the wider asymmetry: `_VALIDATION_SENTINEL` is module-attribute-accessible, so any caller importing the sentinel name can construct `OwnershipValidatedSnapshot` directly, bypassing the factory. The narrowing in PR #486 named the factory side only; the sentinel side is still open.
+> **Footnote (post-implementation, post-Serrano + post-Voronov review of PR #486 — 2026-05-26):** The error message, sentinel comment, and `Closes #469 + F6` framing in the Step 1 code block below were softened/qualified after this plan executed. Specifically:
+> - PR #486 closes **#481** (doc honesty — the `"callable only from operators.position_closure._run_precheck"` wording was a documentation lie) and advances **#477** (registry coherence — Path 3 honest narrowing).
+> - Issue **#477** (originally Serrano F8 — factory single-underscore framing) was widened 2026-05-26 to encompass post-Serrano F2 — the sentinel itself is module-attribute-accessible. Both surfaces (factory name + sentinel name) of the convention bound are now tracked under #477 as one invariant with two surfaces (Voronov reframe: *"two surfaces of one bound do not deserve two issue numbers"*). PR #486 applies Path 3 (honest narrowing) for the docstring + error-message language; structural fix paths (closure pattern / name-mangling / frame inspection / accept-permanently) remain open.
+> - Issue **#488** (post-Voronov meta-architectural) tracks three structural next-moves for the registry itself: schema disambiguation (per-invariant rows vs. closure-scope column), registry-coherence test/CI organ, and verb taxonomy (`Closes` vs `Advances`).
 >
 > **For the current source-of-truth wording, read `operators/precheck.py` on `upstream/main`.** This plan document is a historical snapshot of the original implementation directive and intentionally preserves the original phrasing for archaeological fidelity.
 

--- a/docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md
+++ b/docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md
@@ -1055,6 +1055,12 @@ snapshot, not the raw PositionSnapshot."
 
 ### Task 9: Implement OwnershipValidatedSnapshot + update PrecheckOkToProceed in operators/precheck.py
 
+> **Footnote (post-implementation, post-Serrano review of PR #486 — 2026-05-26):** The error message, sentinel comment, and `Closes #469 + F6` framing in the Step 1 code block below were softened/qualified after this plan executed. Specifically:
+> - PR #486 closes **#481** (doc honesty — the `"callable only from operators.position_closure._run_precheck"` wording was a documentation lie) and advances **#477** (registry coherence — Path 3 honest narrowing of the factory's single-call-site rung).
+> - Issue **#487** (post-Serrano F2) tracks the wider asymmetry: `_VALIDATION_SENTINEL` is module-attribute-accessible, so any caller importing the sentinel name can construct `OwnershipValidatedSnapshot` directly, bypassing the factory. The narrowing in PR #486 named the factory side only; the sentinel side is still open.
+>
+> **For the current source-of-truth wording, read `operators/precheck.py` on `upstream/main`.** This plan document is a historical snapshot of the original implementation directive and intentionally preserves the original phrasing for archaeological fidelity.
+
 **Files:**
 - Modify: `operators/precheck.py`
 

--- a/operators/precheck.py
+++ b/operators/precheck.py
@@ -52,14 +52,24 @@ class PrecheckAlreadyClosed:
 @dataclass(frozen=True)
 class PrecheckOkToProceed:
     """Position passed all precheck conditions. The snapshot is an
-    OwnershipValidatedSnapshot — a type-level guarantee that ownership was
-    checked at precheck time. The write-tx MUST STILL re-validate the
-    snapshot's mutable fields against a fresh re-SELECT inside BEGIN
-    IMMEDIATE (immutable fields trusted directly).
+    OwnershipValidatedSnapshot.
+
+    The sentinel check in OwnershipValidatedSnapshot.__post_init__ is the
+    runtime órgano (rung: tipo); the factory's single call site is
+    convention only (rung: convención — see #477). The sentinel itself is
+    module-attribute-accessible, which widens the convención surface
+    beyond the factory — see #487 for the open wider-asymmetry follow-up.
+
+    The write-tx MUST STILL re-validate the snapshot's mutable fields
+    against a fresh re-SELECT inside BEGIN IMMEDIATE (immutable fields
+    trusted directly).
 
     Runtime organ: __post_init__ rejects construction with a raw
-    PositionSnapshot. The 'tipo' rung in CLAUDE.md is real only because
-    this check exists (mypy is not in CI; annotation alone does not refuse).
+    PositionSnapshot (i.e., without the sentinel). The 'tipo' rung in
+    CLAUDE.md is real only because this check exists (mypy is not in CI;
+    annotation alone does not refuse). Anyone who imports
+    _VALIDATION_SENTINEL can construct directly without going through the
+    factory — see #487.
     """
     snapshot: "OwnershipValidatedSnapshot"
 
@@ -83,8 +93,11 @@ class PrecheckRejectedState:
 PrecheckResult = Union[PrecheckNotFound, PrecheckAlreadyClosed, PrecheckOkToProceed, PrecheckRejectedState]
 
 
-# Module-private sentinel — external callers cannot import this name
-# (single underscore is a convention; the factory check is by `is` identity).
+# Module-private sentinel — single-underscore convention only; Python does
+# NOT prevent `from operators.precheck import _VALIDATION_SENTINEL`. The
+# __post_init__ check is by `is` identity, so any caller who imports this
+# name can construct an OwnershipValidatedSnapshot for any PositionSnapshot.
+# Tracked in #487 (sentinel-import surface — wider asymmetry beyond #477).
 _VALIDATION_SENTINEL = object()
 
 
@@ -108,8 +121,14 @@ class OwnershipValidatedSnapshot:
     the snapshot's mutable fields against a fresh re-SELECT — that is enforced
     in PositionClosure.execute() by explicit field-by-field comparison.
 
-    Closes #469 + F6 (Voronov path C + E): the validation guarantee lives in
-    the type, not in a docstring.
+    Originally framed as "Closes #469 + F6 (Voronov path C + E): the
+    validation guarantee lives in the type, not in a docstring." The
+    Voronov registry-coherence rule (post-Serrano) qualifies this: the
+    guarantee is bounded by the weakest organ that enforces it. #469's
+    closure is rung tipo (sentinel `is` check) PLUS rung convención
+    (factory single-call-site by underscore; sentinel module-importable).
+    See #477 (factory side, advanced by PR #486) and #487 (sentinel side,
+    open) for the live coherence follow-ups.
     """
     inner: PositionSnapshot
     _sentinel: object  # must be _VALIDATION_SENTINEL at construction

--- a/operators/precheck.py
+++ b/operators/precheck.py
@@ -96,9 +96,12 @@ class OwnershipValidatedSnapshot:
     SYSTEM mode: ownership validation does not apply; the snapshot is
     accepted by construction.
 
-    Construction requires the module-private _VALIDATION_SENTINEL. The only
-    legitimate constructor is `_build_validated_snapshot` (called by
-    `operators.position_closure.PositionClosure._run_precheck`).
+    Construction requires the module-private _VALIDATION_SENTINEL. The
+    runtime organ is the sentinel check in `__post_init__` (rung: tipo). The
+    intended constructor is `_build_validated_snapshot`, whose single call
+    site is `operators.position_closure.PositionClosure._run_precheck`; the
+    factory's single-call-site property is convention only (rung: convención
+    — see #477 for the registry-coherence follow-up).
 
     A future write-tx that consumes this type is guaranteed (by construction)
     that ownership was checked at precheck. The write-tx MUST STILL re-validate
@@ -115,16 +118,23 @@ class OwnershipValidatedSnapshot:
         if self._sentinel is not _VALIDATION_SENTINEL:
             raise TypeError(
                 "OwnershipValidatedSnapshot cannot be constructed directly. "
-                "Use the private validation sentinel via "
-                "operators.precheck._build_validated_snapshot (callable only "
-                "from operators.position_closure._run_precheck)."
+                "Use operators.precheck._build_validated_snapshot. "
+                "By convention (not enforced at runtime), the factory's "
+                "single call site is "
+                "operators.position_closure.PositionClosure._run_precheck. "
+                "See #477."
             )
 
 
 def _build_validated_snapshot(snapshot: PositionSnapshot) -> OwnershipValidatedSnapshot:
-    """Internal factory used by PositionClosure._run_precheck.
+    """Module-private factory used by PositionClosure._run_precheck.
 
-    NOT exported from this module's public surface (single underscore).
-    Module-private convention: external code should not call this directly.
+    The single-underscore prefix is convention only; Python does not enforce
+    the module-private boundary at import time. Calling this from any other
+    module will succeed at runtime — the rung is convención, not tipo.
+
+    See #477 for the open registry-coherence follow-up (whether to install a
+    real organ via frame inspection / closure pattern / module relocation, or
+    accept the asymmetry permanently).
     """
     return OwnershipValidatedSnapshot(inner=snapshot, _sentinel=_VALIDATION_SENTINEL)

--- a/operators/precheck.py
+++ b/operators/precheck.py
@@ -56,9 +56,10 @@ class PrecheckOkToProceed:
 
     The sentinel check in OwnershipValidatedSnapshot.__post_init__ is the
     runtime órgano (rung: tipo); the factory's single call site is
-    convention only (rung: convención — see #477). The sentinel itself is
-    module-attribute-accessible, which widens the convención surface
-    beyond the factory — see #487 for the open wider-asymmetry follow-up.
+    convention only (rung: convención). The sentinel itself is module-
+    attribute-accessible, which widens the convención surface beyond the
+    factory — both surfaces (factory name and sentinel name) of the
+    convention bound are tracked in #477.
 
     The write-tx MUST STILL re-validate the snapshot's mutable fields
     against a fresh re-SELECT inside BEGIN IMMEDIATE (immutable fields
@@ -69,7 +70,7 @@ class PrecheckOkToProceed:
     CLAUDE.md is real only because this check exists (mypy is not in CI;
     annotation alone does not refuse). Anyone who imports
     _VALIDATION_SENTINEL can construct directly without going through the
-    factory — see #487.
+    factory — see #477.
     """
     snapshot: "OwnershipValidatedSnapshot"
 
@@ -97,7 +98,8 @@ PrecheckResult = Union[PrecheckNotFound, PrecheckAlreadyClosed, PrecheckOkToProc
 # NOT prevent `from operators.precheck import _VALIDATION_SENTINEL`. The
 # __post_init__ check is by `is` identity, so any caller who imports this
 # name can construct an OwnershipValidatedSnapshot for any PositionSnapshot.
-# Tracked in #487 (sentinel-import surface — wider asymmetry beyond #477).
+# This is one of two surfaces of the convention bound tracked in #477
+# (factory name + sentinel name both single-underscore-convention only).
 _VALIDATION_SENTINEL = object()
 
 
@@ -126,9 +128,9 @@ class OwnershipValidatedSnapshot:
     Voronov registry-coherence rule (post-Serrano) qualifies this: the
     guarantee is bounded by the weakest organ that enforces it. #469's
     closure is rung tipo (sentinel `is` check) PLUS rung convención
-    (factory single-call-site by underscore; sentinel module-importable).
-    See #477 (factory side, advanced by PR #486) and #487 (sentinel side,
-    open) for the live coherence follow-ups.
+    (factory name + sentinel name both single-underscore-convention only).
+    The wider invariant (both surfaces of the convention bound) is tracked
+    in #477, advanced by PR #486 (Path 3 honest narrowing).
     """
     inner: PositionSnapshot
     _sentinel: object  # must be _VALIDATION_SENTINEL at construction

--- a/tests/operators/test_ownership_validated_snapshot.py
+++ b/tests/operators/test_ownership_validated_snapshot.py
@@ -41,8 +41,9 @@ def test_cannot_construct_with_none_sentinel():
 def test_internal_factory_builds_validated_snapshot():
     """_build_validated_snapshot is the INTENDED constructor by single-
     underscore convention. Python does not prevent direct construction
-    via importing _VALIDATION_SENTINEL — that wider asymmetry is tracked
-    in #487. This test only asserts the factory path itself works."""
+    via importing _VALIDATION_SENTINEL — that wider asymmetry (both
+    factory and sentinel surfaces of the convention bound) is tracked in
+    #477. This test only asserts the factory path itself works."""
     from operators.precheck import (
         _build_validated_snapshot,
         OwnershipValidatedSnapshot,

--- a/tests/operators/test_ownership_validated_snapshot.py
+++ b/tests/operators/test_ownership_validated_snapshot.py
@@ -39,9 +39,10 @@ def test_cannot_construct_with_none_sentinel():
 
 
 def test_internal_factory_builds_validated_snapshot():
-    """_build_validated_snapshot is the only legitimate constructor.
-    It is module-private (underscore prefix), not exported from precheck's
-    public surface."""
+    """_build_validated_snapshot is the INTENDED constructor by single-
+    underscore convention. Python does not prevent direct construction
+    via importing _VALIDATION_SENTINEL — that wider asymmetry is tracked
+    in #487. This test only asserts the factory path itself works."""
     from operators.precheck import (
         _build_validated_snapshot,
         OwnershipValidatedSnapshot,
@@ -96,7 +97,9 @@ def test_error_message_does_not_overclaim_enforcement():
     )
     # Positive: must explicitly acknowledge the convention rung, so future
     # readers don't infer a guarantee from the absence of qualifiers.
-    assert "convention" in message.lower() or "convención" in message.lower(), (
+    # Anchored to English single-form — the message lives in English; a
+    # polyglot `or` would let drift hide a regression (Serrano F4).
+    assert "convention" in message.lower(), (
         f"message must name the convention rung explicitly; got: {message!r}"
     )
 

--- a/tests/operators/test_ownership_validated_snapshot.py
+++ b/tests/operators/test_ownership_validated_snapshot.py
@@ -18,8 +18,9 @@ def test_cannot_construct_without_sentinel():
         entry_price=100.0, qty=1.0,
     )
 
-    # Try with a wrong sentinel (e.g., another object()).
-    with pytest.raises(TypeError, match=r"private validation sentinel"):
+    # Try with a wrong sentinel (e.g., another object()). The match anchors
+    # on the factory name — the most stable identifier in the error message.
+    with pytest.raises(TypeError, match=r"_build_validated_snapshot"):
         OwnershipValidatedSnapshot(inner=snap, _sentinel=object())
 
 
@@ -33,7 +34,7 @@ def test_cannot_construct_with_none_sentinel():
         entry_price=100.0, qty=1.0,
     )
 
-    with pytest.raises(TypeError, match=r"private validation sentinel"):
+    with pytest.raises(TypeError, match=r"_build_validated_snapshot"):
         OwnershipValidatedSnapshot(inner=snap, _sentinel=None)
 
 
@@ -56,6 +57,48 @@ def test_internal_factory_builds_validated_snapshot():
     validated = _build_validated_snapshot(snap)
     assert isinstance(validated, OwnershipValidatedSnapshot)
     assert validated.inner == snap
+
+
+def test_error_message_does_not_overclaim_enforcement():
+    """The OwnershipValidatedSnapshot construction error must not claim
+    'callable only from X' — nothing in the runtime enforces caller identity.
+
+    The sentinel pattern is real (rung: tipo), but the factory's single
+    call site is convention only (rung: convención). The message must
+    reflect this asymmetry truthfully.
+
+    See #477 (registry coherence) and #481 (doc honesty).
+    """
+    from operators.precheck import OwnershipValidatedSnapshot, PositionSnapshot
+
+    snap = PositionSnapshot(
+        pos_id=1, tenant_id=42, status="open",
+        symbol="BTCUSDT", direction="long",
+        entry_price=100.0, qty=1.0,
+    )
+
+    try:
+        OwnershipValidatedSnapshot(inner=snap, _sentinel=object())
+    except TypeError as exc:
+        message = str(exc)
+    else:
+        pytest.fail("Expected TypeError when constructing with a foreign sentinel")
+
+    # Positive: must name the factory (so readers know the legitimate entry).
+    assert "_build_validated_snapshot" in message, (
+        f"message must reference the factory by name; got: {message!r}"
+    )
+    # Negative: must NOT claim runtime enforcement of the caller. The previous
+    # wording 'callable only from operators.position_closure._run_precheck'
+    # was a documentation lie — nothing in the code checked the caller frame.
+    assert "callable only" not in message, (
+        f"message must not promise enforcement that does not exist; got: {message!r}"
+    )
+    # Positive: must explicitly acknowledge the convention rung, so future
+    # readers don't infer a guarantee from the absence of qualifiers.
+    assert "convention" in message.lower() or "convención" in message.lower(), (
+        f"message must name the convention rung explicitly; got: {message!r}"
+    )
 
 
 def test_PrecheckOkToProceed_carries_OwnershipValidatedSnapshot():


### PR DESCRIPTION
## Summary

Bundle 1 of the post-Cluster-D follow-up sweep. Closes one Serrano finding from PR #472 clinical review and advances the wider invariant (factory + sentinel convention boundary) by aligning what the runtime enforces with what the code claims.

- **Closes #481 (LOW, AMB)** — Doc honesty: the `OwnershipValidatedSnapshot.__post_init__` error message claimed *"callable only from `operators.position_closure._run_precheck`"*. Nothing in the code checked the caller frame. The message was a documentation lie. Now it states the actual rung: *"By convention (not enforced at runtime), the factory's single call site is …"*.
- **Advances #477 (MEDIUM, CONTRA — widened 2026-05-26)** — Registry coherence: `_build_validated_snapshot` (factory) AND `_VALIDATION_SENTINEL` (sentinel) are both single-underscore-convention only. This PR names both surfaces of that convention bound in docstrings and the construction error. **Substantive close depends on a separate scaffold PR** that updates `.mex/context/conventions.md`'s registry row to *"Tipo + runtime check + convención"*. That PR is being prepared as the canonical scaffold-introduction PR.

This PR takes **Path 3 — honest narrowing** from #481/#477 acceptance criteria. No runtime behavior change beyond the error message text; the sentinel check is byte-identical.

## What changed at runtime

**Error message — before:**
```
OwnershipValidatedSnapshot cannot be constructed directly. Use the private
validation sentinel via operators.precheck._build_validated_snapshot
(callable only from operators.position_closure._run_precheck).
```

**Error message — after:**
```
OwnershipValidatedSnapshot cannot be constructed directly. Use
operators.precheck._build_validated_snapshot. By convention (not enforced at
runtime), the factory's single call site is
operators.position_closure.PositionClosure._run_precheck. See #477.
```

Difference: the *"callable only from"* phrase is removed. Convention is named explicitly. `#477` is cited as the open registry-coherence follow-up.

The runtime construction path with the correct sentinel is byte-identical. The sentinel check itself is untouched.

## Docstrings + comment cleanup

- `OwnershipValidatedSnapshot` docstring now names the rungs explicitly: sentinel check is rung *tipo*, factory single-call-site is rung *convención*, and the *"Closes #469 + F6"* framing is qualified by the Voronov coherence rule with a pointer to #477 (now encompassing both surfaces of the convention bound).
- `_build_validated_snapshot` docstring acknowledges that the single-underscore prefix is convention only.
- `PrecheckOkToProceed` docstring (sibling) softened to match — no longer claims an unqualified type-level guarantee (Serrano F9). Now names both surfaces of the convention bound, tracked under #477.
- `_VALIDATION_SENTINEL` comment header no longer asserts *"external callers cannot import this name"* (which was false; single-underscore does not prevent import). Now describes the actual convention + names this as one of the two surfaces of #477's bound (Serrano F12).
- Plan doc `docs/superpowers/plans/2026-05-26-467-468-469-enforcement-layers-registry.md` Task 9 section gains a footnote noting that the in-doc code-block wording was softened by this PR and pointing at #477 (widened) + #488 (meta-arch) (Serrano F7 + Voronov consolidation).

## Tests

- New: `test_error_message_does_not_overclaim_enforcement` — asserts the message names the factory, names the convention rung (English single-form, pinned after Serrano F4), and does NOT contain *"callable only"*.
- Updated: two existing tests' regex re-anchored from `r"private validation sentinel"` to `r"_build_validated_snapshot"` (stable identifier).
- Updated: `test_internal_factory_builds_validated_snapshot` docstring softened to remove its own *"only legitimate constructor"* overclaim (Serrano F15). Now names the wider asymmetry tracked in #477.
- Suite: `pytest tests/operators/` — **27/27 green**.
- Repo: `pytest tests/` — exit 0 (Binance HTTP 451 geo-block warnings on stderr are unrelated).

## TDD record

| Step | Action | Result |
|------|--------|--------|
| RED  | `test_error_message_does_not_overclaim_enforcement` added | FAILED with `'callable only' is contained here` |
| GREEN | Message text changed in `OwnershipValidatedSnapshot.__post_init__` | Passes |
| Existing-tests update | Two regex matches re-anchored | Passes |
| Post-review (Serrano) | Sibling overclaims + plan-doc footnote + test pin | 27/27 green |
| Post-review (Voronov) | Consolidate #487 → #477 references | 27/27 green |

## Post-review fixes (Serrano + Voronov)

**Serrano clinical review** of this PR surfaced 15 findings (0 BLOCKERs, 2 HIGH, 4 MEDIUM). Tier 1+2+3 remediation applied:

- **Tier 1** (in-PR fixes): F3, F4, F9, F12, F15 — sibling overclaim cleanup + test-contract pin (single language).
- **Tier 2** (follow-up issue): F2 originally opened as #487 (sentinel-importable). Voronov reframed this as duplicate of #477; closed.
- **Tier 3** (plan-doc footnote): F7 → plan document amended in-place with archaeological-fidelity footnote (not rewritten).

**Voronov meta-architectural review** of post-Serrano state surfaced:
- **Issue split was wrong** — #477 and #487 were two surfaces of one invariant pretending to be two invariants. **#487 closed as duplicate of #477.** #477 renamed and body widened to encompass both surfaces ("factory + sentinel convention boundary"). Source references in this PR consolidated to #477.
- **Three structural next-moves opened as #488** — registry schema disambiguation, registry-coherence test/CI organ, verb taxonomy (Closes vs Advances).
- **Held-back commit pattern** — the `.mex/context/conventions.md` registry row update is held back from this PR. Voronov's structural point: when both PRs land, the registry will reflect the code. PR sequencing matters but separate PRs is an explicit choice.

Closure semantics: original PR body claimed `Closes #477 #481`. Per Serrano F1/F13/F14, `Closes #477` was half-honest because the registry update lives in the scaffold PR. PR body reads `Closes #481` and `Advances #477` until that scaffold PR also merges.

## What this does NOT do

- Does **NOT** install an actual runtime organ for the factory/sentinel convention bound. Path 1/2/4 options in #477 (closure pattern, name-mangling, frame inspection, module relocation) are deliberately deferred. Substantive close of #477 requires either an organ install or explicit "accept permanently" decision.
- Does **NOT** include the mex-scaffold infrastructure or its registry row update — that ships as a separate PR.
- Does **NOT** change any code path beyond the error-message text, docstrings, and one comment header. The construction path with the correct sentinel is byte-identical.

## Closes / Advances

- Closes #481 — message and runtime now agree
- Advances #477 — Path 3 selected and documented across both surfaces of the convention bound; substantive close depends on the separate scaffold PR (registry row update) AND a decision among #477's fix paths
- Refs #488 (meta-arch next moves) — surfaced by Voronov

## Test plan

- [x] `pytest tests/operators/test_ownership_validated_snapshot.py` — 5/5 pass (4 existing + 1 new)
- [x] `pytest tests/operators/test_precheck.py` — 5/5 pass
- [x] `pytest tests/operators/` — 27/27 pass
- [x] `pytest tests/` — exit 0 (full repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)