### PR TITLE
fix(operators): close PositionClosure single-use enforcement asymmetry (closes #460)

### DIFF
--- a/docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md
+++ b/docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md
@@ -132,7 +132,7 @@ PositionClosure(
 )
 ```
 
-Validation raises `ValueError` before any DB work. Operator is single-use.
+Validation raises `ValueError` before any DB work. **Single-use semantic:** an instance is bound to at most one `__enter__` and at most one `execute()`; both raise `RuntimeError("...single-use")` on re-use. After `__enter__` returns, a second `__enter__` on the same instance raises — regardless of whether `execute()` was called inside the first block.
 
 ### Lifecycle as context manager
 

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -96,12 +96,24 @@ class PositionClosure:
         self._state: Literal["INIT", "NOT_FOUND", "ALREADY_CLOSED", "OK_TO_PROCEED"] = "INIT"
         self._result_row: Optional[dict] = None
         self._result_pnl: tuple[Optional[float], Optional[float]] = (None, None)
+        # Two flags to enforce single-use symmetrically (#460):
+        #   _entered: set by __enter__. Prevents re-entry on the same instance
+        #             even when execute() was never called inside the first
+        #             enter (degenerate enter-without-execute flow).
+        #   _consumed: set by execute(). Prevents double-execute within a
+        #              single enter block.
+        # Both raise RuntimeError on re-use. Single-use means single-use.
+        self._entered = False
         self._consumed = False
         self._precheck_result: PrecheckResult | None = None
 
     def __enter__(self) -> "PositionClosure":
-        if self._consumed:
-            raise RuntimeError("PositionClosure is single-use; construct a new one")
+        if self._entered:
+            raise RuntimeError(
+                "PositionClosure is single-use; construct a new instance "
+                "for each close attempt (see #460)"
+            )
+        self._entered = True
         with precheck_connection() as precheck_con:
             self._precheck_result = self._run_precheck(precheck_con)
         return self

--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -110,8 +110,7 @@ class PositionClosure:
     def __enter__(self) -> "PositionClosure":
         if self._entered:
             raise RuntimeError(
-                "PositionClosure is single-use; construct a new instance "
-                "for each close attempt (see #460)"
+                "PositionClosure has already been entered; instances are single-use"
             )
         self._entered = True
         with precheck_connection() as precheck_con:
@@ -175,7 +174,9 @@ class PositionClosure:
 
     def execute(self) -> CloseOutcome:
         if self._consumed:
-            raise RuntimeError("PositionClosure already executed; single-use")
+            raise RuntimeError(
+                "PositionClosure has already been executed; instances are single-use"
+            )
         self._consumed = True
 
         result = self._precheck_result

--- a/tests/operators/test_position_closure.py
+++ b/tests/operators/test_position_closure.py
@@ -620,3 +620,38 @@ def test_cross_mutation_race_entry_price_rejects_close(fresh_db_with_two_tenants
         pos = con.execute("SELECT status, entry_price FROM positions WHERE id=1").fetchone()
     assert pos["status"] == "open"
     assert pos["entry_price"] == 999.99  # our UPDATE remains
+
+
+# ---- Invariant 11: single-use enforcement symmetry (#460) ----
+
+def test_reentering_without_execute_still_blocks_second_enter(
+    fresh_db_with_two_tenants
+):
+    """A PositionClosure that is entered (precheck runs) but never executed
+    (early exit, or caller forgets to call execute()) must NOT be re-enterable.
+
+    The semantic is 'single-use': the first __enter__ commits the closure
+    instance to that one attempt, regardless of whether execute() was
+    called inside the block. The previous implementation only set the
+    consumed flag inside execute(), so an enter-without-execute left the
+    instance reusable — Serrano F-NEW-7 finding from PR #452 review.
+
+    Closes #460 (single-use enforcement asymmetry between __enter__ check
+    and execute() set)."""
+    from operators.position_closure import PositionClosure
+
+    closure = PositionClosure(
+        pos_id=1, exit_price=110.0, exit_reason="TP_HIT",
+        mode="USER", caller_tenant_id=1,
+    )
+
+    # First enter: succeeds. Deliberately do NOT call execute() inside.
+    with closure:
+        pass  # caller decided not to execute (degenerate but legal flow)
+
+    # Second enter on the same instance: must raise RuntimeError.
+    # Pre-fix: this would silently succeed because _consumed was only
+    # set by execute() — the enter check passed and a second precheck ran.
+    with pytest.raises(RuntimeError, match=r"single-use"):
+        with closure:
+            closure.execute()


### PR DESCRIPTION
## Summary

Bundle 3 of the post-Cluster-D follow-up sweep. Closes **#460** (Serrano F-NEW-7, MEDIUM) — *PositionClosure single-use enforcement asymmetry*.

The previous implementation had a flag asymmetry: `__enter__` checked `self._consumed` but never set it; `execute()` was the one that set it. A caller who entered the `with` block without calling `execute()` left `_consumed` False and the same instance was re-enterable — silently violating "single-use".

**Fix:** split into two flags with symmetric set-and-check.

| Flag | Set by | Checked by | Prevents |
|---|---|---|---|
| `_entered` (NEW) | `__enter__` | `__enter__` | Re-entry, even when execute() never called |
| `_consumed` (unchanged) | `execute()` | `execute()` | Double-execute within a single enter block |

The canonical flow (one enter, one execute) is byte-identical. The degenerate flow (enter without execute, exit, re-enter) now raises `RuntimeError`.

## Post-review revisions (Voronov 2026-05-26)

Voronov meta-architectural review surfaced 3 findings. Two applied in this PR, one split off as a follow-up issue:

### Finding 1 — `self._state` is a dead field [→ #492]

`operators/position_closure.py:97` declares:
```python
self._state: Literal["INIT", "NOT_FOUND", "ALREADY_CLOSED", "OK_TO_PROCEED"] = "INIT"
```

Grep `self._state =` across the module: zero hits. The field is fossil evidence of a refactor — the spec doc lines 137-148 originally promised a string-state machine; the implementation built something structurally stronger (a `PrecheckResult` tagged union + lifecycle booleans) and never decommissioned the field name.

> *"Adding a new representation of an axis without removing the dead representation of the same family of axes."* — Voronov

This is its own audit, not a side-patch. Tracked as **#492**.

### Finding 2 — error messages mixed rungs (applied in `981ac7b`)

The previous `__enter__` message said *"...single-use; construct a new instance for each close attempt (see #460)"*. The `(see #460)` carries project metadata (convención rung) inside a runtime error string (tipo rung). The two rungs should not mix — the registry was built to keep them separate.

Also, the two error messages had different wording for the same conceptual violation (Serrano F12 pattern recurring at a small scale).

**Fix:** parallel wording, no issue numbers in runtime layer:
- `__enter__`: `"PositionClosure has already been entered; instances are single-use"`
- `execute`:  `"PositionClosure has already been executed; instances are single-use"`

Test contract preserved — `pytest.raises(RuntimeError, match=r"single-use")` anchors on the stable common phrase.

### Finding 3 — spec sentence was under-specified (applied in `981ac7b`)

`docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md:135` said *"Operator is single-use."* — six words, no definition of what "use" means. The original implementer read it as "execute only"; Serrano F-NEW-7 read it as "enter AND execute". This PR chose the stricter reading.

> *"The flags are not the band-aid; the spec sentence was the band-aid, and your code is more honest than your prose."* — Voronov

**Fix:** spec sentence rewritten to match the code:
> *"An instance is bound to at most one `__enter__` and at most one `execute()`; both raise `RuntimeError` on re-use. After `__enter__` returns, a second `__enter__` on the same instance raises — regardless of whether `execute()` was called inside the first block."*

### What Voronov said NOT to change

- **The two-flag pattern itself.** Voronov: *"Yes, there is legitimate orthogonality between 'what did the precheck say about the row' and 'have I been used as an operator'. They are different axes. The accidental complexity is not in the existence of two flags."* The flags are correct; `_state` is the band-aid.
- **The bundling decision (split #460 from #458).** Voronov: *"It is NOT the same category error [as PR #486's #477/#487 split]. #460 and #458 are two genuinely distinct invariants that happen to touch overlapping code. By the bundling rule, splitting them is correct."*

## TDD record

| Step | Test | Pre-fix | Post-fix |
|------|------|---------|----------|
| RED  | `test_reentering_without_execute_still_blocks_second_enter` | DID NOT RAISE (bug) | raises `RuntimeError("...single-use")` ✓ |
| GREEN | Full `tests/operators/` suite | 26/26 | 27/27 ✓ |
| Voronov refactor | Same test against new wording | 27/27 ✓ |

## Closes / Refs

- **Closes #460** (single-use enforcement symmetry — Serrano F-NEW-7)
- **Refs #492** (open follow-up — delete dead `self._state` field — Voronov finding 1)
- Refs PR #452 (introduced PositionClosure)
- Refs PR #486 (Bundle 1 — sibling work in `operators/precheck.py`)
- Refs PR #490 (Bundle 2 — sibling work in `operators/position_closure.py` drift check)

## What this PR does NOT do

- Does NOT delete `self._state` (the dead field). That is **#492**, deliberately split.
- Does NOT address #458 (concurrent multi-field atomicity test). Distinct invariant, future PR.
- Does NOT restructure `PositionClosure` beyond the two-flag split + Voronov finding 2+3 polish.
- Does NOT change `__exit__` behavior. Cleanup unchanged.

## Test plan

- [x] `pytest tests/operators/test_position_closure.py::test_reentering_without_execute_still_blocks_second_enter` — green
- [x] `pytest tests/operators/` — 27/27 green (before + after Voronov refactor)
- [x] Pre-fix RED state confirmed (DID NOT RAISE)
- [x] Post-fix GREEN state confirmed
- [x] Voronov refactor: error message wording change, spec update — same 27/27 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)