### PR TITLE
hotfix(api): fix db lock contention on /status + /signals (use snapshot_connection)

### DIFF
--- a/api/signals.py
+++ b/api/signals.py
@@ -21,7 +21,7 @@ from api.config import load_config
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
 from api.telegram import build_telegram_message
-from db.transaction import transaction
+from db.transaction import transaction, snapshot_connection
 from db.signals import (
     get_latest_signal, get_latest_scan, get_scans, get_signals_summary, save_scan,
 )
@@ -203,7 +203,7 @@ def list_signals(
     since_hours:  Optional[float] = Query(None,  description="Ultimas N horas"),
     symbol:       Optional[str]   = Query(None,  description="Filtrar por par (ej: ETHUSDT)"),
 ):
-    with transaction() as con:
+    with snapshot_connection() as con:
         rows = get_scans(con, limit=limit, only_signals=only_signals,
                          only_setups=only_setups, since_hours=since_hours,
                          symbol=symbol)

--- a/btc_api.py
+++ b/btc_api.py
@@ -40,7 +40,7 @@ from db.auth_schema import (
     has_any_user, init_auth_db, init_system_state,
     is_setup_completed, mark_setup_completed,
 )
-from db.transaction import transaction
+from db.transaction import transaction, snapshot_connection
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPT_DIR)
@@ -457,7 +457,7 @@ def list_symbols():
 @app.get("/status", summary="Estado detallado del scanner",
          dependencies=[Depends(verify_api_key)])
 def status():
-    with transaction() as con:
+    with snapshot_connection() as con:
         latest = get_latest_scan(con)
     return {
         "scanner_state": _scanner_state,


### PR DESCRIPTION
## Problem

The deployed API is intermittently returning 500 to dashboard polls:

\`\`\`
sqlite3.OperationalError: database is locked
  at db/transaction.py:63  con.execute(\"BEGIN IMMEDIATE\")
  via btc_api.py:460 (status) and api/signals.py:206 (list_signals)
\`\`\`

Caught via journalctl on the EC2 host (\`trading-spacial.service\`, PID 1591582, uptime 8h, NRestarts=0 — proceso vivo, lo que flapea son endpoints específicos).

## Root cause

Both endpoints are trivially read-only (single SELECT each):
- \`btc_api.py:460::status\` → calls \`get_latest_scan(con)\`
- \`api/signals.py:206::list_signals\` → calls \`get_scans(con, ...)\`

…but they use \`transaction()\` which does \`BEGIN IMMEDIATE\` (requests RESERVED writer lock). Under dashboard polling concurrency, multiple readers compete for that lock and SQLite returns \"database is locked\" instead of waiting indefinitely. Same patología #466 documented and \`snapshot_connection()\` (PRAGMA query_only=1, no writer lock) was introduced to fix — these two endpoints simply never migrated.

## Fix

4-line surgical change: import \`snapshot_connection\` and swap both \`with transaction()\` → \`with snapshot_connection()\` at the two affected endpoints.

## Scope

This PR fixes ONLY the two endpoints with confirmed evidence from server logs. There are ~100 other \`with transaction()\` call sites in the codebase; some are legitimate writes, some are likely read-only and have the same latent bug. A separate audit PR should sweep them.

## Test plan

- [ ] Targeted suites green: \`pytest tests/db/test_transaction.py tests/api/ -q\` (82 passed local)
- [ ] After merge + deploy: poll \`/api/status\` and \`/api/signals\` rapidly; verify no more 500s
- [ ] Monitor \`journalctl -u trading-spacial -f | grep \"database is locked\"\` — should stop firing for these two endpoints

## Related

- PR #466 introduced \`snapshot_connection()\` for exactly this pattern
- D PR #485 (merged but somehow not deployed — separate issue to investigate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)