### PR TITLE
fix(db): _migrate_qty_not_null robustness sweep — 3 surfaces, 1 invariant (closes #474 #476 #480)

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -31,6 +31,7 @@ Per pre-reg `docs/superpowers/plans/2026-05-15-multi-tenant-b1-schema-pre-reg.md
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 from db.connection import _open_configured_connection, _resolve_db_file
 from db.transaction import transaction
@@ -763,14 +764,22 @@ def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
     Idempotent: detects existing CHECK constraint and skips.
     """
     # Idempotency check: SQLite stores CREATE TABLE in sqlite_master.
+    # Anchor on the specific CHECK constraint DDL fragment, not the bare
+    # string "legacy_unmeasurable" — the latter false-positives on column
+    # defaults, comments, or unrelated CHECK constraints that mention the
+    # status value. Whitespace-normalized + case-folded to tolerate the
+    # variations SQLite uses when echoing back CREATE TABLE in sqlite_master.
+    # See #476 (Serrano F4 [HIGH, OPS/AMB]) for the failure mode.
     schema_row = con.execute(
         "SELECT sql FROM sqlite_master WHERE type='table' AND name='positions'"
     ).fetchone()
-    if schema_row and schema_row[0] and "legacy_unmeasurable" in schema_row[0]:
-        log.info(
-            "_migrate_qty_not_null: positions table already has the quarantine CHECK; skipping."
-        )
-        return
+    if schema_row and schema_row[0]:
+        normalized = "".join(schema_row[0].split()).lower()
+        if "check(qtyisnotnullorstatus='legacy_unmeasurable')" in normalized:
+            log.info(
+                "_migrate_qty_not_null: positions table already has the quarantine CHECK; skipping."
+            )
+            return
 
     # Column-aware migration: an old/stub positions table may not yet have
     # size_usd or qty columns (the earlier _migrate_* helpers are tolerant
@@ -817,6 +826,39 @@ def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
         # No qty column at all — after recreation every existing row will land
         # with qty=NULL in the new schema, so all of them must be quarantined
         # up-front or the CHECK constraint would reject the INSERT.
+        #
+        # SAFETY GUARD (#474, Serrano F3 [HIGH, SEC/GAP]): bulk quarantine of
+        # active rows is dangerous in production. A DB rebuilt from a stale
+        # backup (or any artifact where qty was never added) would have every
+        # position flipped to 'legacy_unmeasurable' silently — kill-switch and
+        # notional code paths then skip these rows with a log.warning and the
+        # trading state is invisibly disabled. Refuse the destructive UPDATE
+        # unless the operator explicitly opts in via env flag.
+        status_counts = con.execute(
+            """SELECT status, COUNT(*) FROM positions
+               WHERE status != 'legacy_unmeasurable'
+               GROUP BY status"""
+        ).fetchall()
+        total_to_quarantine = sum(count for _, count in status_counts)
+        if total_to_quarantine > 0:
+            counts_repr = ", ".join(
+                f"{count} {status!r}" for status, count in status_counts
+            )
+            if os.environ.get("MIGRATE_QTY_ALLOW_BULK_QUARANTINE") != "1":
+                raise RuntimeError(
+                    f"_migrate_qty_not_null: refusing to bulk-quarantine "
+                    f"{total_to_quarantine} rows ({counts_repr}) in the "
+                    f"no-qty-column branch. Set "
+                    f"MIGRATE_QTY_ALLOW_BULK_QUARANTINE=1 to override "
+                    f"(operator acknowledges that the rows present in this "
+                    f"DB predate the qty column and should be marked "
+                    f"'legacy_unmeasurable'). See #474."
+                )
+            log.warning(
+                "_migrate_qty_not_null: bulk-quarantining %d rows under "
+                "MIGRATE_QTY_ALLOW_BULK_QUARANTINE opt-in: %s",
+                total_to_quarantine, counts_repr,
+            )
         con.execute(
             """UPDATE positions
                SET status = 'legacy_unmeasurable'
@@ -837,6 +879,14 @@ def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
         "_migrate_qty_not_null: recreating positions table with CHECK constraint "
         "(qty IS NOT NULL OR status = 'legacy_unmeasurable')."
     )
+    # Defensive cleanup of any orphan positions_new from a prior interrupted
+    # run (#480, Serrano F12 [MEDIUM, OPS]): the idempotency probe at the top
+    # of this function checks for the CHECK constraint on `positions`, NOT for
+    # positions_new existence. If a previous run died between CREATE TABLE
+    # positions_new and ALTER TABLE positions_new RENAME (SIGKILL, OOM, disk
+    # full mid-commit), the next migration would abort on 'table
+    # positions_new already exists'. This DROP IF EXISTS recovers the path.
+    con.execute("DROP TABLE IF EXISTS positions_new")
     con.execute(
         """
         CREATE TABLE positions_new (

--- a/tests/db/test_migrate_qty_not_null.py
+++ b/tests/db/test_migrate_qty_not_null.py
@@ -143,15 +143,23 @@ def test_check_constraint_rejects_null_qty_for_active_status(tmp_path):
     assert row[1] == "legacy_unmeasurable"
 
 
-def test_migration_tolerates_stub_positions_table(tmp_path):
+def test_migration_tolerates_stub_positions_table(tmp_path, monkeypatch):
     """Migration must not crash when positions table predates size_usd/qty.
 
     Simulates a very old DB schema (pre-B.1 stub) — earlier _migrate_* helpers
     add tenant_id incrementally, but _migrate_qty_not_null must not reference
     size_usd/qty in raw SQL if those columns don't yet exist.
+
+    The no-qty-column branch bulk-quarantines all non-quarantined rows. This
+    is dangerous in production (#474 — could silently disable active trading
+    positions on a restored stale backup), so the branch refuses unless an
+    operator explicit opt-in env flag is set. This test sets the flag to
+    exercise the legitimate stub-schema path.
     """
     import sqlite3
     from db.schema import _migrate_qty_not_null
+
+    monkeypatch.setenv("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", "1")
 
     db = tmp_path / "stub.db"
     con = sqlite3.connect(db)
@@ -186,6 +194,173 @@ def test_migration_tolerates_stub_positions_table(tmp_path):
         "SELECT sql FROM sqlite_master WHERE name='positions'"
     ).fetchone()[0]
     assert "legacy_unmeasurable" in schema
+    con.close()
+
+
+def test_no_qty_column_branch_refuses_active_rows_without_opt_in(tmp_path, monkeypatch):
+    """The no-qty-column branch silently quarantines every non-already-quarantined
+    row. In production, this could fire on a restored stale backup and disable
+    every active trading position — operator sees 'position not found' in UI;
+    kill-switch and notional code paths skip the rows with a log.warning. The
+    integrity event is invisible.
+
+    Per Serrano F3 [HIGH, SEC/GAP] (issue #474), this branch must refuse to
+    run when there are non-legacy_unmeasurable rows present, unless the
+    operator explicitly opts in via env flag.
+
+    Closes #474."""
+    import sqlite3
+    from db.schema import _migrate_qty_not_null
+
+    # Ensure the opt-in flag is NOT set (the default safe behavior).
+    monkeypatch.delenv("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", raising=False)
+
+    db = tmp_path / "restored_stale.db"
+    con = sqlite3.connect(db)
+    con.executescript('''
+        CREATE TABLE positions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            symbol TEXT NOT NULL,
+            direction TEXT NOT NULL DEFAULT 'LONG',
+            status TEXT NOT NULL DEFAULT 'open',
+            entry_price REAL NOT NULL,
+            entry_ts TEXT NOT NULL
+        );
+        INSERT INTO positions (symbol, direction, status, entry_price, entry_ts)
+        VALUES ('BTCUSDT', 'LONG', 'open', 50000.0, '2024-01-01T00:00:00');
+        INSERT INTO positions (symbol, direction, status, entry_price, entry_ts)
+        VALUES ('ETHUSDT', 'LONG', 'closed', 3000.0, '2024-01-02T00:00:00');
+    ''')
+    con.commit()
+
+    # Without the opt-in flag, the migration must refuse with a clear error
+    # naming the count + status distribution + the override flag.
+    with pytest.raises(RuntimeError, match=r"MIGRATE_QTY_ALLOW_BULK_QUARANTINE"):
+        _migrate_qty_not_null(con)
+
+    # And the table must NOT have been touched (the dangerous UPDATE didn't run).
+    rows = con.execute("SELECT symbol, status FROM positions ORDER BY id").fetchall()
+    assert rows == [('BTCUSDT', 'open'), ('ETHUSDT', 'closed')]
+    con.close()
+
+
+def test_idempotency_probe_does_not_false_positive_on_misleading_ddl(tmp_path):
+    """The probe `"legacy_unmeasurable" in schema_row[0]` false-positives on
+    ANY mention of the string in the DDL — column defaults, comments,
+    unrelated CHECK constraints. When the probe false-positives, the
+    migration silently skips with no warning and the CHECK constraint never
+    lands.
+
+    Per Serrano F4 [HIGH, OPS/AMB] (issue #476), the probe must anchor on
+    the exact CHECK constraint DDL fragment, not a substring of the string.
+
+    Closes #476."""
+    import sqlite3
+    from db.schema import _migrate_qty_not_null
+
+    db = tmp_path / "misleading.db"
+    con = sqlite3.connect(db)
+    # Construct a positions table whose DDL contains the string
+    # "legacy_unmeasurable" (here in a column DEFAULT) but does NOT have
+    # the actual CHECK constraint. The bare-string probe would skip; the
+    # anchored probe must run the migration.
+    con.executescript("""
+        CREATE TABLE positions (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            symbol      TEXT    NOT NULL,
+            direction   TEXT    NOT NULL DEFAULT 'LONG',
+            status      TEXT    NOT NULL DEFAULT 'open',
+            entry_price REAL    NOT NULL,
+            entry_ts    TEXT    NOT NULL,
+            size_usd    REAL,
+            qty         REAL,
+            notes       TEXT    DEFAULT 'pre-legacy_unmeasurable carve-out era'
+        );
+        INSERT INTO positions (symbol, entry_price, entry_ts, size_usd, qty)
+        VALUES ('BTCUSDT', 100.0, '2024-01-01T00:00:00', 1000.0, NULL);
+    """)
+    con.commit()
+
+    # Pre-condition: DDL contains the string but no real CHECK.
+    pre_ddl = con.execute(
+        "SELECT sql FROM sqlite_master WHERE name='positions'"
+    ).fetchone()[0]
+    assert "legacy_unmeasurable" in pre_ddl, "test setup: string must be present"
+    assert "CHECK" not in pre_ddl.upper(), "test setup: no CHECK must be present"
+
+    # Run the migration. The fix makes the probe anchor on the actual CHECK
+    # fragment, so the migration recognizes the table as NOT yet migrated.
+    _migrate_qty_not_null(con)
+    con.commit()
+
+    # Post-condition: CHECK constraint is now in place, qty was backfilled.
+    post_ddl = con.execute(
+        "SELECT sql FROM sqlite_master WHERE name='positions'"
+    ).fetchone()[0]
+    assert "CHECK" in post_ddl.upper(), (
+        f"migration must have run and added CHECK; got DDL: {post_ddl!r}"
+    )
+    row = con.execute("SELECT qty FROM positions WHERE id = 1").fetchone()
+    assert row[0] == 10.0, "qty must have been backfilled: 1000.0 / 100.0 = 10.0"
+    con.close()
+
+
+def test_migration_recovers_from_orphan_positions_new(tmp_path):
+    """If a prior migration run was interrupted between DROP TABLE positions
+    and ALTER TABLE positions_new RENAME (process killed, OOM, crash), the
+    DB is left with an orphan `positions_new` table alongside `positions`.
+    The next `init_db()` must recover: drop the orphan before recreation.
+
+    Without recovery, CREATE TABLE positions_new aborts with 'table
+    positions_new already exists' and the migration is stuck — the
+    idempotency probe checks for the CHECK on `positions`, not for
+    `positions_new` existence.
+
+    Per Serrano F12 [MEDIUM, OPS] (issue #480).
+
+    Closes #480."""
+    import sqlite3
+    from db.schema import _migrate_qty_not_null
+
+    db = tmp_path / "interrupted.db"
+    con = sqlite3.connect(db)
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, size_usd, qty) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2024-01-01T00:00:00', 1000.0, 10.0)"
+    )
+    # Simulate the orphan from a prior interrupted run: positions_new exists
+    # alongside positions, with whatever transient state it had.
+    con.execute("CREATE TABLE positions_new (id INTEGER PRIMARY KEY)")
+    con.execute("INSERT INTO positions_new (id) VALUES (999)")
+    con.commit()
+
+    # Pre-condition: both tables exist before migration.
+    tables_pre = {
+        row[0] for row in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'positions%'"
+        ).fetchall()
+    }
+    assert tables_pre == {"positions", "positions_new"}, (
+        f"test setup: both tables must be present; got: {tables_pre}"
+    )
+
+    # Migration must recover: drop the orphan, then proceed normally.
+    _migrate_qty_not_null(con)
+    con.commit()
+
+    # Post-condition: only positions remains (the orphan was dropped + recreated +
+    # renamed back to positions), and our original row is preserved.
+    tables_post = {
+        row[0] for row in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'positions%'"
+        ).fetchall()
+    }
+    assert tables_post == {"positions"}, (
+        f"migration must end with only `positions`; got: {tables_post}"
+    )
+    row = con.execute("SELECT id, qty FROM positions").fetchone()
+    assert row == (1, 10.0), "the original row must survive the migration"
     con.close()
 
 

--- a/tests/test_multi_tenant_b1_schema.py
+++ b/tests/test_multi_tenant_b1_schema.py
@@ -336,11 +336,20 @@ class TestBackfillTenant:
 
 
 class TestMigrationOnExistingDB:
-    def test_migration_adds_tenant_id_without_breaking_rows(self, tmp_db):
+    def test_migration_adds_tenant_id_without_breaking_rows(self, tmp_db, monkeypatch):
         """Simulate pre-B.1 DB (positions table without tenant_id), run init_db().
 
         Existing rows should remain accessible; tenant_id column added as NULL.
+
+        Note: this fixture exercises the no-qty-column branch of
+        _migrate_qty_not_null (the stub schema has no qty column). Per #474,
+        that branch refuses to bulk-quarantine non-empty tables unless the
+        operator explicitly opts in via env flag. The test sets the flag
+        because the stub-schema scenario is legitimate (this is what the
+        flag was designed for: pre-qty DBs being upgraded).
         """
+        monkeypatch.setenv("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", "1")
+
         # Step 1: Create OLD-style positions table (without tenant_id)
         con = sqlite3.connect(tmp_db)
         con.execute("""


### PR DESCRIPTION
## Summary

Bundle 4 of the post-Cluster-D follow-up sweep. Closes three Serrano findings on `db/schema.py::_migrate_qty_not_null`.

**Bundling framing (post-Voronov review 2026-05-26):** the three findings are **three distinct predicates co-located in one helper**, not three surfaces of one invariant. Bundled here for review economy (small diffs, adjacent code, same test file), NOT because they share a closure invariant.

| Issue | Predicate | Rung composition | Severity |
|---|---|---|---|
| **#476** | *Epistemic*: idempotency probe returns true iff the post-migration CHECK is structurally present | rung **convención** (stronger anchored substring; not yet rung tipo — see follow-up) | HIGH (OPS/AMB — F4) |
| **#480** | *Transactional*: migration converges to consistent state when a prior invocation left mid-flight side-effects | rung **tipo** (defensive DROP IF EXISTS handles STEP 1–3 kill); remaining recovery scenarios in #497 | MEDIUM (OPS — F12) |
| **#474** | *Deontic*: helper does not default to performing a class-of-action that cannot be safely undone | rung **tipo (default refuse) + convención (env opt-in) + log.warning (observability)** | HIGH (SEC/GAP — F3) |

Per the Voronov bundle-by-invariant rule (PR #486): *"virtues are not invariants. Predicates are."* "Robustness" was a virtue, not a predicate. The diff is correct for what each line enforces; the framing is demoted from "one invariant, three faces" to "three findings, co-located."

## #476 — Epistemic predicate: idempotency probe accuracy

**Previously:** the probe used a bare-string `in` check on the schema DDL. False-positives on any DDL mention of `legacy_unmeasurable` — column defaults, comments, unrelated CHECK constraints.

**Fix:** anchor on the whitespace-normalized + case-folded CHECK fragment (`check(qtyisnotnullorstatus='legacy_unmeasurable')`).

**Honest framing:** this is *stronger convención* (anchored substring), still rung convención. A future refactor that uses different SQL syntax (column order reversed, De Morgan equivalent, double-quotes) would defeat it. The structural fix (rung tipo) would be a `schema_migrations` table recording applied migrations explicitly — see #476 own body for the path. Deferred as broader refactor.

**Why this is safe as interim:** the probe's failure mode under future refactor is "the migration re-runs and is a no-op anyway because the data is already in the right shape." Wasteful, not corrupting.

## #480 — Transactional predicate: partial-failure convergence

**Previously:** `CREATE TABLE positions_new` without defensive cleanup. Orphan from prior interrupted run blocks next `CREATE`.

**Fix:** `DROP TABLE IF EXISTS positions_new` immediately before `CREATE`.

**Honest framing:** this closes ONE scenario from the recovery story — kill between STEP 1 and STEP 2 (orphan positions_new alongside positions). Other scenarios remain:

| Kill point | State after kill | Handled by this PR? |
|---|---|---|
| STEP 1–2 / 2–3 | orphan positions_new, positions intact | **Yes** (DROP IF EXISTS) |
| STEP 3–4 | positions doesnt exist, positions_new has data | **No** — migration aborts on next run |
| STEP 4–5 | positions has CHECK, no idx_positions_tenant | **No** — idempotency probe short-circuits; index permanently missing |

The remaining cases are out of scope for #480 (which named only the STEP 1–3 case) but are now tracked in **#497** as the broader recovery-story-completion follow-up. The fix-paths for #497 converge on the same structural answer as #476 (`schema_migrations` table).

## #474 — Deontic predicate: opt-in for catastrophic default

**Previously:** the no-qty-column branch silently quarantined every non-already-quarantined row. In production restored from a stale backup, this would invisibly disable every active trading position.

**Fix:** count + RuntimeError-refuse by default, with operator opt-in via env flag `MIGRATE_QTY_ALLOW_BULK_QUARANTINE=1`. When opted in, emit log.warning with counts.

**Rung composition (Voronov-explicit):**
- Default refuse: **tipo** (runtime órgano de rechazo)
- Opt-in mechanism: **convención** (env flag — single byte of resolution; static-vs-ambient question deferred)
- Observability: **log.warning** with count + status distribution when opt-in fires (false-opt-in is detectable post-hoc, action is reversible)

The dual-rung composition is category-correct for this risk profile because the bulk-quarantine path is *production-incident-response*, not *normal-operations*; the convención opt-in is acceptable when (a) the default is refuse + (b) opt-in is logged + (c) the action is reversible.

Stronger structural alternative (deferred): a separate `_migrate_qty_not_null_with_bulk_quarantine(con)` function moves the opt-in from process environment (ambient) to import graph (static, auditable, grep-able). Not adopted in this PR.

## TDD record

| Step | Test | Pre-fix | Post-fix |
|------|------|---------|----------|
| RED  | `test_idempotency_probe_does_not_false_positive_on_misleading_ddl` (#476) | migration skipped, no CHECK | CHECK lands ✓ |
| RED  | `test_migration_recovers_from_orphan_positions_new` (#480) | sqlite3.OperationalError: table positions_new already exists | recovers; row preserved ✓ |
| RED  | `test_no_qty_column_branch_refuses_active_rows_without_opt_in` (#474) | DID NOT RAISE (silent quarantine) | RuntimeError with operator-actionable message ✓ |
| Modify | `test_migration_tolerates_stub_positions_table` (#474) | implicit silent quarantine | explicit `MIGRATE_QTY_ALLOW_BULK_QUARANTINE=1` via monkeypatch ✓ |

Suite: `pytest tests/db/test_migrate_qty_not_null.py` — 9/9 green. `pytest tests/db/` — 42/42 green.

## What this PR does NOT do (named explicitly)

- Does **NOT** close the recovery story for STEP 3–4 and STEP 4–5 kills → see **#497**.
- Does **NOT** lift #476 to rung tipo (would require `schema_migrations` table — broader refactor).
- Does **NOT** lift #474 to import-graph opt-in (would require API surface change in `db.schema`).
- Does **NOT** sweep `_migrate_qty_positive` or `_migrate_tenant_id_not_null` for the same patterns.

## On the bundling pattern (Voronov 2026-05-26)

> *"Virtues are not invariants. Predicates are. A virtue is the disposition that produces correct behavior. A predicate is the testable claim about correct behavior."*

Bundle 4 was framed as "one invariant: helper is robust." After review, demoted to "three predicates, co-located." Bundle ships as-is because the fixes are surgical and each predicate has its own test, but the registry rows for #474/#476/#480 should be written **per predicate**, not fused. The pressure point: **the next bundle that bundles 4+ findings will produce a registry row that cannot be written without ambiguity — at which point #488 (registry schema disambiguation + coherence test + verb taxonomy) is no longer deferrable.**

#488 is the next non-Serrano work. Not a blocker for this PR; **is** a blocker for Bundle 5 if it continues to bundle.

## Closes / Refs

- **Closes #474** — bulk quarantine safety (tipo default + convención opt-in + observability)
- **Closes #476** — idempotency probe anchored (stronger convención; rung tipo deferred to schema_migrations)
- **Closes #480** — orphan positions_new recovery (one scenario of the recovery story)
- **Refs #497** — remaining recovery scenarios (STEP 3–4 / 4–5)
- **Refs #488** — meta-architectural: blocker for Bundle 5 if bundling continues

## Test plan

- [x] `pytest tests/db/test_migrate_qty_not_null.py` — 9/9 green
- [x] `pytest tests/db/` — 42/42 green
- [x] Pre-fix RED state confirmed (3 new tests fail for expected reasons)
- [x] Post-fix GREEN state confirmed
- [x] Default-refuse path: RuntimeError with count + status distribution + operator-actionable flag name
- [x] Opt-in path: log.warning with counts, then proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
