### PR TITLE
refactor(operators): delete dead _state field fossil from PositionClosure (closes #492)

### DIFF
--- a/operators/position_closure.py
+++ b/operators/position_closure.py
@@ -94,7 +94,16 @@ class PositionClosure:
         self._cfg = cfg
         self._now = now or datetime.now(timezone.utc)
 
-        self._state: Literal["INIT", "NOT_FOUND", "ALREADY_CLOSED", "OK_TO_PROCEED"] = "INIT"
+        # NOTE: an earlier spec (docs/.../2026-05-25-446-preconditions-synthesis.md
+        # lines 137-148) declared a `_state` field as a four-valued string state
+        # machine for the closure lifecycle. The implementation absorbed that
+        # axis into PrecheckResult (the tagged union stored as
+        # _precheck_result) and the operator-lifecycle axis into _entered /
+        # _consumed booleans. `_state` was declared on this line but never
+        # assigned anywhere — fossil of the abandoned design. Deleted per
+        # Voronov 2026-05-26 (#492): "an operator that has not yet learned to
+        # delete its own ghosts will accumulate them until a future
+        # contributor can no longer tell which fields are load-bearing."
         self._result_row: Optional[dict] = None
         self._result_pnl: tuple[Optional[float], Optional[float]] = (None, None)
         # Two flags to enforce single-use symmetrically (#460):


### PR DESCRIPTION
## Summary

Closes **#492** (Voronov meta-architectural finding from PR #491 review): the `self._state` field declared in `PositionClosure.__init__` was a fossil — declared but never assigned anywhere since PR #452 introduced the operator.

```python
self._state: Literal["INIT", "NOT_FOUND", "ALREADY_CLOSED", "OK_TO_PROCEED"] = "INIT"
```

Grep confirms zero assignments outside the declaration. The field was the leftover from an earlier design where the closure lifecycle was tracked by a four-valued string state machine; the implementation refactored to two stronger representations:

| Axis | Earlier (`_state`) | Current |
|---|---|---|
| Precheck outcome | string variant | `PrecheckResult` tagged union (`_precheck_result`) — type-safe `isinstance` dispatch in `execute()` |
| Operator lifetime | string variant | `_entered` + `_consumed` booleans — both raise `RuntimeError` on re-use |

Both axes have proper homes. `_state` lost its job and the name was never decommissioned.

## What this commit does

1. Removes the unused declaration on line 97.
2. Replaces it with an explanatory comment naming the archaeological context and pointing at the two axes that absorbed the lifecycle tracking. A future contributor who grep-searches the file for `_state` finds the deletion record + the pointer.

## What this commit does NOT do

- Does **NOT** touch the `Literal` import — it's still used by `CloseOutcome.status` (line 55) and the `mode` parameter (line 70). Both are real annotations on different fields.
- Does **NOT** rename `_precheck_result` to `_precheck_finding` (Voronov suggested this as optional during the original review — *"different word, different ontology"*). Out of scope.
- Does **NOT** touch the spec doc (`docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md` lines 137-148 describe the original four-state plan). Per the prior PR #491 footnote pattern, the spec is preserved as historical record.

## Voronov framing

> *"An operator that has not yet learned to delete its own ghosts will accumulate them until a future contributor can no longer tell which fields are load-bearing."*

This is the deletion. The PR is one line minus + ten lines of explanatory comment plus.

## Test plan

- [x] `pytest tests/operators/` — 33/33 green
- [x] No test referenced `_state` (verified by grep before deletion)
- [x] `Literal` import still load-bearing on lines 55 and 70

## Closes / Refs

- **Closes #492** (Voronov meta-arch finding — dead field deletion)
- Refs PR #452 (introduced PositionClosure with the unused field)
- Refs PR #491 (Voronov review surfaced the fossil)
- Refs `docs/superpowers/analysis/2026-05-25-446-preconditions-synthesis.md` lines 137-148 (original four-state design that was refactored away)

🤖 Generated with [Claude Code](https://claude.com/claude-code)