### PR TITLE
fix(db): sweep read-only transaction() → snapshot_connection() in setup + middleware (closes #495 partial)

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -32,7 +32,7 @@ from auth.setup import (
 )
 from auth.setup_html import render_completed_redirect, render_setup_page
 from db.auth_schema import has_any_user, is_setup_completed, mark_setup_completed
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 
 log = logging.getLogger("api.setup")
@@ -55,8 +55,15 @@ def _setup_done() -> bool:
     Note: deleting the row in system_state alone is not enough to reactivate
     /setup if there's still a user; you'd also need to delete that user.
     Conversely, if the user gets deleted but setup_completed_at remains,
-    /setup stays dead — by design (recovery is via CLI per the README)."""
-    with transaction() as con:
+    /setup stays dead — by design (recovery is via CLI per the README).
+
+    Uses snapshot_connection() (PRAGMA query_only=1, no writer lock) per
+    PR #493 patología — this is a terminal read (two boolean queries, no
+    follow-up mutation in the same logical operation). Previously this
+    called transaction() which acquires BEGIN IMMEDIATE; under concurrent
+    test setup it raced with the FastAPI lifespan's init_db() and
+    intermittently failed with 'database is locked' (#495 flake)."""
+    with snapshot_connection() as con:
         return has_any_user(con) or is_setup_completed(con)
 
 

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -38,7 +38,7 @@ from starlette.types import ASGIApp
 
 from auth.models import User
 from auth.tokens import verify_access_token
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 
 def _bypass_role_or_none() -> str | None:
@@ -133,8 +133,16 @@ def _hydrate_user_from_db(user_id: int) -> User | None:
     instead of having to wait until the JWT expires. This is one extra
     sqlite read per protected request — acceptable for 2-5 users at one
     request every few seconds.
+
+    Uses snapshot_connection() (PRAGMA query_only=1, no writer lock) per
+    PR #493 patología — this is a terminal read (one SELECT, no follow-up
+    mutation in the same logical operation). Previously this called
+    transaction() which acquires BEGIN IMMEDIATE on every protected
+    request, racing with concurrent writes (kill-switch calibrator
+    background thread, init_db lifespan, signal scanner) and producing
+    intermittent 'database is locked' under test concurrency (#495).
     """
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             """
             SELECT id, email, role, is_active, created_at, password_changed_at,


### PR DESCRIPTION
## Summary

Sweep of two callsites that match the #493 patología (read-only operations acquiring BEGIN IMMEDIATE writer lock unnecessarily). Both surfaced during the test_setup.py flake investigation (#495).

PR #493 explicitly deferred this:
> *"There are ~100 other with transaction() call sites in the codebase; some are legitimate writes, some are likely read-only and have the same latent bug. A separate audit PR should sweep them."*

This PR is part of that sweep — the two callsites identified as causing the recurring "database is locked" failures.

## What changed

### `api/setup.py::_setup_done()`

Two boolean queries (`has_any_user` + `is_setup_completed`), called from all three `/setup*` endpoints. Was using `with transaction()` (BEGIN IMMEDIATE writer lock) for a pure terminal read. Migrated to `with snapshot_connection()` (PRAGMA query_only=1, no writer lock).

### `auth/middleware.py::_hydrate_user_from_db()`

One SELECT on `users WHERE id = ?`, called on EVERY protected request to verify the user is still active. Was using `with transaction()` for a pure terminal read. Migrated to `with snapshot_connection()`.

This is the highest-traffic read in the system — every authenticated request acquires a writer-lock just to refresh the User row. Under concurrent test execution (or under any non-trivial production load) this is a constant source of writer-lock contention.

## What this PR does NOT do

**Scope: read-only-endpoint sweep only.** The remaining test_setup.py flake comes from a different patología:

```
sqlite3.OperationalError: database is locked
  at db/schema.py:52: pragma_con.execute("PRAGMA journal_mode=WAL")
  via btc_api.py:244 in lifespan
```

The lock is during `PRAGMA journal_mode=WAL` in `init_db()` itself, before any endpoint is called. The contender is the `kill_switch_v2_calibrator` background thread (started by lifespan) holding DB connections that race with the next test's fresh-DB initialization. That is a **test-fixture-lifecycle concern**, NOT a `transaction()`-vs-`snapshot_connection()` concern.

**Separate follow-up will surface that flake.** This PR closes #495 for what its body explicitly named: *"audit api/setup.py for read-only with transaction() callsites + migrate them to snapshot_connection() per #493 pattern."*

The other ~95 `with transaction()` callsites remain in the codebase. Some are legitimate writes; some are read-only and still latent. A broader sweep is appropriate but out of scope here.

## Why these two were prioritized

1. **`auth/middleware.py::_hydrate_user_from_db`** — every protected request hits this. Highest read frequency in the system. Eliminating its writer-lock contention reduces baseline DB pressure across the entire app.

2. **`api/setup.py::_setup_done`** — called from all three `/setup*` endpoints. Tested heavily by `tests/test_setup.py`, which intermittently fails under the contention. This is the most observably-impacted callsite.

Both are TERMINAL reads (caller uses the result for direct decision; no follow-up write in the same logical operation) per `.mex/context/conventions.md` §4b.

## Test plan

- [x] `pytest tests/test_setup.py` — 12/13 green on Windows local. The 1 remaining flake is the PRAGMA WAL race named above; will be addressed by a separate test-fixture follow-up.
- [x] The 4 endpoints (status/get/post/post-error) all pass consistently — the contention they experienced is fixed.
- [x] No new tests added — the existing `tests/test_setup.py` exercises the changed paths heavily.
- [x] `auth/middleware.py` changes covered by `tests/test_auth.py` (which exercises the protected-request path).

## Closes / Refs

- **Closes #495** for the read-only-endpoint sweep scope (will likely open a follow-up for the PRAGMA WAL test-fixture race)
- Refs PR #493 (the explicit sweep deferral that this PR partially addresses)
- Refs `.mex/context/conventions.md` §4b (snapshot_connection contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)