### PR TITLE
feat(db): _migrate_direction_enum — move direction enum to schema rung (closes #484)

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -355,6 +355,7 @@ def init_db() -> None:
     with transaction() as con_d:
         _migrate_qty_positive(con_d)
         _migrate_tenant_id_not_null(con_d)
+        _migrate_direction_enum(con_d)
         _migrate_unique_open_scan(con_d)
         _migrate_idempotency_keys(con_d)
 
@@ -1167,6 +1168,142 @@ def _migrate_tenant_id_not_null(con: sqlite3.Connection) -> None:
     log.info(
         "_migrate_tenant_id_not_null: migration complete. positions enforces "
         "tenant_id IS NOT NULL or quarantine."
+    )
+
+
+def _migrate_direction_enum(con: sqlite3.Connection) -> None:
+    """Schema CHECK: direction IN ('LONG', 'SHORT') OR status='legacy_unmeasurable'
+    — #484 (move direction enum from Pydantic-boundary to schema rung).
+
+    The Pydantic Literal["LONG", "SHORT"] on OpenPositionRequest catches
+    malformed input at the HTTP boundary. But manual UPDATEs, legacy
+    clients, and ad-hoc shell access bypass that boundary entirely. The
+    CHECK constraint enforces the invariant at the schema rung — the
+    strongest rung available.
+
+    Existing rows are migrated as follows:
+      1. SQL UPPER(direction) normalizes case-variants ('long' → 'LONG',
+         'Short' → 'SHORT'). ASCII-only enums; UPPER() is safe.
+      2. Anything that still doesn't match {'LONG', 'SHORT'} (NULL, empty,
+         'NEUTRAL', garbage) is quarantined to status='legacy_unmeasurable'
+         — consistent with the other CHECKs' OR exemption.
+
+    Idempotent: detects `directionin('long','short')` in the whitespace-
+    normalized + case-folded DDL and skips. Anchored on the exact CHECK
+    fragment (not bare "long") to avoid false-positives — same pattern
+    as _migrate_qty_not_null after the #476 fix.
+    """
+    schema_row = con.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='positions'"
+    ).fetchone()
+    if not schema_row or not schema_row[0]:
+        log.warning(
+            "_migrate_direction_enum: positions table not found; skipping."
+        )
+        return
+    normalized = "".join(schema_row[0].split()).lower()
+    if "directionin('long','short')" in normalized:
+        log.info(
+            "_migrate_direction_enum: positions already enforces direction enum; "
+            "skipping."
+        )
+        return
+
+    # 1. Normalize case: 'long'/'Long' → 'LONG', etc.
+    con.execute(
+        """UPDATE positions
+              SET direction = UPPER(direction)
+            WHERE direction != UPPER(direction)"""
+    )
+    normalized_count = con.execute("SELECT changes()").fetchone()[0]
+    log.info(
+        "_migrate_direction_enum: normalized %d rows from mixed-case direction.",
+        normalized_count,
+    )
+
+    # 2. Quarantine anything that doesn't normalize to LONG/SHORT. Common
+    #    candidates: NULL (no DEFAULT applied — old INSERT without column),
+    #    empty string, 'NEUTRAL', typos. They are NOT recoverable to a
+    #    real direction so admit the absence rather than invent a value.
+    con.execute(
+        """UPDATE positions
+              SET status = 'legacy_unmeasurable'
+            WHERE (direction IS NULL OR direction NOT IN ('LONG', 'SHORT'))
+              AND status != 'legacy_unmeasurable'"""
+    )
+    quarantined = con.execute("SELECT changes()").fetchone()[0]
+    if quarantined:
+        log.warning(
+            "_migrate_direction_enum: quarantined %d rows with non-LONG/SHORT "
+            "direction as 'legacy_unmeasurable'.",
+            quarantined,
+        )
+
+    # 3. Recreate the table with the strengthened CHECK. All three CHECKs
+    #    (qty + tenant_id + direction) compose; each was added incrementally
+    #    by its own migration. The partial UNIQUE index from
+    #    _migrate_unique_open_scan is re-created by that migration's own
+    #    CREATE INDEX IF NOT EXISTS, which runs after this in init_db.
+    log.info(
+        "_migrate_direction_enum: recreating positions with CHECK "
+        "(direction IN ('LONG', 'SHORT') OR status='legacy_unmeasurable')."
+    )
+    existing_cols = {
+        row[1] for row in con.execute("PRAGMA table_info(positions)").fetchall()
+    }
+    # Defensive cleanup of any orphan positions_new from a prior interrupted
+    # run (same pattern as _migrate_qty_not_null per #480).
+    con.execute("DROP TABLE IF EXISTS positions_new")
+    con.execute(
+        """
+        CREATE TABLE positions_new (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            scan_id     INTEGER REFERENCES scans(id),
+            symbol      TEXT    NOT NULL,
+            direction   TEXT    NOT NULL DEFAULT 'LONG',
+            status      TEXT    NOT NULL DEFAULT 'open',
+            entry_price REAL    NOT NULL,
+            entry_ts    TEXT    NOT NULL,
+            sl_price    REAL,
+            tp_price    REAL,
+            size_usd    REAL,
+            qty         REAL,
+            exit_price  REAL,
+            exit_ts     TEXT,
+            exit_reason TEXT,
+            pnl_usd     REAL,
+            pnl_pct     REAL,
+            notes       TEXT,
+            atr_entry   REAL,
+            be_mult     REAL,
+            tenant_id   INTEGER,
+            CHECK ((qty IS NOT NULL AND qty > 0) OR status = 'legacy_unmeasurable'),
+            CHECK (tenant_id IS NOT NULL OR status IN ('legacy_unmeasurable', 'legacy_no_tenant')),
+            CHECK (direction IN ('LONG', 'SHORT') OR status = 'legacy_unmeasurable')
+        )
+        """
+    )
+    TARGET_COLS = [
+        "id", "scan_id", "symbol", "direction", "status", "entry_price",
+        "entry_ts", "sl_price", "tp_price", "size_usd", "qty",
+        "exit_price", "exit_ts", "exit_reason", "pnl_usd", "pnl_pct",
+        "notes", "atr_entry", "be_mult", "tenant_id",
+    ]
+    select_expressions = [
+        col if col in existing_cols else "NULL"
+        for col in TARGET_COLS
+    ]
+    insert_sql = (
+        f"INSERT INTO positions_new ({', '.join(TARGET_COLS)}) "
+        f"SELECT {', '.join(select_expressions)} FROM positions"
+    )
+    con.execute(insert_sql)
+    con.execute("DROP TABLE positions")
+    con.execute("ALTER TABLE positions_new RENAME TO positions")
+    con.execute("CREATE INDEX IF NOT EXISTS idx_positions_tenant ON positions(tenant_id)")
+    log.info(
+        "_migrate_direction_enum: migration complete. positions enforces "
+        "direction IN ('LONG', 'SHORT') or quarantine."
     )
 
 

--- a/tests/db/test_migrate_direction_enum.py
+++ b/tests/db/test_migrate_direction_enum.py
@@ -1,0 +1,229 @@
+"""Invariant tests for db.schema._migrate_direction_enum (#484).
+
+Moves the `direction` enum invariant from rung *convención* (only enforced
+at the Pydantic boundary on OpenPositionRequest) to rung *schema* (CHECK
+constraint in `positions`).
+
+Predicate: `direction IN ('LONG', 'SHORT') OR status = 'legacy_unmeasurable'`.
+
+The migration:
+  1. Normalizes existing values via SQL UPPER() (e.g., 'long' → 'LONG').
+  2. Quarantines anything that doesn't normalize to LONG/SHORT
+     (NULL, empty string, 'NEUTRAL', garbage) as status='legacy_unmeasurable'.
+  3. Recreates the positions table with the CHECK constraint.
+
+Idempotent: detects the CHECK fragment in the live schema and skips.
+"""
+import sqlite3
+import pytest
+
+
+def _init_minimal_positions_table(con: sqlite3.Connection) -> None:
+    """Create the positions table matching the post-#471 (tenant_id CHECK)
+    state — qty and tenant_id CHECKs already in place, but NO direction CHECK."""
+    con.execute("""
+        CREATE TABLE positions (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            scan_id     INTEGER,
+            symbol      TEXT    NOT NULL,
+            direction   TEXT    NOT NULL DEFAULT 'LONG',
+            status      TEXT    NOT NULL DEFAULT 'open',
+            entry_price REAL    NOT NULL,
+            entry_ts    TEXT    NOT NULL,
+            sl_price    REAL,
+            tp_price    REAL,
+            size_usd    REAL,
+            qty         REAL,
+            exit_price  REAL,
+            exit_ts     TEXT,
+            exit_reason TEXT,
+            pnl_usd     REAL,
+            pnl_pct     REAL,
+            notes       TEXT,
+            atr_entry   REAL,
+            be_mult     REAL,
+            tenant_id   INTEGER,
+            CHECK ((qty IS NOT NULL AND qty > 0) OR status = 'legacy_unmeasurable'),
+            CHECK (tenant_id IS NOT NULL OR status IN ('legacy_unmeasurable', 'legacy_no_tenant'))
+        )
+    """)
+
+
+def test_migration_normalizes_lowercase_direction(tmp_path):
+    """Existing rows with 'long' / 'short' (lowercase) get normalized to
+    'LONG' / 'SHORT' (uppercase) — they conform to the new CHECK without
+    being quarantined."""
+    from db.schema import _migrate_direction_enum
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1.0, 1, 'long')"
+    )
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction) "
+        "VALUES (2, 'ETHUSDT', 200.0, '2026-04-20T10:00:00+00:00', 0.5, 1, 'Short')"
+    )
+    con.commit()
+
+    _migrate_direction_enum(con)
+    con.commit()
+
+    rows = con.execute("SELECT id, direction, status FROM positions ORDER BY id").fetchall()
+    # 'long' → 'LONG', 'Short' → 'SHORT'. No quarantine — values are recoverable.
+    assert rows[0] == (1, "LONG", "open"), f"lowercase 'long' must normalize to 'LONG'; got: {rows[0]}"
+    assert rows[1] == (2, "SHORT", "open"), f"'Short' must normalize to 'SHORT'; got: {rows[1]}"
+
+
+def test_migration_quarantines_garbage_direction(tmp_path):
+    """Rows with direction values that don't normalize to LONG/SHORT (typos,
+    legacy values like 'NEUTRAL', empty string) get quarantined to
+    status='legacy_unmeasurable' — the new CHECK exempts that status."""
+    from db.schema import _migrate_direction_enum
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1.0, 1, 'NEUTRAL')"
+    )
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction) "
+        "VALUES (2, 'ETHUSDT', 200.0, '2026-04-20T10:00:00+00:00', 0.5, 1, '')"
+    )
+    con.commit()
+
+    _migrate_direction_enum(con)
+    con.commit()
+
+    rows = con.execute("SELECT id, direction, status FROM positions ORDER BY id").fetchall()
+    # Quarantined: status flipped; direction is preserved as historical record.
+    assert rows[0][2] == "legacy_unmeasurable", f"'NEUTRAL' row must be quarantined; got: {rows[0]}"
+    assert rows[1][2] == "legacy_unmeasurable", f"empty direction row must be quarantined; got: {rows[1]}"
+
+
+def test_migration_preserves_already_valid_rows(tmp_path):
+    """Rows that already conform ('LONG' / 'SHORT' uppercase) are unchanged
+    by the migration — neither normalized nor quarantined."""
+    from db.schema import _migrate_direction_enum
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1.0, 1, 'LONG')"
+    )
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction) "
+        "VALUES (2, 'ETHUSDT', 200.0, '2026-04-20T10:00:00+00:00', 0.5, 2, 'SHORT')"
+    )
+    con.commit()
+
+    _migrate_direction_enum(con)
+    con.commit()
+
+    rows = con.execute("SELECT id, direction, status FROM positions ORDER BY id").fetchall()
+    assert rows[0] == (1, "LONG", "open")
+    assert rows[1] == (2, "SHORT", "open")
+
+
+def test_check_constraint_rejects_invalid_direction_after_migration(tmp_path):
+    """After the migration, attempting to INSERT a non-LONG/SHORT direction
+    on a non-quarantine status row raises sqlite3.IntegrityError.
+
+    This is the structural guarantee — the same predicate the Pydantic
+    Literal enforces at the boundary now lives at the schema rung."""
+    from db.schema import _migrate_direction_enum
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.commit()
+
+    _migrate_direction_enum(con)
+    con.commit()
+
+    # Try to INSERT a row with invalid direction (status='open' so quarantine
+    # exemption doesn't apply).
+    with pytest.raises(sqlite3.IntegrityError):
+        con.execute(
+            "INSERT INTO positions (symbol, entry_price, entry_ts, qty, tenant_id, direction, status) "
+            "VALUES ('BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1.0, 1, 'NEUTRAL', 'open')"
+        )
+
+    # And for completeness: a legacy_unmeasurable row CAN have any direction
+    # (the OR in the CHECK exempts that status).
+    con.execute(
+        "INSERT INTO positions (symbol, entry_price, entry_ts, qty, tenant_id, direction, status) "
+        "VALUES ('BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1.0, 1, 'NEUTRAL', 'legacy_unmeasurable')"
+    )
+    con.commit()
+
+
+def test_migration_realistic_chain_position(tmp_path):
+    """In production, _migrate_direction_enum runs AFTER _migrate_qty_not_null,
+    _migrate_qty_positive, and _migrate_tenant_id_not_null. Each prior
+    migration may have already quarantined some rows (qty=NULL or
+    tenant_id=NULL → status='legacy_unmeasurable' / 'legacy_no_tenant').
+
+    Test that the direction migration's table recreation copies those
+    pre-quarantined rows through correctly — the OR exemption in the new
+    direction CHECK keeps them valid."""
+    from db.schema import _migrate_direction_enum
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    # Realistic mix: one active row + one pre-quarantined from prior migrations.
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction, status) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1.0, 1, 'LONG', 'open')"
+    )
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction, status) "
+        "VALUES (2, 'ETHUSDT', 200.0, '2026-04-20T10:00:00+00:00', NULL, 1, 'long', 'legacy_unmeasurable')"
+    )
+    con.commit()
+
+    _migrate_direction_enum(con)
+    con.commit()
+
+    # The active row stays open; direction is preserved (was already LONG).
+    # The pre-quarantined row keeps its status; direction is normalized but
+    # the quarantine exempts it from the new CHECK anyway.
+    rows = con.execute("SELECT id, direction, status FROM positions ORDER BY id").fetchall()
+    assert rows[0] == (1, "LONG", "open"), f"active row preserved; got: {rows[0]}"
+    assert rows[1][2] == "legacy_unmeasurable", f"prior quarantine preserved; got: {rows[1]}"
+
+    # Schema-level: CHECK is present.
+    schema = con.execute(
+        "SELECT sql FROM sqlite_master WHERE name='positions'"
+    ).fetchone()[0]
+    normalized = "".join(schema.split()).lower()
+    assert "directionin('long','short')" in normalized, (
+        f"CHECK must be present post-migration; got: {schema}"
+    )
+
+
+def test_idempotent_on_already_migrated_table(tmp_path):
+    """Running _migrate_direction_enum twice is a no-op the second time."""
+    from db.schema import _migrate_direction_enum
+
+    db_path = tmp_path / "test.db"
+    con = sqlite3.connect(str(db_path))
+    _init_minimal_positions_table(con)
+    con.execute(
+        "INSERT INTO positions (id, symbol, entry_price, entry_ts, qty, tenant_id, direction) "
+        "VALUES (1, 'BTCUSDT', 100.0, '2026-04-20T10:00:00+00:00', 1.0, 1, 'LONG')"
+    )
+    con.commit()
+
+    _migrate_direction_enum(con)
+    _migrate_direction_enum(con)  # second run must not raise
+
+    row = con.execute("SELECT direction FROM positions WHERE id = 1").fetchone()
+    assert row[0] == "LONG"


### PR DESCRIPTION
## Summary

Closes **#484**: move the `direction` enum invariant from rung *convención* (only Pydantic boundary on `OpenPositionRequest`) to rung *schema* (CHECK constraint enforced by SQLite on every INSERT/UPDATE).

The Pydantic `Literal["LONG", "SHORT"]` catches malformed input at the HTTP boundary. But manual UPDATEs, legacy clients, and ad-hoc shell access bypass that boundary entirely. The CHECK constraint enforces the invariant at the strongest available rung.

## Predicate enforced

> *direction column value is in the closed set {'LONG', 'SHORT'} OR the row is marked 'legacy_unmeasurable'.*

Schema rung. Mechanism: `CHECK (direction IN ('LONG', 'SHORT') OR status = 'legacy_unmeasurable')` on positions table.

## Migration mechanics

1. **Idempotency probe:** detects `directionin('long','short')` in the whitespace-normalized + case-folded DDL, skips if present. Anchored on the exact CHECK fragment per #476 lesson — bare-string substring would false-positive on column DEFAULT mentions, etc.

2. **Normalization:** `UPDATE direction = UPPER(direction)` for any row with mixed-case ('long' → 'LONG', 'Short' → 'SHORT'). ASCII-only enum; SQL `UPPER()` is safe.

3. **Quarantine:** rows where direction (post-normalization) is NULL, empty, or NOT IN ('LONG', 'SHORT') get `status='legacy_unmeasurable'` — admit the absence rather than invent a value. The new CHECK's OR exemption keeps them valid. Same policy as the qty / tenant_id migrations.

4. **Recreate table** with the composite CHECK (qty + tenant_id + direction all three coexist). Adds the defensive `DROP TABLE IF EXISTS positions_new` from #480.

## Migration chain ordering

Sequenced in `init_db` between `_migrate_tenant_id_not_null` (last positions-table-recreation migration) and `_migrate_unique_open_scan` (whose `CREATE INDEX IF NOT EXISTS` re-creates the partial UNIQUE index this migration drops):

```python
_migrate_qty_positive(con_d)
_migrate_tenant_id_not_null(con_d)
_migrate_direction_enum(con_d)        # ← NEW
_migrate_unique_open_scan(con_d)
_migrate_idempotency_keys(con_d)
```

## TDD record (6 tests)

| Test | Pre-fix | Post-fix |
|------|---------|----------|
| `test_migration_normalizes_lowercase_direction` | ImportError | 'long'/'Short' → 'LONG'/'SHORT' ✓ |
| `test_migration_quarantines_garbage_direction` | ImportError | 'NEUTRAL'/'' → legacy_unmeasurable ✓ |
| `test_migration_preserves_already_valid_rows` | ImportError | 'LONG'/'SHORT' unchanged ✓ |
| `test_check_constraint_rejects_invalid_direction_after_migration` | ImportError | post-migration `sqlite3.IntegrityError` on INSERT with `direction='NEUTRAL' status='open'` ✓ |
| `test_migration_realistic_chain_position` | ImportError | rows pre-quarantined by earlier migrations pass through cleanly ✓ |
| `test_idempotent_on_already_migrated_table` | ImportError | second run is no-op ✓ |

Suite: `pytest tests/db/ tests/test_multi_tenant_b1_schema.py` — **75/75 green**. No regression on sibling migration tests.

## Voronov framing (per-predicate registry row)

Following Voronov's PR #496 lesson — *"virtues are not invariants; predicates are. Registry rows must carry predicates."*

```
Invariant: direction column value is in the closed set {'LONG','SHORT'}
           OR the row is marked 'legacy_unmeasurable'.
Rung: schema (CHECK constraint enforced by SQLite engine on every
      INSERT/UPDATE).
Mechanism: CHECK (direction IN ('LONG','SHORT') OR status='legacy_unmeasurable')
           on positions table, installed by _migrate_direction_enum.
Issue closed: #484.
```

One predicate, one rung, one mechanism, one row.

## What this PR does NOT do

- Does **NOT** add a new registry row to `.mex/context/conventions.md`. The registry update follows the same scaffold-PR pattern; tracked separately.
- Does **NOT** sweep other Pydantic-boundary-only enums (status values, direction values in other tables if any). Each is its own predicate, would deserve its own migration.
- Does **NOT** touch the application code that writes direction — it already writes 'LONG'/'SHORT' uppercase. The CHECK is a defensive guard against future manual mutations.

## Closes / Refs

- **Closes #484** — direction enum at schema rung
- Refs PR #485 (introduced the existing migration chain that this extends)
- Refs PR #496 (defensive `DROP IF EXISTS` pattern + anchored idempotency probe per #476)
- Refs PR #486 (Voronov bundle-by-invariant rule — this is one predicate so one PR)

## Test plan

- [x] `pytest tests/db/test_migrate_direction_enum.py` — 6/6 green
- [x] `pytest tests/db/` — full migration suite green
- [x] `pytest tests/test_multi_tenant_b1_schema.py` — 27/27 green (no regression on the migration-chain integration)
- [x] Pre-fix RED state confirmed (6 tests fail with ImportError)
- [x] Post-fix GREEN state confirmed (all 6 pass, no sibling regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)