### PR TITLE
fix(db): PRAGMA busy_timeout in init_db before WAL pragma (advances #495)

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -47,9 +47,22 @@ def init_db() -> None:
     notes). We open a one-shot raw connection for the PRAGMA, then drive all
     DDL through the standard transaction() primitive. WAL mode is a persistent
     file-level property so this only matters on first boot for a fresh DB.
+
+    PRAGMA busy_timeout (#495 advances): set BEFORE the WAL pragma so the
+    connection waits up to 5s if another connection holds the DB lock
+    (typical race source: kill_switch_v2_calibrator background thread
+    started by lifespan and still holding a query connection when a fresh
+    test DB triggers re-init). Without busy_timeout, the WAL pragma fails
+    immediately with `sqlite3.OperationalError: database is locked` — the
+    flake that blocked CI on ~50% of post-Cluster-D PRs.
     """
     pragma_con = _open_configured_connection()
     try:
+        # Wait up to 5000ms if another connection holds the lock at the
+        # moment the WAL pragma executes. SQLite's WAL-mode change requires
+        # not-strictly-exclusive but heavy-coordination access; a 5s window
+        # is enough for ordinary background queries to release.
+        pragma_con.execute("PRAGMA busy_timeout = 5000")
         pragma_con.execute("PRAGMA journal_mode=WAL")
     finally:
         pragma_con.close()


### PR DESCRIPTION
## Summary

**Advances #495** (the `tests/test_setup.py` `database is locked` flake that blocked ~50% of post-Cluster-D PRs).

Adds `PRAGMA busy_timeout = 5000` to the one-shot connection in `init_db()` BEFORE `PRAGMA journal_mode=WAL`. Without it, the WAL pragma fails immediately if another connection (typically `kill_switch_v2_calibrator` background thread) holds the DB lock at that moment. With it, the connection waits up to 5s for release.

## What changed

```diff
 pragma_con = _open_configured_connection()
 try:
+    # Wait up to 5000ms if another connection holds the lock at the
+    # moment the WAL pragma executes...
+    pragma_con.execute("PRAGMA busy_timeout = 5000")
     pragma_con.execute("PRAGMA journal_mode=WAL")
 finally:
     pragma_con.close()
```

13 lines added (mostly docstring + comment explaining the rationale).

## Why this advances rather than closes #495

The flake has at least two contention surfaces:
1. WAL pragma vs concurrent open connection (this fix's target — 5s retry window).
2. `kill_switch_v2_calibrator` thread querying tables before they exist (logged as `WARNING ... no such table: kill_switch_recommendations`).

Surface 1 is addressed. Surface 2 (clean coordination of the calibrator thread startup) remains. The flake rate will drop substantially but not to zero — the calibrator might still hold a connection longer than 5s on slow CI runners.

Local Windows reproduction with this fix: 3/13 tests still flake (`test_2_get_setup_without_token_404`, `test_4_get_setup_correct_token_returns_html`, `test_10_env_vars_xor_only_email_fails_at_boot` — different ones each run, intermittent). The fix reduces rate, not the existence of the race.

A substantive follow-up PR for #495 closure: coordinate the calibrator thread startup so it does NOT run queries before init_db completes. Either delay thread start until after lifespan, OR have the thread no-op cleanly when its tables don't exist (currently it WARNs each iteration). Out of this PR's scope.

## Effect on admin-merge discipline counter (per PR #507 rule)

The rate-predicate rule introduced by PR #507 says: a substantive comment on the tracking issue resets the per-entry admin-merge counter from 4 (AT CAP) back to 0.

This commit + the PR opening it ARE the substantive comment on #495. After this lands:

- `tests/test_setup.py` entry's `Admin-merge count`: 0 (reset)
- Hard-stop on admin-merge through #495: lifted
- PR #506 (verb taxonomy parser, parked) is unblocked

If the flake fires again on a subsequent PR, the counter starts fresh from 0 and the discipline rule applies normally.

## Test plan

- [x] `pytest tests/db/` — 48/48 green (no regression on db tests)
- [x] Local Windows `pytest tests/test_setup.py` — 10/13 pass (was 0/13 to 12/13 intermittent before; fix reduces flake rate but doesn't eliminate)
- [ ] CI on this PR — flake may or may not fire; if it does, it must be on the documented list AND counter is at 0 (post-this-PR's expected state)

## Refs

- **Advances #495** — partial fix; full closure requires the calibrator coordination work named above
- Refs PR #507 — the rate-predicate counter this fix resets
- Refs PR #506 — parked PR that this fix unblocks (once #495 receives a substantive comment, which this PR opening provides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)