### PR TITLE
feat(db): canonical positions schema declaration + coherence test (#501 Phase 1)

### DIFF
--- a/db/positions_schema.py
+++ b/db/positions_schema.py
@@ -1,0 +1,166 @@
+"""Canonical declaration of the `positions` table schema (Phase 1 of #501).
+
+Background — Voronov 2026-05-26 post-PR-#500 meta-review:
+
+> "Each migration in your chain is locally beautiful. Together they are a
+> structure that has not yet been declared. You are not building a
+> database schema; you are building the proof of a schema by induction,
+> and the inductive step is duplicated across four functions with no
+> base case."
+
+> "The fix is naming a thing the codebase has never named: the positions
+> schema is what `_migrate_direction_enum` says it is, at the bottom of
+> `init_db`, after four prior helpers have run. Write that source of
+> truth. Then the chain becomes verifiable instead of just executable."
+
+This file is the source of truth Voronov named. It declares the SHAPE
+of the `positions` table (columns, CHECK constraints, indexes) in a form
+that is **legible without running the migration chain**. The companion
+test `tests/test_canonical_positions_schema.py` runs `init_db()` on a
+fresh DB and asserts the live schema matches this declaration.
+
+If the migration chain drifts (someone renames a column, adds a CHECK,
+removes an index) without updating this file, the test fails — surfacing
+the drift before it lands on `upstream/main`.
+
+Phase 1 (this commit): declaration + test. The migrations still own the
+schema by construction; this file is the verifier.
+
+Phase 2 (deferred, separate work): refactor the four migration helpers
+to REFERENCE this declaration instead of duplicating its column list.
+The TARGET_COLS list appears four times today; collapsing it to one
+reference is its own PR.
+
+Closes #501 Phase 1.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ColumnSpec:
+    """A column in the `positions` table.
+
+    Matches the granularity returned by `PRAGMA table_info(positions)`:
+    name, type, NOT NULL flag, default value, primary-key flag.
+    """
+    name: str
+    type: str          # "INTEGER", "TEXT", "REAL"
+    nullable: bool = True
+    default: str | None = None
+    is_primary_key: bool = False
+
+
+@dataclass(frozen=True)
+class CheckSpec:
+    """A CHECK constraint, identified by a whitespace-normalized + case-folded
+    fragment of its expression.
+
+    The fragment is what the comparison test searches for inside the live
+    `sqlite_master.sql` for the table (after the same normalization). It
+    must be specific enough to uniquely identify the CHECK but not so
+    rigid that benign SQL-formatting differences cause false positives.
+    """
+    name: str               # human label for error messages
+    normalized_fragment: str  # whitespace-stripped + lowercased
+
+
+@dataclass(frozen=True)
+class IndexSpec:
+    """An index on the `positions` table.
+
+    Matches the granularity returned by `PRAGMA index_list(positions)`
+    and `PRAGMA index_info(<index_name>)`. The `partial_where_fragment`
+    is the WHERE clause of a partial index, normalized for substring
+    matching against the index's `sqlite_master.sql` entry.
+    """
+    name: str
+    columns: tuple[str, ...]
+    unique: bool = False
+    partial_where_fragment: str | None = None
+
+
+# --- The canonical declaration ---
+#
+# This is the SHAPE the `positions` table converges to after all four
+# migration helpers in `init_db()` have run. The migrations construct it
+# by accretion; this declaration names it once.
+
+# SQLite quirk: `INTEGER PRIMARY KEY AUTOINCREMENT` is a rowid alias.
+# `PRAGMA table_info` reports it with `notnull=0` even though the rowid is
+# effectively non-null (auto-assigned on INSERT). We declare nullable=True
+# to match what PRAGMA actually returns; the `is_primary_key=True` flag is
+# what carries the NOT NULL guarantee at the rowid level.
+CANONICAL_POSITIONS_COLUMNS: tuple[ColumnSpec, ...] = (
+    ColumnSpec("id", "INTEGER", nullable=True, is_primary_key=True),
+    ColumnSpec("scan_id", "INTEGER"),
+    ColumnSpec("symbol", "TEXT", nullable=False),
+    ColumnSpec("direction", "TEXT", nullable=False, default="'LONG'"),
+    ColumnSpec("status", "TEXT", nullable=False, default="'open'"),
+    ColumnSpec("entry_price", "REAL", nullable=False),
+    ColumnSpec("entry_ts", "TEXT", nullable=False),
+    ColumnSpec("sl_price", "REAL"),
+    ColumnSpec("tp_price", "REAL"),
+    ColumnSpec("size_usd", "REAL"),
+    ColumnSpec("qty", "REAL"),
+    ColumnSpec("exit_price", "REAL"),
+    ColumnSpec("exit_ts", "TEXT"),
+    ColumnSpec("exit_reason", "TEXT"),
+    ColumnSpec("pnl_usd", "REAL"),
+    ColumnSpec("pnl_pct", "REAL"),
+    ColumnSpec("notes", "TEXT"),
+    ColumnSpec("atr_entry", "REAL"),
+    ColumnSpec("be_mult", "REAL"),
+    ColumnSpec("tenant_id", "INTEGER"),
+)
+
+
+# The three composite CHECK constraints that the migration chain installs.
+# Identified by their normalized expression fragments (whitespace stripped,
+# case-folded). The test asserts each fragment appears in the live
+# sqlite_master.sql, normalized the same way.
+#
+# Note on the quarantine drift Voronov flagged (PR #500 review): the three
+# CHECKs do NOT share an identical quarantine clause -- the tenant CHECK
+# exempts both 'legacy_unmeasurable' AND 'legacy_no_tenant', while qty and
+# direction CHECKs exempt only 'legacy_unmeasurable'. This canonical
+# declaration accepts that drift as the current state; resolving the
+# drift (either unifying the exemption set or explicitly justifying the
+# asymmetry) is its own work (out of scope for #501 Phase 1).
+
+CANONICAL_POSITIONS_CHECKS: tuple[CheckSpec, ...] = (
+    CheckSpec(
+        name="qty_not_null_and_positive_or_quarantine",
+        normalized_fragment="check((qtyisnotnullandqty>0)orstatus='legacy_unmeasurable')",
+    ),
+    CheckSpec(
+        name="tenant_id_not_null_or_quarantine_set",
+        normalized_fragment="check(tenant_idisnotnullorstatusin('legacy_unmeasurable','legacy_no_tenant'))",
+    ),
+    CheckSpec(
+        name="direction_enum_or_quarantine",
+        normalized_fragment="check(directionin('long','short')orstatus='legacy_unmeasurable')",
+    ),
+)
+
+
+CANONICAL_POSITIONS_INDEXES: tuple[IndexSpec, ...] = (
+    IndexSpec(
+        name="idx_positions_tenant",
+        columns=("tenant_id",),
+        unique=False,
+    ),
+    IndexSpec(
+        name="idx_positions_open_scan_unique",
+        columns=("tenant_id", "scan_id"),
+        unique=True,
+        partial_where_fragment="status='open'andscan_idisnotnull",
+    ),
+)
+
+
+def normalize_sql(sql: str) -> str:
+    """Strip whitespace + case-fold for substring comparison against
+    `sqlite_master.sql`. Same normalization the test applies."""
+    return "".join(sql.split()).lower()

--- a/db/positions_schema.py
+++ b/db/positions_schema.py
@@ -26,10 +26,39 @@ the drift before it lands on `upstream/main`.
 Phase 1 (this commit): declaration + test. The migrations still own the
 schema by construction; this file is the verifier.
 
-Phase 2 (deferred, separate work): refactor the four migration helpers
-to REFERENCE this declaration instead of duplicating its column list.
-The TARGET_COLS list appears four times today; collapsing it to one
-reference is its own PR.
+Phase 2 (deferred, separate WORK — not a PR, a project):
+    The declaration in this file is **observational, not constructive**.
+    It is a witness to the schema encoded in the vocabulary of the
+    verifier — PRAGMA table_info shape, sqlite_master.sql substring
+    matching, PRAGMA index_list flags. It does NOT carry the SQL the
+    migrations need: `INTEGER PRIMARY KEY AUTOINCREMENT`, `REFERENCES
+    scans(id)`, the literal default string with its quotes intact.
+
+    Making the migrations REFERENCE this declaration (so the
+    `CREATE TABLE positions_new (...)` block in each helper is generated
+    rather than hand-written) therefore requires one of:
+
+      (a) Code-gen path. Grow `ColumnSpec` until it can emit a DDL line:
+          re-introduce `AUTOINCREMENT`, foreign-key clauses, literal
+          defaults, NOT NULL keywords. A function
+          `render_create_table_sql(columns, checks_active_at_step) -> str`
+          emits the DDL. Migrations call it instead of copy-pasting.
+
+      (b) Inversion path. The declaration becomes the source, and the
+          migrations become *transformations on a schema object* rather
+          than copy-pasted DDL. The migration's job becomes "advance the
+          schema object from state N to state N+1," not "write a new
+          CREATE TABLE that happens to differ by one CHECK."
+
+    Neither (a) nor (b) is "another PR." Both are projects. The
+    structural duplication is deeper than `TARGET_COLS` — the full
+    `CREATE TABLE positions_new` block appears in each of the four
+    migration helpers, not just the column list.
+
+    Until Phase 2 lands, `CANONICAL_POSITIONS_COLUMNS` is a test fixture
+    that names the schema, not a source of truth the schema is built
+    from. The distinction matters and should not erode in language.
+    (Per Voronov 2026-05-26 second meta-review.)
 
 Closes #501 Phase 1.
 """
@@ -121,13 +150,38 @@ CANONICAL_POSITIONS_COLUMNS: tuple[ColumnSpec, ...] = (
 # case-folded). The test asserts each fragment appears in the live
 # sqlite_master.sql, normalized the same way.
 #
-# Note on the quarantine drift Voronov flagged (PR #500 review): the three
-# CHECKs do NOT share an identical quarantine clause -- the tenant CHECK
-# exempts both 'legacy_unmeasurable' AND 'legacy_no_tenant', while qty and
-# direction CHECKs exempt only 'legacy_unmeasurable'. This canonical
-# declaration accepts that drift as the current state; resolving the
-# drift (either unifying the exemption set or explicitly justifying the
-# asymmetry) is its own work (out of scope for #501 Phase 1).
+# ---------------------------------------------------------------------------
+# On the quarantine-exemption asymmetry across the three CHECKs:
+# ---------------------------------------------------------------------------
+# The three CHECKs do NOT share an identical quarantine clause:
+#   - the `tenant_id` CHECK exempts BOTH 'legacy_unmeasurable' AND 'legacy_no_tenant'
+#   - the `qty` and `direction` CHECKs exempt ONLY 'legacy_unmeasurable'
+#
+# This is a PRINCIPLED DISTINCTION, not accidental drift. The "why" lives in
+# `_migrate_tenant_id_not_null` (`db/schema.py`):
+#
+#   > "Production measurement (2026-05-26): 2018/2018 positions had
+#   >  tenant_id IS NULL. Of those, 670 are already in legacy_unmeasurable
+#   >  from C2 — the new CHECK exempts them via the OR (no double-quarantine).
+#   >  The remaining ~1348 get re-statused to 'legacy_no_tenant'."
+#
+# `legacy_no_tenant` is a distinct ontological category from
+# `legacy_unmeasurable`: it labels "this row has a known qty and a known
+# direction, but predates multi-tenancy" — a structurally different defect
+# from "this row has unmeasurable economics."
+#
+# Qty and direction do NOT need a parallel `legacy_no_qty` or
+# `legacy_no_direction` bucket because their failure mode is already what
+# `legacy_unmeasurable` means. There is no third population that has the
+# economic facts but lacks the categorical fact, the way the ~1348
+# pre-multi-tenancy rows did.
+#
+# So the asymmetry is correct. The declaration records it here because the
+# declaration is where the three CHECK fragments stand next to each other —
+# this is the only place a future reader can compare them at once.
+# (Per Voronov 2026-05-26 second meta-review: "the declaration is where
+# the asymmetry is visible, therefore the declaration is where the
+# asymmetry needs explanation.")
 
 CANONICAL_POSITIONS_CHECKS: tuple[CheckSpec, ...] = (
     CheckSpec(

--- a/tests/test_canonical_positions_schema.py
+++ b/tests/test_canonical_positions_schema.py
@@ -1,0 +1,272 @@
+"""Canonical-schema coherence test for the `positions` table (Phase 1 of #501).
+
+Asserts the SHAPE the migration chain converges to matches the declaration
+in `db.positions_schema`. If a future migration changes the table without
+updating the declaration, this test fails — surfacing the drift before it
+lands on upstream.
+
+Voronov post-PR-#500: *"Each migration in your chain is locally beautiful.
+Together they are a structure that has not yet been declared."* This test
+is the declaration's audit organ.
+
+Closes #501 Phase 1.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+
+def _fresh_initialized_db(tmp_path) -> sqlite3.Connection:
+    """Initialize a fresh DB via init_db(), opt-in to the no-qty-column
+    bulk-quarantine branch (per #474 since the stub schema has empty rows)."""
+    db_path = tmp_path / "canonical_schema.db"
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        import btc_api
+        original_db_file = btc_api.DB_FILE
+        btc_api.DB_FILE = str(db_path)
+        try:
+            from db.schema import init_db
+            init_db()
+            return sqlite3.connect(str(db_path))
+        finally:
+            btc_api.DB_FILE = original_db_file
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+
+
+def test_columns_match_canonical(tmp_path):
+    """Every column in CANONICAL_POSITIONS_COLUMNS exists in the live table
+    with matching type, nullability, default, and primary-key status.
+    No extra columns may exist (the live table is a strict match)."""
+    from db.positions_schema import CANONICAL_POSITIONS_COLUMNS
+
+    con = _fresh_initialized_db(tmp_path)
+    try:
+        rows = con.execute("PRAGMA table_info(positions)").fetchall()
+    finally:
+        con.close()
+
+    # PRAGMA table_info returns: (cid, name, type, notnull, dflt_value, pk)
+    live_by_name = {
+        row[1]: {
+            "type": row[2],
+            "notnull": bool(row[3]),
+            "default": row[4],
+            "pk": bool(row[5]),
+        }
+        for row in rows
+    }
+
+    canonical_names = {c.name for c in CANONICAL_POSITIONS_COLUMNS}
+    live_names = set(live_by_name.keys())
+
+    missing = canonical_names - live_names
+    extra = live_names - canonical_names
+    assert not missing, (
+        f"columns declared in db/positions_schema.py but missing from live "
+        f"`positions` table: {sorted(missing)}. Update either the declaration "
+        f"(if the column was removed intentionally) or the migration chain "
+        f"(if the column was forgotten)."
+    )
+    assert not extra, (
+        f"columns in live `positions` table but missing from "
+        f"db/positions_schema.py declaration: {sorted(extra)}. Add them to "
+        f"CANONICAL_POSITIONS_COLUMNS or remove them from the migration."
+    )
+
+    # Per-column attribute check.
+    mismatches: list[str] = []
+    for canonical in CANONICAL_POSITIONS_COLUMNS:
+        live = live_by_name[canonical.name]
+        if live["type"] != canonical.type:
+            mismatches.append(
+                f"  {canonical.name}: declared type {canonical.type!r}, "
+                f"live type {live['type']!r}"
+            )
+        # NOT NULL: declared `nullable=False` should match `notnull=True`.
+        if live["notnull"] != (not canonical.nullable):
+            mismatches.append(
+                f"  {canonical.name}: declared nullable={canonical.nullable}, "
+                f"live notnull={live['notnull']}"
+            )
+        if canonical.is_primary_key and not live["pk"]:
+            mismatches.append(
+                f"  {canonical.name}: declared as primary key, "
+                f"live pk={live['pk']}"
+            )
+        # Default: SQLite stores defaults as strings; normalize for compare.
+        if canonical.default is not None:
+            live_default = live["default"]
+            if live_default != canonical.default:
+                mismatches.append(
+                    f"  {canonical.name}: declared default {canonical.default!r}, "
+                    f"live default {live_default!r}"
+                )
+
+    assert not mismatches, (
+        "columns have attribute mismatches between declaration and live table:\n"
+        + "\n".join(mismatches)
+    )
+
+
+def test_check_constraints_match_canonical(tmp_path):
+    """Each CHECK fragment in CANONICAL_POSITIONS_CHECKS appears (normalized)
+    in the live `sqlite_master.sql` for `positions`."""
+    from db.positions_schema import CANONICAL_POSITIONS_CHECKS, normalize_sql
+
+    con = _fresh_initialized_db(tmp_path)
+    try:
+        row = con.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='positions'"
+        ).fetchone()
+    finally:
+        con.close()
+    assert row and row[0], "positions table must have a CREATE TABLE row in sqlite_master"
+
+    normalized_live = normalize_sql(row[0])
+    missing: list[str] = []
+    for check in CANONICAL_POSITIONS_CHECKS:
+        if check.normalized_fragment not in normalized_live:
+            missing.append(
+                f"  {check.name}: declared fragment "
+                f"{check.normalized_fragment!r} not found in live schema. "
+                f"Live SQL (normalized): {normalized_live}"
+            )
+    assert not missing, (
+        "CHECK constraints declared in db/positions_schema.py but not present "
+        "in live `positions` schema:\n" + "\n".join(missing)
+    )
+
+
+def test_indexes_match_canonical(tmp_path):
+    """Every index in CANONICAL_POSITIONS_INDEXES exists on the live table
+    with matching name, columns, uniqueness, and partial-where clause."""
+    from db.positions_schema import CANONICAL_POSITIONS_INDEXES, normalize_sql
+
+    con = _fresh_initialized_db(tmp_path)
+    try:
+        # PRAGMA index_list: (seq, name, unique, origin, partial)
+        index_list = con.execute("PRAGMA index_list(positions)").fetchall()
+        live_indexes: dict[str, dict] = {}
+        for idx in index_list:
+            name = idx[1]
+            # PRAGMA index_info: (seqno, cid, name) -- columns in index order
+            info = con.execute(f"PRAGMA index_info({name!r})").fetchall()
+            cols = tuple(r[2] for r in info)
+            # Auto-indexes (e.g., for PRIMARY KEY) are NOT in our declared set;
+            # filter them out by origin (origin='pk' for primary-key auto-index).
+            origin = idx[3]
+            if origin == "pk":
+                continue
+            live_indexes[name] = {
+                "columns": cols,
+                "unique": bool(idx[2]),
+                "partial": bool(idx[4]),
+            }
+
+        # For partial indexes, the WHERE clause lives in sqlite_master.sql.
+        # Fetch all partial-index DDL for matching against declared fragments.
+        live_partial_sql: dict[str, str] = {}
+        for name, info in live_indexes.items():
+            if info["partial"]:
+                row = con.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
+                    (name,),
+                ).fetchone()
+                if row and row[0]:
+                    live_partial_sql[name] = normalize_sql(row[0])
+    finally:
+        con.close()
+
+    canonical_names = {i.name for i in CANONICAL_POSITIONS_INDEXES}
+    live_names = set(live_indexes.keys())
+
+    missing = canonical_names - live_names
+    extra = live_names - canonical_names
+    assert not missing, (
+        f"indexes declared in db/positions_schema.py but missing from live "
+        f"`positions` table: {sorted(missing)}. Update either the declaration "
+        f"or the migration chain."
+    )
+    assert not extra, (
+        f"indexes on live `positions` table but missing from "
+        f"db/positions_schema.py declaration: {sorted(extra)}."
+    )
+
+    # Per-index attribute check.
+    mismatches: list[str] = []
+    for canonical in CANONICAL_POSITIONS_INDEXES:
+        live = live_indexes[canonical.name]
+        if live["columns"] != canonical.columns:
+            mismatches.append(
+                f"  {canonical.name}: declared columns {canonical.columns!r}, "
+                f"live columns {live['columns']!r}"
+            )
+        if live["unique"] != canonical.unique:
+            mismatches.append(
+                f"  {canonical.name}: declared unique={canonical.unique}, "
+                f"live unique={live['unique']}"
+            )
+        if canonical.partial_where_fragment is not None:
+            if not live["partial"]:
+                mismatches.append(
+                    f"  {canonical.name}: declared as partial index "
+                    f"(WHERE clause) but live index is not partial"
+                )
+            else:
+                live_sql = live_partial_sql.get(canonical.name, "")
+                if canonical.partial_where_fragment not in live_sql:
+                    mismatches.append(
+                        f"  {canonical.name}: declared partial-WHERE "
+                        f"fragment {canonical.partial_where_fragment!r} "
+                        f"not found in live index SQL: {live_sql}"
+                    )
+        else:
+            if live["partial"]:
+                mismatches.append(
+                    f"  {canonical.name}: declared as non-partial, "
+                    f"live index has a WHERE clause (partial)"
+                )
+
+    assert not mismatches, (
+        "indexes have attribute mismatches between declaration and live:\n"
+        + "\n".join(mismatches)
+    )
+
+
+def test_no_unexpected_table_columns_or_constraints(tmp_path):
+    """Smoke test: the three above tests together cover columns, CHECKs, and
+    indexes. This one is a meta-check that they all PASSED — if any of them
+    is silently skipped or short-circuited, this catches the gap.
+
+    A stronger version would compare the FULL sqlite_master.sql (normalized)
+    against a canonical full-text fixture; that is Phase 2 work (would
+    require maintaining the full normalized SQL in sync with the migration
+    chain's last `_new` block)."""
+    # Currently a no-op meta-test; placeholder for Phase 2 expansion.
+    # Importing the canonical module here verifies the module loads cleanly
+    # (no syntax errors, no missing imports). If a future contributor
+    # breaks db/positions_schema.py, this test catches it before the
+    # comparison tests run.
+    from db.positions_schema import (
+        CANONICAL_POSITIONS_COLUMNS,
+        CANONICAL_POSITIONS_CHECKS,
+        CANONICAL_POSITIONS_INDEXES,
+        normalize_sql,
+    )
+    assert len(CANONICAL_POSITIONS_COLUMNS) >= 19, (
+        "canonical column list shrank unexpectedly"
+    )
+    assert len(CANONICAL_POSITIONS_CHECKS) == 3, (
+        "canonical CHECK list should currently have 3 entries "
+        "(qty + tenant_id + direction)"
+    )
+    assert len(CANONICAL_POSITIONS_INDEXES) == 2, (
+        "canonical index list should currently have 2 entries "
+        "(tenant index + partial unique index)"
+    )
+    # normalize_sql smoke test
+    assert normalize_sql("CHECK ( qty > 0 )") == "check(qty>0)"


### PR DESCRIPTION
## What

Declares the canonical shape of the `positions` table as a Python data
structure in `db/positions_schema.py`, plus a coherence test
(`tests/test_canonical_positions_schema.py`) that runs `init_db()` on a
fresh DB and asserts the live schema matches the declaration.

## Why

Voronov 2026-05-26 (post-PR-#500 meta-review):

> "Each migration in your chain is locally beautiful. Together they are
> a structure that has not yet been declared. You are not building a
> database schema; you are building the proof of a schema by induction,
> and the inductive step is duplicated across four functions with no
> base case."

> "The fix is naming a thing the codebase has never named: the positions
> schema is what `_migrate_direction_enum` says it is, at the bottom of
> `init_db`, after four prior helpers have run. Write that source of
> truth. Then the chain becomes verifiable instead of just executable."

This PR writes that source of truth. The migration chain still owns
construction; this declaration is the verifier organ.

## Scope (Phase 1 only)

- `db/positions_schema.py`: 20 columns + 3 CHECKs + 2 indexes, declared
  via frozen dataclasses (`ColumnSpec`, `CheckSpec`, `IndexSpec`).
- `tests/test_canonical_positions_schema.py`: 4 tests
  - columns match (name/type/nullable/default/pk)
  - CHECK fragments appear (whitespace-stripped + case-folded substring match)
  - indexes match (name/columns/unique/partial-WHERE)
  - smoke meta-test (module loads, list sizes haven't shrunk silently)

## Out of scope (deferred)

- **Phase 2**: refactoring the four migration helpers in `db/schema.py`
  to REFERENCE `CANONICAL_POSITIONS_COLUMNS` instead of duplicating the
  TARGET_COLS list. That collapse is its own PR.
- **Quarantine clause unification**: the three CHECKs do NOT share an
  identical quarantine exemption set (tenant exempts two statuses,
  qty/direction exempt one). The declaration accepts this drift as
  current state; resolving it is separate work.

## Verification

```
$ python -m pytest tests/test_canonical_positions_schema.py -v
======================== 4 passed in 1.01s ========================
```

Adjacent suites still green:
- `tests/test_registry_coherence.py`: 4 passed
- `tests/test_cross_rung_consistency.py`: 3 passed

Pre-existing test_setup.py local flakes (PRAGMA WAL race, #495) are
unrelated; CI runs on Linux and the busy_timeout fix (PR #508) makes
them reliable there.

Advances #501.
