### PR TITLE
test(db): lock-in init_db() index self-healing (Closes #518)

### DIFF
--- a/tests/test_init_db_index_self_healing.py
+++ b/tests/test_init_db_index_self_healing.py
@@ -1,0 +1,133 @@
+"""Lock-in regression test: init_db() is self-healing for indexes.
+
+This test exists to anchor the empirical refutation of #518 (Halberg's
+runtime-review side-finding on #497) into the test suite.
+
+#518 hypothesized that idx_positions_tenant lives only inside four
+short-circuiting migration helpers (db/schema.py:1037, :1154, :1267, :1403),
+so on a steady-state DB where the index is dropped externally,
+init_db() would not heal it. Empirical check showed this is false:
+_migrate_multi_tenant_b1:502 contains a top-level
+`CREATE INDEX IF NOT EXISTS idx_positions_tenant ON positions(tenant_id)`
+and that helper has NO short-circuit — it runs every init_db() call.
+
+The broader claim: every index created by init_db() is self-healing. If
+any index is dropped between calls, the next init_db() recreates it.
+
+If this test ever fails, it means:
+  (a) A new index has been added inside a short-circuiting helper, with
+      no top-level guarantor — file an issue and decide whether to add
+      a top-level CREATE INDEX IF NOT EXISTS or accept the gap.
+  (b) A top-level guarantor was moved behind a short-circuit — revert
+      that move.
+  (c) The full migration chain itself short-circuits in a way that bypasses
+      every CREATE INDEX statement — much larger structural change to
+      investigate.
+
+Related:
+  - #518 (closed wontfix — premise refuted by this test)
+  - #497 (closed wontfix — the parent issue that spawned the #518 side-finding)
+  - db/schema.py:502 (the load-bearing CREATE INDEX IF NOT EXISTS idx_positions_tenant)
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+
+@pytest.fixture
+def fresh_db(monkeypatch, tmp_path):
+    """Fresh DB pointed at by btc_api.DB_FILE. The MIGRATE_QTY_ALLOW_BULK_QUARANTINE
+    flag is unused on an empty fresh DB (no rows to quarantine), but set defensively
+    in case future migration shapes need it on initial creation.
+    """
+    db_path = tmp_path / "index_healing.db"
+    monkeypatch.setenv("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", "1")
+    import btc_api
+    monkeypatch.setattr(btc_api, "DB_FILE", str(db_path))
+    return str(db_path)
+
+
+def _list_user_indexes(db_path: str) -> list[str]:
+    """Return all user-created (non-sqlite_*) indexes on the DB."""
+    con = sqlite3.connect(db_path)
+    try:
+        return [r[0] for r in con.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND name NOT LIKE 'sqlite_%' "
+            "ORDER BY name"
+        ).fetchall()]
+    finally:
+        con.close()
+
+
+def test_init_db_recreates_idx_positions_tenant_after_drop(fresh_db):
+    """Specific regression for #518 (Halberg side-finding). On a steady-state
+    DB where idx_positions_tenant has been manually dropped, the next
+    init_db() call must recreate it.
+
+    The load-bearing helper is _migrate_multi_tenant_b1, which runs
+    unconditionally on every init_db() call and contains:
+        CREATE INDEX IF NOT EXISTS idx_positions_tenant ON positions(tenant_id)
+    at db/schema.py:502.
+    """
+    from db.schema import init_db
+
+    init_db()
+    assert "idx_positions_tenant" in _list_user_indexes(fresh_db)
+
+    # Drop the index externally — simulates manual `DROP INDEX`, restore
+    # from partial backup, schema repair gone wrong, etc.
+    con = sqlite3.connect(fresh_db, isolation_level=None)
+    con.execute("DROP INDEX idx_positions_tenant")
+    con.close()
+    assert "idx_positions_tenant" not in _list_user_indexes(fresh_db)
+
+    # Re-run init_db. The index must reappear.
+    init_db()
+    assert "idx_positions_tenant" in _list_user_indexes(fresh_db), (
+        "init_db() did not heal a dropped idx_positions_tenant. "
+        "Check that db/schema.py:502 (CREATE INDEX IF NOT EXISTS idx_positions_tenant "
+        "inside _migrate_multi_tenant_b1) has not moved behind a short-circuit. "
+        "If it has, file the regression as a real instance of #518."
+    )
+
+
+def test_init_db_recreates_every_user_index_after_drop(fresh_db):
+    """Broader property: init_db() is self-healing for ALL its indexes.
+
+    Drops every user-created index on the DB after a successful init_db(),
+    re-runs init_db(), asserts every index is back. If a future helper
+    introduces an index that lives only inside a short-circuit path, this
+    test will catch it.
+    """
+    from db.schema import init_db
+
+    init_db()
+    initial_indexes = _list_user_indexes(fresh_db)
+    assert initial_indexes, "fresh init_db() produced no user indexes — schema broken?"
+
+    # Drop every user index.
+    con = sqlite3.connect(fresh_db, isolation_level=None)
+    try:
+        for ix in initial_indexes:
+            con.execute(f"DROP INDEX {ix}")
+    finally:
+        con.close()
+    assert _list_user_indexes(fresh_db) == [], (
+        "DROP INDEX did not clear all user indexes"
+    )
+
+    # Re-run init_db. Every index must reappear.
+    init_db()
+    after_indexes = _list_user_indexes(fresh_db)
+
+    missing = sorted(set(initial_indexes) - set(after_indexes))
+    assert not missing, (
+        f"init_db() did not heal {len(missing)} dropped index(es): {missing}. "
+        f"Initial set: {initial_indexes}. After re-init: {after_indexes}. "
+        f"A new helper has introduced an index without a top-level guarantor; "
+        f"investigate as a #518-class structural defect."
+    )


### PR DESCRIPTION
## Summary

Closes #518 with an empirical refutation: idx_positions_tenant IS self-healed by `init_db()`. The hypothesized gap does not exist. Locks the finding in as `tests/test_init_db_index_self_healing.py`.

## Background

#518 was a side-finding from Halberg's runtime review of #497. The reasoning was: `idx_positions_tenant` is recreated in four helper bodies (`db/schema.py:1037, :1154, :1267, :1403`), all of which live past their helpers' idempotency short-circuits. So on a steady-state DB where every helper short-circuits, none of those four `CREATE INDEX` lines should run; if the index were dropped externally, it would stay missing.

This was a localized miss. The reasoning omitted `_migrate_multi_tenant_b1:502`:

```python
con.execute(
    "CREATE INDEX IF NOT EXISTS idx_positions_tenant "
    "ON positions(tenant_id)"
)
```

That helper has no top-level short-circuit. It runs unconditionally on every `init_db()` call. The four helper-local statements are redundant defense; `:502` is the load-bearing guarantor.

## Evidence

Empirical drop+heal test, parametrized over every user-created index after a fresh `init_db()`:

```
HEALED (22): [idx_agent_conv_conversation, idx_agent_conv_meta_tenant_last,
idx_agent_conv_meta_tenant_pinned, idx_agent_conv_tenant_ts,
idx_agent_messages_expires, idx_agent_messages_tenant_conv_ts,
idx_agent_messages_tenant_ts, idx_agent_side_effects_tenant_ts,
idx_capital_tenant, idx_health_events_symbol, idx_idempotency_expires,
idx_ks_decisions_symbol_ts, idx_ks_decisions_ts, idx_notif_sent_unread,
idx_notif_tenant_unread, idx_portfolio_events_tenant_ts,
idx_portfolio_events_ts, idx_positions_open_scan_unique,
idx_positions_tenant, idx_recommendations_ts, idx_signal_outcomes_tenant,
idx_user_prefs_tenant]
NOT HEALED (0): []
```

22/22 indexes self-heal. Zero gaps.

## What the test locks in

Two tests:

1. **Specific case** — drop `idx_positions_tenant`, re-init, assert recreated. Names `db/schema.py:502` in the failure message so a future regression points straight at the load-bearing line.
2. **Broader property** — drop EVERY user-created index, re-init, assert every one is back. Catches the structural class of bug #518 hypothesized, in case a future helper introduces an index without a top-level guarantor.

## Halberg's parent verdict on #497 is unaffected

Halberg's runtime review correctly rejected #497's central premise (WAL + `BEGIN IMMEDIATE` forbids mid-tx kill leaks). That verdict was load-bearing and stands. #518 was a localized misread inside the same review; this PR corrects it. PR #520 already closed the parent thread.

## Test plan

- [x] `tests/test_init_db_index_self_healing.py` — 2/2 pass
- [x] `tests/db/` + `tests/test_migration_wal_atomicity.py` + `tests/test_canonical_positions_schema.py` — 61/61 pass (full schema-touching surface)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)