### PR TITLE
docs(conventions): jurisdictional convergence + range-fixed-point patterns (Voronov 8th meta-review)

### DIFF
--- a/.mex/context/conventions.md
+++ b/.mex/context/conventions.md
@@ -304,6 +304,46 @@ Las siguientes patologías están reconocidas y deferidas — no son parte del c
 - **`entry_ts` window relajada (Serrano MEDIUM 9)** — `[now-7d, now+60s]` rechaza backfills legítimos y clientes con skew >60s. Requiere decisión UX antes de relajar. Sin issue formal aún.
 - **`legacy_no_tenant` consumer filters (Serrano MEDIUM 12)** — el status nuevo está en el schema; ningún consumer del UI / agente filtra rows con ese status explícitamente. Hoy es teórico (rows con `legacy_no_tenant` no son `open`, y las queries más activas filtran por status). Audit de cada consumer pendiente.
 
+## Review process patterns
+
+### Jurisdictional convergence — the 4-way triangulation rule (Voronov 2026-05-27, 8th meta-review on PR #521 / #518)
+
+When multiple roles (Serrano clinical, Voronov categorical, Halberg runtime, plus an empirical reproducer when there is a falsifiable claim) are dispatched against the same artifact and converge on the same verdict, the convergence is **load-bearing only on the central predicate the frontiers were asked about**. Side-findings — the asides each role drops while answering the central question — inherit the epistemic standard of casual claims, not of the convergence.
+
+Voronov's formulation:
+
+> *"The triangulation certifies the central predicate, not the surrounding prose."*
+
+Concrete instance: in the #497 review chain, Halberg's runtime verdict on WAL atomicity (the central question) was correct and load-bearing — his frontier. His side-finding about an `idx_positions_tenant` recreation gap (filed as #518) was wrong — his frontier did not extend to "did the author grep all definitions of the named identifier." Empirical drop+heal test (22/22 indexes healed by `init_db()`) refuted it. The convergence on the central question did not, and could not, extend to the side-finding.
+
+**Operational rule (review side):** when receiving any role's output, mark which claims the role had jurisdiction over and which were asides.
+- Claims within the role's frontier inherit whatever weight the role's verdict carries (and, if convergence with other roles exists on the same claim, the load-bearing convergence too).
+- Asides receive the standard of any casual claim — verify them at the appropriate frontier before acting on them.
+
+**Operational rule (verify side):** before treating a side-finding as load-bearing for a follow-up PR or issue, run the cheapest possible verification at the relevant frontier:
+- Side-finding asserts a runtime property → run the experiment (Halberg's frontier, but cheap-locally).
+- Side-finding asserts a local code fact ("X is created in N places") → grep the identifier.
+- Side-finding asserts a structural claim → apply the structural test the role used for the central verdict.
+
+This rule is the meta-application of the **discrete-cells fallacy** (Voronov's 7th reframe, recorded above and in #497 closing comment): a review's enumeration of side-findings is itself enumeration substituted for closure — *"a reviewer's side-findings inherit the epistemic standard of casual claims, not of the central verdict, and must be re-verified at that standard before being acted on."*
+
+### Range-fixed-point tests — a useful intermediate (Voronov 2026-05-27, same 8th meta-review)
+
+Between **enumeration** (test cells 1..N explicitly) and **closure** (`state_of(state) → S` total over the universe), there is a third shape:
+
+**Range-fixed-point test:** quantify over the function-under-test's own range. `f(state) ⊇ range(f, fresh_state)` under arbitrary perturbation of `state`.
+
+Concrete instance: `tests/test_init_db_index_self_healing.py::test_init_db_recreates_every_user_index_after_drop` drops every index after a successful `init_db()`, re-runs `init_db()`, asserts every index is back. The universe quantified over is "indexes that exist after a successful init_db on an empty DB" — defined by the function under test.
+
+**When to use:**
+- Question is "does f's range include X" — range-fixed-point is the right artifact.
+- Question is "does production have X that f does not promise" — range-fixed-point is **insufficient** (the universe is defined by the function, not by reality); full closure is needed (see #519 territory: declared schema state space).
+
+**When to avoid:**
+- If the failure mode lives outside f's range, the test will not catch it. Confirm the failure mode lives inside f's range before adopting this shape.
+
+Operational: when writing a regression test for a structural defect, name explicitly which of the three shapes (enumeration / range-fixed-point / closure) the test instantiates and why that shape is adequate for the defect.
+
 ## Verify Checklist
 
 Before merging any change touching `db/`, `operators/`, `auth/`, `api/`, or schema migrations:


### PR DESCRIPTION
## Summary

Records two structural rules surfaced by Voronov's 8th meta-review (2026-05-27 on PR #521 / #518) under a new "Review process patterns" heading in `.mex/context/conventions.md`:

1. **Jurisdictional convergence rule** — the 4-way triangulation (Serrano + Voronov + Halberg + empirical reproducer) certifies the central predicate the frontiers were asked about, not the surrounding prose. Side-findings inherit casual-claim standard.
2. **Range-fixed-point tests** — between enumeration and full closure. Quantify over the function-under-test's own range. Adequate for "does f's range include X" (the #518 shape); insufficient for "does production have X that f doesn't promise" (the #519 shape).

Docs-only PR. No code changes.

## Background

The session that closed #497 (PR #520) and #518 (PR #521) produced one wrong side-finding from a load-bearing role: Halberg's runtime review correctly rejected #497's WAL atomicity premise (central question, his frontier) but dropped a side-finding about an `idx_positions_tenant` recreation gap that turned out wrong — empirical drop+heal showed 22/22 indexes self-heal because `_migrate_multi_tenant_b1:502` is the top-level guarantor he did not grep for.

Voronov's 8th invocation diagnosed:
- The convergence does not extend to side-findings (jurisdictional, not granular).
- The broader regression test is a **range-fixed-point** test (stronger than enumeration, weaker than full closure) — adequate for #518, insufficient for #519.
- Enumeration-substituted-for-closure is recursive: a reviewer who catches it at the issue layer can commit it at the side-finding layer.

These are operationally useful before they decay. The conventions doc is the durable surface for review-process patterns; adding the section now keeps the rules accessible to future PR reviewers and dispatch decisions.

## Why this matters operationally

Without these rules:
- Future side-findings from triangulation roles risk being treated as load-bearing when they are not.
- Future regression tests risk being designed at the wrong shape (enumeration when closure is needed, or vice versa).
- The discipline of bundle-by-predicate (which depends on knowing which predicate a test actually pins) gets fuzzy.

With them: the dispatch agent (myself / future Claude / Samuel manually) has a written rule for which claims to verify at which standard, and which test shape to use for which defect class.

## Verb taxonomy

- `Refs #497 #518 #521` — the chain of artifacts the rules were extracted from.

## Test plan

- [x] mex check shows 59 pre-existing MISSING_PATH false positives (URLs, globs, pytest paths per CLAUDE.md guidance); no new ones introduced by this edit.
- [x] No code changes; nothing to test in CI beyond doc render.
- [ ] CI green (frontend + backend run for completeness; both should be no-ops on a docs-only diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)