### PR TITLE
fix(mex): resolve dead frontmatter edges in context/

### DIFF
--- a/.mex/context/ci-discipline.md
+++ b/.mex/context/ci-discipline.md
@@ -9,7 +9,7 @@ triggers:
   - "bypass"
   - "merge blocked"
 edges:
-  - target: conventions.md
+  - target: context/conventions.md
     condition: when the CI failure surfaces an actual invariant violation (not a flake)
 last_updated: 2026-05-26
 ---

--- a/.mex/context/verb-taxonomy.md
+++ b/.mex/context/verb-taxonomy.md
@@ -11,7 +11,7 @@ triggers:
   - "verb taxonomy"
   - "pr body"
 edges:
-  - target: ci-discipline.md
+  - target: context/ci-discipline.md
     condition: when a PR body's verb choice intersects with admin-merge or flake-list decisions
 last_updated: 2026-05-26
 ---


### PR DESCRIPTION
## Summary

Two `.mex/context/` files declared `edges` with bare filenames as targets:

- `verb-taxonomy.md` → `target: ci-discipline.md`
- `ci-discipline.md` → `target: conventions.md`

`mex check` resolves edge targets relative to the `.mex/` root, per the canonical format used by `ROUTER.md`, `architecture.md`, `conventions.md`, `decisions.md`, `setup.md`, and `stack.md`. The two files above did not follow that convention and were flagged as `DEAD_EDGE`.

Updated to:

- `target: context/ci-discipline.md`
- `target: context/conventions.md`

## Blast radius

Documentation only — frontmatter metadata in two `.mex/context/` files. No code paths, schemas, configs, or tests touched.

## Verification

Local `mex check` confirms both `DEAD_EDGE` findings drop after the fix. The remaining `MISSING_PATH:113` on `verb-taxonomy.md` (pointing to `.github/workflows/verb-taxonomy.yml`) is legitimate — that workflow is Phase 2 of #488 sub-task C, not yet implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)