### PR TITLE
feat(ci): verb-taxonomy workflow — Phase 2 architecture (Advances #515)

### DIFF
--- a/.github/workflows/verb-taxonomy.yml
+++ b/.github/workflows/verb-taxonomy.yml
@@ -1,0 +1,65 @@
+name: Verb taxonomy
+
+# Phase 2 of #488 sub-task C (tracked under #515): promote the verb
+# taxonomy from rung *test* (parser unit-tested) to rung *test* enforced
+# at the PR boundary. The workflow reads each PR body and posts a comment
+# if it finds conflicts (same issue with multiple actionable verbs) or
+# non-canonical verbs (typos, unauthorized synonyms).
+#
+# The workflow is non-blocking by design — findings post a comment but
+# do not fail the check. Acceptance criteria from #515: "Workflow posts
+# comments instead of failing the check (warning level, not blocking)."
+#
+# Opt-out: a PR labelled `skip-verb-taxonomy` skips the job entirely.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+# Cancel in-flight runs on the same PR when the body is edited rapidly.
+# Saves CI minutes; only the latest edit gets a check.
+concurrency:
+  group: verb-taxonomy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write   # to post a comment with findings
+  contents: read         # to checkout the repo
+
+jobs:
+  verb-check:
+    name: Verb taxonomy check
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # Skip the job entirely if the PR is labelled with the opt-out.
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-verb-taxonomy')"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          # No pip install — the parser is pure stdlib (re, dataclasses).
+
+      - name: Run verb taxonomy check
+        id: check
+        env:
+          # Pass body via env var (not inline) to avoid shell injection
+          # from anything a contributor might write in the PR body.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" | python -m scripts.verb_taxonomy_check > comment.md
+          if [ -s comment.md ]; then
+            echo "has_findings=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post comment with findings
+        if: steps.check.outputs.has_findings == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body-file comment.md \
+            --repo ${{ github.repository }}

--- a/scripts/verb_taxonomy_check.py
+++ b/scripts/verb_taxonomy_check.py
@@ -1,0 +1,104 @@
+"""CLI for the verb-taxonomy parser, invoked by the GitHub Action.
+
+Reads a PR body from stdin (default) or from `--body-file <path>` and
+emits a markdown-formatted summary of findings to stdout. Designed to be
+piped directly into `gh pr comment --body-file -` by the workflow.
+
+If there are no findings (no conflicts, no non-canonical verbs), the
+script emits no output and exits 0. The workflow uses the empty output
+to decide whether to post a comment at all.
+
+Exit code is always 0 — the verb taxonomy check is a warning surface,
+not a merge blocker (per #515 acceptance criteria). The workflow itself
+is non-blocking: it posts a comment if findings exist, and that's it.
+
+Usage:
+    echo "$PR_BODY" | python scripts/verb_taxonomy_check.py
+    python scripts/verb_taxonomy_check.py --body-file body.txt
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from scripts.verb_taxonomy_parser import parse_pr_body, ParseResult
+
+
+_COMMENT_HEADER = "## Verb taxonomy findings"
+
+_OPT_OUT_FOOTER = (
+    "_To opt out of this check on a specific PR, add the "
+    "`skip-verb-taxonomy` label. The canonical verb list lives in "
+    "[`.mex/context/verb-taxonomy.md`](../blob/main/.mex/context/verb-taxonomy.md)._"
+)
+
+
+def _read_body(args: argparse.Namespace) -> str:
+    """Read the PR body from --body-file or stdin."""
+    if args.body_file:
+        with open(args.body_file, encoding="utf-8") as f:
+            return f.read()
+    return sys.stdin.read()
+
+
+def format_comment(result: ParseResult) -> str:
+    """Format a ParseResult as a markdown PR comment.
+
+    Returns the empty string if there are no findings (no conflicts and
+    no non-canonical verbs), so the caller can decide not to post.
+    """
+    if not result.conflicts and not result.non_canonical:
+        return ""
+
+    parts: list[str] = [_COMMENT_HEADER, ""]
+    parts.append(
+        "This PR's body has the following issues with the canonical "
+        "verb taxonomy:"
+    )
+    parts.append("")
+
+    if result.conflicts:
+        parts.append("### Conflicts (must fix)")
+        parts.append("")
+        for c in result.conflicts:
+            parts.append(f"- {c}")
+        parts.append("")
+
+    if result.non_canonical:
+        parts.append("### Non-canonical verbs (please review)")
+        parts.append("")
+        for w in result.non_canonical:
+            parts.append(f"- {w}")
+        parts.append("")
+
+    parts.append(_OPT_OUT_FOOTER)
+    return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verb-taxonomy check for PR bodies. Reads body from stdin "
+            "(default) or --body-file. Emits a markdown comment to stdout "
+            "if there are findings, or nothing if clean."
+        ),
+    )
+    parser.add_argument(
+        "--body-file",
+        default=None,
+        help="Read PR body from this file instead of stdin.",
+    )
+    args = parser.parse_args(argv)
+
+    body = _read_body(args)
+    result = parse_pr_body(body)
+    comment = format_comment(result)
+
+    if comment:
+        sys.stdout.write(comment)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verb_taxonomy_parser.py
+++ b/scripts/verb_taxonomy_parser.py
@@ -1,0 +1,149 @@
+"""Verb-taxonomy parser for PR body verb directives.
+
+The parser extracts `<Verb> #<number>` directives from a PR body and
+classifies each verb against the canonical taxonomy documented in
+`.mex/context/verb-taxonomy.md`:
+
+  - Actionable: Closes, Advances, Narrows, Bounds
+  - Non-actionable: Refs, Tracks
+  - GitHub synonyms for Closes (Fixes, Resolves, ...): accepted but
+    flagged as non-canonical for this repo.
+  - Anything else (typos, unknown verbs): flagged as non-canonical.
+
+The parser also detects conflicts: the same issue referenced by more
+than one actionable verb in the same body (ambiguous merge intent).
+
+Pure Python, no I/O, no API calls. Importable from tests and from the
+CI workflow (via `scripts/verb_taxonomy_check.py`).
+
+Originally lived inline in `tests/test_verb_taxonomy_parser.py` and was
+extracted to a module so the GitHub Action `.github/workflows/verb-
+taxonomy.yml` (sub-task C Phase 2 of #488) can invoke it without
+importing from `tests/`.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+# --- Taxonomy ---
+
+CANONICAL_ACTIONABLE_VERBS: frozenset[str] = frozenset({
+    "Closes", "Advances", "Narrows", "Bounds",
+})
+
+CANONICAL_NON_ACTIONABLE_VERBS: frozenset[str] = frozenset({
+    "Refs", "Tracks",
+})
+
+CANONICAL_VERBS: frozenset[str] = (
+    CANONICAL_ACTIONABLE_VERBS | CANONICAL_NON_ACTIONABLE_VERBS
+)
+
+# GitHub-recognized synonyms for Closes. Accepted by the parser as
+# semantically-Closes but flagged as non-canonical for this repo.
+GITHUB_CLOSES_SYNONYMS: frozenset[str] = frozenset({
+    "Fixes", "Resolves", "Close", "Fix", "Resolve",
+    "Closed", "Fixed", "Resolved",
+})
+
+
+# --- Data types ---
+
+@dataclass(frozen=True)
+class VerbDirective:
+    """A parsed `<Verb> #<number>` directive from a PR body."""
+    verb: str
+    issue: int
+    line_number: int  # 1-indexed
+    is_actionable: bool
+
+
+@dataclass(frozen=True)
+class ParseResult:
+    """The output of parsing a PR body."""
+    directives: tuple[VerbDirective, ...]
+    conflicts: tuple[str, ...]      # human-readable conflict descriptions
+    non_canonical: tuple[str, ...]  # human-readable warnings
+
+
+# --- Parser ---
+
+# Match: word starting with capital letter, followed by space, then `#NNN`.
+# Capture verb (group 1) and issue number (group 2). We capture the verb
+# loosely (any capitalized word) so the parser can detect typos and
+# unauthorized verbs by name, rather than missing them entirely.
+_DIRECTIVE_PATTERN = re.compile(
+    r"\b([A-Z][a-z]+)\s+#(\d+)\b",
+)
+
+
+def parse_pr_body(body: str) -> ParseResult:
+    """Parse a PR body and return all verb directives + conflicts.
+
+    The parser is permissive on verb capture (any capitalized word
+    followed by `#N` matches) so that typos and unauthorized verbs are
+    detected by name rather than silently ignored.
+    """
+    if not body:
+        return ParseResult(directives=(), conflicts=(), non_canonical=())
+
+    lines = body.split("\n")
+    directives: list[VerbDirective] = []
+    non_canonical: list[str] = []
+
+    for line_num, line in enumerate(lines, start=1):
+        for match in _DIRECTIVE_PATTERN.finditer(line):
+            verb = match.group(1)
+            issue = int(match.group(2))
+
+            if verb in CANONICAL_VERBS:
+                directives.append(VerbDirective(
+                    verb=verb,
+                    issue=issue,
+                    line_number=line_num,
+                    is_actionable=verb in CANONICAL_ACTIONABLE_VERBS,
+                ))
+            elif verb in GITHUB_CLOSES_SYNONYMS:
+                directives.append(VerbDirective(
+                    verb=verb,
+                    issue=issue,
+                    line_number=line_num,
+                    is_actionable=True,
+                ))
+                non_canonical.append(
+                    f"line {line_num}: {verb!r} is a GitHub synonym for "
+                    f"Closes but is non-canonical for this repo. Use "
+                    f"Closes #{issue} instead for consistency."
+                )
+            else:
+                # Possible typo or unknown verb. Flag.
+                non_canonical.append(
+                    f"line {line_num}: {verb!r} is not a recognized verb. "
+                    f"Did you mean one of: "
+                    f"{', '.join(sorted(CANONICAL_VERBS))}? "
+                    f"(See .mex/context/verb-taxonomy.md.)"
+                )
+
+    # Detect conflicts: same issue with multiple actionable verbs.
+    actionable_by_issue: dict[int, list[VerbDirective]] = {}
+    for d in directives:
+        if d.is_actionable:
+            actionable_by_issue.setdefault(d.issue, []).append(d)
+
+    conflicts: list[str] = []
+    for issue, ds in actionable_by_issue.items():
+        if len(ds) > 1:
+            verbs_used = [(d.verb, d.line_number) for d in ds]
+            conflicts.append(
+                f"issue #{issue} has {len(ds)} actionable verb directives: "
+                + ", ".join(f"{v} on line {ln}" for v, ln in verbs_used)
+                + ". Pick exactly one. (See .mex/context/verb-taxonomy.md.)"
+            )
+
+    return ParseResult(
+        directives=tuple(directives),
+        conflicts=tuple(conflicts),
+        non_canonical=tuple(non_canonical),
+    )

--- a/tests/test_verb_taxonomy_parser.py
+++ b/tests/test_verb_taxonomy_parser.py
@@ -1,153 +1,23 @@
-"""Verb-taxonomy parser + tests for PR body verb directives.
+"""Tests for the verb-taxonomy parser (`scripts/verb_taxonomy_parser`).
 
 Promotes the verb taxonomy from rung *convención* (documented in
 `.mex/context/verb-taxonomy.md`) to rung *test* (Phase 1 — parser is
-unit-tested; Phase 2 wiring into a GitHub Action that runs on PR events
-is tracked under #488 sub-task C).
+unit-tested; Phase 2 wires it into a GitHub Action that runs on PR
+events, tracked under #515).
 
-The parser:
-  - Extracts patterns matching `<Verb> #<number>` from a PR body.
-  - Classifies each verb as actionable (`Closes`, `Advances`, `Narrows`,
-    `Bounds`) or non-actionable (`Refs`, `Tracks`).
-  - Detects conflicts: same issue with multiple actionable verbs.
-  - Detects unknown verbs (typos like `Cloesd`, unauthorized verbs like
-    `Resolves` -- the latter is GitHub-recognized but discouraged in
-    this repo for consistency).
-
-The parser is pure Python with no API calls. It can be invoked locally
-before opening a PR, or wired to a CI action via Phase 2.
-
-Closes #488 sub-task C (Phase 1).
+The parser itself lives in `scripts/verb_taxonomy_parser.py` so the
+Phase 2 GitHub Action can import it without depending on `tests/`.
 """
 from __future__ import annotations
 
-import re
-from dataclasses import dataclass
-
-
-# --- Taxonomy ---
-
-CANONICAL_ACTIONABLE_VERBS: frozenset[str] = frozenset({
-    "Closes", "Advances", "Narrows", "Bounds",
-})
-
-CANONICAL_NON_ACTIONABLE_VERBS: frozenset[str] = frozenset({
-    "Refs", "Tracks",
-})
-
-CANONICAL_VERBS: frozenset[str] = (
-    CANONICAL_ACTIONABLE_VERBS | CANONICAL_NON_ACTIONABLE_VERBS
+from scripts.verb_taxonomy_parser import (
+    CANONICAL_ACTIONABLE_VERBS,
+    CANONICAL_NON_ACTIONABLE_VERBS,
+    CANONICAL_VERBS,
+    GITHUB_CLOSES_SYNONYMS,
+    parse_pr_body,
 )
 
-# GitHub-recognized synonyms for Closes. Accepted by the parser as
-# semantically-Closes but flagged as non-canonical for this repo.
-GITHUB_CLOSES_SYNONYMS: frozenset[str] = frozenset({
-    "Fixes", "Resolves", "Close", "Fix", "Resolve",
-    "Closed", "Fixed", "Resolved",
-})
-
-
-# --- Data types ---
-
-@dataclass(frozen=True)
-class VerbDirective:
-    """A parsed `<Verb> #<number>` directive from a PR body."""
-    verb: str
-    issue: int
-    line_number: int  # 1-indexed
-    is_actionable: bool
-
-
-@dataclass(frozen=True)
-class ParseResult:
-    """The output of parsing a PR body."""
-    directives: tuple[VerbDirective, ...]
-    conflicts: tuple[str, ...]      # human-readable conflict descriptions
-    non_canonical: tuple[str, ...]  # human-readable warnings
-
-
-# --- Parser ---
-
-# Match: word starting with capital letter, followed by space, then `#NNN`.
-# Capture verb (group 1) and issue number (group 2). We capture the verb
-# loosely (any capitalized word) so the parser can detect typos and
-# unauthorized verbs by name, rather than missing them entirely.
-_DIRECTIVE_PATTERN = re.compile(
-    r"\b([A-Z][a-z]+)\s+#(\d+)\b",
-)
-
-
-def parse_pr_body(body: str) -> ParseResult:
-    """Parse a PR body and return all verb directives + conflicts.
-
-    The parser is permissive on verb capture (any capitalized word
-    followed by `#N` matches) so that typos and unauthorized verbs are
-    detected by name rather than silently ignored.
-    """
-    if not body:
-        return ParseResult(directives=(), conflicts=(), non_canonical=())
-
-    lines = body.split("\n")
-    directives: list[VerbDirective] = []
-    non_canonical: list[str] = []
-
-    for line_num, line in enumerate(lines, start=1):
-        for match in _DIRECTIVE_PATTERN.finditer(line):
-            verb = match.group(1)
-            issue = int(match.group(2))
-
-            if verb in CANONICAL_VERBS:
-                directives.append(VerbDirective(
-                    verb=verb,
-                    issue=issue,
-                    line_number=line_num,
-                    is_actionable=verb in CANONICAL_ACTIONABLE_VERBS,
-                ))
-            elif verb in GITHUB_CLOSES_SYNONYMS:
-                directives.append(VerbDirective(
-                    verb=verb,
-                    issue=issue,
-                    line_number=line_num,
-                    is_actionable=True,
-                ))
-                non_canonical.append(
-                    f"line {line_num}: {verb!r} is a GitHub synonym for "
-                    f"Closes but is non-canonical for this repo. Use "
-                    f"Closes #{issue} instead for consistency."
-                )
-            else:
-                # Possible typo or unknown verb. Flag.
-                non_canonical.append(
-                    f"line {line_num}: {verb!r} is not a recognized verb. "
-                    f"Did you mean one of: "
-                    f"{', '.join(sorted(CANONICAL_VERBS))}? "
-                    f"(See .mex/context/verb-taxonomy.md.)"
-                )
-
-    # Detect conflicts: same issue with multiple actionable verbs.
-    actionable_by_issue: dict[int, list[VerbDirective]] = {}
-    for d in directives:
-        if d.is_actionable:
-            actionable_by_issue.setdefault(d.issue, []).append(d)
-
-    conflicts: list[str] = []
-    for issue, ds in actionable_by_issue.items():
-        if len(ds) > 1:
-            verbs_used = [(d.verb, d.line_number) for d in ds]
-            conflicts.append(
-                f"issue #{issue} has {len(ds)} actionable verb directives: "
-                + ", ".join(f"{v} on line {ln}" for v, ln in verbs_used)
-                + ". Pick exactly one. (See .mex/context/verb-taxonomy.md.)"
-            )
-
-    return ParseResult(
-        directives=tuple(directives),
-        conflicts=tuple(conflicts),
-        non_canonical=tuple(non_canonical),
-    )
-
-
-# --- Tests ---
 
 def test_parser_extracts_canonical_actionable_verbs():
     """Each of the four actionable verbs is recognized and classified."""


### PR DESCRIPTION
## Summary

Phase 2 of #488 sub-task C — promote the verb taxonomy from rung *test* (parser unit-tested) to rung *test enforced at the PR boundary*. This PR ships the **architecture** for the workflow: extracts the parser to a module, adds a CLI wrapper, and wires the GitHub Action for the verb-validation predicate. A follow-up PR will add the checkbox-completion predicate and close #515 entirely.

## Changes

- **Extract parser** from `tests/test_verb_taxonomy_parser.py` → `scripts/verb_taxonomy_parser.py`. Pure Python stdlib; pure function `parse_pr_body(body) -> ParseResult`. Tests now import from the module; zero logic duplication.
- **Add CLI wrapper** `scripts/verb_taxonomy_check.py`. Reads PR body from stdin (or `--body-file`), runs the parser, emits a markdown-formatted comment to stdout if findings exist, or nothing if clean. Exit code is always 0 — non-blocking.
- **Add workflow** `.github/workflows/verb-taxonomy.yml`. Runs on `pull_request: [opened, edited, synchronize]`. Skips the entire job if PR has the `skip-verb-taxonomy` label. Posts a comment with findings via `gh pr comment` if any. Cancels in-flight runs on rapid edits.

## Acceptance criteria coverage (from #515)

- [x] `.github/workflows/verb-taxonomy.yml` exists.
- [x] Workflow runs on `pull_request: [opened, edited, synchronize]`.
- [x] Workflow calls the parser via CLI (`python -m scripts.verb_taxonomy_check`).
- [x] Workflow posts comments instead of failing the check (CLI always exits 0; workflow posts only if findings).
- [x] Workflow opt-out: label `skip-verb-taxonomy` skips the job.
- [ ] On `Closes #N`, validate issue's checkbox acceptance criteria — **deferred to follow-up PR** (separate predicate, Sequence X discipline).

## Test plan

- The existing 13 parser unit tests still pass after the extraction (relocated from inline-in-test to import-from-module).
- Verified CLI locally with three cases: clean body → empty output (exit 0); non-canonical synonym + typo → comment with "Non-canonical" section; conflict → comment with "Conflicts" section. All exit 0.
- The workflow will self-validate on this PR: this body uses `Advances #515` (canonical) — expected no comment posted.

## Blast radius

- No application code paths touched (`db/`, `operators/`, `auth/`, `api/`, `strategy/`, `scanner/` all untouched).
- New module + new CLI + new workflow only. The test file is rewritten to import the module but logic is unchanged.
- The workflow has `pull-requests: write` permission to post comments; minimum needed.

## Why split into two PRs

Per Sequence X / per-predicate discipline:

- **This PR**: verb validation on `[opened, edited, synchronize]` (predicate: "the verb directives in this PR body are canonical").
- **Follow-up PR**: checkbox check on `[closed]` + `merged==true` (predicate: "the issue's stated acceptance criteria are checked when we close it").

Two predicates, two PRs. The architecture (extraction + CLI + base workflow) belongs in the first.

## Advances / Refs

- Advances #515 — substantive close depends on the checkbox-check follow-up PR.
- Refs #488 sub-task C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)