### PR TITLE
feat(ci): verb-taxonomy checkbox completion check on merge (Closes #515)

### DIFF
--- a/.github/workflows/verb-taxonomy.yml
+++ b/.github/workflows/verb-taxonomy.yml
@@ -2,19 +2,24 @@ name: Verb taxonomy
 
 # Phase 2 of #488 sub-task C (tracked under #515): promote the verb
 # taxonomy from rung *test* (parser unit-tested) to rung *test* enforced
-# at the PR boundary. The workflow reads each PR body and posts a comment
-# if it finds conflicts (same issue with multiple actionable verbs) or
-# non-canonical verbs (typos, unauthorized synonyms).
+# at the PR boundary. Two predicates, two jobs:
 #
-# The workflow is non-blocking by design — findings post a comment but
-# do not fail the check. Acceptance criteria from #515: "Workflow posts
+#   - verb-check: on open/edit/sync, post a comment if the PR body has
+#     conflicts (same issue with multiple actionable verbs) or non-canonical
+#     verbs (typos, unauthorized synonyms).
+#   - checkbox-check: on merge, fetch each issue named by a Closes/Fixes/
+#     Resolves directive, parse its checkbox acceptance criteria, post a
+#     comment if any are unchecked.
+#
+# Both jobs are non-blocking by design — findings post a comment but do
+# not fail the check. Per #515 acceptance criteria: "Workflow posts
 # comments instead of failing the check (warning level, not blocking)."
 #
-# Opt-out: a PR labelled `skip-verb-taxonomy` skips the job entirely.
+# Opt-out: a PR labelled `skip-verb-taxonomy` skips both jobs entirely.
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited, synchronize, closed]
 
 # Cancel in-flight runs on the same PR when the body is edited rapidly.
 # Saves CI minutes; only the latest edit gets a check.
@@ -25,14 +30,18 @@ concurrency:
 permissions:
   pull-requests: write   # to post a comment with findings
   contents: read         # to checkout the repo
+  issues: read           # checkbox-check fetches issue bodies via gh
 
 jobs:
   verb-check:
     name: Verb taxonomy check
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    # Skip the job entirely if the PR is labelled with the opt-out.
-    if: "!contains(github.event.pull_request.labels.*.name, 'skip-verb-taxonomy')"
+    # Skip on close events (handled by checkbox-check) and skip entirely
+    # if the PR is labelled with the opt-out.
+    if: |
+      github.event.action != 'closed' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-verb-taxonomy')
     steps:
       - uses: actions/checkout@v4
 
@@ -49,6 +58,49 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           printf '%s' "$PR_BODY" | python -m scripts.verb_taxonomy_check > comment.md
+          if [ -s comment.md ]; then
+            echo "has_findings=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post comment with findings
+        if: steps.check.outputs.has_findings == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body-file comment.md \
+            --repo ${{ github.repository }}
+
+  checkbox-check:
+    name: Issue checkbox completion check on merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only run on actual merges (PR closed AND merged==true). Skipped
+    # on close-without-merge (the issues weren't auto-closed). Skipped
+    # if the PR carries the opt-out label.
+    if: |
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-verb-taxonomy')
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run checkbox completion check
+        id: check
+        env:
+          # `gh` reads GH_TOKEN automatically for issue fetches inside
+          # the script. Pass the PR body via env to avoid shell injection.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" | python -m scripts.issue_checkbox_check \
+            --repo "${{ github.repository }}" > comment.md
           if [ -s comment.md ]; then
             echo "has_findings=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/issue_checkbox_check.py
+++ b/scripts/issue_checkbox_check.py
@@ -1,0 +1,201 @@
+"""Issue checkbox-completion check for merged PRs.
+
+Reads a PR body from stdin, extracts every `Closes #N` directive (and its
+GitHub-recognized synonyms — Fixes/Resolves/etc.), fetches each named
+issue's body via `gh issue view`, parses Markdown checkbox list items
+(`- [ ]` vs `- [x]`), and emits a Markdown-formatted PR comment to stdout
+if any closed issue has unchecked acceptance criteria.
+
+The check is non-blocking by design — at merge time, the action has
+already happened. The comment is a warning surface, not a gate. Per
+#515 acceptance criteria: "If not all checked: warn (don't block — the
+merger may have verified offline)."
+
+If there are no findings (every issue closed by this PR has all
+checkboxes ticked, or the PR closes no issues) the script emits no
+output and exits 0.
+
+Usage (inside GitHub Action):
+
+    cat <<<"$PR_BODY" | python -m scripts.issue_checkbox_check \
+        --repo "$GITHUB_REPOSITORY" > comment.md
+
+Requires `gh` CLI on PATH with a valid GH_TOKEN in env (both standard on
+GitHub-hosted runners).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+from scripts.verb_taxonomy_parser import (
+    GITHUB_CLOSES_SYNONYMS,
+    parse_pr_body,
+)
+
+
+# GitHub auto-closes on these verbs (Closes + every synonym the parser
+# already recognises). The checkbox check applies to all of them.
+_CLOSING_VERBS: frozenset[str] = frozenset({"Closes"}) | GITHUB_CLOSES_SYNONYMS
+
+# Matches a Markdown task-list item:
+#   - [ ] label
+#   - [x] label
+#   * [X] label
+# The first capture group is the state character (' ', 'x', 'X'); the
+# second is the label text. Use `[ \t]` rather than `\s` so a missing
+# label does not let the engine consume the trailing newline and merge
+# with the next bullet.
+_CHECKBOX_PATTERN = re.compile(
+    r"^[ \t]*[-*][ \t]+\[([ xX])\][ \t]*(.*)$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class IssueFinding:
+    issue: int
+    checked: tuple[str, ...]
+    unchecked: tuple[str, ...]
+
+
+def parse_checkboxes(body: str) -> tuple[list[str], list[str]]:
+    """Return ``(checked, unchecked)`` checkbox labels from an issue body.
+
+    Order is preserved per group. Empty labels are kept (they reflect
+    how the issue was written and the warning's job is to mirror that).
+    """
+    checked: list[str] = []
+    unchecked: list[str] = []
+    if not body:
+        return checked, unchecked
+    for match in _CHECKBOX_PATTERN.finditer(body):
+        state = match.group(1)
+        label = match.group(2).strip()
+        if state in ("x", "X"):
+            checked.append(label)
+        else:
+            unchecked.append(label)
+    return checked, unchecked
+
+
+def fetch_issue_body(issue_number: int, repo: str) -> str | None:
+    """Fetch the body of one issue via ``gh issue view``.
+
+    Returns ``None`` if the fetch fails for any reason (issue missing,
+    network error, auth missing). The caller should treat ``None`` as
+    "skip this issue" rather than a fatal failure.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "view", str(issue_number),
+                "--repo", repo,
+                "--json", "body",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    body = data.get("body")
+    return body if isinstance(body, str) else None
+
+
+def format_comment(findings: list[IssueFinding]) -> str:
+    """Format incomplete-acceptance-criteria warnings as a Markdown comment.
+
+    Returns the empty string if no findings, so the caller can decide
+    not to post.
+    """
+    if not findings:
+        return ""
+
+    parts: list[str] = [
+        "## Checkbox completion check (warning)",
+        "",
+        (
+            "This PR closes one or more issues whose body contains "
+            "checkbox-listed acceptance criteria that are **not all "
+            "checked**:"
+        ),
+        "",
+    ]
+    for f in findings:
+        parts.append(f"### Issue #{f.issue}")
+        parts.append("")
+        parts.append(f"**Unchecked ({len(f.unchecked)}):**")
+        for label in f.unchecked:
+            display = label if label else "_(no label)_"
+            parts.append(f"  - [ ] {display}")
+        if f.checked:
+            parts.append("")
+            parts.append(f"_({len(f.checked)} item(s) already checked.)_")
+        parts.append("")
+    parts.append(
+        "_If the acceptance criteria were verified offline (manual "
+        "testing, external review, etc.) this is just a reminder. The "
+        "merge has already happened. If something was missed, follow up "
+        "in a subsequent PR or by editing the issue checkboxes for "
+        "accuracy. To opt out, add the `skip-verb-taxonomy` label._"
+    )
+    return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Issue checkbox-completion check for merged PRs. Reads PR "
+            "body from stdin, fetches each Closes-referenced issue, and "
+            "emits a Markdown comment to stdout if any issue has "
+            "unchecked acceptance criteria."
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="GitHub repo in owner/name format (e.g. sssimon/trading-spacial).",
+    )
+    args = parser.parse_args(argv)
+
+    body = sys.stdin.read()
+    result = parse_pr_body(body)
+
+    # Extract issue numbers from Closes/Fixes/Resolves directives.
+    closing_issues = sorted({
+        d.issue for d in result.directives
+        if d.verb in _CLOSING_VERBS
+    })
+
+    findings: list[IssueFinding] = []
+    for issue_number in closing_issues:
+        issue_body = fetch_issue_body(issue_number, args.repo)
+        if issue_body is None:
+            # Skip issues we can't fetch — don't fail the whole check.
+            continue
+        checked, unchecked = parse_checkboxes(issue_body)
+        if unchecked:
+            findings.append(IssueFinding(
+                issue=issue_number,
+                checked=tuple(checked),
+                unchecked=tuple(unchecked),
+            ))
+
+    comment = format_comment(findings)
+    if comment:
+        sys.stdout.write(comment)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue_checkbox_check.py
+++ b/tests/test_issue_checkbox_check.py
@@ -1,0 +1,148 @@
+"""Tests for `scripts/issue_checkbox_check`.
+
+Covers the two pure-function units: checkbox parsing on issue bodies,
+and Markdown comment formatting for the findings. The `gh`-invoking
+fetch path is exercised at runtime in CI rather than mocked here — its
+contract is small (subprocess returns stdout JSON) and the failure mode
+is "return None and skip", which is intentionally non-fatal.
+"""
+from __future__ import annotations
+
+from scripts.issue_checkbox_check import (
+    IssueFinding,
+    format_comment,
+    parse_checkboxes,
+)
+
+
+# --- parse_checkboxes ---
+
+def test_parse_checkboxes_separates_checked_from_unchecked():
+    body = (
+        "## Acceptance criteria\n"
+        "\n"
+        "- [ ] First criterion\n"
+        "- [x] Second criterion\n"
+        "- [ ] Third criterion\n"
+    )
+    checked, unchecked = parse_checkboxes(body)
+    assert checked == ["Second criterion"]
+    assert unchecked == ["First criterion", "Third criterion"]
+
+
+def test_parse_checkboxes_handles_capital_X_as_checked():
+    """GitHub renders both `[x]` and `[X]` as checked."""
+    body = "- [X] Done\n- [x] Also done\n- [ ] Not done"
+    checked, unchecked = parse_checkboxes(body)
+    assert checked == ["Done", "Also done"]
+    assert unchecked == ["Not done"]
+
+
+def test_parse_checkboxes_handles_asterisk_bullets():
+    """`* [ ]` is valid Markdown task-list syntax."""
+    body = "* [ ] First\n* [x] Second"
+    checked, unchecked = parse_checkboxes(body)
+    assert checked == ["Second"]
+    assert unchecked == ["First"]
+
+
+def test_parse_checkboxes_ignores_non_checkbox_lines():
+    """Plain text and headers must not be classified as checkboxes."""
+    body = (
+        "Some intro paragraph.\n"
+        "\n"
+        "## A header\n"
+        "- A bullet that is not a checkbox\n"
+        "- [ ] Actual checkbox\n"
+    )
+    checked, unchecked = parse_checkboxes(body)
+    assert checked == []
+    assert unchecked == ["Actual checkbox"]
+
+
+def test_parse_checkboxes_handles_indented_checkboxes():
+    """Nested task-list items are still detected."""
+    body = "  - [ ] Indented unchecked\n    - [x] Deeper checked"
+    checked, unchecked = parse_checkboxes(body)
+    assert checked == ["Deeper checked"]
+    assert unchecked == ["Indented unchecked"]
+
+
+def test_parse_checkboxes_handles_empty_or_none_body():
+    """Empty or missing body returns empty lists without crashing."""
+    assert parse_checkboxes("") == ([], [])
+    # Type-checker doesn't allow passing None, but the runtime guard
+    # exists, so call it via Any to verify.
+    assert parse_checkboxes(None) == ([], [])  # type: ignore[arg-type]
+
+
+def test_parse_checkboxes_preserves_empty_labels():
+    """An empty-label checkbox (`- [ ]` with nothing after) is captured."""
+    body = "- [ ]\n- [x] With label"
+    checked, unchecked = parse_checkboxes(body)
+    assert checked == ["With label"]
+    assert unchecked == [""]
+
+
+# --- format_comment ---
+
+def test_format_comment_returns_empty_string_when_no_findings():
+    assert format_comment([]) == ""
+
+
+def test_format_comment_renders_single_issue_finding():
+    finding = IssueFinding(
+        issue=515,
+        checked=("Workflow runs on PR events",),
+        unchecked=("Workflow posts comments", "Opt-out label"),
+    )
+    comment = format_comment([finding])
+    assert "## Checkbox completion check (warning)" in comment
+    assert "Issue #515" in comment
+    assert "Unchecked (2)" in comment
+    assert "- [ ] Workflow posts comments" in comment
+    assert "- [ ] Opt-out label" in comment
+    assert "1 item(s) already checked" in comment
+    assert "skip-verb-taxonomy" in comment
+
+
+def test_format_comment_renders_multiple_issues():
+    findings = [
+        IssueFinding(
+            issue=100,
+            checked=(),
+            unchecked=("First item",),
+        ),
+        IssueFinding(
+            issue=200,
+            checked=("Done",),
+            unchecked=("Pending",),
+        ),
+    ]
+    comment = format_comment(findings)
+    assert "Issue #100" in comment
+    assert "Issue #200" in comment
+    assert "- [ ] First item" in comment
+    assert "- [ ] Pending" in comment
+
+
+def test_format_comment_handles_empty_label_in_unchecked():
+    finding = IssueFinding(
+        issue=999,
+        checked=(),
+        unchecked=("",),
+    )
+    comment = format_comment([finding])
+    # An empty label should not collapse into a hyphen with no content;
+    # the comment renders a placeholder so the line still reads.
+    assert "_(no label)_" in comment
+
+
+def test_format_comment_omits_checked_count_when_zero_checked():
+    finding = IssueFinding(
+        issue=42,
+        checked=(),
+        unchecked=("Single unchecked",),
+    )
+    comment = format_comment([finding])
+    assert "already checked" not in comment


### PR DESCRIPTION
## Summary

Phase 2 of #488 sub-task C, **part 2 of 2** — adds the second predicate of the verb-taxonomy workflow: on PR merge, fetch each issue named by a `Closes/Fixes/Resolves` directive and warn if any of its checkbox-listed acceptance criteria are unchecked.

Together with PR #525 (verb validation on `open/edit/sync`), this closes the verb-taxonomy enforcement at the PR boundary. Sub-task C of #488 is now 5/5.

## Changes

- **`scripts/issue_checkbox_check.py`** — new CLI. Reads PR body from stdin, uses the existing parser to extract closing directives, fetches each issue body via `gh issue view`, parses Markdown task-list items (`- [ ]` / `- [x]` / `* [X]`), and emits a Markdown comment if any acceptance criteria are unchecked. Non-fetchable issues are skipped (non-fatal). Exit code always 0.
- **`tests/test_issue_checkbox_check.py`** — 12 unit tests covering checkbox parsing (canonical, capital X, asterisk bullets, indented, empty labels, no-body edge cases) and comment formatting (single/multiple issues, empty labels, omit-checked-count when zero).
- **`.github/workflows/verb-taxonomy.yml`** — adds `closed` to trigger types, adds a second job `checkbox-check` gated on `action == 'closed' && merged == true && !skip-label`. The existing `verb-check` job gains an `action != 'closed'` guard so it does not double-run on merge. Both jobs share the `skip-verb-taxonomy` opt-out label.

## Acceptance criteria coverage (from #515)

- [x] `.github/workflows/verb-taxonomy.yml` exists (already from PR #525).
- [x] Workflow runs on `pull_request: [opened, edited, synchronize]`.
- [x] Workflow calls the parser via CLI.
- [x] Workflow posts comments instead of failing the check.
- [x] Workflow opt-out: `skip-verb-taxonomy` label.
- [x] **On `Closes #N`, validate issue's checkbox acceptance criteria** — this PR.

## Test plan

- 12 new unit tests for `parse_checkboxes` and `format_comment` pass locally.
- The 13 existing parser tests still pass (no parser changes).
- The workflow will self-validate on this PR: verb-check runs on open (this body has only canonical verbs → no comment posted). checkbox-check runs on merge — if #515's checkboxes are not all checked at merge time, a warning comment will be posted on this PR. **That is expected and validates the end-to-end flow.**

## Blast radius

- No application code paths touched.
- New CLI + new tests + workflow modification only.
- The `checkbox-check` job is non-blocking (CLI exits 0 always; workflow posts a comment if findings).
- `issues: read` permission added to the workflow (needed for `gh issue view`).

## Closes / Refs

- Closes #515 — the verb-taxonomy GitHub Action is now complete (both predicates: verb validation on edits + checkbox check on merge).
- Refs #488 sub-task C — now at 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)