### PR TITLE
fix(signals): project sl/tp/direction from scan payload (Closes #211)

### DIFF
--- a/api/signals.py
+++ b/api/signals.py
@@ -195,6 +195,21 @@ def append_signal_log(rep: dict, scan_id: int):
         log.warning(f"append_signal_log error: {e}")
 
 
+def _payload_dict(row: dict) -> dict:
+    """Parse the JSON `payload` column of a scans row; tolerate corruption.
+
+    Used to project fields the scans schema doesn't dedicate columns for
+    (e.g. direction, sizing_1h.sl_precio/tp_precio) without a migration.
+    """
+    raw = row.get("payload")
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
 @router.get("", summary="Historial de escaneos / señales")
 def list_signals(
     limit:        int             = Query(50,    ge=1, le=500),
@@ -207,27 +222,32 @@ def list_signals(
         rows = get_scans(con, limit=limit, only_signals=only_signals,
                          only_setups=only_setups, since_hours=since_hours,
                          symbol=symbol)
-    return {
-        "total": len(rows),
-        "signals": [
-            {
-                "id":          r["id"],
-                "ts":          r["ts"],
-                "symbol":      r["symbol"],
-                "estado":      r["estado"],
-                "señal":       bool(r["señal"]),
-                "setup":       bool(r["setup"]),
-                "price":       r["price"],
-                "lrc_pct":     r["lrc_pct"],
-                "rsi_1h":      r["rsi_1h"],
-                "score":       r["score"],
-                "score_label": r["score_label"],
-                "macro_ok":    bool(r["macro_ok"]),
-                "gatillo":     bool(r["gatillo"]),
-            }
-            for r in rows
-        ],
-    }
+    items = []
+    for r in rows:
+        # sl_precio/tp_precio/direction live in the payload JSON (not in
+        # dedicated columns) — project them so the frontend can prefill the
+        # OpenPositionModal directly from a signal row (Closes #211).
+        payload = _payload_dict(r)
+        sizing  = payload.get("sizing_1h") or {}
+        items.append({
+            "id":          r["id"],
+            "ts":          r["ts"],
+            "symbol":      r["symbol"],
+            "estado":      r["estado"],
+            "señal":       bool(r["señal"]),
+            "setup":       bool(r["setup"]),
+            "price":       r["price"],
+            "lrc_pct":     r["lrc_pct"],
+            "rsi_1h":      r["rsi_1h"],
+            "score":       r["score"],
+            "score_label": r["score_label"],
+            "macro_ok":    bool(r["macro_ok"]),
+            "gatillo":     bool(r["gatillo"]),
+            "direction":   payload.get("direction"),
+            "sl_precio":   sizing.get("sl_precio"),
+            "tp_precio":   sizing.get("tp_precio"),
+        })
+    return {"total": len(rows), "signals": items}
 
 
 @router.get("/performance", summary="Métricas de éxito de las señales históricas")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -235,9 +235,12 @@ const App: React.FC = () => {
   useEffect(() => {
     if (signalForPos) {
       setOpenPositionPrefill({
-        symbol:  signalForPos.symbol,
-        price:   signalForPos.price,
-        scan_id: signalForPos.id,
+        symbol:    signalForPos.symbol,
+        price:     signalForPos.price,
+        scan_id:   signalForPos.id,
+        sl:        signalForPos.sl_precio ?? null,
+        tp:        signalForPos.tp_precio ?? null,
+        direction: signalForPos.direction ?? undefined,
       });
       setOpenPositionModalOpen(true);
       setSignalForPos(null);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -98,6 +98,11 @@ export interface Signal {
   macro_ok: boolean;
   gatillo: boolean;
   direction?: 'LONG' | 'SHORT' | null;
+  /** Historical SL/TP from sizing_1h at the time of the scan — projected from
+   *  the scan's payload by /signals (Closes #211). Null on pre-direction rows
+   *  or rows without sizing. Used by the OpenPositionModal prefill. */
+  sl_precio?: number | null;
+  tp_precio?: number | null;
 }
 
 export interface SignalsResponse {

--- a/tests/_baselines/signals.json
+++ b/tests/_baselines/signals.json
@@ -3,6 +3,7 @@
     "body": {
       "signals": [
         {
+          "direction": null,
           "estado": "LONG",
           "gatillo": true,
           "id": 2,
@@ -14,10 +15,13 @@
           "score_label": "premium",
           "setup": false,
           "se\u00f1al": true,
+          "sl_precio": null,
           "symbol": "BTCUSDT",
+          "tp_precio": null,
           "ts": "2026-01-15T10:05:00Z"
         },
         {
+          "direction": null,
           "estado": "NEUTRAL",
           "gatillo": false,
           "id": 1,
@@ -29,7 +33,9 @@
           "score_label": "standard",
           "setup": false,
           "se\u00f1al": false,
+          "sl_precio": null,
           "symbol": "BTCUSDT",
+          "tp_precio": null,
           "ts": "2026-01-15T10:00:00Z"
         }
       ],
@@ -118,6 +124,7 @@
     "body": {
       "signals": [
         {
+          "direction": null,
           "estado": "LONG",
           "gatillo": true,
           "id": 2,
@@ -129,10 +136,13 @@
           "score_label": "premium",
           "setup": false,
           "se\u00f1al": true,
+          "sl_precio": null,
           "symbol": "BTCUSDT",
+          "tp_precio": null,
           "ts": "2026-01-15T10:05:00Z"
         },
         {
+          "direction": null,
           "estado": "NEUTRAL",
           "gatillo": false,
           "id": 1,
@@ -144,7 +154,9 @@
           "score_label": "standard",
           "setup": false,
           "se\u00f1al": false,
+          "sl_precio": null,
           "symbol": "BTCUSDT",
+          "tp_precio": null,
           "ts": "2026-01-15T10:00:00Z"
         }
       ],
@@ -156,6 +168,7 @@
     "body": {
       "signals": [
         {
+          "direction": null,
           "estado": "LONG",
           "gatillo": true,
           "id": 2,
@@ -167,7 +180,9 @@
           "score_label": "premium",
           "setup": false,
           "se\u00f1al": true,
+          "sl_precio": null,
           "symbol": "BTCUSDT",
+          "tp_precio": null,
           "ts": "2026-01-15T10:05:00Z"
         }
       ],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,7 @@ def sample_report():
         "symbol": "BTCUSDT",
         "estado": "✅ SEÑAL + GATILLO CONFIRMADOS — Calidad: PREMIUM ⭐⭐⭐ (sizing 150%)",
         "señal_activa": True,
+        "direction": "LONG",
         "price": 85000.0,
         "lrc_1h": {"pct": 15.5, "upper": 90000.0, "lower": 80000.0, "mid": 85000.0},
         "rsi_1h": 32.5,
@@ -394,6 +395,32 @@ class TestAPIEndpoints:
         r = client.get("/signals")
         assert r.status_code == 200
         assert r.json()["total"] == 1
+
+    def test_signals_projects_sl_tp_direction_from_payload(self, client, sample_report):
+        """#211: /signals must project sl_precio/tp_precio/direction from the
+        scan payload so the frontend can prefill the OpenPositionModal."""
+        import btc_api
+        btc_api.save_scan(sample_report)
+        r = client.get("/signals")
+        assert r.status_code == 200
+        sig = r.json()["signals"][0]
+        assert sig["direction"] == "LONG"
+        assert sig["sl_precio"] == 83300.0
+        assert sig["tp_precio"] == 88400.0
+
+    def test_signals_tolerates_missing_payload_fields(self, client, sample_report):
+        """Pre-#211 rows had no `direction` and possibly no sizing_1h.
+        The endpoint must surface null rather than KeyError-ing."""
+        import btc_api
+        legacy = {k: v for k, v in sample_report.items()
+                  if k not in ("direction", "sizing_1h")}
+        btc_api.save_scan(legacy)
+        r = client.get("/signals")
+        assert r.status_code == 200
+        sig = r.json()["signals"][0]
+        assert sig["direction"] is None
+        assert sig["sl_precio"] is None
+        assert sig["tp_precio"] is None
 
     def test_signals_latest_con_datos(self, client, sample_report):
         import btc_api


### PR DESCRIPTION
## Summary

- The `/signals` endpoint stopped surfacing `sl_precio` / `tp_precio` / `direction` during the PR5 api+db refactor (2026-04-27). The values still live in `scans.payload`, but the frontend prefill that opens a position from a signal row was silently feeding the modal `direction='LONG'` and an empty TP — yielding `tp_price=null` in DB and a `TP_HIT` path that never fires for SHORTs.
- Fix projects the three fields from the payload (read-only — no schema change), types the new fields on the frontend `Signal`, and threads them into `OpenPositionModal`'s prefill (which was already wired to accept them).
- Bug 2 from #211 (BE badge on every SHORT) was retired collaterally by the PositionsPanel redesign — verified in the issue's 2026-05-24 status update.

## Changes

| File | Change |
|---|---|
| `api/signals.py` | Add `_payload_dict` helper; project `direction`, `sl_precio`, `tp_precio` from payload in `list_signals`. |
| `frontend/src/types.ts` | Declare `sl_precio?` / `tp_precio?` on `Signal` (direction was already typed). |
| `frontend/src/App.tsx` | Pass the three fields into `setOpenPositionPrefill`. |
| `tests/test_api.py` | Add `direction='LONG'` to `sample_report`; cover projection + legacy-row null-fallback. |

## Test plan

- [x] `python -m pytest tests/test_api.py` → 127/127 passing (incl. 2 new: `test_signals_projects_sl_tp_direction_from_payload`, `test_signals_tolerates_missing_payload_fields`)
- [x] `cd frontend && npm run build` → `tsc && vite build` clean
- [ ] Smoke check on running scanner: open a SHORT signal from the signals table, confirm modal opens with direction=SHORT and TP populated

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)