### PR TITLE
fix(frontend): replace hardcoded killSwitchActive + pnlToday (Advances #383)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -247,9 +247,19 @@ const App: React.FC = () => {
     }
   }, [signalForPos]);
 
+  // Count of symbols paused by the kill switch — derived from /health/dashboard
+  // (PAUSED + PROBATION tiers, per #383). Replaces the previous hardcoded 0.
+  const killSwitchActiveCount = useMemo(() => {
+    if (!dashboard) return 0;
+    return dashboard.symbols.reduce(
+      (n, s) => n + (s.state === 'PAUSED' || s.state === 'PROBATION' ? 1 : 0),
+      0,
+    );
+  }, [dashboard]);
+
   // Compose the MacroState the agent (Brief + Dock) consumes — merges the
-  // /macro response with /status scanner counters. Kill-switch count isn't
-  // exposed by /status yet, so we placeholder to 0 — same as StatusBar.
+  // /macro response with /status scanner counters and the per-symbol kill
+  // switch tiers from /health/dashboard.
   const macroState: MacroState = useMemo(() => ({
     regime:           macro?.regime ?? null,
     fng:              macro?.fear_greed_index ?? null,
@@ -257,8 +267,8 @@ const App: React.FC = () => {
     scansToday:       status?.scanner_state?.scans_total   ?? 0,
     signalsToday:     status?.scanner_state?.signals_total ?? 0,
     errors:           status?.scanner_state?.errors        ?? 0,
-    killSwitchActive: 0,
-  }), [macro, status]);
+    killSwitchActive: killSwitchActiveCount,
+  }), [macro, status, killSwitchActiveCount]);
 
   // Auto-tune view shape — our backend's TuneResult is structurally the same
   // as the view's TuneRun, minus the client-derived `hoursAgo` and the
@@ -330,16 +340,29 @@ const App: React.FC = () => {
     return out;
   }, [closedPositions]);
 
-  // PortfolioSummary for PositionsView's hero strip. Derived from /capital
-  // and the open-position pnl_pct totals.
-  // - equity: capital balance, fallback to 0 if /capital 404s
-  // - pnlToday: not exposed by backend yet → 0 with TODO
+  // Today's realized P&L — sum of pnl_usd over positions closed since
+  // 00:00 UTC. Derived client-side (no backend endpoint for intraday delta);
+  // replaces the previous hardcoded 0 (#383).
+  const pnlToday = useMemo(() => {
+    const now = new Date();
+    const todayStartMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+    return closedPositions.reduce((acc, p) => {
+      if (!p.exit_ts || p.pnl_usd == null) return acc;
+      const t = new Date(p.exit_ts).getTime();
+      if (!Number.isFinite(t) || t < todayStartMs) return acc;
+      return acc + p.pnl_usd;
+    }, 0);
+  }, [closedPositions]);
+
+  // PortfolioSummary for PositionsView's hero strip.
+  // - equity:   capital balance, fallback to 0 if /capital 404s
+  // - pnlToday: sum of realized PnL over today's closed positions (UTC)
   // - drawdown: capital.max_drawdown_pct
   const portfolio: PortfolioSummary = useMemo(() => ({
     equity:   capital?.balance ?? 0,
-    pnlToday: 0,   // TODO: backend doesn't expose intraday delta yet
+    pnlToday,
     drawdown: capital?.max_drawdown_pct ?? 0,
-  }), [capital]);
+  }), [capital, pnlToday]);
 
   // Highest-score symbol with señal=true — used as the empty-state
   // suggestion in PositionsView.
@@ -614,7 +637,7 @@ const App: React.FC = () => {
                   onSymbolClick={setSelectedSymbol}
                   belowPageBar={
                     <>
-                      <StatusBar status={status} macro={macro} />
+                      <StatusBar status={status} macro={macro} killSwitchActive={killSwitchActiveCount} />
                       {AGENT_ENABLED ? (
                         <AgentBrief
                           symbols={symbols}

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -16,6 +16,11 @@ import type { MacroResponse } from '../api';
 interface StatusBarProps {
   status: StatusResponse | null;
   macro:  MacroResponse | null;
+  /** Count of symbols currently PAUSED or in PROBATION by the kill switch.
+   *  Derived in App.tsx from /health/dashboard. Optional so existing call
+   *  sites that don't have the dashboard yet keep compiling (the cell shows
+   *  "todos activos" / 0 in that case). */
+  killSwitchActive?: number;
 }
 
 type Tone = 'bull' | 'bear' | 'warn' | 'neutral' | 'dim';
@@ -60,7 +65,7 @@ function fundingTone(v: number | null | undefined): Tone {
   return 'neutral';
 }
 
-const StatusBar: React.FC<StatusBarProps> = ({ status, macro }) => {
+const StatusBar: React.FC<StatusBarProps> = ({ status, macro, killSwitchActive }) => {
   const s = status?.scanner_state;
   const scansTotal   = s?.scans_total   ?? 0;
   const signalsTotal = s?.signals_total ?? 0;
@@ -72,9 +77,7 @@ const StatusBar: React.FC<StatusBarProps> = ({ status, macro }) => {
   const fgLabel   = macro?.fear_greed_label ?? '—';
   const funding   = macro?.funding_rate_pct;
 
-  // Kill-switch paused count not yet exposed by /status — placeholder of 0
-  // with "todos activos" until wired (see follow-up note in PR #374).
-  const ksPaused  = 0;
+  const ksPaused  = killSwitchActive ?? 0;
 
   return (
     <div className={styles.strip}>


### PR DESCRIPTION
## Summary

Two of the three "datos hardcoded en UI" items from the 2026-05-19 E2E review:

| Item | Before | After |
|---|---|---|
| `killSwitchActive` (App.tsx + StatusBar.tsx) | literal `0` + "todos activos" copy regardless of state | derived from `/health/dashboard` symbols where `state IN ('PAUSED','PROBATION')` |
| `pnlToday` (App.tsx hero strip) | literal `0` with TODO comment | summed client-side from `closedPositions` filtered by `exit_ts >= Date.UTC(today)` |

The dashboard payload was already being polled by `fetchAll` (for the KillSwitchView); this is consumer-side wiring only — no extra request, no backend change.

## What is NOT in this PR

`buildFactors()` in `SymbolDetail.tsx` — the third item from #383. Verification revealed the backend `confirmations` model (8 keys C1-C8) does not 1:1 map to the frontend `SCORE_FACTORS` (9 entries, includes gates MACRO/REG/TRIG that aren't in the score). Out of scope for this P0 — needs a model-decision before wiring. Tracked as **#528**.

Closes #383 contingent on #528.

## Test plan

- [x] `npm run build` (tsc + vite) → clean
- [x] Backend untouched — CI suite to re-run on push as sanity check
- [ ] Smoke check on a running scanner: load the app, confirm the Kill-switch cell reflects PAUSED+PROBATION count (manual when running locally)
- [ ] Confirm hero strip shows non-zero `pnlToday` after a position closes today

🤖 Generated with [Claude Code](https://claude.com/claude-code)