### PR TITLE
fix(frontend): kill mock greeting in SymbolDetail copilot (Closes #528)

### DIFF
--- a/frontend/src/agent/useAgentStream.ts
+++ b/frontend/src/agent/useAgentStream.ts
@@ -51,6 +51,11 @@ export interface UseAgentStreamOptions {
   surface: AgentSurface;
 }
 
+export interface GreetingResult {
+  ok:   boolean;
+  text: string;
+}
+
 export interface UseAgentStreamReturn {
   msgs:              ChatMsg[];
   loading:           boolean;
@@ -67,6 +72,19 @@ export interface UseAgentStreamReturn {
    *  point conversationIdRef at the loaded id so the next sendTurn
    *  continues the conversation instead of starting a new one. */
   loadConversation:  (conversation_id: string) => Promise<void>;
+  /** #528 follow-up: fire a one-shot turn whose response NEVER enters
+   *  the rolling transcript and NEVER carries into the next sendTurn's
+   *  apiMessages. Used for the proactive greeting bubble of the
+   *  SymbolDetail copilot — the operator never typed anything to elicit
+   *  it, so it must not appear as a phantom assistant turn in the chat
+   *  history. Uses a fresh conversation_id per call. text_delta events
+   *  accumulate and stream via `onUpdate`. Tool calls, proposals, and
+   *  reasoning channels are intentionally ignored — greeting is text. */
+  streamGreeting:    (
+    prompt:   string,
+    hints:    AgentContextHints | undefined,
+    onUpdate: (text: string) => void,
+  ) => Promise<GreetingResult>;
 }
 
 /**
@@ -231,7 +249,53 @@ export function useAgentStream(opts: UseAgentStreamOptions): UseAgentStreamRetur
     }
   }, []);
 
-  return { msgs, loading, hydrating, sendTurn, resetConversation, confirmProposal, loadConversation };
+  const streamGreeting = useCallback(
+    async (
+      prompt: string,
+      hints: AgentContextHints | undefined,
+      onUpdate: (text: string) => void,
+    ): Promise<GreetingResult> => {
+      // Fresh conversation id — greeting must NOT inherit or contaminate
+      // the operator's rolling conversation. This call is fire-and-collect:
+      // text accumulates locally, never enters `msgs`, never carries into
+      // the next sendTurn's apiMessages.
+      const greetingConvId = newConversationId();
+      const apiMessages: AgentApiMessage[] = [
+        { role: 'user' as const, content: prompt },
+      ];
+      let accumulated = '';
+      try {
+        for await (const ev of streamAgentTurn({
+          conversation_id: greetingConvId,
+          surface:         opts.surface,
+          messages:        apiMessages,
+          context_hints:   hints,
+        })) {
+          if (ev.type === 'text_delta') {
+            accumulated += ev.text;
+            onUpdate(accumulated);
+          } else if (ev.type === 'error') {
+            // Treat any backend error as a failed enrichment — the caller
+            // falls back to the template greeting.
+            return { ok: false, text: accumulated };
+          }
+          // tool_use_*, proposal, reasoning_delta, keepalive, message_end:
+          // intentionally ignored. Greeting is text; proposals/tools would
+          // be a UX surprise in a bubble the operator never asked for.
+        }
+        return { ok: accumulated.length > 0, text: accumulated };
+      } catch {
+        // Network / stream-level failure → fallback to template.
+        return { ok: false, text: accumulated };
+      }
+    },
+    [opts.surface],
+  );
+
+  return {
+    msgs, loading, hydrating, sendTurn, resetConversation, confirmProposal,
+    loadConversation, streamGreeting,
+  };
 }
 
 // ── REST → transcript shape ─────────────────────────────────────────────

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -35,7 +35,7 @@ import { formatPrice } from '../utils';
 import { getOhlcv } from '../api';
 import { useAgentStream } from '../agent/useAgentStream';
 import { SURFACE_SYMBOL_DETAIL } from '../agent/surfaces';
-import type { ProposalChip, ToolChip } from '../agent/types';
+import type { AgentContextHints, ProposalChip, ToolChip } from '../agent/types';
 
 // ── Public types ─────────────────────────────────────────────
 
@@ -374,16 +374,15 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, agentEnabled }) => {
   // system prompt with the streaming hook. The server owns the prompt
   // (api/agent/prompts/system.py + surfaces.py), the tool schema, and
   // the audit. The model never sees a frontend-built system prompt.
-  const { msgs, loading, sendTurn, confirmProposal } = useAgentStream({
+  const { msgs, loading, sendTurn, confirmProposal, streamGreeting } = useAgentStream({
     surface: SURFACE_SYMBOL_DETAIL,
   });
 
-  // Proactive greeting computed locally from backend fields — never goes on
-  // the wire, never enters the rolling transcript. Re-derives whenever the
-  // symbol changes. Cites symbol.señal / symbol.gatillo / symbol.estado /
-  // symbol.score / symbol.direction directly — no thresholds invented here,
-  // no mock components fabricated (#528).
-  const greeting = useMemo<{ text: string; verdict: Verdict } | null>(() => {
+  // Template greeting computed locally from backend fields — instant, 0ms,
+  // cites symbol.señal / symbol.gatillo / symbol.estado / symbol.score /
+  // symbol.direction directly. No thresholds invented, no factors fabricated
+  // (#528). This is the fallback the LLM-enriched bubble replaces below.
+  const templateGreeting = useMemo<{ text: string; verdict: Verdict } | null>(() => {
     if (!symbol) return null;
     const base   = symbol.symbol.replace('USDT', '');
     const score  = symbol.score ?? 0;
@@ -399,6 +398,95 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, agentEnabled }) => {
       : `${base} sin setup ahora — score ${score}/9. ¿Te explico el estado actual?`;
     return { text, verdict };
   }, [symbol]);
+
+  // Hybrid greeting #528: the template above shows instantly (0ms). In
+  // parallel, fire a one-shot LLM call to the copilot with the symbol's
+  // live state as context. When the model responds, replace the bubble
+  // with its richer prose. Cache by `symbol + ts` so re-opening the same
+  // drawer for the same scan doesn't re-burn tokens; a new scan (ts
+  // changes) invalidates the cache and re-enriches.
+  //
+  // Race resolution: if the operator switches symbols mid-stream, the
+  // useEffect cleanup discards the in-flight result via a "live" flag —
+  // the dropped response stays out of `enrichedText`, the new drawer's
+  // own effect fires fresh. No explicit AbortController needed because
+  // the response is ignored, not the network call (greeting calls are
+  // short and the cost of letting them finish is bounded).
+  const greetingCacheRef = useRef<Map<string, string>>(new Map());
+  const [enrichedText, setEnrichedText] = useState<string | null>(null);
+  const [enrichedKey, setEnrichedKey]   = useState<string | null>(null);
+
+  // Key for cache + race detection. Null when symbol/ts not available yet —
+  // skip enrichment until the scan has actually run.
+  const greetingKey = useMemo(() => {
+    if (!symbol || !symbol.ts) return null;
+    return `${symbol.symbol}:${symbol.ts}`;
+  }, [symbol]);
+
+  useEffect(() => {
+    if (!greetingKey || !symbol) {
+      setEnrichedText(null);
+      setEnrichedKey(null);
+      return;
+    }
+    // Cache hit — paint instantly, no LLM call.
+    const cached = greetingCacheRef.current.get(greetingKey);
+    if (cached) {
+      setEnrichedText(cached);
+      setEnrichedKey(greetingKey);
+      return;
+    }
+    // Cache miss — clear stale enrichment from the previous symbol's drawer,
+    // then fire the LLM call. Mark this effect-instance "live" so a switch
+    // mid-stream discards its result.
+    setEnrichedText(null);
+    setEnrichedKey(null);
+    let live = true;
+    // The prompt carries the live state of the symbol so the model
+    // doesn't need a tool round-trip to know what to comment on. The
+    // hint also passes `symbol` so the backend's per-surface prompt
+    // can scope tool calls if it needs them.
+    const dirLbl = symbol.direction ?? 'LONG';
+    const sigLbl = symbol.señal ? 'señal activa' : symbol.setup ? 'setup' : 'sin setup';
+    const trgLbl = symbol.gatillo ? 'gatillo 5M activo' : 'sin gatillo';
+    const prompt =
+      `Saluda al operador con un brief breve (1-2 oraciones, máximo 3) sobre ` +
+      `el estado actual de ${symbol.symbol}. Estado real del scanner: ` +
+      `${sigLbl}, ${trgLbl}, score ${symbol.score ?? 0}/9, dirección ${dirLbl}, ` +
+      `LRC ${(symbol.lrc_pct ?? 0).toFixed(1)}%, estado="${symbol.estado ?? '—'}". ` +
+      `Sé directo, sin marketing. No prometas señales que el estado no indica. ` +
+      `Termina con una pregunta corta que invite a explorar (qué falta, simular, historial).`;
+    const hints: AgentContextHints = { symbol: symbol.symbol };
+    streamGreeting(prompt, hints, (partial) => {
+      if (!live) return;
+      setEnrichedText(partial);
+      setEnrichedKey(greetingKey);
+    }).then((result) => {
+      if (!live) return;
+      if (result.ok && result.text.trim().length > 0) {
+        greetingCacheRef.current.set(greetingKey, result.text);
+        setEnrichedText(result.text);
+        setEnrichedKey(greetingKey);
+      } else {
+        // Failure — keep enrichedText null so render falls back to template.
+        setEnrichedText(null);
+        setEnrichedKey(null);
+      }
+    });
+    return () => {
+      live = false;
+    };
+  }, [greetingKey, symbol, streamGreeting]);
+
+  // The bubble the JSX renders. Enriched if the LLM responded for the
+  // current key; template otherwise (instant + always honest).
+  const greeting = useMemo<{ text: string; verdict: Verdict } | null>(() => {
+    if (!templateGreeting) return null;
+    if (enrichedText && enrichedKey === greetingKey) {
+      return { text: enrichedText, verdict: templateGreeting.verdict };
+    }
+    return templateGreeting;
+  }, [templateGreeting, enrichedText, enrichedKey, greetingKey]);
 
   // Autoscroll on new messages
   useEffect(() => {

--- a/frontend/src/components/SymbolDetail.tsx
+++ b/frontend/src/components/SymbolDetail.tsx
@@ -36,7 +36,6 @@ import { getOhlcv } from '../api';
 import { useAgentStream } from '../agent/useAgentStream';
 import { SURFACE_SYMBOL_DETAIL } from '../agent/surfaces';
 import type { ProposalChip, ToolChip } from '../agent/types';
-import { SCORE_FACTORS } from '../constants/score-factors';
 
 // ── Public types ─────────────────────────────────────────────
 
@@ -74,26 +73,6 @@ function cssVar(name: string, fallback: string): string {
   if (typeof window === 'undefined') return fallback;
   const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
   return v || fallback;
-}
-
-// TODO: replace when backend exposes symbol.score_components: boolean[].
-// See: frontend/src/constants/score-factors.ts for the 9-factor catalog.
-function buildFactors(symbol: SymbolStatus) {
-  const score   = symbol.score ?? 0;
-  const lrc     = symbol.lrc_pct ?? 50;
-  const trigger = symbol.señal === true;
-  const seed = symbol.symbol.split('').reduce((a, c) => a + c.charCodeAt(0), 0);
-
-  const passes = new Set<number>();
-  if (lrc < 25) passes.add(0);   // LRC
-  if (trigger)  passes.add(8);   // TRIG
-  let i = 0;
-  while (passes.size < score && i < 100) {
-    const idx = (seed + i * 7) % 9;
-    passes.add(idx);
-    i++;
-  }
-  return SCORE_FACTORS.map((f, idx) => ({ ...f, pass: passes.has(idx) }));
 }
 
 // Note: the `<<<TOOL:name>>>` marker protocol the Copilot used to parse
@@ -399,25 +378,25 @@ const Copilot: React.FC<CopilotProps> = ({ symbol, agentEnabled }) => {
     surface: SURFACE_SYMBOL_DETAIL,
   });
 
-  // Proactive synthetic greeting computed locally — never goes on the
-  // wire, never enters the rolling transcript. Re-derives whenever
-  // the symbol or its score-relevant fields change.
+  // Proactive greeting computed locally from backend fields — never goes on
+  // the wire, never enters the rolling transcript. Re-derives whenever the
+  // symbol changes. Cites symbol.señal / symbol.gatillo / symbol.estado /
+  // symbol.score / symbol.direction directly — no thresholds invented here,
+  // no mock components fabricated (#528).
   const greeting = useMemo<{ text: string; verdict: Verdict } | null>(() => {
     if (!symbol) return null;
-    const factors = buildFactors(symbol);
-    const passing = factors.filter((f) => f.pass);
-    const failing = factors.filter((f) => !f.pass);
-    const verdict: Verdict =
-      passing.length >= 6 ? 'bull' :
-      passing.length >= 4 ? 'warn' :
-      'bear';
-    const base = symbol.symbol.replace('USDT', '');
-    const text =
-      verdict === 'bull'
-        ? `Detecté **setup firme** en ${base}. Score ${passing.length}/9, gatillo activo. ¿Quieres que te explique los factores o prefieres simular una posición?`
-        : verdict === 'warn'
-        ? `${base} muestra **setup parcial** (${passing.length}/9). Faltan ${failing.length} confirmaciones. ¿Te explico cuáles?`
-        : `${base} **no recomienda entrar ahora** — sólo ${passing.length} de 9 filtros se cumplen. ¿Te muestro qué falta?`;
+    const base   = symbol.symbol.replace('USDT', '');
+    const score  = symbol.score ?? 0;
+    const dir    = symbol.direction ?? 'LONG';
+    const isSig  = symbol.señal === true;
+    const isStp  = symbol.setup === true;
+    const isTrig = symbol.gatillo === true;
+    const verdict: Verdict = isSig ? 'bull' : isStp ? 'warn' : 'bear';
+    const text = isSig
+      ? `Señal ${dir} confirmada en ${base}. Score ${score}/9${isTrig ? ', gatillo activo' : ''}. ¿Quieres simular una posición o ver historial del par?`
+      : isStp
+      ? `${base} en setup ${dir.toLowerCase()}, ${isTrig ? 'gatillo activo' : 'esperando gatillo 5M'}. Score ${score}/9. ¿Te explico qué falta para señal?`
+      : `${base} sin setup ahora — score ${score}/9. ¿Te explico el estado actual?`;
     return { text, verdict };
   }, [symbol]);
 


### PR DESCRIPTION
## Summary

Two-commit progression on the SymbolDetail copilot greeting:

### Commit 1 — Kill the mock greeting (Closes #528)

The proactive greeting bubble was citing fabricated state. Live reproducer (2026-05-28, prod):

| Capa | Mensaje |
|---|---|
| Backend (`symbol.estado`) | `"SIN SETUP — LRC% fuera de zona (25%-75%)"` |
| Bubble del copilot | `"RUNE muestra setup parcial (4/9). Faltan 5 confirmaciones."` |

Verdict (bull/warn/bear) was decided by a local threshold on a mock component count (`passing.length`), not on `symbol.señal` / `symbol.setup`. The bull-branch even asserted `"gatillo activo"` as a hardcoded string, without ever consulting `symbol.gatillo`. Fix rewrites the `useMemo` to cite `symbol.señal` / `symbol.setup` / `symbol.gatillo` / `symbol.score` / `symbol.direction` literally. `buildFactors()` and its `SCORE_FACTORS` import deleted.

### Commit 2 — Hybrid LLM enrichment

Template above is instant (0ms, always honest) and stays as fallback. In parallel, a one-shot LLM call fires with the symbol's live state — when the model responds, the bubble is replaced with the richer prose. Tooks 4 design decisions, all frontend-only:

| # | Decisión | Elección |
|---|---|---|
| 1 | Caché key | `symbol + ts` (ts already exists on SymbolStatus) |
| 2 | Cancelación mid-stream | `live` flag per effect-instance (no AbortController) |
| 3 | Separación del transcript | `streamGreeting()` paralela en `useAgentStream` |
| 4 | Surface | Reusa `SURFACE_SYMBOL_DETAIL` (no backend touch) |

Cero backend changes. Cero surface nueva. La conversación principal del operador no recibe el greeting como historial; las cuatro acciones rápidas siguen funcionando igual.

## Changes

| File | Lines | What |
|---|---|---|
| `frontend/src/components/SymbolDetail.tsx` | -38 / +98 | Kill mock + hybrid greeting render |
| `frontend/src/agent/useAgentStream.ts` | +63 | New `streamGreeting` API |

Net: +123 lines, 2 files.

## Process note

This PR was the first dispatch of `plumb-lindgren`, the new pre-dispatch fix-size calibrator agent (`~/.claude/agents/plumb-lindgren.md`). For Commit 1, Plumb measured the defect as size **S** (~40-60 lines, 0 architectural decisions) and explicitly **blocked** a proposed `brainstorming` invocation. For Commit 2, Plumb re-measured the scope as **M** (4 architectural decisions on cache/cancellation/transcript-separation/surface) and authorized `brainstorming` acotado a esas 4 decisiones. The whole episode and the Ley de Proporcionalidad de Proceso (LPP) are documented in user memory.

## Test plan

- [x] `npm run build` (tsc + vite) → clean
- [x] Backend not touched — CI suite to re-run as sanity
- [ ] Smoke on `trading.sdar.dev` after deploy:
  - [ ] Open any card with `señal=false, setup=false` — verify the bubble shows the template instantly (no "setup firme" / "gatillo activo" lies) and then the LLM-enriched version replaces it within ~1-2s
  - [ ] Open a card with `señal=true` — verify "Señal LONG/SHORT confirmada"
  - [ ] Re-open the SAME drawer within the same scan_ts — verify NO LLM call fires (cache hit)
  - [ ] Switch between drawers quickly — verify no "ghost greeting" from a previous drawer leaks
- [ ] Confirm in network tab: greeting calls use a fresh `conversation_id` per drawer-open (not the rolling operator conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)