### PR TITLE
feat(walk-forward): scaffold harness + compute_windows (Advances #276)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,63 @@ jobs:
         # data/ohlcv.db (705 MB, gitignored) auto-skip via @pytest.mark.skipif.
         run: pytest -m "not network"
 
+  walk-forward-smoke:
+    name: Walk-forward (CI smoke)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Smoke job for #276. Validates that the harness CLI imports cleanly,
+    # parses args, computes windows on a degenerate (zero-fold) range,
+    # and exits 1 with the documented "no windows fit" branch — without
+    # touching data/ohlcv.db (gitignored, 705 MB) or invoking the real
+    # auto_tune.optimize_symbol. The point is wiring, not metrics.
+    # Real-window pipeline coverage lives in tests/test_walk_forward_main.py
+    # under the pytest suite (Property 3) — that path stubs auto_tune so
+    # the runner is never reached.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        # Same requirements-dev.txt as the backend job — `walk_forward`
+        # only needs the runtime deps + dateutil, but installing dev
+        # avoids a second resolver pass.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run walk-forward CLI smoke
+        # Degenerate range: initial_train_months > available history →
+        # compute_windows returns []. The CLI's "no windows" branch
+        # surfaces rc=1 and prints a warning, no OHLCV is read, no
+        # auto_tune call is made. We assert rc == 1 explicitly: any
+        # other exit code means the wiring broke.
+        run: |
+          set +e
+          python walk_forward.py \
+            --history-start 2023-01-01 \
+            --history-end   2023-02-01 \
+            --holdout-start 2026-01-01 \
+            --initial-train-months 12 \
+            --test-months 3 \
+            --step-months 3 \
+            --execute \
+            --ci-mode \
+            --config-path tests/fixtures/walk_forward_ci_config.json
+          rc=$?
+          set -e
+          if [ "$rc" != "1" ]; then
+            echo "::error::walk_forward.py smoke expected rc=1 (zero-window range), got rc=$rc"
+            exit 1
+          fi
+          echo "walk_forward smoke OK (rc=1 = no windows fit, as expected)"
+
   frontend:
     name: Frontend (tsc + vitest + build)
     runs-on: ubuntu-latest

--- a/docs/superpowers/specs/es/2026-05-29-walk-forward-harness-sample.md
+++ b/docs/superpowers/specs/es/2026-05-29-walk-forward-harness-sample.md
@@ -1,0 +1,268 @@
+# Walk-forward harness — sample report (demo shape, sin números reales)
+
+**Fecha**: 2026-05-29
+**Issue**: #276 — Walk-forward harness (A.4-2)
+**Tipo**: Demo de la forma del reporte. **Sin métricas reales.**
+
+---
+
+## ⚠️ AVISO PROMINENTE — LEER ANTES DE CITAR
+
+Este documento es un **ejemplo de forma**, no un resultado de evaluación.
+
+- Cada celda numérica aparece como `n/a` deliberadamente.
+- **Ningún número de este archivo proviene de una corrida del harness.** No fue
+  ejecutado contra `data/ohlcv.db`, no consumió el snapshot bloqueado
+  `data/holdout/`, y no produjo decisión alguna sobre parámetros, símbolos o
+  régimen.
+- El propósito es congelar la **forma** del JSON que emite
+  `walk_forward.py --execute` y el **layout** del reporte humano que se
+  publicará cuando el harness se corra de verdad. Forma, no contenido.
+
+**Non-Negotiable #5** (CLAUDE.md): los números de backtest pre-#223/#224 están
+inflados; **no citarlos como baseline**. El re-baselining se trabaja en
+[#272](https://github.com/sssimon/trading-spacial/issues/272). Hasta que #272
+cierre, cualquier número que aparezca en un reporte de walk-forward es
+provisional y debe llevar el aviso explícito de "post-#272 re-baseline pending"
+o equivalente.
+
+**Non-Negotiable #3** (CLAUDE.md): A.4-3 (evaluación sobre holdout) está
+**bloqueada**. Este documento es la antesala de A.4-2 (walk-forward
+cross-validation). Ninguna línea de este reporte autoriza, sugiere ni adelanta
+la lectura de `data/holdout/`. La bala única muere también con vistazos
+parciales.
+
+---
+
+## 1. Inputs (forma)
+
+| Campo | Valor demo |
+|---|---|
+| `history_start` | `n/a` |
+| `history_end` | `n/a` |
+| `holdout_start` | `n/a` |
+| `initial_train_months` | `n/a` |
+| `test_months` | `n/a` |
+| `step_months` | `n/a` |
+| `warmup_gap_days` | `n/a` |
+| `ci_mode` | `n/a` |
+| `app_config source` | `n/a` (`load_config()` o `--config-path <file>`) |
+| `symbols evaluados` | `n/a` |
+
+---
+
+## 2. Windows computados
+
+`compute_windows(...)` produce una lista ordenada de `Window` dataclasses. En un
+reporte real, cada fila refleja un fold; aquí todas las celdas son `n/a`.
+
+| index | train_start | train_end | test_start | test_end | warmup_gap_days |
+|---|---|---|---|---|---|
+| 0 | `n/a` | `n/a` | `n/a` | `n/a` | `n/a` |
+| 1 | `n/a` | `n/a` | `n/a` | `n/a` | `n/a` |
+| … | `n/a` | `n/a` | `n/a` | `n/a` | `n/a` |
+
+Invariantes garantizadas por `compute_windows` (cubiertas por
+`tests/test_walk_forward_windows.py`):
+
+- **Anclado**: cada `train_start == history_start` (modo `anchored=True`,
+  único soportado en este commit).
+- **Sin solape**: los rangos de test de folds consecutivos son disjuntos.
+- **Exclusión de holdout**: `test_end <= holdout_start` para todo fold.
+- **Warmup gap**: `test_start - train_end >= warmup_gap_days`.
+
+---
+
+## 3. Per-window reports (forma de `evaluate_window`)
+
+Cada fold emite un report con esta forma (`tests/test_walk_forward_eval.py`
+fija el contrato):
+
+```json
+{
+  "window_index": "n/a",
+  "train_range": {"start": "n/a", "end": "n/a"},
+  "test_range":  {"start": "n/a", "end": "n/a"},
+  "params": {
+    "<symbol>": {
+      "atr_sl_mult": "n/a",
+      "atr_tp_mult": "n/a",
+      "atr_be_mult": "n/a"
+    }
+  },
+  "results": {
+    "<symbol>": {
+      "n_trades": "n/a",
+      "metrics": {
+        "total_trades":     "n/a",
+        "net_pnl":          "n/a",
+        "profit_factor":    "n/a",
+        "sharpe_ratio":     "n/a",
+        "max_drawdown_pct": "n/a",
+        "win_rate":         "n/a",
+        "total_return_pct": "n/a"
+      },
+      "regime_tag": null,
+      "error":      null
+    }
+  },
+  "skipped": [
+    {"symbol": "n/a", "reason": "no_usable_params"}
+  ],
+  "is_pnl_by_symbol": {
+    "<symbol>": "n/a"
+  }
+}
+```
+
+Notas de forma (no son números, son contratos):
+
+- `regime_tag` es siempre `null` en este commit: el simulador clasifica
+  régimen por-trade, no por-run. Un fold-level regime tag requiere una decisión
+  agregada (modo? mayoría?) que el harness aún no fija — surfacearla ahora sería
+  inventar semántica.
+- `error` se popula sólo cuando el runner retorna su sentinel
+  (`{"error": ..., "total_trades": 0, "net_pnl": 0, "profit_factor": 0}`) — por
+  ejemplo cuando `data/ohlcv.db` no cubre el rango.
+- `is_pnl_by_symbol` lo añade el orquestador (no `evaluate_window`) y carga el
+  `val_pnl` del lado IS de cada símbolo para que el agregador calcule el ratio
+  OOS/IS sin acoplar `evaluate_window` al dict de tuning.
+
+---
+
+## 4. Aggregate summary (forma de `aggregate_run_stats`)
+
+El JSON que `walk_forward.py --execute` imprime en stdout (después del marker
+`=== walk-forward summary (JSON) ===`) tiene esta forma:
+
+```json
+{
+  "n_windows":              "n/a",
+  "n_windows_with_trades":  "n/a",
+  "n_windows_skipped":      "n/a",
+  "n_windows_errored":      "n/a",
+  "total_trades":           "n/a",
+  "oos_is_ratio": {
+    "value":  "n/a",
+    "n":      "n/a",
+    "metric": "net_pnl",
+    "reason": "n/a"
+  },
+  "cv": {
+    "net_pnl":          {"value": "n/a", "n": "n/a"},
+    "profit_factor":    {"value": "n/a", "n": "n/a"},
+    "sharpe_ratio":     {"value": "n/a", "n": "n/a"},
+    "max_drawdown_pct": {"value": "n/a", "n": "n/a"},
+    "win_rate":         {"value": "n/a", "n": "n/a"},
+    "total_return_pct": {"value": "n/a", "n": "n/a"}
+  },
+  "best_window":  {"index": "n/a", "metric": "sharpe_ratio", "value": "n/a"},
+  "worst_window": {"index": "n/a", "metric": "sharpe_ratio", "value": "n/a"}
+}
+```
+
+### Decisiones de agregación (defendidas en `walk_forward.py`):
+
+- **OOS metric**: `net_pnl` de `evaluate_window` por (window, símbolo), proyectado
+  a través de `_REPORT_METRIC_KEYS`.
+- **IS metric (load-bearing)**: el `val_pnl` que `auto_tune.optimize_symbol`
+  expone del lado validate — `proposal_detail.val_pnl` cuando la recomendación
+  es `CHANGE`, `current_val_pnl` en `KEEP / KEEP_CURRENT / NO_DATA / ERROR`. **No
+  hay IS Sharpe**: el optimizer no la expone; manufacturar una requeriría
+  re-correr el simulador sobre la slice de train (scope deferido).
+- **CV (coefficient of variation)**: `std/|mean|` por métrica a través de los
+  windows. Población (`N`), no muestra (`N-1`) — los folds son la población,
+  no una muestra. `|mean| < 1e-9` retorna `value: null` con
+  `reason: "mean_near_zero"`.
+- **Best/worst window**: ranking por `sharpe_ratio` (cuando hay valores
+  numéricos), con fallback a `total_return_pct`. La métrica usada se reporta
+  en el campo `metric` del bloque.
+
+### Razones por las que `value` puede ser `null`:
+
+| Campo | Reason | Significado |
+|---|---|---|
+| `cv.*.value` | `no_samples` | Ningún (window, símbolo) produjo valor numérico para esa métrica. |
+| `cv.*.value` | `single_sample` | Sólo un dato — CV no está definido con un único punto. |
+| `cv.*.value` | `mean_near_zero` | `|mean| < 1e-9` — el ratio sería un disparate inflado. |
+| `oos_is_ratio.value` | `is_pnl_not_on_report` | El run no llevó `is_pnl_by_symbol` (e.g. tests con hand-rolled reports). |
+| `oos_is_ratio.value` | `no_paired_windows` | Bloque IS presente pero sin pares (IS, OOS) numéricos. |
+| `oos_is_ratio.value` | `is_pnl_near_zero` | `|is_total| < 1e-9` — degrada en vez de fabricar un ratio. |
+| `best_window` / `worst_window` | `null` (todo el bloque) | Ningún window produjo Sharpe ni `total_return_pct` numéricos. |
+
+---
+
+## 5. Cómo correr el harness (referencia operativa)
+
+**Modo dry-run** (sólo computar windows, no ejecutar):
+
+```bash
+python walk_forward.py \
+    --history-start 2023-01-01 \
+    --history-end   2025-12-31 \
+    --holdout-start 2026-01-01 \
+    --initial-train-months 12 \
+    --test-months 3 \
+    --step-months 3 \
+    --dry-run
+```
+
+**Modo execute** (drive `run_walk_forward` + `aggregate_run_stats`, imprimir
+JSON):
+
+```bash
+python walk_forward.py \
+    --history-start 2023-01-01 \
+    --history-end   2025-12-31 \
+    --holdout-start 2026-01-01 \
+    --initial-train-months 12 \
+    --test-months 3 \
+    --step-months 3 \
+    --execute
+```
+
+Sin `--ci-mode`, esto invoca `auto_tune.optimize_symbol` real por (window,
+símbolo) — **minutos por símbolo** sobre el grid completo. Para CI smoke
+existe el escape hatch:
+
+```bash
+python walk_forward.py \
+    --history-start 2023-01-01 \
+    --history-end   2023-02-01 \
+    --holdout-start 2026-01-01 \
+    --initial-train-months 12 \
+    --test-months 3 \
+    --step-months 3 \
+    --execute \
+    --ci-mode \
+    --config-path tests/fixtures/walk_forward_ci_config.json
+```
+
+`--ci-mode` reemplaza el tuning por `frozen_params_for_window` — usa los ATR
+multipliers ya presentes en `symbol_overrides`. `--config-path` permite drive
+un fixture sin pasar por la cadena de merge de `api.config.load_config()`.
+
+---
+
+## ⚠️ AVISO PROMINENTE — REPETIDO AL CIERRE
+
+Repito para que ningún lector apurado se confunda:
+
+- **Ninguno de los `n/a` de este reporte representa una métrica real.**
+- **Ninguna decisión de producto, parámetros ni régimen se basa en este
+  documento.**
+- Las celdas `n/a` existen para **congelar la forma** del reporte que se
+  publicará cuando `walk_forward.py --execute` se corra de verdad en una
+  ventana post-#272 re-baselineada.
+- Citar este archivo como evidencia de cualquier hallazgo (positivo o
+  negativo) sobre el sistema es una violación de **Non-Negotiable #5**.
+- No tocar `data/holdout/` está cubierto por **Non-Negotiable #3** — este
+  reporte explícitamente no autoriza ningún peek.
+
+---
+
+**Versión de la forma**: corresponde al estado del módulo `walk_forward.py` en
+el commit que introduce `--execute` (commit 7 de #276). Cuando el shape del
+JSON cambie (nuevas métricas, nuevos campos en `oos_is_ratio.reason`, regime
+tag agregado por fold), regenerar este sample en una versión nueva y dejar
+ésta como histórica.

--- a/tests/fixtures/walk_forward_ci_config.json
+++ b/tests/fixtures/walk_forward_ci_config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Minimal app_config fixture for the walk-forward CI smoke job (#276). Two symbols from btc_scanner.DEFAULT_SYMBOLS with full ATR overrides so frozen_params_for_window keeps them. Numbers are demo placeholders — do NOT cite as tuned production values (Non-Negotiable #5: pre-#223/#224 baselines inflated). The smoke job validates wiring only.",
+  "symbol_overrides": {
+    "BTCUSDT": {
+      "atr_sl_mult": 1.5,
+      "atr_tp_mult": 3.0,
+      "atr_be_mult": 1.0
+    },
+    "ETHUSDT": {
+      "atr_sl_mult": 1.4,
+      "atr_tp_mult": 2.8,
+      "atr_be_mult": 0.9
+    }
+  }
+}

--- a/tests/test_holdout_isolation.py
+++ b/tests/test_holdout_isolation.py
@@ -75,6 +75,13 @@ HOLDOUT_LEGITIMATE_MODULES: set[str] = {
     # not a data path). No `data/holdout/` access; assertion messages
     # legitimately name the boundary parameter for fold debugging.
     "tests/test_walk_forward_windows.py",
+    # A.2 walk-forward evaluation tests (#276, commit 4). Module docstring
+    # names `holdout_start` as the upper bound on `test_end` (commit 1
+    # contract reference). No `data/holdout/` access; the runner is mocked
+    # and reads nothing from disk. Pre-emptive whitelist to avoid the
+    # near-miss the commit 2 → 3 → 4 cascade demonstrated when a holdout
+    # reference moved out of a docstring during a later edit.
+    "tests/test_walk_forward_eval.py",
 }
 
 # Directories that don't contain trading code; scanning them would be noise

--- a/tests/test_holdout_isolation.py
+++ b/tests/test_holdout_isolation.py
@@ -68,8 +68,16 @@ HOLDOUT_LEGITIMATE_MODULES: set[str] = {
     # as a console label — `HOLDOUT_START` is the cutoff timestamp constant,
     # the literal string is operator-facing output, not a data access path.
     "tools/r2_gates_rederivation.py",
-    # A.2 walk-forward harness modules and A.4 evaluation modules will be
-    # added here when those tickets land.
+    # A.2 walk-forward harness + A.4-3 final-winner holdout evaluation
+    # (#276, commit 8). `evaluate_winner_on_holdout` is the ONLY function in
+    # the repo that legitimately reads `data/holdout/` for evaluation, via
+    # `open_holdout(rel_path, evaluation_mode=True)` (Non-Negotiable #2). The
+    # call is WIRED but UNREACHABLE: a hard `raise HoldoutExecutionBlocked`
+    # guarded by the `_HOLDOUT_322_CLOSED` module constant (default False)
+    # precedes every holdout access, so A.4-3 cannot run until #322 closure
+    # criteria are met (Non-Negotiable #3 / decisions.md §Caveat 5). Whitelisted
+    # in the same commit that introduces the mention, per the commit-4 rule.
+    "walk_forward.py",
     # A.2 walk-forward harness property tests (#276). Validates structural
     # invariants on window boundaries against `holdout_start` (a date cutoff,
     # not a data path). No `data/holdout/` access; assertion messages
@@ -382,3 +390,65 @@ def test_wrapper_path_traversal_is_refused():
 
     with pytest.raises(HoldoutAccessError):
         open_holdout("../ohlcv.db", evaluation_mode=True)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A.4-3 kill-switch — gate stays blocked and fires BEFORE any holdout read
+# (#276 commit 8 / #322 / Non-Negotiable #3). Regression net for the
+# adversarial audit tripwire: the gate must raise before open_holdout runs.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_a43_gate_constant_defaults_to_blocked():
+    """`_HOLDOUT_322_CLOSED` must stay False until #322 closure.
+
+    This is a deliberate checkpoint: flipping the harness gate to True requires
+    editing THIS assertion as well as `walk_forward._HOLDOUT_322_CLOSED`, in a
+    reviewed PR tied to #322 closure (Non-Negotiable #3). If this fails on a
+    PR that is not closing #322, the bala única is being spent by accident.
+    """
+    import walk_forward
+
+    assert walk_forward._HOLDOUT_322_CLOSED is False, (
+        "A.4-3 gate flipped to True outside a #322-closure PR — the holdout "
+        "bala única must not be spendable until #322 criteria are all met. "
+        "See CLAUDE.md Non-Negotiable #3 and .mex/context/decisions.md §Caveat 5."
+    )
+
+
+def test_a43_gate_fires_before_any_holdout_read(monkeypatch):
+    """`evaluate_winner_on_holdout` must raise BEFORE `open_holdout` is reached.
+
+    Regression for the adversarial-audit tripwire (commit 8 / faddd1c): we
+    sabotage `data.holdout_access.open_holdout` so that *any* call to it
+    explodes, then invoke the harness entry point. The gate must raise
+    `HoldoutExecutionBlocked` without `open_holdout` ever being called — proving
+    no partial peek at `data/holdout/` is possible while #322 is open. The
+    import inside `evaluate_winner_on_holdout` is local, so patching the symbol
+    on the source module is what the call resolves at runtime.
+    """
+    import data.holdout_access as holdout_access
+    import walk_forward
+
+    sentinel = {"called": False}
+
+    def _explode(*args, **kwargs):
+        sentinel["called"] = True
+        raise AssertionError(
+            "open_holdout was reached — the A.4-3 gate did NOT fire first. "
+            "A peek at the locked holdout was possible. This burns the bala única."
+        )
+
+    monkeypatch.setattr(holdout_access, "open_holdout", _explode)
+
+    with pytest.raises(walk_forward.HoldoutExecutionBlocked):
+        walk_forward.evaluate_winner_on_holdout(
+            winning_params_by_symbol={},
+            config={},
+            holdout_rel_path="fng.parquet",
+        )
+
+    assert sentinel["called"] is False, (
+        "open_holdout was invoked despite the gate — access guard ordering is "
+        "broken; the read happens before the block."
+    )

--- a/tests/test_holdout_isolation.py
+++ b/tests/test_holdout_isolation.py
@@ -82,6 +82,14 @@ HOLDOUT_LEGITIMATE_MODULES: set[str] = {
     # near-miss the commit 2 → 3 → 4 cascade demonstrated when a holdout
     # reference moved out of a docstring during a later edit.
     "tests/test_walk_forward_eval.py",
+    # A.2 walk-forward orchestrator + aggregate tests (#276, commit 5).
+    # Module docstring references the locked holdout snapshot to assert
+    # that no fold fixture's `test_end` exceeds `holdout_start`. No
+    # `data/holdout/` access; tune_window and evaluate_window are
+    # monkeypatched with fakes and the aggregator runs on hand-rolled
+    # report fixtures. Pre-emptive whitelist (same near-miss rule as
+    # the commit-4 entry above).
+    "tests/test_walk_forward_aggregate.py",
 }
 
 # Directories that don't contain trading code; scanning them would be noise

--- a/tests/test_holdout_isolation.py
+++ b/tests/test_holdout_isolation.py
@@ -70,6 +70,11 @@ HOLDOUT_LEGITIMATE_MODULES: set[str] = {
     "tools/r2_gates_rederivation.py",
     # A.2 walk-forward harness modules and A.4 evaluation modules will be
     # added here when those tickets land.
+    # A.2 walk-forward harness property tests (#276). Validates structural
+    # invariants on window boundaries against `holdout_start` (a date cutoff,
+    # not a data path). No `data/holdout/` access; assertion messages
+    # legitimately name the boundary parameter for fold debugging.
+    "tests/test_walk_forward_windows.py",
 }
 
 # Directories that don't contain trading code; scanning them would be noise

--- a/tests/test_walk_forward_aggregate.py
+++ b/tests/test_walk_forward_aggregate.py
@@ -1,0 +1,643 @@
+"""Tests for `walk_forward.run_walk_forward` and `aggregate_run_stats`.
+
+Covers commit 5 of #276 — the orchestrator loop that drives
+`tune_window` → `evaluate_window` over a list of folds, and the
+aggregator that summarises a `WalkForwardRun` into cross-window stats
+(OOS/IS, CV, best/worst, counts).
+
+Test isolation contract:
+  * `auto_tune.optimize_symbol` and `auto_tune.run_backtest_with_params`
+    are NEVER invoked here. The orchestrator tests monkeypatch
+    `walk_forward.tune_window` and `walk_forward.evaluate_window`
+    directly with fakes; the aggregator tests build window reports as
+    hand-rolled fixtures. The locked holdout snapshot is never read —
+    no fold's `test_end` is allowed to exceed a `holdout_start`
+    boundary in any fixture.
+
+Invariants exercised:
+  1. The orchestrator iterates the window list in order, calls
+     `tune_window` then `evaluate_window` per window, and passes the
+     tune output verbatim into the eval.
+  2. An empty window list returns an empty run without raising.
+  3. A per-window failure in tune or eval is captured on that window's
+     report under `"error"`; subsequent windows still run.
+  4. The orchestrator attaches `is_pnl_by_symbol` to each window's
+     report so the aggregator can compute a real OOS/IS ratio.
+  5. `aggregate_run_stats` computes OOS/IS on `net_pnl`, CV across the
+     six ratio/return metrics, best/worst window on `sharpe_ratio`
+     (with `total_return_pct` fallback), and counters
+     (n_windows, n_windows_with_trades, n_skipped, n_errored,
+     total_trades).
+  6. Degenerate cases — empty run, single-window CV, all-windows
+     errored, near-zero IS — produce structured `None` with an
+     explicit `reason` rather than fabricated numbers.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from walk_forward import (
+    WalkForwardRun,
+    Window,
+    aggregate_run_stats,
+    run_walk_forward,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers — Window + report fixtures
+# --------------------------------------------------------------------------- #
+
+
+def _make_window(index: int = 0) -> Window:
+    return Window(
+        index=index,
+        train_start=date(2023, 1, 1),
+        train_end=date(2024, 1, 1),
+        test_start=date(2024, 1, 1),
+        test_end=date(2024, 4, 1),
+        warmup_gap_days=0,
+    )
+
+
+def _three_windows() -> list[Window]:
+    return [
+        Window(
+            index=i,
+            train_start=date(2023, 1, 1),
+            train_end=date(2024, 1 + i, 1),
+            test_start=date(2024, 1 + i, 1),
+            test_end=date(2024, 4 + i, 1),
+            warmup_gap_days=0,
+        )
+        for i in range(3)
+    ]
+
+
+def _sym_entry(
+    n_trades: int = 1,
+    net_pnl: float = 100.0,
+    sharpe: float = 1.5,
+    pf: float = 2.0,
+    dd: float = -5.0,
+    wr: float = 60.0,
+    tr_pct: float = 5.0,
+    error: str | None = None,
+) -> dict:
+    return {
+        "n_trades": n_trades,
+        "metrics": {
+            "total_trades": n_trades,
+            "net_pnl": net_pnl,
+            "profit_factor": pf,
+            "sharpe_ratio": sharpe,
+            "max_drawdown_pct": dd,
+            "win_rate": wr,
+            "total_return_pct": tr_pct,
+        },
+        "regime_tag": None,
+        "error": error,
+    }
+
+
+def _window_report(
+    index: int,
+    results: dict | None = None,
+    skipped: list | None = None,
+    is_pnl_by_symbol: dict | None = None,
+    error: dict | None = None,
+) -> dict:
+    r: dict = {
+        "window_index": index,
+        "train_range": {"start": "2023-01-01", "end": "2024-01-01"},
+        "test_range": {"start": "2024-01-01", "end": "2024-04-01"},
+        "params": {sym: {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5}
+                   for sym in (results or {}).keys()},
+        "results": results or {},
+        "skipped": skipped or [],
+    }
+    if is_pnl_by_symbol is not None:
+        r["is_pnl_by_symbol"] = is_pnl_by_symbol
+    if error is not None:
+        r["error"] = error
+    return r
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator — Invariant 1: iterates in order, passes tuned -> eval
+# --------------------------------------------------------------------------- #
+
+
+def test_orchestrator_iterates_windows_in_order(monkeypatch):
+    """tune_window and evaluate_window must be called once per window,
+    in the same order as the input list, and the tune output must reach
+    evaluate_window verbatim."""
+    import walk_forward as wf
+
+    calls: list[tuple[str, int, object]] = []
+
+    def fake_tune(window, config):
+        out = {
+            "window_index": window.index,
+            "train_end": window.train_end.isoformat(),
+            "results": {"BTCUSDT": {
+                "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+                "current_val_pnl": 50.0 + window.index,
+                "proposed_params": None,
+                "proposal_detail": None,
+                "recommendation": "KEEP",
+            }},
+        }
+        calls.append(("tune", window.index, out))
+        return out
+
+    def fake_eval(window, tuned, config):
+        calls.append(("eval", window.index, tuned))
+        return _window_report(
+            window.index,
+            results={"BTCUSDT": _sym_entry(net_pnl=100.0 + window.index)},
+        )
+
+    monkeypatch.setattr(wf, "tune_window", fake_tune)
+    monkeypatch.setattr(wf, "evaluate_window", fake_eval)
+
+    windows = _three_windows()
+    run = run_walk_forward(windows, app_config={"symbol_overrides": {}})
+
+    # Call ordering: tune(0), eval(0), tune(1), eval(1), tune(2), eval(2).
+    phases = [(p, i) for p, i, _ in calls]
+    assert phases == [
+        ("tune", 0), ("eval", 0),
+        ("tune", 1), ("eval", 1),
+        ("tune", 2), ("eval", 2),
+    ]
+
+    # The tuned dict reaching eval(i) must be identity-equal to the
+    # object tune(i) returned — no munging in between.
+    tune_outputs = [obj for p, _, obj in calls if p == "tune"]
+    eval_inputs = [obj for p, _, obj in calls if p == "eval"]
+    for tout, ein in zip(tune_outputs, eval_inputs):
+        assert tout is ein, "tune output must reach eval verbatim"
+
+    # Run shape: 3 windows, 3 reports, indices preserved.
+    assert isinstance(run, WalkForwardRun)
+    assert len(run.window_reports) == 3
+    assert [r["window_index"] for r in run.window_reports] == [0, 1, 2]
+
+
+def test_orchestrator_attaches_is_pnl_block(monkeypatch):
+    """The orchestrator must attach `is_pnl_by_symbol` to every
+    successful report so the aggregator can compute a real OOS/IS."""
+    import walk_forward as wf
+
+    def fake_tune(window, config):
+        # CHANGE → proposal_detail.val_pnl is the IS for the symbol.
+        return {
+            "results": {
+                "BTCUSDT": {
+                    "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+                    "current_val_pnl": 10.0,
+                    "proposed_params": {"atr_sl_mult": 1.2, "atr_tp_mult": 5.0, "atr_be_mult": 1.8},
+                    "proposal_detail": {"val_pnl": 77.0, "val_pf": 1.7},
+                    "recommendation": "CHANGE",
+                },
+                "ETHUSDT": {
+                    "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+                    "current_val_pnl": -5.0,
+                    "proposed_params": None,
+                    "proposal_detail": None,
+                    "recommendation": "KEEP",
+                },
+            },
+        }
+
+    def fake_eval(window, tuned, config):
+        # Both symbols reached the runner; both get embedded in params.
+        return _window_report(
+            window.index,
+            results={
+                "BTCUSDT": _sym_entry(net_pnl=110.0),
+                "ETHUSDT": _sym_entry(net_pnl=-3.0),
+            },
+        )
+
+    monkeypatch.setattr(wf, "tune_window", fake_tune)
+    monkeypatch.setattr(wf, "evaluate_window", fake_eval)
+
+    run = run_walk_forward([_make_window(0)], app_config={"symbol_overrides": {}})
+
+    assert len(run.window_reports) == 1
+    block = run.window_reports[0]["is_pnl_by_symbol"]
+    # CHANGE → val_pnl of proposal_detail. KEEP → current_val_pnl.
+    assert block == {"BTCUSDT": 77.0, "ETHUSDT": -5.0}
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator — Invariant 2: empty window list
+# --------------------------------------------------------------------------- #
+
+
+def test_orchestrator_empty_windows_yields_empty_run(monkeypatch):
+    import walk_forward as wf
+
+    # The fakes must not be invoked at all. If they are, the test fails
+    # via the explicit pytest.fail() — easier to read than a call counter.
+    def boom_tune(*a, **kw):
+        pytest.fail("tune_window must not be called on empty window list")
+
+    def boom_eval(*a, **kw):
+        pytest.fail("evaluate_window must not be called on empty window list")
+
+    monkeypatch.setattr(wf, "tune_window", boom_tune)
+    monkeypatch.setattr(wf, "evaluate_window", boom_eval)
+
+    run = run_walk_forward([], app_config={})
+    assert isinstance(run, WalkForwardRun)
+    assert run.windows == []
+    assert run.window_reports == []
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator — Invariant 3: best-effort across folds on per-window error
+# --------------------------------------------------------------------------- #
+
+
+def test_orchestrator_continues_after_tune_failure(monkeypatch):
+    """If `tune_window` raises on a fold, the orchestrator records the
+    error on that fold's report and continues with the rest."""
+    import walk_forward as wf
+
+    def fake_tune(window, config):
+        if window.index == 1:
+            raise RuntimeError("synthetic tune failure on window 1")
+        return {"results": {"BTCUSDT": {
+            "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+            "current_val_pnl": 50.0,
+            "proposed_params": None,
+            "proposal_detail": None,
+            "recommendation": "KEEP",
+        }}}
+
+    eval_called_on: list[int] = []
+
+    def fake_eval(window, tuned, config):
+        eval_called_on.append(window.index)
+        return _window_report(
+            window.index,
+            results={"BTCUSDT": _sym_entry(net_pnl=100.0)},
+        )
+
+    monkeypatch.setattr(wf, "tune_window", fake_tune)
+    monkeypatch.setattr(wf, "evaluate_window", fake_eval)
+
+    run = run_walk_forward(_three_windows(), app_config={})
+
+    # evaluate_window must NOT be called for the failed-tune fold.
+    assert eval_called_on == [0, 2]
+
+    # Report shape: failed fold carries `error`, others do not.
+    assert "error" in run.window_reports[1]
+    assert run.window_reports[1]["error"]["phase"] == "tune"
+    assert run.window_reports[1]["error"]["type"] == "RuntimeError"
+    assert "synthetic tune failure" in run.window_reports[1]["error"]["message"]
+    assert "error" not in run.window_reports[0]
+    assert "error" not in run.window_reports[2]
+    # Successful folds carry the IS-pnl block; errored fold does not.
+    assert "is_pnl_by_symbol" in run.window_reports[0]
+    assert "is_pnl_by_symbol" not in run.window_reports[1]
+
+
+def test_orchestrator_continues_after_eval_failure(monkeypatch):
+    """If `evaluate_window` raises, the fold gets an error report with
+    phase=='evaluate' and the loop continues."""
+    import walk_forward as wf
+
+    def fake_tune(window, config):
+        return {"results": {"BTCUSDT": {
+            "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+            "current_val_pnl": 50.0,
+            "proposed_params": None,
+            "proposal_detail": None,
+            "recommendation": "KEEP",
+        }}}
+
+    def fake_eval(window, tuned, config):
+        if window.index == 0:
+            raise ValueError("synthetic eval failure on window 0")
+        return _window_report(
+            window.index,
+            results={"BTCUSDT": _sym_entry(net_pnl=100.0)},
+        )
+
+    monkeypatch.setattr(wf, "tune_window", fake_tune)
+    monkeypatch.setattr(wf, "evaluate_window", fake_eval)
+
+    run = run_walk_forward(_three_windows(), app_config={})
+
+    assert "error" in run.window_reports[0]
+    assert run.window_reports[0]["error"]["phase"] == "evaluate"
+    assert run.window_reports[0]["error"]["type"] == "ValueError"
+    # The other two folds completed normally.
+    assert "error" not in run.window_reports[1]
+    assert "error" not in run.window_reports[2]
+
+
+# --------------------------------------------------------------------------- #
+# Aggregator — counts, CV, OOS/IS, best/worst
+# --------------------------------------------------------------------------- #
+
+
+def test_aggregate_counts_basic():
+    """Three windows, two with trades, one with zero trades, plus an
+    error fold → aggregated counters reflect each bucket."""
+    reports = [
+        _window_report(
+            0,
+            results={"BTCUSDT": _sym_entry(n_trades=3, net_pnl=120.0)},
+            is_pnl_by_symbol={"BTCUSDT": 80.0},
+        ),
+        _window_report(
+            1,
+            results={"BTCUSDT": _sym_entry(n_trades=0, net_pnl=0.0, sharpe=0.0)},
+            is_pnl_by_symbol={"BTCUSDT": 5.0},
+        ),
+        _window_report(
+            2,
+            results={"BTCUSDT": _sym_entry(n_trades=5, net_pnl=200.0)},
+            is_pnl_by_symbol={"BTCUSDT": 150.0},
+        ),
+        _window_report(
+            3,
+            error={"phase": "tune", "type": "RuntimeError", "message": "x"},
+        ),
+    ]
+    run = WalkForwardRun(windows=[_make_window(i) for i in range(4)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    assert stats["n_windows"] == 4
+    assert stats["n_windows_with_trades"] == 2
+    assert stats["n_windows_errored"] == 1
+    assert stats["total_trades"] == 8
+
+
+def test_aggregate_oos_is_ratio_on_net_pnl():
+    """OOS/IS = sum(OOS net_pnl) / sum(IS val_pnl) across paired
+    (symbol, window) cells."""
+    reports = [
+        _window_report(
+            0,
+            results={
+                "BTCUSDT": _sym_entry(net_pnl=120.0),
+                "ETHUSDT": _sym_entry(net_pnl=80.0),
+            },
+            is_pnl_by_symbol={"BTCUSDT": 100.0, "ETHUSDT": 50.0},
+        ),
+        _window_report(
+            1,
+            results={"BTCUSDT": _sym_entry(net_pnl=50.0)},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        ),
+    ]
+    run = WalkForwardRun(windows=[_make_window(0), _make_window(1)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    # OOS total = 120 + 80 + 50 = 250
+    # IS total  = 100 + 50 + 50 = 200
+    # ratio     = 250 / 200 = 1.25
+    assert stats["oos_is_ratio"]["metric"] == "net_pnl"
+    assert stats["oos_is_ratio"]["value"] == pytest.approx(1.25)
+    assert stats["oos_is_ratio"]["n"] == 3
+
+
+def test_aggregate_oos_is_ratio_missing_block_degrades():
+    """If reports lack `is_pnl_by_symbol`, the ratio must come back
+    `None` with a reason — not fabricated."""
+    reports = [
+        _window_report(0, results={"BTCUSDT": _sym_entry(net_pnl=100.0)}),
+        _window_report(1, results={"BTCUSDT": _sym_entry(net_pnl=50.0)}),
+    ]
+    run = WalkForwardRun(windows=[_make_window(0), _make_window(1)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    assert stats["oos_is_ratio"]["value"] is None
+    assert stats["oos_is_ratio"]["reason"] == "is_pnl_not_on_report"
+
+
+def test_aggregate_oos_is_ratio_near_zero_is_degrades():
+    """A near-zero IS total must surface `None` with reason rather than
+    blow up to infinity."""
+    reports = [
+        _window_report(
+            0,
+            results={"BTCUSDT": _sym_entry(net_pnl=50.0)},
+            is_pnl_by_symbol={"BTCUSDT": 0.0},
+        ),
+        _window_report(
+            1,
+            results={"BTCUSDT": _sym_entry(net_pnl=30.0)},
+            is_pnl_by_symbol={"BTCUSDT": 0.0},
+        ),
+    ]
+    run = WalkForwardRun(windows=[_make_window(0), _make_window(1)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    assert stats["oos_is_ratio"]["value"] is None
+    assert stats["oos_is_ratio"]["reason"] == "is_pnl_near_zero"
+
+
+def test_aggregate_cv_across_windows():
+    """CV = std/mean across (window, symbol) cells per metric."""
+    # Three windows, one symbol, Sharpe values 1.0, 2.0, 3.0
+    # mean = 2.0, population stdev = sqrt((1+0+1)/3) = sqrt(2/3) ≈ 0.8165
+    # CV ≈ 0.4082
+    reports = [
+        _window_report(
+            i,
+            results={"BTCUSDT": _sym_entry(sharpe=float(i + 1))},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        )
+        for i in range(3)
+    ]
+    run = WalkForwardRun(windows=[_make_window(i) for i in range(3)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    cv_sharpe = stats["cv"]["sharpe_ratio"]
+    assert cv_sharpe["n"] == 3
+    assert cv_sharpe["value"] == pytest.approx((2.0 / 3.0) ** 0.5 / 2.0, rel=1e-6)
+
+
+def test_aggregate_cv_single_window_is_undefined():
+    """One data point → CV is None with reason 'single_sample'."""
+    reports = [
+        _window_report(
+            0,
+            results={"BTCUSDT": _sym_entry(sharpe=1.5)},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        ),
+    ]
+    run = WalkForwardRun(windows=[_make_window(0)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    assert stats["cv"]["sharpe_ratio"]["value"] is None
+    assert stats["cv"]["sharpe_ratio"]["reason"] == "single_sample"
+
+
+def test_aggregate_cv_zero_mean_is_undefined():
+    """Mean near zero → CV is None with reason 'mean_near_zero'."""
+    reports = [
+        _window_report(
+            0,
+            results={"BTCUSDT": _sym_entry(sharpe=1.0)},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        ),
+        _window_report(
+            1,
+            results={"BTCUSDT": _sym_entry(sharpe=-1.0)},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        ),
+    ]
+    run = WalkForwardRun(windows=[_make_window(0), _make_window(1)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    assert stats["cv"]["sharpe_ratio"]["value"] is None
+    assert stats["cv"]["sharpe_ratio"]["reason"] == "mean_near_zero"
+
+
+def test_aggregate_best_worst_window_on_sharpe():
+    """Best/worst indexed on Sharpe (default metric)."""
+    reports = [
+        _window_report(
+            0,
+            results={"BTCUSDT": _sym_entry(sharpe=0.5)},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        ),
+        _window_report(
+            1,
+            results={"BTCUSDT": _sym_entry(sharpe=2.5)},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        ),
+        _window_report(
+            2,
+            results={"BTCUSDT": _sym_entry(sharpe=-1.0)},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        ),
+    ]
+    run = WalkForwardRun(windows=[_make_window(i) for i in range(3)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    assert stats["best_window"] == {"index": 1, "metric": "sharpe_ratio", "value": 2.5}
+    assert stats["worst_window"] == {"index": 2, "metric": "sharpe_ratio", "value": -1.0}
+
+
+def test_aggregate_best_worst_falls_back_to_total_return_when_no_sharpe():
+    """If reports carry total_return_pct but no sharpe_ratio, the
+    ranking falls back to total_return_pct."""
+    reports = []
+    for i, tr in enumerate((1.0, 5.0, -2.0)):
+        entry = _sym_entry(tr_pct=tr)
+        del entry["metrics"]["sharpe_ratio"]  # remove sharpe entirely
+        reports.append(_window_report(
+            i,
+            results={"BTCUSDT": entry},
+            is_pnl_by_symbol={"BTCUSDT": 50.0},
+        ))
+    run = WalkForwardRun(windows=[_make_window(i) for i in range(3)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    assert stats["best_window"]["metric"] == "total_return_pct"
+    assert stats["best_window"]["index"] == 1
+    assert stats["worst_window"]["index"] == 2
+
+
+def test_aggregate_empty_run():
+    """An empty run produces all-zero counters and None ratios with
+    explicit reasons — not a crash."""
+    run = WalkForwardRun(windows=[], window_reports=[])
+    stats = aggregate_run_stats(run)
+
+    assert stats["n_windows"] == 0
+    assert stats["n_windows_with_trades"] == 0
+    assert stats["n_windows_errored"] == 0
+    assert stats["total_trades"] == 0
+    assert stats["oos_is_ratio"]["value"] is None
+    assert stats["best_window"] is None
+    assert stats["worst_window"] is None
+    for key in (
+        "net_pnl", "profit_factor", "sharpe_ratio",
+        "max_drawdown_pct", "win_rate", "total_return_pct",
+    ):
+        assert stats["cv"][key]["value"] is None
+        assert stats["cv"][key]["reason"] == "no_samples"
+
+
+def test_aggregate_all_windows_errored():
+    """When every fold is an error report, OOS/IS comes back with the
+    paired-zero reason and best/worst are None."""
+    reports = [
+        _window_report(0, error={"phase": "tune", "type": "RuntimeError", "message": "a"}),
+        _window_report(1, error={"phase": "evaluate", "type": "ValueError", "message": "b"}),
+    ]
+    run = WalkForwardRun(windows=[_make_window(0), _make_window(1)], window_reports=reports)
+    stats = aggregate_run_stats(run)
+
+    assert stats["n_windows"] == 2
+    assert stats["n_windows_errored"] == 2
+    assert stats["n_windows_with_trades"] == 0
+    assert stats["total_trades"] == 0
+    assert stats["best_window"] is None
+    assert stats["worst_window"] is None
+    assert stats["oos_is_ratio"]["value"] is None
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: orchestrator output feeds aggregator without ceremony
+# --------------------------------------------------------------------------- #
+
+
+def test_run_and_aggregate_end_to_end(monkeypatch):
+    """Drive the orchestrator on three folds with deterministic fakes,
+    then hand the resulting `WalkForwardRun` to the aggregator. This
+    is the contract the harness will exercise in production: build
+    windows → run → aggregate."""
+    import walk_forward as wf
+
+    def fake_tune(window, config):
+        # Deterministic IS pnl per window — distinct values so the
+        # paired OOS/IS arithmetic is unambiguous.
+        return {
+            "results": {"BTCUSDT": {
+                "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+                "current_val_pnl": 100.0 + window.index * 10.0,
+                "proposed_params": None,
+                "proposal_detail": None,
+                "recommendation": "KEEP",
+            }},
+        }
+
+    def fake_eval(window, tuned, config):
+        return _window_report(
+            window.index,
+            results={"BTCUSDT": _sym_entry(
+                n_trades=2,
+                net_pnl=200.0 + window.index * 10.0,
+                sharpe=float(window.index + 1),
+            )},
+        )
+
+    monkeypatch.setattr(wf, "tune_window", fake_tune)
+    monkeypatch.setattr(wf, "evaluate_window", fake_eval)
+
+    run = run_walk_forward(_three_windows(), app_config={})
+    stats = aggregate_run_stats(run)
+
+    # IS totals: 100 + 110 + 120 = 330
+    # OOS totals: 200 + 210 + 220 = 630
+    # Ratio: 630 / 330 ≈ 1.909
+    assert stats["oos_is_ratio"]["value"] == pytest.approx(630.0 / 330.0, rel=1e-6)
+    assert stats["total_trades"] == 6
+    assert stats["n_windows_with_trades"] == 3
+    assert stats["best_window"]["index"] == 2
+    assert stats["worst_window"]["index"] == 0

--- a/tests/test_walk_forward_ci_mode.py
+++ b/tests/test_walk_forward_ci_mode.py
@@ -1,0 +1,351 @@
+"""Tests for `walk_forward.run_walk_forward(..., ci_mode=True)` and
+`frozen_params_for_window`.
+
+Commit 6 of #276 adds a CI escape hatch: instead of driving
+`auto_tune.optimize_symbol` (minutes per symbol, full grid) per
+window, the orchestrator can be asked to use the ATR multipliers
+already in `app_config["symbol_overrides"]` as frozen params. This
+keeps the orchestrator → evaluate_window contract intact while
+making the loop cheap enough for CI smoke runs.
+
+Invariants exercised:
+
+  1. `ci_mode=True` skips `tune_window` entirely — the real
+     `auto_tune.optimize_symbol` must NEVER be reached.
+  2. The frozen params come verbatim from
+     `symbol_overrides[symbol]` and feed downstream
+     `evaluate_window` (and `_build_is_pnl_block`) without shape
+     drift.
+  3. Symbols whose override lacks the three ATR keys are skipped:
+     they have no frozen params to use.
+  4. `ci_mode` defaults to `False`; production behaviour is
+     unchanged when the flag is absent.
+  5. `frozen_params_for_window` returns the `tune_window`-shaped
+     dict downstream callers expect.
+
+The real `auto_tune.optimize_symbol` and `run_backtest_with_params`
+are NEVER invoked. Fakes for `get_portfolio_symbols` are installed
+via `sys.modules`, mirroring the pattern in
+`tests/test_walk_forward_tune.py`.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+
+import pytest
+
+import walk_forward
+from walk_forward import (
+    Window,
+    frozen_params_for_window,
+    run_walk_forward,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_window(index: int = 0) -> Window:
+    return Window(
+        index=index,
+        train_start=date(2023, 1, 1),
+        train_end=date(2024, 1, 1),
+        test_start=date(2024, 1, 1),
+        test_end=date(2024, 4, 1),
+        warmup_gap_days=0,
+    )
+
+
+class _FakeAutoTune:
+    """Minimal stand-in for the `auto_tune` module.
+
+    Records every `optimize_symbol` invocation so a test can assert it
+    was NEVER reached. Provides `get_portfolio_symbols` so
+    `frozen_params_for_window` can resolve the active symbol list.
+    """
+
+    def __init__(self, symbols: list[str]):
+        self._symbols = list(symbols)
+        self.optimize_calls: list[dict] = []
+
+    def get_portfolio_symbols(self, config: dict) -> list[str]:
+        return list(self._symbols)
+
+    def optimize_symbol(self, symbol, config, today=None, *, cutoff=None):
+        # If this lands in ci_mode something is very wrong.
+        self.optimize_calls.append(
+            {"symbol": symbol, "today": today, "cutoff": cutoff}
+        )
+        raise AssertionError(
+            f"optimize_symbol must not be called in ci_mode (symbol={symbol!r})"
+        )
+
+
+@pytest.fixture
+def patch_auto_tune(monkeypatch):
+    def _install(symbols: list[str]) -> _FakeAutoTune:
+        fake = _FakeAutoTune(symbols)
+        monkeypatch.setitem(sys.modules, "auto_tune", fake)
+        return fake
+
+    return _install
+
+
+# --------------------------------------------------------------------------- #
+# Property 1: ci_mode skips tune_window entirely
+# --------------------------------------------------------------------------- #
+
+
+def test_skips_tune_window(patch_auto_tune, monkeypatch):
+    """When `ci_mode=True`, `tune_window` must never be called."""
+    symbols = ["BTCUSDT", "ETHUSDT"]
+    fake = patch_auto_tune(symbols)
+
+    overrides = {
+        "BTCUSDT": {"atr_sl_mult": 1.5, "atr_tp_mult": 3.0, "atr_be_mult": 1.0},
+        "ETHUSDT": {"atr_sl_mult": 1.4, "atr_tp_mult": 2.8, "atr_be_mult": 0.9},
+    }
+    app_config = {"symbol_overrides": overrides}
+
+    tune_calls: list = []
+
+    def boom_tune(window, config):  # pragma: no cover — must not be reached
+        tune_calls.append(window.index)
+        raise AssertionError("tune_window must not be called in ci_mode")
+
+    monkeypatch.setattr(walk_forward, "tune_window", boom_tune)
+
+    # Stub evaluate_window so we don't try to actually run a backtest.
+    def fake_eval(window, tuned, config):
+        return {
+            "window_index": window.index,
+            "train_range": {
+                "start": window.train_start.isoformat(),
+                "end": window.train_end.isoformat(),
+            },
+            "test_range": {
+                "start": window.test_start.isoformat(),
+                "end": window.test_end.isoformat(),
+            },
+            "params": dict(tuned["results"].get(s, {}).get("current_params", {})
+                           for s in []),  # not load-bearing for this test
+            "results": {},
+            "skipped": [],
+        }
+
+    monkeypatch.setattr(walk_forward, "evaluate_window", fake_eval)
+
+    run = run_walk_forward(
+        [_make_window(0), _make_window(1)],
+        app_config=app_config,
+        ci_mode=True,
+    )
+
+    assert tune_calls == [], "tune_window must not be invoked in ci_mode"
+    assert fake.optimize_calls == [], (
+        "optimize_symbol must not be invoked in ci_mode"
+    )
+    assert len(run.window_reports) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Property 2: frozen params come from symbol_overrides and feed evaluate
+# --------------------------------------------------------------------------- #
+
+
+def test_uses_config_overrides(patch_auto_tune, monkeypatch):
+    """The params evaluate_window receives must be the frozen overrides."""
+    symbols = ["BTCUSDT", "ETHUSDT"]
+    patch_auto_tune(symbols)
+
+    overrides = {
+        "BTCUSDT": {"atr_sl_mult": 1.5, "atr_tp_mult": 3.0, "atr_be_mult": 1.0},
+        "ETHUSDT": {"atr_sl_mult": 1.4, "atr_tp_mult": 2.8, "atr_be_mult": 0.9},
+    }
+    app_config = {"symbol_overrides": overrides}
+
+    seen_tuned: list[dict] = []
+
+    def fake_eval(window, tuned, config):
+        seen_tuned.append(tuned)
+        # Mirror the evaluate_window envelope.
+        params = {
+            sym: {k: v for k, v in r["current_params"].items()}
+            for sym, r in tuned["results"].items()
+        }
+        return {
+            "window_index": window.index,
+            "train_range": {
+                "start": window.train_start.isoformat(),
+                "end": window.train_end.isoformat(),
+            },
+            "test_range": {
+                "start": window.test_start.isoformat(),
+                "end": window.test_end.isoformat(),
+            },
+            "params": params,
+            "results": {},
+            "skipped": [],
+        }
+
+    monkeypatch.setattr(walk_forward, "evaluate_window", fake_eval)
+
+    run = run_walk_forward(
+        [_make_window(0)],
+        app_config=app_config,
+        ci_mode=True,
+    )
+
+    assert len(seen_tuned) == 1
+    tuned = seen_tuned[0]
+    assert set(tuned["results"].keys()) == {"BTCUSDT", "ETHUSDT"}
+    assert tuned["results"]["BTCUSDT"]["current_params"] == overrides["BTCUSDT"]
+    assert tuned["results"]["ETHUSDT"]["current_params"] == overrides["ETHUSDT"]
+    assert tuned["results"]["BTCUSDT"]["recommendation"] == "KEEP_CURRENT"
+    assert tuned["results"]["BTCUSDT"]["proposed_params"] is None
+    # The report's `params` block — what would be evaluated — must match.
+    report = run.window_reports[0]
+    assert report["params"]["BTCUSDT"] == overrides["BTCUSDT"]
+    assert report["params"]["ETHUSDT"] == overrides["ETHUSDT"]
+
+
+# --------------------------------------------------------------------------- #
+# Property 3: symbols missing ATR overrides are skipped
+# --------------------------------------------------------------------------- #
+
+
+def test_skips_symbol_without_overrides(patch_auto_tune, monkeypatch):
+    """If `symbol_overrides[sym]` lacks the ATR keys, the symbol is dropped."""
+    symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT"]
+    patch_auto_tune(symbols)
+
+    overrides = {
+        # Full override — kept.
+        "BTCUSDT": {"atr_sl_mult": 1.5, "atr_tp_mult": 3.0, "atr_be_mult": 1.0},
+        # Partial — missing atr_be_mult — dropped.
+        "ETHUSDT": {"atr_sl_mult": 1.4, "atr_tp_mult": 2.8},
+        # SOLUSDT not present in overrides at all — dropped.
+    }
+    app_config = {"symbol_overrides": overrides}
+
+    window = _make_window(0)
+    out = frozen_params_for_window(window, app_config)
+
+    assert set(out["results"].keys()) == {"BTCUSDT"}, (
+        "only symbols whose overrides carry the three ATR keys must be kept"
+    )
+    assert out["results"]["BTCUSDT"]["current_params"] == overrides["BTCUSDT"]
+
+
+# --------------------------------------------------------------------------- #
+# Property 4: ci_mode defaults to False (production behaviour unchanged)
+# --------------------------------------------------------------------------- #
+
+
+def test_default_off(patch_auto_tune, monkeypatch):
+    """`ci_mode` defaults to False; `tune_window` is the path taken."""
+    symbols = ["BTCUSDT"]
+    patch_auto_tune(symbols)
+
+    overrides = {
+        "BTCUSDT": {"atr_sl_mult": 1.5, "atr_tp_mult": 3.0, "atr_be_mult": 1.0},
+    }
+    app_config = {"symbol_overrides": overrides}
+
+    tune_calls: list[int] = []
+
+    def fake_tune(window, config):
+        tune_calls.append(window.index)
+        return {
+            "window_index": window.index,
+            "train_end": window.train_end.isoformat(),
+            "cutoff": window.train_end.isoformat(),
+            "results": {
+                "BTCUSDT": {
+                    "symbol": "BTCUSDT",
+                    "recommendation": "KEEP_CURRENT",
+                    "current_params": overrides["BTCUSDT"],
+                    "current_val_pnl": 0.0,
+                    "proposed_params": None,
+                    "proposal_detail": None,
+                }
+            },
+        }
+
+    def fake_eval(window, tuned, config):
+        return {
+            "window_index": window.index,
+            "train_range": {
+                "start": window.train_start.isoformat(),
+                "end": window.train_end.isoformat(),
+            },
+            "test_range": {
+                "start": window.test_start.isoformat(),
+                "end": window.test_end.isoformat(),
+            },
+            "params": {"BTCUSDT": overrides["BTCUSDT"]},
+            "results": {},
+            "skipped": [],
+        }
+
+    monkeypatch.setattr(walk_forward, "tune_window", fake_tune)
+    monkeypatch.setattr(walk_forward, "evaluate_window", fake_eval)
+
+    # Note: no ci_mode kwarg.
+    run = run_walk_forward([_make_window(0)], app_config=app_config)
+
+    assert tune_calls == [0], (
+        "by default ci_mode=False — tune_window must drive the loop"
+    )
+    assert len(run.window_reports) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Property 5: frozen_params_for_window output shape matches tune_window
+# --------------------------------------------------------------------------- #
+
+
+def test_frozen_params_shape(patch_auto_tune):
+    """`frozen_params_for_window` returns a tune_window-shaped envelope.
+
+    Required keys at the top level: window_index, train_end, cutoff,
+    results. Each per-symbol entry carries the keys downstream
+    consumers (`evaluate_window._select_params_for_eval`,
+    `_extract_is_pnl`) expect: recommendation, current_params,
+    proposed_params, proposal_detail, current_val_pnl.
+    """
+    symbols = ["BTCUSDT"]
+    patch_auto_tune(symbols)
+
+    overrides = {
+        "BTCUSDT": {"atr_sl_mult": 1.5, "atr_tp_mult": 3.0, "atr_be_mult": 1.0},
+    }
+    app_config = {"symbol_overrides": overrides}
+
+    window = _make_window(index=7)
+    out = frozen_params_for_window(window, app_config)
+
+    assert set(out.keys()) == {"window_index", "train_end", "cutoff", "results"}
+    assert out["window_index"] == 7
+    assert out["train_end"] == window.train_end.isoformat()
+    assert out["cutoff"].startswith(window.train_end.isoformat())
+
+    sym_entry = out["results"]["BTCUSDT"]
+    expected_keys = {
+        "symbol",
+        "recommendation",
+        "current_params",
+        "current_val_pnl",
+        "proposed_params",
+        "proposal_detail",
+    }
+    assert set(sym_entry.keys()) == expected_keys
+    assert sym_entry["recommendation"] == "KEEP_CURRENT"
+    assert sym_entry["current_params"] == overrides["BTCUSDT"]
+    assert sym_entry["proposed_params"] is None
+    assert sym_entry["proposal_detail"] is None
+    assert sym_entry["current_val_pnl"] == 0.0

--- a/tests/test_walk_forward_eval.py
+++ b/tests/test_walk_forward_eval.py
@@ -1,0 +1,493 @@
+"""Tests for `walk_forward.evaluate_window`.
+
+This module covers commit 4 of #276 — running the strategy on the
+fold's **test range** with the params produced by `tune_window`.
+
+The real `auto_tune.run_backtest_with_params` loads OHLCV from disk,
+runs the full bar-by-bar simulator, and takes seconds-to-minutes per
+call. It is **always mocked here**: a unit test that lets it through
+would block CI and would also break the test isolation contract.
+
+Invariants exercised:
+
+  1. `run_backtest_with_params` is called with `sim_start == test_start`
+     and `sim_end == test_end`. The TRAIN range is never passed to the
+     evaluation runner (the tuner already consumed it). The locked
+     snapshot is never reached because `compute_windows` bounds
+     `test_end <= holdout_start` (commit 1 contract).
+  2. Per-symbol params come from the tune output: `proposed_params`
+     when `recommendation == "CHANGE"`, `current_params` otherwise.
+  3. The returned report shape carries `window_index`, `train_range`,
+     `test_range`, `params`, `results[symbol].{n_trades, metrics,
+     regime_tag, error}`, and `skipped`.
+  4. Degenerate test range (`test_start >= test_end`) returns the
+     envelope with no runner calls.
+  5. A symbol whose tune dict carries no usable params is recorded in
+     `skipped`; the runner is not called for it.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from walk_forward import Window, evaluate_window
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_window(
+    test_start: date = date(2025, 4, 1),
+    test_end: date = date(2025, 7, 1),
+    train_start: date = date(2023, 1, 1),
+    train_end: date = date(2025, 4, 1),
+    index: int = 0,
+) -> Window:
+    """Build a Window with non-degenerate boundaries for evaluation tests."""
+    return Window(
+        index=index,
+        train_start=train_start,
+        train_end=train_end,
+        test_start=test_start,
+        test_end=test_end,
+        warmup_gap_days=0,
+    )
+
+
+class _FakeAutoTune:
+    """Stand-in for the `auto_tune` module.
+
+    Records every `run_backtest_with_params` invocation so tests can
+    assert on argument shape, call count, and per-symbol routing. The
+    fake returns canned (trades, metrics) so the evaluator's projection
+    logic can be exercised end-to-end.
+    """
+
+    def __init__(self, per_symbol_outputs: dict | None = None):
+        # Per-symbol override: {symbol: (trades, metrics)}. Falls back
+        # to a default 1-trade success metric when a symbol is not
+        # named.
+        self._outputs = per_symbol_outputs or {}
+        self.calls: list[dict] = []
+
+    def _default_output(self) -> tuple[list[dict], dict]:
+        trades = [{"pnl_usd": 10.0, "exit_reason": "TP"}]
+        metrics = {
+            "total_trades": 1,
+            "net_pnl": 10.0,
+            "profit_factor": 1.5,
+            "sharpe_ratio": 0.8,
+            "max_drawdown_pct": -2.0,
+            "win_rate": 100.0,
+            "total_return_pct": 0.1,
+            # Extra key that should NOT appear in the projection.
+            "score_tiers": {},
+        }
+        return trades, metrics
+
+    def run_backtest_with_params(
+        self,
+        symbol,
+        params,
+        sim_start,
+        sim_end,
+        *,
+        cutoff=None,
+        app_config=None,
+    ):
+        self.calls.append(
+            {
+                "symbol": symbol,
+                "params": dict(params),
+                "sim_start": sim_start,
+                "sim_end": sim_end,
+                "cutoff": cutoff,
+                "app_config_id": id(app_config) if app_config is not None else None,
+            }
+        )
+        if symbol in self._outputs:
+            return self._outputs[symbol]
+        return self._default_output()
+
+
+@pytest.fixture
+def patch_auto_tune(monkeypatch):
+    """Inject `_FakeAutoTune` in place of the real module.
+
+    `evaluate_window` imports `auto_tune` lazily inside the function,
+    so we patch via `sys.modules` exactly like the tune-window tests.
+    """
+
+    def _install(per_symbol_outputs: dict | None = None) -> _FakeAutoTune:
+        fake = _FakeAutoTune(per_symbol_outputs)
+        import sys
+
+        monkeypatch.setitem(sys.modules, "auto_tune", fake)
+        return fake
+
+    return _install
+
+
+def _tune_result_change(symbol: str, sl: float, tp: float, be: float) -> dict:
+    """Build a tune dict that recommends CHANGE → proposed_params used."""
+    return {
+        "symbol": symbol,
+        "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+        "current_val_pnl": 0,
+        "proposed_params": {"atr_sl_mult": sl, "atr_tp_mult": tp, "atr_be_mult": be},
+        "proposal_detail": {"val_pnl": 100, "val_pf": 1.8},
+        "recommendation": "CHANGE",
+    }
+
+
+def _tune_result_keep(symbol: str, sl: float = 1.0, tp: float = 4.0, be: float = 1.5) -> dict:
+    """Build a tune dict that recommends KEEP → current_params used."""
+    return {
+        "symbol": symbol,
+        "current_params": {"atr_sl_mult": sl, "atr_tp_mult": tp, "atr_be_mult": be},
+        "current_val_pnl": 0,
+        "proposed_params": None,
+        "proposal_detail": None,
+        "recommendation": "KEEP",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 1: runner sees test range, NOT train range
+# --------------------------------------------------------------------------- #
+
+
+def test_runner_receives_test_range_not_train_range(patch_auto_tune):
+    """The single most important assertion in this module.
+
+    The evaluation runner must be called with `sim_start == test_start`
+    and `sim_end == test_end`. If a future refactor accidentally passes
+    `train_start`/`train_end` (or any cutoff that clips below
+    `test_start`), every per-window report becomes meaningless. This
+    test bites first.
+    """
+    fake = patch_auto_tune()
+    window = _make_window(
+        train_start=date(2023, 1, 1),
+        train_end=date(2025, 4, 1),
+        test_start=date(2025, 4, 1),
+        test_end=date(2025, 7, 1),
+    )
+    tuned = {
+        "window_index": 0,
+        "train_end": "2025-04-01",
+        "results": {"BTCUSDT": _tune_result_change("BTCUSDT", 1.2, 5.0, 1.8)},
+    }
+
+    evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    assert len(fake.calls) == 1, "exactly one runner call per active symbol"
+    call = fake.calls[0]
+
+    expected_start = datetime(2025, 4, 1, tzinfo=timezone.utc)
+    expected_end = datetime(2025, 7, 1, tzinfo=timezone.utc)
+    assert call["sim_start"] == expected_start, (
+        f"sim_start must equal test_start at UTC midnight; "
+        f"got {call['sim_start']!r}"
+    )
+    assert call["sim_end"] == expected_end, (
+        f"sim_end must equal test_end at UTC midnight; "
+        f"got {call['sim_end']!r}"
+    )
+    # Neither train boundary may ever surface on the evaluation call.
+    train_start_dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    train_end_dt = datetime(2025, 4, 1, tzinfo=timezone.utc)
+    assert call["sim_start"] != train_start_dt
+    # train_end == test_start in the anchored adjacency case, so the
+    # negative-equality check on sim_end is the load-bearing one:
+    assert call["sim_end"] != train_end_dt
+
+
+def test_runner_receives_no_cutoff(patch_auto_tune):
+    """`cutoff` is a tune-side concept; evaluation must NOT pass it.
+
+    Passing a `cutoff <= test_end` would strip the very bars we want to
+    evaluate. The evaluator must let the runner see the full test
+    range.
+    """
+    fake = patch_auto_tune()
+    window = _make_window()
+    tuned = {"results": {"BTCUSDT": _tune_result_keep("BTCUSDT")}}
+
+    evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    assert fake.calls[0]["cutoff"] is None, (
+        "evaluation runner must be called WITHOUT a cutoff so the test "
+        "range is fully visible to the simulator"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 2: params source — CHANGE uses proposed, KEEP uses current
+# --------------------------------------------------------------------------- #
+
+
+def test_change_recommendation_evaluates_proposed_params(patch_auto_tune):
+    fake = patch_auto_tune()
+    window = _make_window()
+    tuned = {
+        "results": {
+            "BTCUSDT": _tune_result_change("BTCUSDT", sl=2.0, tp=6.0, be=2.5),
+        },
+    }
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    assert fake.calls[0]["params"] == {
+        "atr_sl_mult": 2.0,
+        "atr_tp_mult": 6.0,
+        "atr_be_mult": 2.5,
+    }
+    assert report["params"]["BTCUSDT"]["atr_sl_mult"] == 2.0
+
+
+def test_keep_recommendation_evaluates_current_params(patch_auto_tune):
+    fake = patch_auto_tune()
+    window = _make_window()
+    tuned = {
+        "results": {
+            "ETHUSDT": _tune_result_keep("ETHUSDT", sl=1.1, tp=4.4, be=1.6),
+        },
+    }
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    assert fake.calls[0]["params"] == {
+        "atr_sl_mult": 1.1,
+        "atr_tp_mult": 4.4,
+        "atr_be_mult": 1.6,
+    }
+    assert report["params"]["ETHUSDT"]["atr_sl_mult"] == 1.1
+
+
+def test_multi_symbol_routes_params_per_symbol(patch_auto_tune):
+    """Each symbol carries its own param set into its own runner call."""
+    fake = patch_auto_tune()
+    window = _make_window()
+    tuned = {
+        "results": {
+            "BTCUSDT": _tune_result_change("BTCUSDT", 2.0, 6.0, 2.5),
+            "ETHUSDT": _tune_result_keep("ETHUSDT", 1.0, 4.0, 1.5),
+            "SOLUSDT": _tune_result_change("SOLUSDT", 1.5, 5.5, 2.0),
+        },
+    }
+
+    evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    by_symbol = {c["symbol"]: c["params"] for c in fake.calls}
+    assert by_symbol["BTCUSDT"]["atr_sl_mult"] == 2.0
+    assert by_symbol["ETHUSDT"]["atr_sl_mult"] == 1.0
+    assert by_symbol["SOLUSDT"]["atr_sl_mult"] == 1.5
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 3: report structure
+# --------------------------------------------------------------------------- #
+
+
+def test_report_has_declared_shape(patch_auto_tune):
+    patch_auto_tune()
+    window = _make_window(index=7)
+    tuned = {"results": {"BTCUSDT": _tune_result_change("BTCUSDT", 1.2, 5.0, 1.8)}}
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    # Top-level keys.
+    for key in ("window_index", "train_range", "test_range", "params", "results", "skipped"):
+        assert key in report, f"missing top-level key: {key}"
+
+    assert report["window_index"] == 7
+    assert report["train_range"] == {"start": "2023-01-01", "end": "2025-04-01"}
+    assert report["test_range"] == {"start": "2025-04-01", "end": "2025-07-01"}
+
+    # Per-symbol entry.
+    entry = report["results"]["BTCUSDT"]
+    for key in ("n_trades", "metrics", "regime_tag", "error"):
+        assert key in entry, f"missing per-symbol key: {key}"
+
+    assert entry["n_trades"] == 1
+    assert entry["regime_tag"] is None, (
+        "regime_tag is intentionally None until a fold-aggregation rule "
+        "is agreed on; the simulator emits regime per-trade, not per-run"
+    )
+    assert entry["error"] is None
+
+
+def test_metrics_projection_keeps_only_report_keys(patch_auto_tune):
+    """The projection must drop unrelated metric keys (e.g. score_tiers)
+    and surface the seven canonical ones when present."""
+    patch_auto_tune()
+    window = _make_window()
+    tuned = {"results": {"BTCUSDT": _tune_result_change("BTCUSDT", 1.2, 5.0, 1.8)}}
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+    metrics = report["results"]["BTCUSDT"]["metrics"]
+
+    expected_keys = {
+        "total_trades",
+        "net_pnl",
+        "profit_factor",
+        "sharpe_ratio",
+        "max_drawdown_pct",
+        "win_rate",
+        "total_return_pct",
+    }
+    assert set(metrics.keys()) == expected_keys
+    # The extra key the fake returned must not surface.
+    assert "score_tiers" not in metrics
+
+
+def test_runner_error_sentinel_surfaces_in_report(patch_auto_tune):
+    """When the runner returns the `{"error": ..., ...}` sentinel (no
+    trades or no data), the report must capture the error string and
+    `n_trades == 0`."""
+    sentinel = (
+        [],
+        {"error": "No trades", "total_trades": 0, "net_pnl": 0, "profit_factor": 0},
+    )
+    patch_auto_tune({"BTCUSDT": sentinel})
+    window = _make_window()
+    tuned = {"results": {"BTCUSDT": _tune_result_change("BTCUSDT", 1.2, 5.0, 1.8)}}
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+    entry = report["results"]["BTCUSDT"]
+
+    assert entry["error"] == "No trades"
+    assert entry["n_trades"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 4: degenerate test range — no runner calls
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_test_range_skips_runner(patch_auto_tune):
+    """When `test_start >= test_end`, the function returns the envelope
+    without invoking the runner. Defensive — `compute_windows` does not
+    emit such folds today, but a hand-rolled `Window` could."""
+    fake = patch_auto_tune()
+    window = Window(
+        index=3,
+        train_start=date(2023, 1, 1),
+        train_end=date(2025, 7, 1),
+        test_start=date(2025, 7, 1),
+        test_end=date(2025, 7, 1),  # equal → empty range
+        warmup_gap_days=0,
+    )
+    tuned = {"results": {"BTCUSDT": _tune_result_change("BTCUSDT", 1.2, 5.0, 1.8)}}
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    assert fake.calls == [], "empty test range must not invoke the runner"
+    assert report["window_index"] == 3
+    assert report["results"] == {}
+    assert report["skipped"] == []
+    # Range metadata still reflects the (degenerate) input.
+    assert report["test_range"]["start"] == report["test_range"]["end"]
+
+
+def test_inverted_test_range_skips_runner(patch_auto_tune):
+    """`test_start > test_end` is also treated as degenerate. No runner
+    call; empty results."""
+    fake = patch_auto_tune()
+    window = Window(
+        index=0,
+        train_start=date(2023, 1, 1),
+        train_end=date(2025, 7, 1),
+        test_start=date(2025, 8, 1),
+        test_end=date(2025, 7, 1),
+        warmup_gap_days=0,
+    )
+    tuned = {"results": {"BTCUSDT": _tune_result_change("BTCUSDT", 1.2, 5.0, 1.8)}}
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    assert fake.calls == []
+    assert report["results"] == {}
+
+
+# --------------------------------------------------------------------------- #
+# Invariant 5: unusable params land in `skipped`
+# --------------------------------------------------------------------------- #
+
+
+def test_symbol_with_no_usable_params_is_skipped(patch_auto_tune):
+    """A tune result with neither proposed nor current params (ERROR
+    path with empty current) must be recorded in `skipped`, NOT
+    silently dropped, NOT invoked on the runner."""
+    fake = patch_auto_tune()
+    window = _make_window()
+    tuned = {
+        "results": {
+            "BTCUSDT": _tune_result_change("BTCUSDT", 1.2, 5.0, 1.8),
+            "BROKEN":  {
+                "symbol": "BROKEN",
+                "current_params": None,  # corrupt
+                "proposed_params": None,
+                "recommendation": "ERROR",
+            },
+        },
+    }
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    # Only BTCUSDT reaches the runner.
+    assert [c["symbol"] for c in fake.calls] == ["BTCUSDT"]
+    # BROKEN lands in skipped with a reason.
+    assert report["skipped"] == [
+        {"symbol": "BROKEN", "reason": "no_usable_params"},
+    ]
+    # And BROKEN does NOT show up in results.
+    assert "BROKEN" not in report["results"]
+
+
+def test_no_data_recommendation_falls_back_to_current(patch_auto_tune):
+    """`recommendation == "NO_DATA"` still carries current_params; the
+    evaluator must fall back to those rather than skip."""
+    fake = patch_auto_tune()
+    window = _make_window()
+    tuned = {
+        "results": {
+            "BTCUSDT": {
+                "symbol": "BTCUSDT",
+                "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+                "current_val_pnl": 0,
+                "proposed_params": None,
+                "proposal_detail": None,
+                "recommendation": "NO_DATA",
+            },
+        },
+    }
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["params"]["atr_sl_mult"] == 1.0
+    assert "BTCUSDT" in report["results"]
+    assert report["skipped"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Empty tune result envelope
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_tune_results_yields_empty_report(patch_auto_tune):
+    fake = patch_auto_tune()
+    window = _make_window()
+    tuned = {"window_index": 0, "train_end": "2025-04-01", "results": {}}
+
+    report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
+
+    assert fake.calls == []
+    assert report["results"] == {}
+    assert report["skipped"] == []

--- a/tests/test_walk_forward_main.py
+++ b/tests/test_walk_forward_main.py
@@ -1,0 +1,291 @@
+"""Tests for `walk_forward.main()` — the CLI entry point.
+
+Commit 7 of #276 wires `--execute` to drive `run_walk_forward` +
+`aggregate_run_stats` and dump the summary as JSON. These tests cover:
+
+  1. `--dry-run` (no `--execute`) returns 0 and prints the window list
+     without invoking any orchestrator function.
+  2. `--execute --ci-mode --config-path <fixture>` with a degenerate
+     (zero-window) range returns 0 and prints a JSON summary with
+     `n_windows == 0`. This is the exact shape the CI smoke job
+     consumes — no OHLCV touched, no `auto_tune` import-time cost.
+  3. `--execute --ci-mode --config-path <fixture>` with a real window
+     range drives the loop through `frozen_params_for_window` and
+     `evaluate_window`. `auto_tune.run_backtest_with_params` and
+     `get_portfolio_symbols` are stubbed via `sys.modules` so we
+     never touch `data/ohlcv.db` (matches the discipline in
+     `tests/test_walk_forward_ci_mode.py`).
+  4. `--config-path` rejects missing files and non-object JSON with a
+     clear error rather than a stacktrace at the JSON layer.
+
+The real `api.config.load_config` is never reached — every test
+passes `--config-path` explicitly so we don't depend on the
+production config graph being on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+import walk_forward
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent / "fixtures" / "walk_forward_ci_config.json"
+)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+class _FakeAutoTune:
+    """Stand-in for `auto_tune` installed via `sys.modules`.
+
+    Records `run_backtest_with_params` calls so a test can assert the
+    runner was reached (Property 3) or NEVER reached (Properties 1, 2).
+    The sentinel return matches `auto_tune.run_backtest_with_params`'s
+    no-data path — `evaluate_window` consumes it transparently.
+    """
+
+    def __init__(self, symbols: list[str]):
+        self._symbols = list(symbols)
+        self.runner_calls: list[dict] = []
+
+    def get_portfolio_symbols(self, config):
+        return list(self._symbols)
+
+    def run_backtest_with_params(
+        self, symbol, params, sim_start, sim_end, *, app_config=None,
+    ):
+        self.runner_calls.append({
+            "symbol": symbol,
+            "params": dict(params),
+            "sim_start": sim_start,
+            "sim_end": sim_end,
+        })
+        # Mirror the "No data" sentinel — evaluate_window will record
+        # n_trades=0 + an `error` string on the per-symbol entry.
+        return [], {
+            "error": "No data",
+            "total_trades": 0,
+            "net_pnl": 0,
+            "profit_factor": 0,
+        }
+
+    def optimize_symbol(self, *args, **kwargs):  # pragma: no cover
+        raise AssertionError(
+            "optimize_symbol must not be called from the smoke CLI path"
+        )
+
+
+@pytest.fixture
+def fake_auto_tune(monkeypatch):
+    def _install(symbols):
+        fake = _FakeAutoTune(symbols)
+        monkeypatch.setitem(sys.modules, "auto_tune", fake)
+        return fake
+    return _install
+
+
+def _split_json_payload(stdout: str) -> dict:
+    """Extract the JSON block that follows the summary marker."""
+    marker = "=== walk-forward summary (JSON) ==="
+    assert marker in stdout, (
+        f"summary marker missing from stdout; got:\n{stdout!r}"
+    )
+    _, _, payload = stdout.partition(marker)
+    return json.loads(payload.strip())
+
+
+# --------------------------------------------------------------------------- #
+# Property 1: --dry-run prints windows, exits 0, never touches the orchestrator
+# --------------------------------------------------------------------------- #
+
+
+def test_dry_run_no_execute(capsys, monkeypatch):
+    """Without `--execute`, the CLI must not invoke `run_walk_forward`."""
+    run_calls: list = []
+
+    def boom_run(*args, **kwargs):  # pragma: no cover — must not be reached
+        run_calls.append(1)
+        raise AssertionError("run_walk_forward called without --execute")
+
+    monkeypatch.setattr(walk_forward, "run_walk_forward", boom_run)
+
+    rc = walk_forward.main([
+        "--history-start", "2023-01-01",
+        "--history-end",   "2024-06-30",
+        "--holdout-start", "2026-01-01",
+        "--initial-train-months", "6",
+        "--test-months", "3",
+        "--step-months", "3",
+        "--dry-run",
+    ])
+
+    assert rc == 0
+    assert run_calls == []
+    out = capsys.readouterr().out
+    # Smoke check: at least one window row printed.
+    assert "train 2023-01-01" in out
+
+
+# --------------------------------------------------------------------------- #
+# Property 2: --execute on a zero-window range emits a clean JSON summary
+# --------------------------------------------------------------------------- #
+
+
+def test_execute_zero_windows_emits_json(capsys, fake_auto_tune):
+    """A range that yields no windows still produces a valid summary.
+
+    This is the exact configuration the CI smoke job runs: small enough
+    that `compute_windows` returns `[]`, so the orchestrator never
+    reaches `auto_tune` and the OHLCV layer is not touched.
+    """
+    fake = fake_auto_tune(["BTCUSDT"])
+
+    rc = walk_forward.main([
+        "--history-start", "2023-01-01",
+        "--history-end",   "2023-02-01",
+        "--holdout-start", "2026-01-01",
+        # initial_train (12mo) > available history → zero windows.
+        "--initial-train-months", "12",
+        "--test-months", "3",
+        "--step-months", "3",
+        "--execute",
+        "--ci-mode",
+        "--config-path", str(FIXTURE_PATH),
+    ])
+
+    # Zero windows = exit code 1 per the existing "no windows" branch.
+    # The summary JSON is intentionally NOT printed in that case (the
+    # branch returns before `--execute` lands). This is the right shape
+    # for CI: if a range degenerates, surface a non-zero exit.
+    assert rc == 1
+    assert fake.runner_calls == []
+
+
+def test_execute_zero_windows_via_holdout_clip(capsys, fake_auto_tune):
+    """Alternate zero-window construction: holdout sits before any test
+    window would land. The `--execute` branch still emits the summary
+    JSON because windows were *requested* but pruned to zero.
+
+    Reality check: the current main() short-circuits on `not windows`
+    BEFORE the `--execute` branch (returns 1). Both branches collapse
+    to the same exit semantics; this test pins the contract so a
+    future refactor that re-orders the branches still fails loudly if
+    it accidentally emits JSON on a degenerate range.
+    """
+    fake = fake_auto_tune(["BTCUSDT"])
+
+    rc = walk_forward.main([
+        "--history-start", "2024-01-01",
+        "--history-end",   "2024-02-01",
+        "--holdout-start", "2024-01-15",
+        "--initial-train-months", "6",
+        "--test-months", "3",
+        "--step-months", "3",
+        "--execute",
+        "--ci-mode",
+        "--config-path", str(FIXTURE_PATH),
+    ])
+
+    assert rc == 1
+    assert fake.runner_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Property 3: --execute with real windows drives frozen path + evaluate_window
+# --------------------------------------------------------------------------- #
+
+
+def test_execute_drives_full_pipeline(capsys, fake_auto_tune):
+    """A real range produces windows, runs `frozen_params_for_window`
+    per fold, calls the (stubbed) runner, and emits a parseable JSON
+    summary on stdout.
+
+    The fake `auto_tune` returns the no-data sentinel — so we expect
+    `total_trades == 0` and `n_windows_with_trades == 0`. The point is
+    that the orchestrator + aggregator wiring is exercised end-to-end.
+    """
+    fake = fake_auto_tune(["BTCUSDT", "ETHUSDT"])
+
+    rc = walk_forward.main([
+        "--history-start", "2023-01-01",
+        "--history-end",   "2024-06-30",
+        "--holdout-start", "2026-01-01",
+        "--initial-train-months", "6",
+        "--test-months", "3",
+        "--step-months", "3",
+        "--execute",
+        "--ci-mode",
+        "--config-path", str(FIXTURE_PATH),
+    ])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    summary = _split_json_payload(out)
+
+    # Wiring assertions — shape, not numbers.
+    assert summary["n_windows"] >= 1
+    assert summary["total_trades"] == 0
+    assert summary["n_windows_with_trades"] == 0
+    assert "cv" in summary and isinstance(summary["cv"], dict)
+    assert "oos_is_ratio" in summary
+    assert summary["oos_is_ratio"]["metric"] == "net_pnl"
+
+    # Runner was reached per (window, symbol) cell that produced frozen
+    # params. The fixture lists 2 symbols, each with full ATR overrides
+    # → both reach the runner per window.
+    assert len(fake.runner_calls) == 2 * summary["n_windows"]
+    runner_symbols = {c["symbol"] for c in fake.runner_calls}
+    assert runner_symbols == {"BTCUSDT", "ETHUSDT"}
+
+
+# --------------------------------------------------------------------------- #
+# Property 4: --config-path validation
+# --------------------------------------------------------------------------- #
+
+
+def test_config_path_missing_file_raises(tmp_path, fake_auto_tune):
+    """A non-existent --config-path must error loudly, not silently
+    fall back to load_config().
+    """
+    fake_auto_tune(["BTCUSDT"])
+    missing = tmp_path / "does_not_exist.json"
+    with pytest.raises(FileNotFoundError):
+        walk_forward.main([
+            "--history-start", "2023-01-01",
+            "--history-end",   "2024-06-30",
+            "--holdout-start", "2026-01-01",
+            "--initial-train-months", "6",
+            "--test-months", "3",
+            "--step-months", "3",
+            "--execute",
+            "--ci-mode",
+            "--config-path", str(missing),
+        ])
+
+
+def test_config_path_non_object_rejected(tmp_path, fake_auto_tune):
+    """A JSON file whose top level is not an object must be rejected."""
+    fake_auto_tune(["BTCUSDT"])
+    bad = tmp_path / "bad.json"
+    bad.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON object"):
+        walk_forward.main([
+            "--history-start", "2023-01-01",
+            "--history-end",   "2024-06-30",
+            "--holdout-start", "2026-01-01",
+            "--initial-train-months", "6",
+            "--test-months", "3",
+            "--step-months", "3",
+            "--execute",
+            "--ci-mode",
+            "--config-path", str(bad),
+        ])

--- a/tests/test_walk_forward_tune.py
+++ b/tests/test_walk_forward_tune.py
@@ -1,0 +1,238 @@
+"""Tests for `walk_forward.tune_window`.
+
+This module covers the per-window integration into `auto_tune.optimize_symbol`
+added in commit 3 of #276. The real optimizer takes minutes per symbol and
+hits OHLCV / regime data; both are mocked here so the test runs in
+milliseconds and never reaches across the holdout boundary.
+
+Invariants exercised:
+
+  1. `optimize_symbol` is called exactly once per symbol that
+     `get_portfolio_symbols` returns.
+  2. Each call passes `today=cutoff=<train_end at midnight UTC, tz-aware>`.
+  3. Per-symbol returns are aggregated into `results[symbol]` preserving
+     the symbol order from `get_portfolio_symbols`.
+  4. Empty / single-symbol / multi-symbol portfolios all behave correctly.
+
+The real `auto_tune.optimize_symbol` is NEVER invoked. Any test that lets
+it through would take minutes and would also break the holdout safety
+contract by touching live OHLCV state.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+import walk_forward
+from walk_forward import Window, tune_window
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_window(train_end: date, index: int = 0) -> Window:
+    """Build a Window where only `train_end` and `index` matter for tune_window.
+
+    The other fields are filled with consistent placeholders so the
+    `frozen=True` dataclass invariants are satisfied.
+    """
+    return Window(
+        index=index,
+        train_start=date(2023, 1, 1),
+        train_end=train_end,
+        test_start=train_end,
+        test_end=date(train_end.year, train_end.month, train_end.day),
+        warmup_gap_days=0,
+    )
+
+
+class _FakeAutoTune:
+    """Stand-in for the `auto_tune` module.
+
+    Records every `optimize_symbol` invocation so tests can assert on
+    argument shape, call count, and ordering.
+    """
+
+    def __init__(self, symbols: list[str]):
+        self._symbols = list(symbols)
+        self.calls: list[dict] = []
+
+    def get_portfolio_symbols(self, config: dict) -> list[str]:
+        # Return a fresh list so the caller cannot mutate our state.
+        return list(self._symbols)
+
+    def optimize_symbol(self, symbol, config, today=None, *, cutoff=None):
+        self.calls.append(
+            {
+                "symbol": symbol,
+                "config_id": id(config),
+                "today": today,
+                "cutoff": cutoff,
+            }
+        )
+        return {
+            "symbol": symbol,
+            "recommendation": "KEEP_CURRENT",
+            "current_params": {"atr_sl_mult": 1.0},
+            "current_val_pnl": 0,
+            "proposed_params": None,
+            "proposal_detail": None,
+        }
+
+
+@pytest.fixture
+def patch_auto_tune(monkeypatch):
+    """Inject a `_FakeAutoTune` in place of the real module.
+
+    Returns a factory the test can call with the symbol list it wants the
+    fake to advertise via `get_portfolio_symbols`.
+    """
+
+    def _install(symbols: list[str]) -> _FakeAutoTune:
+        fake = _FakeAutoTune(symbols)
+        # `tune_window` imports `auto_tune` lazily inside the function body,
+        # so we patch the module-level binding via sys.modules.
+        import sys
+
+        monkeypatch.setitem(sys.modules, "auto_tune", fake)
+        return fake
+
+    return _install
+
+
+# --------------------------------------------------------------------------- #
+# Property 1: one call per symbol, in order
+# --------------------------------------------------------------------------- #
+
+
+def test_calls_optimize_symbol_once_per_portfolio_symbol(patch_auto_tune):
+    symbols = ["BTCUSDT", "ETHUSDT", "SOLUSDT"]
+    fake = patch_auto_tune(symbols)
+
+    window = _make_window(train_end=date(2025, 6, 30))
+    config = {"symbol_overrides": {}}
+
+    out = tune_window(window, config)
+
+    assert [c["symbol"] for c in fake.calls] == symbols, (
+        "optimize_symbol must be called once per active symbol, in the "
+        "order returned by get_portfolio_symbols"
+    )
+    assert set(out["results"].keys()) == set(symbols)
+
+
+# --------------------------------------------------------------------------- #
+# Property 2: today=cutoff=train_end (UTC midnight, tz-aware)
+# --------------------------------------------------------------------------- #
+
+
+def test_passes_train_end_as_today_and_cutoff(patch_auto_tune):
+    fake = patch_auto_tune(["BTCUSDT"])
+    train_end = date(2025, 6, 30)
+    window = _make_window(train_end=train_end)
+    config = {"symbol_overrides": {}}
+
+    tune_window(window, config)
+
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    expected = datetime(2025, 6, 30, tzinfo=timezone.utc)
+    assert call["today"] == expected, (
+        f"today must equal train_end at UTC midnight; got {call['today']!r}"
+    )
+    assert call["cutoff"] == expected, (
+        f"cutoff must equal train_end at UTC midnight; got {call['cutoff']!r}"
+    )
+    # Both today and cutoff must be the same object-shape: tz-aware UTC.
+    assert call["today"].tzinfo is not None
+    assert call["cutoff"].tzinfo is not None
+
+
+# --------------------------------------------------------------------------- #
+# Property 3: per-symbol returns aggregated under `results`
+# --------------------------------------------------------------------------- #
+
+
+def test_aggregates_per_symbol_returns(patch_auto_tune):
+    symbols = ["BTCUSDT", "ETHUSDT"]
+    patch_auto_tune(symbols)
+
+    window = _make_window(train_end=date(2025, 6, 30), index=4)
+    out = tune_window(window, {"symbol_overrides": {}})
+
+    assert out["window_index"] == 4
+    assert out["train_end"] == "2025-06-30"
+    assert out["cutoff"].startswith("2025-06-30T00:00:00")
+    assert set(out["results"]) == set(symbols)
+    for sym in symbols:
+        r = out["results"][sym]
+        assert r["symbol"] == sym
+        assert r["recommendation"] == "KEEP_CURRENT"
+
+
+# --------------------------------------------------------------------------- #
+# Property 4: edge cases
+# --------------------------------------------------------------------------- #
+
+
+def test_empty_portfolio_yields_empty_results(patch_auto_tune):
+    fake = patch_auto_tune([])  # no active symbols
+    window = _make_window(train_end=date(2025, 6, 30))
+
+    out = tune_window(window, {"symbol_overrides": {}})
+
+    assert fake.calls == [], "no symbols → no optimize_symbol calls"
+    assert out["results"] == {}
+    assert out["window_index"] == 0
+    assert out["train_end"] == "2025-06-30"
+
+
+def test_single_symbol_portfolio(patch_auto_tune):
+    fake = patch_auto_tune(["BTCUSDT"])
+    window = _make_window(train_end=date(2024, 12, 31))
+
+    out = tune_window(window, {"symbol_overrides": {}})
+
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["symbol"] == "BTCUSDT"
+    assert list(out["results"]) == ["BTCUSDT"]
+
+
+def test_multiple_symbols_preserve_order(patch_auto_tune):
+    # Non-alphabetical input to make the order-preservation assertion bite.
+    symbols = ["SOLUSDT", "BTCUSDT", "ETHUSDT", "AVAXUSDT"]
+    fake = patch_auto_tune(symbols)
+    window = _make_window(train_end=date(2025, 3, 31))
+
+    tune_window(window, {"symbol_overrides": {}})
+
+    assert [c["symbol"] for c in fake.calls] == symbols
+
+
+# --------------------------------------------------------------------------- #
+# Internal: _train_end_to_cutoff helper
+# --------------------------------------------------------------------------- #
+
+
+def test_train_end_to_cutoff_from_date_is_utc_midnight():
+    out = walk_forward._train_end_to_cutoff(date(2025, 6, 30))
+    assert out == datetime(2025, 6, 30, tzinfo=timezone.utc)
+    assert out.tzinfo is not None
+
+
+def test_train_end_to_cutoff_from_naive_datetime_attaches_utc():
+    naive = datetime(2025, 6, 30, 12, 34, 56)
+    out = walk_forward._train_end_to_cutoff(naive)
+    assert out.tzinfo is timezone.utc
+    # The walltime is preserved; only tz is attached.
+    assert out.replace(tzinfo=None) == naive
+
+
+def test_train_end_to_cutoff_from_aware_datetime_is_passthrough():
+    aware = datetime(2025, 6, 30, 12, 34, 56, tzinfo=timezone.utc)
+    out = walk_forward._train_end_to_cutoff(aware)
+    assert out == aware

--- a/tests/test_walk_forward_windows.py
+++ b/tests/test_walk_forward_windows.py
@@ -1,0 +1,184 @@
+"""Property tests for `walk_forward.compute_windows`.
+
+Four invariants the harness must guarantee for #276:
+
+  1. Anchored: every window.train_start == history_start.
+  2. Non-overlap: consecutive test ranges are disjoint.
+  3. Holdout-exclusion: no window's test span touches holdout_start.
+  4. Warmup-gap: test_start - train_end >= warmup_gap_days.
+
+These tests are intentionally small and deterministic — no strategy
+execution, no data files, no DB. The scaffold passes them and any future
+edit to the window math has to keep passing them.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from walk_forward import Window, compute_windows
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def base_config() -> dict:
+    """Three-year history, 12-month initial train, 3-month test, 3-month step.
+
+    Yields six folds before bumping against the holdout edge.
+    """
+    return dict(
+        history_start=date(2023, 1, 1),
+        history_end=date(2025, 12, 31),
+        holdout_start=date(2026, 1, 1),
+        initial_train_months=12,
+        test_months=3,
+        step_months=3,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Property 1: anchored
+# --------------------------------------------------------------------------- #
+
+
+def test_anchored_mode_pins_train_start(base_config):
+    windows = compute_windows(**base_config)
+    assert len(windows) > 0, "fixture should yield at least one fold"
+    for w in windows:
+        assert w.train_start == base_config["history_start"], (
+            f"window {w.index} train_start={w.train_start} drifted from "
+            f"history_start={base_config['history_start']}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Property 2: non-overlap
+# --------------------------------------------------------------------------- #
+
+
+def test_test_ranges_do_not_overlap(base_config):
+    windows = compute_windows(**base_config)
+    assert len(windows) >= 2, "need at least two folds to test overlap"
+    for prev, curr in zip(windows, windows[1:]):
+        assert prev.test_end <= curr.test_start, (
+            f"overlap: window {prev.index} test_end={prev.test_end} > "
+            f"window {curr.index} test_start={curr.test_start}"
+        )
+
+
+def test_test_ranges_strictly_advance(base_config):
+    """Stronger than non-overlap: each test_start is past the previous one."""
+    windows = compute_windows(**base_config)
+    for prev, curr in zip(windows, windows[1:]):
+        assert curr.test_start > prev.test_start
+        assert curr.test_end > prev.test_end
+
+
+# --------------------------------------------------------------------------- #
+# Property 3: holdout exclusion
+# --------------------------------------------------------------------------- #
+
+
+def test_no_window_touches_holdout(base_config):
+    windows = compute_windows(**base_config)
+    for w in windows:
+        assert w.test_end <= base_config["holdout_start"], (
+            f"window {w.index} test_end={w.test_end} crosses holdout_start="
+            f"{base_config['holdout_start']}"
+        )
+        assert w.train_end <= base_config["holdout_start"]
+
+
+def test_holdout_clips_history_end(base_config):
+    """history_end past holdout_start gets silently clipped to holdout_start."""
+    cfg = {**base_config, "history_end": date(2030, 1, 1)}
+    windows = compute_windows(**cfg)
+    for w in windows:
+        assert w.test_end <= base_config["holdout_start"]
+
+
+def test_holdout_at_history_start_yields_no_folds():
+    windows = compute_windows(
+        history_start=date(2024, 1, 1),
+        history_end=date(2025, 1, 1),
+        holdout_start=date(2024, 1, 1),
+        initial_train_months=12,
+        test_months=3,
+        step_months=3,
+    )
+    assert windows == []
+
+
+# --------------------------------------------------------------------------- #
+# Property 4: warmup gap
+# --------------------------------------------------------------------------- #
+
+
+def test_warmup_gap_zero_default(base_config):
+    windows = compute_windows(**base_config)
+    for w in windows:
+        assert (w.test_start - w.train_end).days == 0
+        assert w.warmup_gap_days == 0
+
+
+def test_warmup_gap_respected_when_positive(base_config):
+    gap = 7
+    windows = compute_windows(**base_config, warmup_gap_days=gap)
+    assert len(windows) > 0
+    for w in windows:
+        delta_days = (w.test_start - w.train_end).days
+        assert delta_days >= gap, (
+            f"window {w.index} warmup gap {delta_days}d < requested {gap}d"
+        )
+        assert w.warmup_gap_days == gap
+
+
+# --------------------------------------------------------------------------- #
+# Sanity / construction tests
+# --------------------------------------------------------------------------- #
+
+
+def test_window_is_frozen_dataclass(base_config):
+    windows = compute_windows(**base_config)
+    w = windows[0]
+    assert isinstance(w, Window)
+    with pytest.raises(Exception):
+        w.train_start = date(1999, 1, 1)  # type: ignore[misc]
+
+
+def test_string_dates_accepted():
+    windows = compute_windows(
+        history_start="2023-01-01",
+        history_end="2025-12-31",
+        holdout_start="2026-01-01",
+        initial_train_months=12,
+        test_months=3,
+        step_months=3,
+    )
+    assert all(w.train_start == date(2023, 1, 1) for w in windows)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(initial_train_months=0),
+        dict(test_months=0),
+        dict(step_months=0),
+        dict(warmup_gap_days=-1),
+    ],
+)
+def test_invalid_arguments_raise(base_config, kwargs):
+    cfg = {**base_config, **kwargs}
+    with pytest.raises(ValueError):
+        compute_windows(**cfg)
+
+
+def test_rolling_mode_not_implemented(base_config):
+    with pytest.raises(NotImplementedError):
+        compute_windows(**base_config, anchored=False)

--- a/tests/test_walk_forward_windows.py
+++ b/tests/test_walk_forward_windows.py
@@ -18,7 +18,7 @@ from datetime import date
 
 import pytest
 
-from walk_forward import Window, compute_windows
+from walk_forward import Window, compute_windows, compute_warmup_bars
 
 
 # --------------------------------------------------------------------------- #
@@ -182,3 +182,73 @@ def test_invalid_arguments_raise(base_config, kwargs):
 def test_rolling_mode_not_implemented(base_config):
     with pytest.raises(NotImplementedError):
         compute_windows(**base_config, anchored=False)
+
+
+# --------------------------------------------------------------------------- #
+# Warmup bars (commit 2 of #276)
+# --------------------------------------------------------------------------- #
+#
+# Indicator lookbacks are sourced from strategy/constants.py and the active
+# call sites in strategy/core.py / strategy/regime.py / strategy/patterns.py.
+# The expected values below are the maximum lookback per TF that the harness
+# must respect when slicing fold history.
+
+
+def test_warmup_bars_4h_dominated_by_sma100():
+    """4h path runs SMA100 (strategy/core.py:576). Nothing on 4h goes deeper."""
+    assert compute_warmup_bars("4h") == 100
+
+
+def test_warmup_bars_1h_dominated_by_sma200():
+    """1h path runs LRC100 + SMA200 (computed unconditionally, core.py:556-559).
+
+    SMA200 1h is computed on every bar (the value is exposed in
+    `decision.indicators` regardless of the `trend_pullback_enabled` flag,
+    which only feature-gates its downstream *use*). Compute-warmup must
+    therefore cover it. If SMA200 1h is removed from the compute path,
+    drop this back to 100.
+    """
+    assert compute_warmup_bars("1h") == 200
+
+
+def test_warmup_bars_5m_dominated_by_bb20():
+    """5m path runs RSI14 + BB20 + VOL20 (patterns.py / core.py)."""
+    assert compute_warmup_bars("5m") == 20
+
+
+@pytest.mark.parametrize("tf", ["4h", "1h", "5m"])
+def test_warmup_bars_returns_positive_int(tf):
+    bars = compute_warmup_bars(tf)
+    assert isinstance(bars, int)
+    assert bars > 0
+
+
+@pytest.mark.parametrize(
+    "tf,floor",
+    [
+        ("4h", 100),   # SMA100
+        ("1h", 200),   # SMA200 1h computed unconditionally (use is feature-gated)
+        ("5m", 20),    # BB20 / VOL20
+    ],
+)
+def test_warmup_bars_at_least_declared_max(tf, floor):
+    """Sanity: the return value is never below the declared max for the TF."""
+    assert compute_warmup_bars(tf) >= floor
+
+
+@pytest.mark.parametrize("tf", ["4H", "1H", "5M", " 1h "])
+def test_warmup_bars_case_and_whitespace_insensitive(tf):
+    """Operators type these by hand. Be lenient with case + surrounding space."""
+    assert compute_warmup_bars(tf) > 0
+
+
+@pytest.mark.parametrize("bad_tf", ["", "1d", "15m", "2h", "1w", "foo"])
+def test_warmup_bars_rejects_unknown_timeframe(bad_tf):
+    with pytest.raises(ValueError):
+        compute_warmup_bars(bad_tf)
+
+
+@pytest.mark.parametrize("bad", [None, 60, 1.0, ("1h",)])
+def test_warmup_bars_rejects_non_string(bad):
+    with pytest.raises(ValueError):
+        compute_warmup_bars(bad)  # type: ignore[arg-type]

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -677,12 +677,79 @@ def _fold_error_report(window: Window, phase: str, exc: BaseException) -> dict:
     }
 
 
-def run_walk_forward(windows: list[Window], app_config: dict) -> WalkForwardRun:
+def frozen_params_for_window(window: Window, app_config: dict) -> dict:
+    """Build a `tune_window`-shaped dict from frozen `symbol_overrides` ATR
+    params, without running `auto_tune.optimize_symbol` at all.
+
+    Rationale (commit 6 of #276): CI cannot afford to drive the real
+    optimizer per window — `optimize_symbol` is minutes per symbol and
+    walks the full grid. For smoke / regression tests the loop only
+    needs to prove that orchestration + eval is wired correctly; the
+    tuning recommendation itself can be replaced by the params already
+    present in `app_config["symbol_overrides"]`. This function
+    materialises that substitution.
+
+    Contract:
+      - Output shape is byte-compatible with `tune_window` so
+        downstream `evaluate_window` + `_build_is_pnl_block` consume it
+        without branching on a "frozen" flag.
+      - One entry per symbol in `get_portfolio_symbols(app_config)`
+        whose override is a dict carrying all three ATR keys
+        (`atr_sl_mult`, `atr_tp_mult`, `atr_be_mult`). Symbols missing
+        any key are skipped: there is no params to freeze.
+      - Recommendation is always `"KEEP_CURRENT"`. `proposed_params`
+        and `proposal_detail` are `None`. `current_val_pnl` is `0.0`
+        because no IS measurement was taken — the aggregator's
+        OOS/IS ratio in CI mode therefore reports `is_pnl_near_zero`,
+        which is the honest signal (we did not measure IS).
+
+    Holdout safety (Non-Negotiable #3):
+      - No data is loaded. No `optimize_symbol` is invoked. No
+        backtest runs. The function reads `symbol_overrides` from the
+        in-memory config dict and nothing else. The locked snapshot is
+        not touched even indirectly.
+    """
+    import auto_tune  # noqa: PLC0415 — same import policy as tune_window
+
+    symbols = auto_tune.get_portfolio_symbols(app_config)
+    overrides = (app_config or {}).get("symbol_overrides", {}) or {}
+    cutoff = _train_end_to_cutoff(window.train_end)
+
+    results: dict[str, dict] = {}
+    for sym in symbols:
+        sym_cfg = overrides.get(sym)
+        if not isinstance(sym_cfg, dict):
+            continue
+        if not all(k in sym_cfg for k in _TUNED_PARAM_KEYS):
+            continue
+        frozen = {k: sym_cfg[k] for k in _TUNED_PARAM_KEYS}
+        results[sym] = {
+            "symbol": sym,
+            "recommendation": "KEEP_CURRENT",
+            "current_params": frozen,
+            "current_val_pnl": 0.0,
+            "proposed_params": None,
+            "proposal_detail": None,
+        }
+
+    return {
+        "window_index": window.index,
+        "train_end": window.train_end.isoformat(),
+        "cutoff": cutoff.isoformat(),
+        "results": results,
+    }
+
+
+def run_walk_forward(
+    windows: list[Window],
+    app_config: dict,
+    ci_mode: bool = False,
+) -> WalkForwardRun:
     """Drive `tune_window` → `evaluate_window` over every fold in `windows`.
 
     The loop is in-process and single-threaded. Process-pool / async
-    orchestration is deferred to a downstream commit (commit 6/7 of
-    #276 if the cost profile justifies it).
+    orchestration is deferred to a downstream commit of #276 if the
+    cost profile justifies it.
 
     Best-effort policy: a per-window exception in tune or evaluate is
     recorded on that fold's report under `"error"` and iteration
@@ -694,6 +761,13 @@ def run_walk_forward(windows: list[Window], app_config: dict) -> WalkForwardRun:
         windows: Output of `compute_windows`. May be empty.
         app_config: Application config dict, propagated unchanged to
             `tune_window` and `evaluate_window`.
+        ci_mode: When True, replace the per-window tune step with
+            `frozen_params_for_window` — uses the ATR multipliers
+            already in `symbol_overrides` instead of invoking the
+            optimizer. The orchestrator's contract with
+            `evaluate_window` (and the resulting report shape) is
+            unchanged; only the source of per-symbol params differs.
+            Default False (production behaviour unchanged).
 
     Returns:
         A `WalkForwardRun` carrying the original window list and one
@@ -706,7 +780,10 @@ def run_walk_forward(windows: list[Window], app_config: dict) -> WalkForwardRun:
     reports: list[dict] = []
     for window in windows:
         try:
-            tuned = tune_window(window, app_config)
+            if ci_mode:
+                tuned = frozen_params_for_window(window, app_config)
+            else:
+                tuned = tune_window(window, app_config)
         except BaseException as exc:  # noqa: BLE001 — best-effort across folds
             log.warning(
                 "walk_forward: tune_window failed on window %d (%s): %s",
@@ -1144,6 +1221,15 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print computed windows and exit. Currently the only mode.",
     )
+    p.add_argument(
+        "--ci-mode",
+        action="store_true",
+        help=(
+            "Skip per-window auto_tune.optimize_symbol calls; reuse the "
+            "ATR multipliers already in symbol_overrides as frozen params. "
+            "Cheap enough for CI smoke runs. Default off (production)."
+        ),
+    )
     return p
 
 
@@ -1177,6 +1263,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     _print_windows(windows)
+
+    if args.ci_mode:
+        log.info(
+            "ci-mode requested: when the execution path lands, "
+            "tuning will be skipped and symbol_overrides ATR params "
+            "will be used as frozen params per window."
+        )
 
     if not args.dry_run:
         log.warning(

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -1202,6 +1202,160 @@ def _best_worst(reports: list[dict]) -> tuple[dict | None, dict | None]:
 
 
 # --------------------------------------------------------------------------- #
+# Final-winner holdout evaluation (commit 8 of #276) — WIRED, NOT INVOKED
+# --------------------------------------------------------------------------- #
+#
+# This is the last leg of the harness: once a walk-forward run has produced a
+# single winning parameter set, A.4-3 evaluates that winner ONCE against the
+# locked out-of-sample snapshot under `data/holdout/`. That read is the bala
+# única — there is exactly one honest shot at it, and a partial peek burns it
+# just as surely as a full run.
+#
+# Per Non-Negotiable #3 and decisions.md §Caveat 5 (#322), A.4-3 holdout
+# execution is BLOCKED until ALL THREE closure criteria for #322 are met:
+#   1. the pre-holdout re-tune produces viable candidates (not NO_DATA), AND
+#   2. the A.4-2 walk-forward passes, AND
+#   3. the drift check on the holdout snapshots is completed.
+#
+# Until then this leg is wired but unreachable. The gate below is a hard
+# `raise HoldoutExecutionBlocked` placed BEFORE any `open_holdout(...)` call,
+# guarded by a module constant (`_HOLDOUT_322_CLOSED`) that defaults to
+# "blocked". This constant is a KILL-SWITCH, not a cryptographic lock: a
+# deliberate, reviewed PR can reassign it (and the test in fix B that asserts
+# it stays False) once #322 closure criteria are met — and module-attribute
+# reassignment is the idiomatic mechanism here (the test suite already uses
+# `monkeypatch.setattr(walk_forward, ...)`). The REAL control is PROCEDURAL:
+# the human-reviewed PR is the checkpoint that the bala única is being spent
+# intentionally, NOT the immutability of the constant. That is by design — the
+# review is the gate, not the inability to reassign an attribute.
+#
+# The `open_holdout(..., evaluation_mode=True)` call is written below so the
+# access shape is correct, wired, and review-auditable the day #322 closes. It
+# is the only legitimate read of `data/holdout/` (Non-Negotiable #2). To make a
+# stray peek impossible even if the kill-switch were flipped without finishing
+# #322, the `raise NotImplementedError` is placed BEFORE `open_holdout(...)`:
+# the access wrapper is unreachable until the NotImplementedError is ALSO
+# removed (which is #322-closure work). open_holdout therefore stays grep-able
+# and wired as the integration point, but cannot run today.
+
+
+class HoldoutExecutionBlocked(RuntimeError):
+    """Raised when A.4-3 holdout evaluation is attempted while #322 is open.
+
+    This is the harness-level guard for Non-Negotiable #3. It fires *before*
+    any holdout read, so no partial peek is possible. It is distinct from
+    `data.holdout_access.HoldoutAccessError` (the wrapper-level guard): this
+    one says "the harness is not authorised to run A.4-3 yet", the wrapper
+    one says "you reached the wrapper without evaluation_mode=True".
+    """
+
+
+# A.4-3 kill-switch. Defaults to False = BLOCKED. Flipping this to True is a
+# reviewed decision tied to #322 closure (re-tune candidates AND A.4-2 pass
+# AND drift check done — see decisions.md §Caveat 5). It is a module constant
+# so there is no caller-supplied runtime path, no kwarg, and no env var that
+# flips it: the only ways to reach holdout execution are (a) reassign this
+# attribute and (b) remove the NotImplementedError below — both edits live in
+# source and both are caught in PR review. The constant is NOT immune to
+# deliberate `walk_forward._HOLDOUT_322_CLOSED = True` reassignment (the suite
+# uses `monkeypatch.setattr` on this very module), and it is not meant to be:
+# the human-reviewed PR is the checkpoint that the bala única is being spent
+# intentionally, not the immutability of the symbol.
+_HOLDOUT_322_CLOSED: bool = False
+
+
+def evaluate_winner_on_holdout(
+    winning_params_by_symbol: dict,
+    config: dict,
+    *,
+    holdout_rel_path: str,
+) -> dict:
+    """Evaluate the walk-forward winner ONCE against the locked holdout.
+
+    A.4-3, the final leg of #276. Consumes a single winning parameter set
+    (per symbol) selected from a completed walk-forward run and scores it on
+    the out-of-sample snapshot under `data/holdout/`. This is the bala única:
+    one honest shot, no peeking.
+
+    **This function is wired but CANNOT execute today.** Per Non-Negotiable #3
+    and decisions.md §Caveat 5 (#322), A.4-3 is blocked until the re-tune
+    produces candidates, A.4-2 passes, and the drift check is done.
+
+    The block is enforced by ONE access guard: the hard
+    ``HoldoutExecutionBlocked`` raise gated on ``_HOLDOUT_322_CLOSED`` (default
+    False). That raise is the only thing standing between a caller and the
+    holdout read. ``_HOLDOUT_322_CLOSED`` is a kill-switch, not a cryptographic
+    lock — a reviewed PR can reassign it (and edit the fix-B test that asserts
+    it stays False); the human review IS the checkpoint, by design. There is no
+    caller-supplied runtime path, kwarg, or env var that flips it.
+
+    A second statement — the ``NotImplementedError`` raised BEFORE
+    ``open_holdout(...)`` — marks that the A.4-3 evaluation body is
+    intentionally undefined until #322 closes. It is NOT a second guard on the
+    read; it is a placeholder that also has to be removed for the read to
+    become reachable, which adds one more line of #322-closure work in front of
+    the bala única. As a result ``open_holdout(...)`` stays grep-able and wired
+    as the integration point but is unreachable today even if the kill-switch
+    were flipped on its own.
+
+    Args:
+        winning_params_by_symbol: ``{symbol: {atr_sl_mult, atr_tp_mult,
+            atr_be_mult}}`` — the single winner chosen from the run.
+        config: Application config dict (same shape the rest of the harness
+            consumes).
+        holdout_rel_path: Relative path inside `data/holdout/` to load, resolved
+            through the access wrapper. Required (no default): `data/holdout/`
+            holds parquet/JSON snapshots, not a single sqlite file, so the
+            #322-closure PR must name the real target explicitly rather than
+            inherit an invented layout.
+
+    Returns:
+        A holdout evaluation report (shape TBD when A.4-3 is unblocked —
+        defined alongside the closure of #322, not invented here).
+
+    Raises:
+        HoldoutExecutionBlocked: Always, while `_HOLDOUT_322_CLOSED` is False.
+            This is the load-bearing access guard. Do not remove it, do not
+            pass a flag to skip it, do not flip the constant outside a
+            #322-closure PR.
+    """
+    # ── HARD GATE (Non-Negotiable #3 / #322) ──────────────────────────────
+    # This raise precedes every holdout access below. While #322 is open the
+    # bala única stays in the chamber — no full run, no partial peek. This is
+    # the ONLY guard on the holdout read.
+    if not _HOLDOUT_322_CLOSED:
+        raise HoldoutExecutionBlocked(
+            "A.4-3 holdout execution is blocked until #322 closure criteria "
+            "are ALL met: (1) pre-holdout re-tune produces viable candidates, "
+            "(2) A.4-2 walk-forward passes, (3) drift check on holdout "
+            "snapshots completed. See CLAUDE.md Non-Negotiable #3 and "
+            ".mex/context/decisions.md §Caveat 5. A partial peek burns the "
+            "bala única just as surely as a full run."
+        )
+
+    # ── Unreachable until #322 closes ─────────────────────────────────────
+    # The NotImplementedError is placed BEFORE open_holdout on purpose: even if
+    # the kill-switch above were flipped, control still cannot reach the read
+    # until this line is also removed (#322-closure work). The body of A.4-3 is
+    # intentionally undefined here.
+    raise NotImplementedError(
+        "A.4-3 evaluation body is defined alongside #322 closure, not here."
+    )
+
+    # The only legitimate entry to data/holdout/ is the access wrapper with
+    # evaluation_mode=True (Non-Negotiable #2) — no string literals, no
+    # Path(...) / "holdout". This call is the wired, grep-able integration
+    # point; it is unreachable until the raise above is removed at #322 closure.
+    from data.holdout_access import open_holdout  # noqa: PLC0415
+
+    holdout_db = open_holdout(holdout_rel_path, evaluation_mode=True)
+    raise NotImplementedError(  # pragma: no cover
+        f"A.4-3 evaluation body is defined alongside #322 closure, not here. "
+        f"Resolved holdout path would be: {holdout_db}"
+    )
+
+
+# --------------------------------------------------------------------------- #
 # CLI (placeholder — no strategy execution yet)
 # --------------------------------------------------------------------------- #
 

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -29,10 +29,12 @@ up — see issue #276 for the staged rollout.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sys
 from dataclasses import dataclass, asdict
 from datetime import date, datetime, timezone
+from pathlib import Path
 from typing import Iterable
 
 from dateutil.relativedelta import relativedelta
@@ -1230,6 +1232,28 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "Cheap enough for CI smoke runs. Default off (production)."
         ),
     )
+    p.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Drive run_walk_forward + aggregate_run_stats over the computed "
+            "windows and print the aggregate summary as JSON on stdout. "
+            "Without --ci-mode this calls the real optimizer per window "
+            "(minutes per symbol). With --ci-mode the loop uses frozen "
+            "symbol_overrides params — cheap enough for CI smoke runs."
+        ),
+    )
+    p.add_argument(
+        "--config-path",
+        type=str,
+        default=None,
+        help=(
+            "Path to a JSON file used as the app_config dict. When omitted, "
+            "api.config.load_config() is invoked (production behaviour). The "
+            "flag exists so CI smoke can drive a 1-2 symbol fixture without "
+            "pulling the full production config graph."
+        ),
+    )
     return p
 
 
@@ -1240,6 +1264,36 @@ def _print_windows(windows: Iterable[Window]) -> None:
             f"test {w.test_start}..{w.test_end}  "
             f"(warmup={w.warmup_gap_days}d)"
         )
+
+
+def _load_app_config(config_path: str | None) -> dict:
+    """Load the app_config dict the harness drives `tune_window` /
+    `frozen_params_for_window` / `evaluate_window` with.
+
+    When `config_path` is provided, the file is read as JSON and returned
+    verbatim — no merge with the production layered config, no env-var
+    overlay, no defaults file. This is intentional: CI smoke needs to
+    drive a *minimal* fixture (1-2 symbols, ATR overrides) without
+    pulling the full production graph.
+
+    When `config_path` is `None`, `api.config.load_config()` is invoked
+    (the same call `btc_api`, the scanner and the legacy
+    `auto_tune.load_config()` use). Production behaviour stays unchanged.
+    """
+    if config_path is None:
+        from api.config import load_config  # noqa: PLC0415
+        return load_config()
+    path = Path(config_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"--config-path not found: {config_path}")
+    with path.open("r", encoding="utf-8") as fh:
+        cfg = json.load(fh)
+    if not isinstance(cfg, dict):
+        raise ValueError(
+            f"--config-path must contain a JSON object at the top level, "
+            f"got {type(cfg).__name__}"
+        )
+    return cfg
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1264,16 +1318,29 @@ def main(argv: list[str] | None = None) -> int:
 
     _print_windows(windows)
 
+    if args.execute:
+        # Execution path (commit 7 of #276). Loads the app config (fixture
+        # or production), drives `run_walk_forward` over the computed
+        # windows, then prints the aggregate stats as JSON on stdout. The
+        # human-readable per-window dump above stays on stderr-equivalent
+        # (stdout before the JSON marker) so a consumer can split on the
+        # `=== walk-forward summary (JSON) ===` line.
+        app_config = _load_app_config(args.config_path)
+        run = run_walk_forward(windows, app_config, ci_mode=args.ci_mode)
+        summary = aggregate_run_stats(run)
+        print("=== walk-forward summary (JSON) ===")
+        print(json.dumps(summary, indent=2, sort_keys=True, default=str))
+        return 0
+
     if args.ci_mode:
         log.info(
-            "ci-mode requested: when the execution path lands, "
-            "tuning will be skipped and symbol_overrides ATR params "
-            "will be used as frozen params per window."
+            "ci-mode requested without --execute: window math only. "
+            "Pass --execute to drive the orchestrator + aggregate path."
         )
 
     if not args.dry_run:
         log.warning(
-            "Execution path not implemented yet — see #276. "
+            "Execution path requires --execute. "
             "Re-run with --dry-run to silence this warning."
         )
     return 0

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -366,6 +366,226 @@ def tune_window(window: Window, config: dict) -> dict:
 
 
 # --------------------------------------------------------------------------- #
+# Per-window evaluation (commit 4 of #276)
+# --------------------------------------------------------------------------- #
+#
+# `evaluate_window` consumes the per-symbol tune output produced by
+# `tune_window` (commit 3) and runs the strategy on the fold's **test
+# range** — the slice `[window.test_start, window.test_end)` that follows
+# `train_end + warmup_gap_days`. The train range was already consumed
+# during tuning; the holdout is never touched.
+#
+# Contract:
+#   - The runner is `auto_tune.run_backtest_with_params`, the same wrapper
+#     that the tuner exercises every iteration. It loads OHLCV via
+#     `get_cached_data`, slices to `sim_start..sim_end`, and goes through
+#     the standard `cfg + symbol_overrides` path when `app_config` is
+#     supplied (gates active: time_limit + participation cap). Re-using
+#     it here keeps tune-vs-eval comparable bar-for-bar.
+#   - `cutoff` is deliberately NOT passed. `cutoff` belongs to the tune
+#     side (no-leakage upper bound on training data). For evaluation we
+#     **want** the test range to be visible — `compute_windows` already
+#     guarantees `window.test_end <= holdout_start` so the holdout
+#     remains untouched regardless.
+#   - Per-symbol params source: prefer `proposed_params` when the tuner
+#     recommended a change, fall back to `current_params` for KEEP /
+#     NO_DATA / ERROR / KEEP_CURRENT. Mirrors the policy that
+#     `tools/retune_pre_holdout.py::_build_params_block` applies when
+#     emitting the drop-in symbol_overrides block.
+#   - One call per symbol in the tune results. Single-threaded; downstream
+#     orchestration owns parallelism (same stance as `tune_window`).
+#
+# Holdout safety (Non-Negotiable #3):
+#   - The test range is bounded above by `holdout_start` (compute_windows
+#     contract). This function consumes that contract; it does not
+#     re-verify it.
+#   - `run_backtest_with_params` loads from `data/ohlcv.db`, never from
+#     `data/holdout/`. No code path here touches the locked snapshot.
+
+
+# Params slots the optimizer tunes. Mirrors the keys that
+# `tools/retune_pre_holdout.py::_build_params_block` emits and that
+# `run_backtest_with_params` consumes.
+_TUNED_PARAM_KEYS = ("atr_sl_mult", "atr_tp_mult", "atr_be_mult")
+
+# Metric keys we surface from `calculate_metrics` into the per-window
+# report. The full metrics dict from the simulator carries ~25 keys; we
+# project to the ones operators read first when comparing folds. Keep
+# this list in sync with `backtest.calculate_metrics` return shape if
+# field names change there.
+_REPORT_METRIC_KEYS = (
+    "total_trades",
+    "net_pnl",
+    "profit_factor",
+    "sharpe_ratio",
+    "max_drawdown_pct",
+    "win_rate",
+    "total_return_pct",
+)
+
+
+def _select_params_for_eval(tune_result: dict) -> dict | None:
+    """Pick the parameter set to evaluate from a single symbol's tune dict.
+
+    Returns the dict shape expected by ``run_backtest_with_params`` (the
+    three ATR keys), or ``None`` when no usable params are available
+    (e.g. recommendation == "ERROR" with no current_params either).
+    """
+    reco = tune_result.get("recommendation")
+    if reco == "CHANGE":
+        proposed = tune_result.get("proposed_params")
+        if isinstance(proposed, dict):
+            return {k: proposed[k] for k in _TUNED_PARAM_KEYS if k in proposed}
+    # KEEP / KEEP_CURRENT / NO_DATA / ERROR all fall back to current.
+    current = tune_result.get("current_params")
+    if isinstance(current, dict):
+        return {k: current[k] for k in _TUNED_PARAM_KEYS if k in current}
+    return None
+
+
+def _project_metrics(metrics: dict) -> dict:
+    """Project the simulator's metrics dict down to the report keys.
+
+    Missing keys are kept missing (not zero-filled) so the consumer can
+    distinguish "not computed" from "computed as zero". The error path
+    where `run_backtest_with_params` returns its sentinel dict
+    (``{"error": ..., "total_trades": 0, "net_pnl": 0, "profit_factor": 0}``)
+    is still legible — the keys that exist will land in the projection.
+    """
+    if not isinstance(metrics, dict):
+        return {}
+    return {k: metrics[k] for k in _REPORT_METRIC_KEYS if k in metrics}
+
+
+def _date_to_sim_datetime(d: date) -> datetime:
+    """Lift a fold boundary `date` to a midnight UTC `datetime`.
+
+    `run_backtest_with_params` expects `sim_start`/`sim_end` as
+    `datetime`. The harness stores boundaries as `date`; midnight UTC is
+    the canonical lift (same convention as `_train_end_to_cutoff`).
+    """
+    if isinstance(d, datetime):
+        return d if d.tzinfo is not None else d.replace(tzinfo=timezone.utc)
+    return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
+
+
+def evaluate_window(window: Window, tuned: dict, config: dict) -> dict:
+    """Evaluate per-symbol tuned params on the fold's **test range**.
+
+    The train range was consumed during tuning (commit 3). The locked
+    snapshot is never touched — `compute_windows` (commit 1) guarantees
+    `window.test_end <= holdout_start` and the runner reads from
+    `data/ohlcv.db` exclusively.
+
+    Args:
+        window: Fold descriptor from `compute_windows`. The simulation
+            range is `[window.test_start, window.test_end)`.
+        tuned: The return value of `tune_window(window, config)`. Must
+            carry `tuned["results"][symbol]` for every symbol the
+            harness wants evaluated. Symbol order in the output mirrors
+            the iteration order of `tuned["results"]`.
+        config: Application config dict, same shape as `tune_window`
+            consumes. Passed through to `run_backtest_with_params` so
+            the standard `cfg + symbol_overrides` path stays active
+            (time_limit + participation cap gates on).
+
+    Returns:
+        A per-window report shaped::
+
+            {
+                "window_index": int,
+                "train_range": {"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"},
+                "test_range":  {"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"},
+                "params": {symbol: {atr_sl_mult, atr_tp_mult, atr_be_mult}, ...},
+                "results": {
+                    symbol: {
+                        "n_trades": int,
+                        "metrics": dict,     # projection of calculate_metrics
+                        "regime_tag": None,  # see Note below
+                        "error": str | None, # populated on runner sentinel
+                    },
+                    ...
+                },
+                "skipped": [{"symbol": str, "reason": str}, ...],
+            }
+
+        ``regime_tag`` is always ``None`` here. The simulator emits
+        regime classification per-trade (see ``classify_market_regime``),
+        not a single tag per run. A fold-level summary would require an
+        aggregate decision (mode? majority?) the harness has not yet
+        agreed on; surfacing it now would invent semantics. Leave
+        ``None`` until a downstream commit chooses the rule.
+
+        ``skipped`` lists symbols whose tune dict had no usable params
+        and whose evaluation was therefore skipped (no runner call).
+
+    Empty-range handling:
+        If `window.test_start >= window.test_end` the report is returned
+        with empty `results` and `skipped`. No runner is invoked. This
+        is the harness's response to a degenerate fold at the history
+        edge — callers can detect it via `len(report["results"]) == 0`.
+    """
+    # Local import: keep `auto_tune` (and its pandas / strategy deps)
+    # out of `walk_forward` import time. Same rationale as `tune_window`.
+    import auto_tune  # noqa: PLC0415
+
+    report: dict = {
+        "window_index": window.index,
+        "train_range": {
+            "start": window.train_start.isoformat(),
+            "end": window.train_end.isoformat(),
+        },
+        "test_range": {
+            "start": window.test_start.isoformat(),
+            "end": window.test_end.isoformat(),
+        },
+        "params": {},
+        "results": {},
+        "skipped": [],
+    }
+
+    # Degenerate fold: empty test range. Return the envelope; do not
+    # invoke the runner. `compute_windows` does not produce such folds
+    # today, but the function must remain robust if a caller hand-rolls
+    # a Window for ad-hoc evaluation.
+    if window.test_start >= window.test_end:
+        return report
+
+    sim_start = _date_to_sim_datetime(window.test_start)
+    sim_end = _date_to_sim_datetime(window.test_end)
+
+    tune_results = tuned.get("results", {}) if isinstance(tuned, dict) else {}
+
+    for symbol, sym_tune in tune_results.items():
+        params = _select_params_for_eval(sym_tune)
+        if params is None or len(params) != len(_TUNED_PARAM_KEYS):
+            report["skipped"].append({
+                "symbol": symbol,
+                "reason": "no_usable_params",
+            })
+            continue
+
+        report["params"][symbol] = params
+
+        trades, metrics = auto_tune.run_backtest_with_params(
+            symbol,
+            params,
+            sim_start,
+            sim_end,
+            app_config=config,
+        )
+
+        report["results"][symbol] = {
+            "n_trades": len(trades) if trades else 0,
+            "metrics": _project_metrics(metrics),
+            "regime_tag": None,  # see docstring — intentionally unset
+            "error": metrics.get("error") if isinstance(metrics, dict) else None,
+        }
+
+    return report
+
+
+# --------------------------------------------------------------------------- #
 # CLI (placeholder — no strategy execution yet)
 # --------------------------------------------------------------------------- #
 

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -586,6 +586,543 @@ def evaluate_window(window: Window, tuned: dict, config: dict) -> dict:
 
 
 # --------------------------------------------------------------------------- #
+# Orchestrator + aggregate stats (commit 5 of #276)
+# --------------------------------------------------------------------------- #
+#
+# `run_walk_forward` drives the per-window pipeline end-to-end: for each
+# `Window` it calls `tune_window` → `evaluate_window` and collects the
+# per-window report into a single `WalkForwardRun` dict. The loop is
+# best-effort across folds — if a window's tune or eval raises, the error
+# is recorded on that window's report and iteration continues. This keeps
+# a single corrupt symbol cache or a transient I/O hiccup from blackening
+# the whole run.
+#
+# Aggregation rationale (read once, defend later):
+#
+#   - **OOS metric**: drawn from `evaluate_window` output, which projects
+#     `backtest.calculate_metrics` down to the seven keys in
+#     `_REPORT_METRIC_KEYS`. These include `sharpe_ratio`, `profit_factor`,
+#     `max_drawdown_pct`, `win_rate`, `net_pnl`, `total_return_pct`,
+#     `total_trades`.
+#
+#   - **IS metric (load-bearing decision)**: `auto_tune.optimize_symbol`
+#     does NOT expose a Sharpe on its train/validate split. It exposes
+#     `proposal_detail.val_pnl` / `val_pf` (proposed params on validate)
+#     and `current_val_pnl` (current params on validate baseline). The
+#     OOS/IS ratio in this commit is therefore computed on **net_pnl**:
+#       * IS  := the val_pnl of the params actually evaluated downstream
+#                (proposal_detail.val_pnl for CHANGE, current_val_pnl for
+#                KEEP/NO_DATA/KEEP_CURRENT/ERROR).
+#       * OOS := metrics.net_pnl from `evaluate_window`.
+#     The orchestrator attaches `is_pnl_by_symbol` to each window's
+#     report after `evaluate_window` returns — `evaluate_window` is not
+#     mutated (commit-4 contract preserved). Sharpe IS would require
+#     re-running the simulator on the train slice to manufacture an IS
+#     Sharpe — a different scope decision, deferred (see #276 follow-ups).
+#
+#   - **CV across windows**: computed per metric across windows that
+#     produced a numeric value. CV = std / mean. Zero or near-zero mean
+#     yields `None` with an explicit reason so consumers can distinguish
+#     "stable around zero" from "computed and meaningful".
+#
+#   - **Best/worst window**: indexed on `sharpe_ratio` when present (the
+#     OOS metric is available; the tune-side has no Sharpe but that's
+#     irrelevant — best/worst is an OOS comparison). Falls back to
+#     `total_return_pct` when Sharpe is missing across the run.
+
+
+@dataclass(frozen=True)
+class WalkForwardRun:
+    """End-to-end output of `run_walk_forward`.
+
+    Attributes:
+        windows:          The Window list the orchestrator was driven on
+                          (verbatim, in order). Empty list => empty run.
+        window_reports:   List of per-window reports in the same order as
+                          `windows`. Each entry is the dict shape
+                          documented on `evaluate_window`, plus an
+                          optional `error` key when the fold raised
+                          during tune or eval (best-effort policy).
+    """
+
+    windows: list[Window]
+    window_reports: list[dict]
+
+
+def _fold_error_report(window: Window, phase: str, exc: BaseException) -> dict:
+    """Build a minimal per-window report carrying a fold-level error.
+
+    Shape mirrors `evaluate_window`'s envelope so aggregation code does
+    not need to special-case errored folds — empty `results` plus an
+    `error` block at the top.
+    """
+    return {
+        "window_index": window.index,
+        "train_range": {
+            "start": window.train_start.isoformat(),
+            "end": window.train_end.isoformat(),
+        },
+        "test_range": {
+            "start": window.test_start.isoformat(),
+            "end": window.test_end.isoformat(),
+        },
+        "params": {},
+        "results": {},
+        "skipped": [],
+        "error": {
+            "phase": phase,            # "tune" | "evaluate"
+            "type": type(exc).__name__,
+            "message": str(exc),
+        },
+    }
+
+
+def run_walk_forward(windows: list[Window], app_config: dict) -> WalkForwardRun:
+    """Drive `tune_window` → `evaluate_window` over every fold in `windows`.
+
+    The loop is in-process and single-threaded. Process-pool / async
+    orchestration is deferred to a downstream commit (commit 6/7 of
+    #276 if the cost profile justifies it).
+
+    Best-effort policy: a per-window exception in tune or evaluate is
+    recorded on that fold's report under `"error"` and iteration
+    continues. The bala única (#322 holdout) is not at risk here — the
+    test ranges of every fold are bounded above by `holdout_start` via
+    `compute_windows`.
+
+    Args:
+        windows: Output of `compute_windows`. May be empty.
+        app_config: Application config dict, propagated unchanged to
+            `tune_window` and `evaluate_window`.
+
+    Returns:
+        A `WalkForwardRun` carrying the original window list and one
+        report per window (in the same order). Empty windows → empty
+        `window_reports`.
+    """
+    if not windows:
+        return WalkForwardRun(windows=[], window_reports=[])
+
+    reports: list[dict] = []
+    for window in windows:
+        try:
+            tuned = tune_window(window, app_config)
+        except BaseException as exc:  # noqa: BLE001 — best-effort across folds
+            log.warning(
+                "walk_forward: tune_window failed on window %d (%s): %s",
+                window.index, type(exc).__name__, exc,
+            )
+            reports.append(_fold_error_report(window, phase="tune", exc=exc))
+            continue
+
+        try:
+            report = evaluate_window(window, tuned, app_config)
+        except BaseException as exc:  # noqa: BLE001 — best-effort across folds
+            log.warning(
+                "walk_forward: evaluate_window failed on window %d (%s): %s",
+                window.index, type(exc).__name__, exc,
+            )
+            reports.append(_fold_error_report(window, phase="evaluate", exc=exc))
+            continue
+
+        # Enrich the report with the IS val_pnl per symbol so the
+        # aggregator can compute a real OOS/IS ratio. The orchestrator
+        # is the right layer for this: it holds both sides of the
+        # train/test boundary at once. We do NOT mutate `evaluate_window`
+        # (scope strictness for commit 5) — we attach a sibling block
+        # named `is_pnl_by_symbol`, which `_aggregate_oos_is` consumes.
+        report["is_pnl_by_symbol"] = _build_is_pnl_block(tuned, report)
+        reports.append(report)
+
+    return WalkForwardRun(windows=list(windows), window_reports=reports)
+
+
+# Metrics the aggregator computes CV over. Mirrors `_REPORT_METRIC_KEYS`
+# minus `total_trades` (a count, summed instead) — keeping ratio/return
+# metrics that have meaningful dispersion across folds.
+_CV_METRIC_KEYS = (
+    "net_pnl",
+    "profit_factor",
+    "sharpe_ratio",
+    "max_drawdown_pct",
+    "win_rate",
+    "total_return_pct",
+)
+
+
+def _extract_is_pnl(tune_result: dict) -> float | None:
+    """Pick the IS validate-pnl that corresponds to the params actually
+    evaluated downstream by `evaluate_window`.
+
+    Mirrors `_select_params_for_eval` policy:
+      - CHANGE  → `proposal_detail.val_pnl`
+      - KEEP / KEEP_CURRENT / NO_DATA / ERROR → `current_val_pnl`
+
+    Returns None if neither is available (e.g. ERROR with no current
+    baseline). The aggregator records the reason explicitly so a missing
+    IS does not silently collapse the ratio.
+    """
+    if not isinstance(tune_result, dict):
+        return None
+    reco = tune_result.get("recommendation")
+    if reco == "CHANGE":
+        detail = tune_result.get("proposal_detail")
+        if isinstance(detail, dict) and "val_pnl" in detail:
+            try:
+                return float(detail["val_pnl"])
+            except (TypeError, ValueError):
+                return None
+    # Fall back to baseline. May still be 0 or negative — that's a real
+    # IS signal, not a missing value.
+    val = tune_result.get("current_val_pnl")
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def _stdev(values: list[float], mean: float) -> float:
+    # Population stdev (N), not sample (N-1). Walk-forward folds are
+    # the whole population the harness produced — not a sample of a
+    # larger one — so dividing by N is the honest call. Single-window
+    # CV is undefined regardless of which divisor we pick; we handle
+    # that upstream by returning `None` with a reason.
+    n = len(values)
+    if n == 0:
+        return 0.0
+    return (sum((v - mean) ** 2 for v in values) / n) ** 0.5
+
+
+# Threshold below which |mean| is treated as "indistinguishable from
+# zero" for CV purposes. Picked conservatively — net_pnl in USD, ratios
+# unitless. Below this we report `None` with reason rather than emit a
+# wildly inflated CV.
+_CV_MEAN_EPSILON = 1e-9
+
+
+def _cv_or_reason(values: list[float]) -> dict:
+    """Compute CV = std/mean over `values`, returning a structured
+    dict so consumers can distinguish "not enough data" from
+    "near-zero mean" from a real number.
+
+    Shape:
+        {"value": float, "n": int} on success.
+        {"value": None, "n": int, "reason": str} on degenerate input.
+    """
+    n = len(values)
+    if n == 0:
+        return {"value": None, "n": 0, "reason": "no_samples"}
+    if n == 1:
+        return {"value": None, "n": 1, "reason": "single_sample"}
+    m = _mean(values)
+    if abs(m) < _CV_MEAN_EPSILON:
+        return {"value": None, "n": n, "reason": "mean_near_zero"}
+    s = _stdev(values, m)
+    return {"value": s / abs(m), "n": n}
+
+
+def _collect_metric_values(
+    window_reports: list[dict], metric_key: str
+) -> list[float]:
+    """Walk every (window, symbol) cell and collect the numeric values
+    of `metric_key` from the projected metrics dict.
+
+    Skips: error sentinels, missing keys, non-numeric values. The
+    aggregator decides per-metric whether to fold these into CV
+    (collected here) or surface them as counters (handled separately).
+    """
+    out: list[float] = []
+    for report in window_reports:
+        results = report.get("results") if isinstance(report, dict) else None
+        if not isinstance(results, dict):
+            continue
+        for sym_entry in results.values():
+            if not isinstance(sym_entry, dict):
+                continue
+            metrics = sym_entry.get("metrics")
+            if not isinstance(metrics, dict):
+                continue
+            v = metrics.get(metric_key)
+            if isinstance(v, bool):  # bool is an int subclass — guard
+                continue
+            if isinstance(v, (int, float)):
+                out.append(float(v))
+    return out
+
+
+def _window_score(report: dict, metric_key: str) -> float | None:
+    """Aggregate `metric_key` over a single window's per-symbol results
+    by mean. Returns None when no symbol produced a numeric value.
+
+    Best/worst are window-level decisions, so we collapse the per-symbol
+    metrics to one number per window before ranking.
+    """
+    results = report.get("results") if isinstance(report, dict) else None
+    if not isinstance(results, dict) or not results:
+        return None
+    vals: list[float] = []
+    for sym_entry in results.values():
+        if not isinstance(sym_entry, dict):
+            continue
+        metrics = sym_entry.get("metrics")
+        if not isinstance(metrics, dict):
+            continue
+        v = metrics.get(metric_key)
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)):
+            vals.append(float(v))
+    if not vals:
+        return None
+    return _mean(vals)
+
+
+def aggregate_run_stats(run: WalkForwardRun) -> dict:
+    """Compute cross-window summary statistics from a WalkForwardRun.
+
+    Shape:
+        {
+            "n_windows": int,
+            "n_windows_with_trades": int,
+            "n_windows_skipped": int,   # folds that emitted no results
+            "n_windows_errored": int,   # folds that raised in tune/eval
+            "total_trades": int,
+            "oos_is_ratio": {
+                "value": float | None,
+                "n": int,
+                "reason": str,          # when value is None
+                "metric": "net_pnl",
+            },
+            "cv": {
+                metric_key: {"value": float | None, "n": int, "reason"?: str},
+                ...
+            },
+            "best_window": {"index": int, "metric": str, "value": float} | None,
+            "worst_window": {"index": int, "metric": str, "value": float} | None,
+        }
+
+    All ranking decisions are documented at the module top of the
+    `Orchestrator + aggregate stats` block. The defaults are deliberate:
+    OOS/IS on `net_pnl` (because the tuner does not expose IS Sharpe),
+    best/worst on `sharpe_ratio` with a `total_return_pct` fallback.
+    """
+    reports = run.window_reports if isinstance(run, WalkForwardRun) else []
+    n_windows = len(reports)
+
+    # Counters
+    n_with_trades = 0
+    n_errored = 0
+    n_skipped = 0
+    total_trades = 0
+    for r in reports:
+        if not isinstance(r, dict):
+            continue
+        if "error" in r and isinstance(r.get("error"), dict):
+            n_errored += 1
+            continue
+        results = r.get("results") or {}
+        window_trades = 0
+        for sym_entry in results.values():
+            if isinstance(sym_entry, dict):
+                nt = sym_entry.get("n_trades", 0)
+                if isinstance(nt, (int, float)) and not isinstance(nt, bool):
+                    window_trades += int(nt)
+        total_trades += window_trades
+        if window_trades > 0:
+            n_with_trades += 1
+        if not results:
+            # No symbols evaluated at all (e.g. empty tune results, or
+            # degenerate fold). Distinct from "errored" — record it.
+            n_skipped += 1
+
+    # CV per metric
+    cv: dict[str, dict] = {}
+    for key in _CV_METRIC_KEYS:
+        cv[key] = _cv_or_reason(_collect_metric_values(reports, key))
+
+    # OOS/IS on net_pnl. We need both sides per window:
+    #   OOS = window-aggregated net_pnl from `evaluate_window`
+    #   IS  = window-aggregated val_pnl from the tune dict that drove
+    #         this window's eval (which we do NOT carry on the report).
+    # The report does carry `params` per symbol but not the IS pnl. The
+    # honest answer: with the current report shape, IS is recoverable
+    # only at the symbol level if `evaluate_window` later embeds the
+    # tune's val_pnl. Until then, OOS/IS degrades elegantly.
+    oos_values: list[float] = _collect_metric_values(reports, "net_pnl")
+    is_block = _aggregate_oos_is(reports)
+    oos_is_ratio: dict
+    if is_block is None:
+        oos_is_ratio = {
+            "value": None,
+            "n": len(oos_values),
+            "reason": "is_pnl_not_on_report",
+            "metric": "net_pnl",
+        }
+    else:
+        is_total, oos_total, n_pairs = is_block
+        if n_pairs == 0:
+            oos_is_ratio = {
+                "value": None,
+                "n": 0,
+                "reason": "no_paired_windows",
+                "metric": "net_pnl",
+            }
+        elif abs(is_total) < _CV_MEAN_EPSILON:
+            oos_is_ratio = {
+                "value": None,
+                "n": n_pairs,
+                "reason": "is_pnl_near_zero",
+                "metric": "net_pnl",
+            }
+        else:
+            oos_is_ratio = {
+                "value": oos_total / is_total,
+                "n": n_pairs,
+                "metric": "net_pnl",
+            }
+
+    # Best / worst on sharpe with total_return_pct fallback.
+    best_block, worst_block = _best_worst(reports)
+
+    return {
+        "n_windows": n_windows,
+        "n_windows_with_trades": n_with_trades,
+        "n_windows_skipped": n_skipped,
+        "n_windows_errored": n_errored,
+        "total_trades": total_trades,
+        "oos_is_ratio": oos_is_ratio,
+        "cv": cv,
+        "best_window": best_block,
+        "worst_window": worst_block,
+    }
+
+
+def _build_is_pnl_block(tuned: dict, report: dict) -> dict:
+    """Build the per-symbol IS val_pnl block for a window's report.
+
+    Iterates symbols that actually reached the runner (present in
+    `report["params"]`) and pulls the IS pnl from the tune dict using
+    the same policy as `_select_params_for_eval` (CHANGE →
+    proposal_detail.val_pnl, else current_val_pnl). Symbols that the
+    evaluator skipped (no usable params) are deliberately absent from
+    the block — pairing them would be meaningless.
+
+    Returns:
+        {symbol: float} — only symbols where IS pnl is a finite number.
+        Symbols whose IS pnl is missing or non-numeric are dropped (the
+        aggregator's denominator should not silently include zeros it
+        did not measure).
+    """
+    out: dict[str, float] = {}
+    if not isinstance(tuned, dict):
+        return out
+    tune_results = tuned.get("results") or {}
+    if not isinstance(tune_results, dict):
+        return out
+    params_block = report.get("params") if isinstance(report, dict) else {}
+    if not isinstance(params_block, dict):
+        params_block = {}
+    for sym in params_block.keys():
+        is_pnl = _extract_is_pnl(tune_results.get(sym))
+        if is_pnl is None:
+            continue
+        out[sym] = is_pnl
+    return out
+
+
+def _aggregate_oos_is(
+    reports: list[dict],
+) -> tuple[float, float, int] | None:
+    """Compute paired (IS, OOS) net_pnl totals across windows.
+
+    Returns:
+        (is_total, oos_total, n_pairs) when at least one report carries
+        embedded IS pnl per symbol via a top-level `is_pnl_by_symbol`
+        dict (see contract note below). Otherwise None — the caller
+        surfaces `oos_is_ratio.value = None` with reason
+        ``is_pnl_not_on_report``.
+
+    Contract note:
+        `evaluate_window` itself does NOT embed IS val_pnl into its
+        report (that would couple it to the tune dict). The orchestrator
+        attaches `is_pnl_by_symbol` to the report after the eval call —
+        it is the layer that holds both sides of the train/test
+        boundary. If a caller invokes `aggregate_run_stats` on a run
+        built outside `run_walk_forward` (e.g. hand-rolled reports for
+        testing), `is_pnl_by_symbol` may be absent — we degrade with
+        the explicit `is_pnl_not_on_report` reason rather than fabricate
+        a number.
+    """
+    is_total = 0.0
+    oos_total = 0.0
+    n_pairs = 0
+    saw_is_block = False
+    for r in reports:
+        if not isinstance(r, dict) or "error" in r:
+            continue
+        is_block = r.get("is_pnl_by_symbol")
+        if not isinstance(is_block, dict):
+            continue
+        saw_is_block = True
+        results = r.get("results") or {}
+        for sym, is_pnl in is_block.items():
+            if not isinstance(is_pnl, (int, float)) or isinstance(is_pnl, bool):
+                continue
+            sym_entry = results.get(sym)
+            if not isinstance(sym_entry, dict):
+                continue
+            metrics = sym_entry.get("metrics")
+            if not isinstance(metrics, dict):
+                continue
+            oos = metrics.get("net_pnl")
+            if not isinstance(oos, (int, float)) or isinstance(oos, bool):
+                continue
+            is_total += float(is_pnl)
+            oos_total += float(oos)
+            n_pairs += 1
+    if not saw_is_block:
+        return None
+    return (is_total, oos_total, n_pairs)
+
+
+def _best_worst(reports: list[dict]) -> tuple[dict | None, dict | None]:
+    """Rank windows by aggregated Sharpe (fallback total_return_pct).
+
+    Returns (best, worst) as dicts shaped::
+        {"index": int, "metric": str, "value": float}
+    or (None, None) when no window produced a numeric score under
+    either metric.
+    """
+    for metric in ("sharpe_ratio", "total_return_pct"):
+        scored: list[tuple[int, float]] = []
+        for r in reports:
+            if not isinstance(r, dict) or "error" in r:
+                continue
+            score = _window_score(r, metric)
+            if score is None:
+                continue
+            idx = r.get("window_index")
+            if not isinstance(idx, int):
+                continue
+            scored.append((idx, score))
+        if not scored:
+            continue
+        best_idx, best_val = max(scored, key=lambda t: t[1])
+        worst_idx, worst_val = min(scored, key=lambda t: t[1])
+        return (
+            {"index": best_idx, "metric": metric, "value": best_val},
+            {"index": worst_idx, "metric": metric, "value": worst_val},
+        )
+    return (None, None)
+
+
+# --------------------------------------------------------------------------- #
 # CLI (placeholder — no strategy execution yet)
 # --------------------------------------------------------------------------- #
 

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Walk-Forward — Time-anchored cross-validation harness for the trading portfolio.
+
+Scaffold for issue #276. This module computes train/test windows for
+walk-forward evaluation while guaranteeing:
+
+  - Test ranges never overlap each other.
+  - No window touches the locked holdout (start <= holdout_start).
+  - A configurable warmup gap separates train_end from test_start
+    (avoids leakage from indicators that look back across the boundary).
+  - Anchored mode pins every train_start to history_start
+    (expanding window). Rolling mode is not in this commit.
+
+Usage (CLI is a placeholder — no strategy execution yet):
+    python walk_forward.py --history-start 2023-01-01 \
+                           --history-end 2025-12-31 \
+                           --holdout-start 2026-01-01 \
+                           --initial-train-months 12 \
+                           --test-months 3 \
+                           --step-months 3 \
+                           --dry-run
+
+The CLI currently only prints the computed windows. The execution
+path (running the strategy on each fold) is intentionally not wired
+up — see issue #276 for the staged rollout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass, asdict
+from datetime import date, datetime
+from typing import Iterable
+
+from dateutil.relativedelta import relativedelta
+
+log = logging.getLogger("walk_forward")
+
+
+# --------------------------------------------------------------------------- #
+# Data model
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Window:
+    """A single walk-forward fold.
+
+    All boundaries are inclusive on the start side, exclusive on the end
+    side ([train_start, train_end), [test_start, test_end)), which matches
+    the half-open convention used elsewhere in the project.
+
+    `warmup_gap_days` records the gap actually applied between train_end
+    and test_start so callers can audit fold construction.
+    """
+
+    index: int
+    train_start: date
+    train_end: date
+    test_start: date
+    test_end: date
+    warmup_gap_days: int
+
+    def as_dict(self) -> dict:
+        d = asdict(self)
+        for k in ("train_start", "train_end", "test_start", "test_end"):
+            d[k] = d[k].isoformat()
+        return d
+
+
+# --------------------------------------------------------------------------- #
+# Window computation
+# --------------------------------------------------------------------------- #
+
+
+def _coerce_date(value) -> date:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    raise TypeError(f"Cannot coerce {value!r} ({type(value).__name__}) to date")
+
+
+def compute_windows(
+    history_start,
+    history_end,
+    holdout_start,
+    initial_train_months: int,
+    test_months: int,
+    step_months: int,
+    warmup_gap_days: int = 0,
+    anchored: bool = True,
+) -> list[Window]:
+    """Compute the list of walk-forward folds.
+
+    Properties guaranteed (covered by tests/test_walk_forward_windows.py):
+      - Anchored: every window.train_start == history_start.
+      - Non-overlap: test ranges of consecutive windows are disjoint.
+      - Holdout exclusion: window.test_end <= holdout_start for every fold.
+      - Warmup gap: test_start - train_end >= warmup_gap_days for every fold.
+
+    Args:
+        history_start: First date available for training (inclusive).
+        history_end:   Last date available for testing  (exclusive upper bound).
+        holdout_start: Start of the locked holdout. No window may touch it.
+        initial_train_months: Length of the first training span.
+        test_months:   Length of each test span.
+        step_months:   Stride between consecutive folds.
+        warmup_gap_days: Minimum gap between train_end and test_start.
+        anchored:      If True, every fold pins train_start to history_start.
+
+    Returns:
+        Ordered list of Window dataclasses. May be empty if no fold fits.
+    """
+    if initial_train_months <= 0:
+        raise ValueError("initial_train_months must be > 0")
+    if test_months <= 0:
+        raise ValueError("test_months must be > 0")
+    if step_months <= 0:
+        raise ValueError("step_months must be > 0")
+    if warmup_gap_days < 0:
+        raise ValueError("warmup_gap_days must be >= 0")
+    if not anchored:
+        # Rolling mode deliberately deferred. Re-open #276 when needed.
+        raise NotImplementedError("Rolling (non-anchored) mode not implemented yet")
+
+    history_start = _coerce_date(history_start)
+    history_end = _coerce_date(history_end)
+    holdout_start = _coerce_date(holdout_start)
+
+    if history_end > holdout_start:
+        # Clip the usable history at the holdout edge — never peek across.
+        history_end = holdout_start
+    if history_start >= history_end:
+        return []
+
+    windows: list[Window] = []
+    fold = 0
+    # Train span advances by `step_months` per fold in anchored mode by
+    # extending train_end, not train_start.
+    while True:
+        train_end = history_start + relativedelta(
+            months=initial_train_months + step_months * fold
+        )
+        test_start = train_end + relativedelta(days=warmup_gap_days)
+        test_end = test_start + relativedelta(months=test_months)
+
+        if test_end > history_end:
+            break
+        if test_end > holdout_start:
+            break
+
+        windows.append(
+            Window(
+                index=fold,
+                train_start=history_start,
+                train_end=train_end,
+                test_start=test_start,
+                test_end=test_end,
+                warmup_gap_days=warmup_gap_days,
+            )
+        )
+        fold += 1
+
+    return windows
+
+
+# --------------------------------------------------------------------------- #
+# CLI (placeholder — no strategy execution yet)
+# --------------------------------------------------------------------------- #
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="walk_forward",
+        description="Walk-forward harness (scaffold — see #276).",
+    )
+    p.add_argument("--history-start", required=True, help="YYYY-MM-DD")
+    p.add_argument("--history-end", required=True, help="YYYY-MM-DD")
+    p.add_argument("--holdout-start", required=True, help="YYYY-MM-DD")
+    p.add_argument("--initial-train-months", type=int, default=12)
+    p.add_argument("--test-months", type=int, default=3)
+    p.add_argument("--step-months", type=int, default=3)
+    p.add_argument("--warmup-gap-days", type=int, default=0)
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print computed windows and exit. Currently the only mode.",
+    )
+    return p
+
+
+def _print_windows(windows: Iterable[Window]) -> None:
+    for w in windows:
+        print(
+            f"[{w.index:02d}] train {w.train_start}..{w.train_end}  "
+            f"test {w.test_start}..{w.test_end}  "
+            f"(warmup={w.warmup_gap_days}d)"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s  %(levelname)-8s  %(message)s"
+    )
+    args = _build_arg_parser().parse_args(argv)
+
+    windows = compute_windows(
+        history_start=args.history_start,
+        history_end=args.history_end,
+        holdout_start=args.holdout_start,
+        initial_train_months=args.initial_train_months,
+        test_months=args.test_months,
+        step_months=args.step_months,
+        warmup_gap_days=args.warmup_gap_days,
+    )
+
+    if not windows:
+        log.warning("No windows fit the requested configuration.")
+        return 1
+
+    _print_windows(windows)
+
+    if not args.dry_run:
+        log.warning(
+            "Execution path not implemented yet — see #276. "
+            "Re-run with --dry-run to silence this warning."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -41,6 +41,98 @@ log = logging.getLogger("walk_forward")
 
 
 # --------------------------------------------------------------------------- #
+# Warmup bar accounting
+# --------------------------------------------------------------------------- #
+#
+# The walk-forward harness must hand each fold enough leading history to let
+# every indicator on the active scanner/strategy path reach a stable value
+# before the test window begins. The lookbacks below are sourced directly
+# from `strategy/constants.py` and the per-TF call sites in `strategy/core.py`,
+# `strategy/regime.py`, `strategy/patterns.py`, `backtest.py`, and
+# `strategies/trend_following*.py`. Re-verify the table whenever a new
+# indicator joins the active path or a period constant changes.
+#
+# Per-TF active indicator lookbacks (commit 2 of #276):
+#
+# Scope note: this table tracks **compute-warmup** — the bars an indicator
+# needs to produce a non-NaN value. It is a property of the indicator, not
+# of the downstream decision path. An indicator that is computed but whose
+# output is feature-gated (only consumed when a flag is on) still drives
+# warmup, because the computation runs on every bar regardless.
+#
+#   4h: SMA100 (strategy/core.py:576, strategies/trend_following*.py)
+#       → max = 100
+#
+#   1h: LRC100 (constants.LRC_PERIOD),
+#       SMA10/20 (always), SMA50/200 (computed unconditionally; downstream
+#       use is feature-gated by `trend_pullback_enabled` — see core.py:546-559),
+#       BB20 (constants.BB_PERIOD), RSI14 (constants.RSI_PERIOD),
+#       ATR14 (constants.ATR_PERIOD), ADX14 (core.py:566), VOL20
+#       → max = 200 (SMA200 1h is computed every bar; its value is exposed
+#         in `decision.indicators` regardless of `trend_pullback_enabled`)
+#
+#   5m: RSI14 (patterns.py:92,116), BB20 (constants.BB_PERIOD), VOL20
+#       → max = 20
+#
+# The daily SMA200 in strategy/regime.py operates on a separate 1d frame
+# fetched independently inside `detect_regime()` via `md.get_klines(..., '1d',
+# limit=250)`. It is not driven from the fold's OHLCV TF, so it does not
+# enlarge the per-TF warmup. If that ever changes, fold it into the table.
+
+_INDICATOR_LOOKBACKS_BY_TF: dict[str, int] = {
+    "4h": 100,   # SMA100 on 4h close
+    "1h": 200,   # SMA200 1h computed unconditionally (use is feature-gated)
+    "5m": 20,    # BB20 / VOL20 dominate; RSI14 / ATR14 trail
+}
+
+
+def compute_warmup_bars(timeframe: str) -> int:
+    """Return the **compute-warmup** bars required for every indicator the
+    system computes on ``timeframe``.
+
+    "Warmup" is three distinct things this flat signature does not separate.
+    This function answers (1) only:
+
+      1. **Compute-warmup** — bars needed for the indicator to produce a
+         non-NaN value. Property of the indicator. Deterministic. This is
+         what this function returns: the max over indicators the system
+         *computes* on the TF, regardless of whether their output is then
+         consumed by the decision path.
+      2. **Use-warmup** — bars needed for the indicator's output to influence
+         a decision. Property of the path; depends on feature flags / regime.
+         Not modelled here. An indicator computed-but-not-used still drives
+         this function's return value, because computation runs every bar.
+      3. **Determinism-warmup** — bars needed for the harness to produce
+         reproducible results across reruns. Property of the contract.
+         Out of scope.
+
+    Callers should prepend at least this many bars before the test window
+    so the first scored bar is not contaminated by indicator initialisation
+    noise.
+
+    Args:
+        timeframe: One of ``'4h'``, ``'1h'``, ``'5m'``.
+
+    Returns:
+        Positive int. Always ``>= max(lookback_for_tf)`` declared above.
+
+    Raises:
+        ValueError: If ``timeframe`` is not a recognised active TF.
+    """
+    if not isinstance(timeframe, str):
+        raise ValueError(
+            f"timeframe must be str, got {type(timeframe).__name__}"
+        )
+    key = timeframe.lower().strip()
+    if key not in _INDICATOR_LOOKBACKS_BY_TF:
+        supported = ", ".join(sorted(_INDICATOR_LOOKBACKS_BY_TF))
+        raise ValueError(
+            f"Unsupported timeframe {timeframe!r}. Active TFs: {supported}."
+        )
+    return _INDICATOR_LOOKBACKS_BY_TF[key]
+
+
+# --------------------------------------------------------------------------- #
 # Data model
 # --------------------------------------------------------------------------- #
 

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -32,7 +32,7 @@ import argparse
 import logging
 import sys
 from dataclasses import dataclass, asdict
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Iterable
 
 from dateutil.relativedelta import relativedelta
@@ -260,6 +260,109 @@ def compute_windows(
         fold += 1
 
     return windows
+
+
+# --------------------------------------------------------------------------- #
+# Per-window tuning (commit 3 of #276)
+# --------------------------------------------------------------------------- #
+#
+# `tune_window` drives `auto_tune.optimize_symbol` over the active portfolio
+# for a single fold, using `window.train_end` as both the "today" reference
+# (anchors `calculate_periods`) and the `cutoff` (no-leakage upper bound on
+# every backtest call inside the optimizer).
+#
+# Contract:
+#   - `auto_tune.optimize_symbol(symbol, config, today=cutoff, cutoff=cutoff)`
+#     is the canonical invocation pattern. The pre-holdout retune wrapper
+#     (`tools/retune_pre_holdout.py:74`) uses the same shape; do not diverge.
+#   - `window.train_end` is a `datetime.date`. `optimize_symbol` reaches into
+#     `calculate_periods` which does `relativedelta` arithmetic on a UTC
+#     `datetime`, so we lift `train_end` to midnight UTC before passing.
+#   - The portfolio comes from `auto_tune.get_portfolio_symbols(config)` —
+#     filters out symbols whose override is exactly `False`.
+#   - One call per active symbol. No process pool here: that orchestration
+#     belongs to a downstream commit (whoever wires the harness end-to-end
+#     decides whether to parallelise; this layer stays single-threaded so
+#     callers can monkeypatch in tests without ProcessPoolExecutor friction).
+#
+# Holdout safety (Non-Negotiable #3):
+#   - `window.train_end <= holdout_start` is guaranteed by `compute_windows`
+#     (commit 1 contract). This function consumes that contract; it does not
+#     re-verify it.
+#   - `cutoff` is propagated into `optimize_symbol` so every internal
+#     `run_backtest_with_params` strips bars `>= cutoff`. The assertion in
+#     `_slice_below_cutoff` is the load-bearing guard.
+
+
+def _train_end_to_cutoff(train_end: date) -> datetime:
+    """Lift a fold's `train_end` (date) to a tz-aware UTC datetime at midnight.
+
+    `auto_tune.calculate_periods` does month arithmetic with `relativedelta`
+    against `today`, and downstream `_slice_below_cutoff` compares against
+    OHLCV index timestamps. Both need a `datetime`. Midnight UTC is the
+    canonical lift used by `tools/retune_pre_holdout.py`.
+    """
+    if isinstance(train_end, datetime):
+        # Already a datetime; ensure tz-aware UTC.
+        return train_end if train_end.tzinfo is not None else train_end.replace(tzinfo=timezone.utc)
+    return datetime(train_end.year, train_end.month, train_end.day, tzinfo=timezone.utc)
+
+
+def tune_window(window: Window, config: dict) -> dict:
+    """Run `auto_tune.optimize_symbol` for every active portfolio symbol
+    against a single walk-forward fold.
+
+    The cutoff is pinned to `window.train_end` (lifted to midnight UTC) and
+    passed as both `today` and `cutoff` — matching the contract that
+    `tools/retune_pre_holdout.py:74` exercises in production.
+
+    Args:
+        window: Fold descriptor produced by `compute_windows`. Only
+            `train_end` is consumed here; `test_*` boundaries are not
+            referenced because optimization is anchored to the train edge.
+        config: Application config dict (the same shape `auto_tune` loads
+            via `load_app_config`). Must contain `symbol_overrides` for
+            `get_portfolio_symbols` to filter, and `auto_tune.seed` if a
+            non-default RNG seed is desired.
+
+    Returns:
+        A dict shaped::
+
+            {
+                "window_index": int,
+                "train_end": "YYYY-MM-DD",
+                "cutoff": "<iso datetime>",
+                "results": {symbol: <optimize_symbol return dict>, ...},
+            }
+
+        Symbol order in `results` matches the order returned by
+        `get_portfolio_symbols`. An empty portfolio yields `results == {}`.
+
+    Raises:
+        Whatever `auto_tune.optimize_symbol` raises is propagated. The
+        pre-holdout wrapper swallows per-symbol exceptions in its process
+        pool; this layer leaves that policy to callers.
+    """
+    # Local import to avoid pulling `auto_tune` (and its heavy transitive
+    # deps — pandas, the strategy module, etc.) at walk_forward import
+    # time. The CLI scaffold and the window math do not need them.
+    import auto_tune  # noqa: PLC0415
+
+    symbols = auto_tune.get_portfolio_symbols(config)
+    cutoff = _train_end_to_cutoff(window.train_end)
+
+    results: dict[str, dict] = {}
+    for sym in symbols:
+        results[sym] = auto_tune.optimize_symbol(
+            sym, config, today=cutoff, cutoff=cutoff
+        )
+
+    return {
+        "window_index": window.index,
+        "train_end": window.train_end.isoformat(),
+        "cutoff": cutoff.isoformat(),
+        "results": results,
+    }
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Cadena ks-v2 completa que destraba #272 (re-baselining honesto). Branch al día sobre `73cdbfc`, CI verde end-to-end.

- `walk_forward.py`: `Window` dataclass + `compute_windows()` + warmup wiring + auto_tune por ventana + evaluación train/val + aggregate stats (OOS/IS, CV) + `--ci-mode` frozen fallback + holdout wired (gated).
- Tests: `tests/test_walk_forward_windows.py` (15 tests geometría) + cobertura por commit subsiguiente.

## Cadena (back-chain hacia #272)

#276 (este PR, A.0.1 walk-forward harness)
↓
#278 (A.0.3 deflated metrics)
↓
#249 (A.3 bar cuantitativo)
↓
#272 (re-baselining honesto) — desbloquea brainstorming del agregador ks-v2 (PR #533 pausado)

## Commits sobre esta branch (8/8 cerrados)

1. ✅ Scaffold + `compute_windows` + tests (3ecca15)
2. ✅ Warmup wiring por lookback de indicadores (5780869)
3. ✅ `auto_tune.optimize_symbol` por ventana — import directo, patrón vigente de `tools/retune_pre_holdout.py:74` (bf59944)
4. ✅ Evaluación de params tuneados sobre test range — NO holdout, Non-Negotiable #3 (bb3600f)
5. ✅ Orchestrator loop + aggregate stats (OOS/IS ratio + CV) across windows (aacd068)
6. ✅ `--ci-mode` flag con frozen-params fallback (6373552)
7. ✅ CI smoke wiring + sample report (799b34d)
8. ✅ Holdout integration — wired pero gated en #322, no invocada (73cdbfc)

## Auditoría adversarial

Los commits 6-8 fueron auditados y endurecidos antes de sacar de draft. La exención del scanner de aislamiento de holdout se acotó (whole-file skip → `open_holdout`-only) bajo seguimiento en **#535**. El holdout queda cableado pero NO ejecutable hasta cerrar #322 (Non-Negotiable #3 intacto).

## Test plan

- [x] `pytest tests/test_walk_forward_windows.py -v` — 15 passed local
- [x] CI verde sobre la branch (Backend 2m23s, Frontend, Verb taxonomy, Walk-forward smoke — todos pass sobre 73cdbfc)
- [x] Tests adicionales por commit subsiguiente
- [x] Sample report en docs/ tras commit 7
- [ ] Holdout invocada solo tras cierre de #322 (intencionalmente diferido — fuera de scope de este PR)

## Follow-ups abiertos

- #535 — acotar la exención del scanner de holdout-guard (open `open_holdout`-only).
- Holdout execution permanece bloqueada hasta cierre de #322.

Advances #276.
