### PR TITLE
feat(walk-forward): per-window regime_tag + per-regime breakdown (completes #276)

### DIFF
--- a/docs/superpowers/specs/es/2026-05-29-walk-forward-harness-sample.md
+++ b/docs/superpowers/specs/es/2026-05-29-walk-forward-harness-sample.md
@@ -102,13 +102,24 @@ fija el contrato):
         "win_rate":         "n/a",
         "total_return_pct": "n/a"
       },
-      "regime_tag": null,
       "error":      null
     }
   },
   "skipped": [
     {"symbol": "n/a", "reason": "no_usable_params"}
   ],
+  "regime_tag": {
+    "regime":     "n/a",
+    "score":      "n/a",
+    "components": {"price": "n/a", "fng": "n/a", "funding": "n/a"},
+    "n_days":     "n/a",
+    "method":     "composite_mean"
+  },
+  "per_regime": {
+    "BULL":    {"trades": "n/a", "win_rate": "n/a", "avg_pnl_pct": "n/a", "total_pnl_usd": "n/a"},
+    "BEAR":    {"trades": "n/a", "win_rate": "n/a", "avg_pnl_pct": "n/a", "total_pnl_usd": "n/a"},
+    "NEUTRAL": {"trades": "n/a", "win_rate": "n/a", "avg_pnl_pct": "n/a", "total_pnl_usd": "n/a"}
+  },
   "is_pnl_by_symbol": {
     "<symbol>": "n/a"
   }
@@ -117,10 +128,23 @@ fija el contrato):
 
 Notas de forma (no son números, son contratos):
 
-- `regime_tag` es siempre `null` en este commit: el simulador clasifica
-  régimen por-trade, no por-run. Un fold-level regime tag requiere una decisión
-  agregada (modo? mayoría?) que el harness aún no fija — surfacearla ahora sería
-  inventar semántica.
+- `regime_tag` y `per_regime` son **window-level** (#536, completa #276). Se
+  pueblan sólo cuando el orquestador carga `regime_data` de fuentes
+  **NON-HOLDOUT** (`data/ohlcv.db` + `data/backtest/*.csv`) y lo pasa a
+  `evaluate_window` (`run_walk_forward(..., load_regime=True)`); sin ese dato
+  quedan `null` y no se hace I/O de régimen.
+  - `regime_tag` = composite **BULL/BEAR/NEUTRAL** de la test window bajo la
+    regla acordada en el Paso 0 (`method: "composite_mean"`): clasificar la
+    **media** del composite diario `40% precio + 30% F&G + 30% funding` (pesos
+    `mode='global'` de `strategy.regime`, umbrales `>60` BULL / `<40` BEAR).
+    `method` es un contrato fijo, no una métrica medida.
+  - `per_regime` agrupa los trades de la ventana por el régimen composite del
+    **día de entrada** de cada trade — misma taxonomía que `regime_tag` (un solo
+    vocabulario en todo el reporte). Forma por bucket idéntica a
+    `backtest.classify_market_regime`.
+- El antiguo placeholder **per-symbol** `regime_tag` (siempre `null`) queda
+  **retirado**: la decisión de agregación ya está fijada y vive a nivel de
+  ventana.
 - `error` se popula sólo cuando el runner retorna su sentinel
   (`{"error": ..., "total_trades": 0, "net_pnl": 0, "profit_factor": 0}`) — por
   ejemplo cuando `data/ohlcv.db` no cubre el rango.
@@ -261,8 +285,11 @@ Repito para que ningún lector apurado se confunda:
 
 ---
 
-**Versión de la forma**: corresponde al estado del módulo `walk_forward.py` en
-el commit que introduce `--execute` (commit 7 de #276). Cuando el shape del
-JSON cambie (nuevas métricas, nuevos campos en `oos_is_ratio.reason`, regime
-tag agregado por fold), regenerar este sample en una versión nueva y dejar
-ésta como histórica.
+**Versión de la forma**: corresponde al estado del módulo `walk_forward.py`
+tras #536 (completa #276) — `regime_tag` + `per_regime` window-level añadidos
+sobre el shape de `--execute` (commit 7). Actualizado in-place porque #536
+cierra el mismo epic #276 el mismo día; el git history preserva el shape
+anterior (per-symbol `regime_tag: null`). Cuando el shape del JSON vuelva a
+cambiar (nuevas métricas, nuevos campos en `oos_is_ratio.reason`, deflated
+metrics de #278), regenerar este sample en una versión nueva y dejar ésta como
+histórica.

--- a/tests/test_walk_forward_aggregate.py
+++ b/tests/test_walk_forward_aggregate.py
@@ -154,7 +154,7 @@ def test_orchestrator_iterates_windows_in_order(monkeypatch):
         calls.append(("tune", window.index, out))
         return out
 
-    def fake_eval(window, tuned, config):
+    def fake_eval(window, tuned, config, regime_data=None):
         calls.append(("eval", window.index, tuned))
         return _window_report(
             window.index,
@@ -214,7 +214,7 @@ def test_orchestrator_attaches_is_pnl_block(monkeypatch):
             },
         }
 
-    def fake_eval(window, tuned, config):
+    def fake_eval(window, tuned, config, regime_data=None):
         # Both symbols reached the runner; both get embedded in params.
         return _window_report(
             window.index,
@@ -283,7 +283,7 @@ def test_orchestrator_continues_after_tune_failure(monkeypatch):
 
     eval_called_on: list[int] = []
 
-    def fake_eval(window, tuned, config):
+    def fake_eval(window, tuned, config, regime_data=None):
         eval_called_on.append(window.index)
         return _window_report(
             window.index,
@@ -324,7 +324,7 @@ def test_orchestrator_continues_after_eval_failure(monkeypatch):
             "recommendation": "KEEP",
         }}}
 
-    def fake_eval(window, tuned, config):
+    def fake_eval(window, tuned, config, regime_data=None):
         if window.index == 0:
             raise ValueError("synthetic eval failure on window 0")
         return _window_report(
@@ -617,7 +617,7 @@ def test_run_and_aggregate_end_to_end(monkeypatch):
             }},
         }
 
-    def fake_eval(window, tuned, config):
+    def fake_eval(window, tuned, config, regime_data=None):
         return _window_report(
             window.index,
             results={"BTCUSDT": _sym_entry(

--- a/tests/test_walk_forward_ci_mode.py
+++ b/tests/test_walk_forward_ci_mode.py
@@ -120,7 +120,7 @@ def test_skips_tune_window(patch_auto_tune, monkeypatch):
     monkeypatch.setattr(walk_forward, "tune_window", boom_tune)
 
     # Stub evaluate_window so we don't try to actually run a backtest.
-    def fake_eval(window, tuned, config):
+    def fake_eval(window, tuned, config, regime_data=None):
         return {
             "window_index": window.index,
             "train_range": {
@@ -170,7 +170,7 @@ def test_uses_config_overrides(patch_auto_tune, monkeypatch):
 
     seen_tuned: list[dict] = []
 
-    def fake_eval(window, tuned, config):
+    def fake_eval(window, tuned, config, regime_data=None):
         seen_tuned.append(tuned)
         # Mirror the evaluate_window envelope.
         params = {
@@ -276,7 +276,7 @@ def test_default_off(patch_auto_tune, monkeypatch):
             },
         }
 
-    def fake_eval(window, tuned, config):
+    def fake_eval(window, tuned, config, regime_data=None):
         return {
             "window_index": window.index,
             "train_range": {

--- a/tests/test_walk_forward_eval.py
+++ b/tests/test_walk_forward_eval.py
@@ -18,8 +18,10 @@ Invariants exercised:
   2. Per-symbol params come from the tune output: `proposed_params`
      when `recommendation == "CHANGE"`, `current_params` otherwise.
   3. The returned report shape carries `window_index`, `train_range`,
-     `test_range`, `params`, `results[symbol].{n_trades, metrics,
-     regime_tag, error}`, and `skipped`.
+     `test_range`, `params`, `results[symbol].{n_trades, metrics, error}`,
+     `skipped`, and the window-level `regime_tag` / `per_regime` (None here
+     because these eval tests pass no `regime_data`; populated path is
+     covered in `test_walk_forward_regime.py`).
   4. Degenerate test range (`test_start >= test_end`) returns the
      envelope with no runner calls.
   5. A symbol whose tune dict carries no usable params is recorded in
@@ -302,23 +304,28 @@ def test_report_has_declared_shape(patch_auto_tune):
     report = evaluate_window(window, tuned, config={"symbol_overrides": {}})
 
     # Top-level keys.
-    for key in ("window_index", "train_range", "test_range", "params", "results", "skipped"):
+    for key in (
+        "window_index", "train_range", "test_range", "params", "results",
+        "skipped", "regime_tag", "per_regime",
+    ):
         assert key in report, f"missing top-level key: {key}"
 
     assert report["window_index"] == 7
     assert report["train_range"] == {"start": "2023-01-01", "end": "2025-04-01"}
     assert report["test_range"] == {"start": "2025-04-01", "end": "2025-07-01"}
 
-    # Per-symbol entry.
+    # regime_tag / per_regime are window-level (#536) and stay None when no
+    # regime_data is supplied — these eval tests never pass it.
+    assert report["regime_tag"] is None
+    assert report["per_regime"] is None
+
+    # Per-symbol entry — the old per-symbol `regime_tag` placeholder is retired.
     entry = report["results"]["BTCUSDT"]
-    for key in ("n_trades", "metrics", "regime_tag", "error"):
+    for key in ("n_trades", "metrics", "error"):
         assert key in entry, f"missing per-symbol key: {key}"
+    assert "regime_tag" not in entry, "regime_tag is now window-level, not per-symbol"
 
     assert entry["n_trades"] == 1
-    assert entry["regime_tag"] is None, (
-        "regime_tag is intentionally None until a fold-aggregation rule "
-        "is agreed on; the simulator emits regime per-trade, not per-run"
-    )
     assert entry["error"] is None
 
 

--- a/tests/test_walk_forward_regime.py
+++ b/tests/test_walk_forward_regime.py
@@ -1,0 +1,393 @@
+"""Tests for the per-window regime composite (#536, completes #276).
+
+This module covers the regime layer added on top of commit 4's
+`evaluate_window`:
+
+  - `_classify_regime_score`   — score → BULL/BEAR/NEUTRAL (thresholds
+    mirror `strategy.regime._compute_local_regime`: >60 BULL, <40 BEAR).
+  - `_build_window_regime_series` — per-day composite (40% price + 30%
+    F&G + 30% funding, mode='global' weights) over the test window,
+    built from already-loaded NON-HOLDOUT historical frames.
+  - `_window_regime_tag`        — Residual 1: the window's `regime_tag`
+    via the agreed rule (Paso 0 → C, "composite_mean"): classify the
+    mean of the daily composite.
+  - `_per_regime_breakdown`     — Residual 2: bucket the window's trades
+    by the composite regime active on each trade's entry day (same
+    taxonomy as the window tag — agreed in #536).
+
+The pure helpers take frames as arguments and read no data source, so
+they are unit-testable without network or disk and cannot touch the
+locked holdout.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pandas as pd
+import pytest
+
+from walk_forward import (
+    Window,
+    evaluate_window,
+    _build_window_regime_series,
+    _classify_regime_score,
+    _per_regime_breakdown,
+    _window_regime_tag,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic historical frames (NON-HOLDOUT — built in memory)
+# --------------------------------------------------------------------------- #
+
+
+def _btc_daily(start: date, n_days: int, *, direction: str) -> pd.DataFrame:
+    """Daily BTC OHLCV-ish frame with a `close` column and a DatetimeIndex.
+
+    `direction`:
+      - "bull": monotonically rising close → price_score near 100.
+      - "bear": monotonically falling close → death cross + below SMA200
+        + negative 30d return → low price_score.
+    """
+    idx = pd.date_range(pd.Timestamp(start), periods=n_days, freq="D")
+    if direction == "bull":
+        close = [100.0 + i for i in range(n_days)]
+    elif direction == "bear":
+        close = [100.0 + n_days - i for i in range(n_days)]
+    else:
+        raise ValueError(direction)
+    return pd.DataFrame({"close": close}, index=idx)
+
+
+def _fng(start: date, n_days: int, value: int) -> pd.DataFrame:
+    """Daily Fear & Greed frame: index='date', column 'fng' (0-100)."""
+    idx = pd.date_range(pd.Timestamp(start), periods=n_days, freq="D")
+    return pd.DataFrame({"fng": [value] * n_days}, index=idx)
+
+
+def _funding(start: date, n_days: int, rate: float) -> pd.DataFrame:
+    """8h funding-rate frame: index='time', column 'rate'."""
+    idx = pd.date_range(pd.Timestamp(start), periods=n_days * 3, freq="8h")
+    return pd.DataFrame({"rate": [rate] * (n_days * 3)}, index=idx)
+
+
+# --------------------------------------------------------------------------- #
+# _classify_regime_score — thresholds mirror production (>60 BULL, <40 BEAR)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "score,expected",
+    [
+        (90.0, "BULL"),
+        (61.0, "BULL"),
+        (60.0, "NEUTRAL"),   # strict >: 60 is NOT bull
+        (50.0, "NEUTRAL"),
+        (40.0, "NEUTRAL"),   # strict <: 40 is NOT bear
+        (39.0, "BEAR"),
+        (5.0, "BEAR"),
+    ],
+)
+def test_classify_regime_score_thresholds(score, expected):
+    assert _classify_regime_score(score) == expected
+
+
+# --------------------------------------------------------------------------- #
+# _build_window_regime_series — composite math + windowing
+# --------------------------------------------------------------------------- #
+
+
+def test_series_covers_only_the_test_window_left_inclusive():
+    btc = _btc_daily(date(2024, 1, 1), 400, direction="bull")
+    fng = _fng(date(2024, 1, 1), 400, 70)
+    fund = _funding(date(2024, 1, 1), 400, 0.004)
+
+    series = _build_window_regime_series(
+        btc, fng, fund, date(2025, 1, 1), date(2025, 1, 11)
+    )
+
+    # [2025-01-01, 2025-01-11) → exactly 10 days.
+    assert len(series) == 10
+    assert series.index.min() == pd.Timestamp(2025, 1, 1)
+    assert series.index.max() == pd.Timestamp(2025, 1, 10)
+    for col in ("price", "fng", "funding", "composite"):
+        assert col in series.columns
+
+
+def test_composite_is_global_weighted_sum_of_components():
+    btc = _btc_daily(date(2024, 1, 1), 400, direction="bull")
+    fng = _fng(date(2024, 1, 1), 400, 70)
+    fund = _funding(date(2024, 1, 1), 400, 0.004)  # score 50 + 0.004*5000 = 70
+
+    series = _build_window_regime_series(
+        btc, fng, fund, date(2025, 1, 1), date(2025, 1, 11)
+    )
+
+    for _, row in series.iterrows():
+        expected = row["price"] * 0.40 + row["fng"] * 0.30 + row["funding"] * 0.30
+        assert row["composite"] == pytest.approx(expected, abs=1e-9)
+    # F&G pass-through and funding mapping land as expected.
+    assert (series["fng"] == 70).all()
+    assert (series["funding"] == 70).all()  # _compute_funding_score(0.004)
+
+
+def test_bull_setup_scores_above_bull_threshold():
+    btc = _btc_daily(date(2024, 1, 1), 400, direction="bull")
+    fng = _fng(date(2024, 1, 1), 400, 80)
+    fund = _funding(date(2024, 1, 1), 400, 0.005)
+
+    series = _build_window_regime_series(
+        btc, fng, fund, date(2025, 1, 1), date(2025, 2, 1)
+    )
+    assert (series["composite"] > 60).all()
+
+
+def test_bear_setup_scores_below_bear_threshold():
+    btc = _btc_daily(date(2024, 1, 1), 400, direction="bear")
+    fng = _fng(date(2024, 1, 1), 400, 15)
+    fund = _funding(date(2024, 1, 1), 400, -0.005)
+
+    series = _build_window_regime_series(
+        btc, fng, fund, date(2025, 1, 1), date(2025, 2, 1)
+    )
+    assert (series["composite"] < 40).all()
+
+
+def test_missing_funding_defaults_to_neutral_fifty():
+    """Funding history that does not cover the window → neutral 50 (mirrors
+    production `detect_regime` funding-error fallback)."""
+    btc = _btc_daily(date(2024, 1, 1), 400, direction="bull")
+    fng = _fng(date(2024, 1, 1), 400, 70)
+    fund = pd.DataFrame({"rate": []}, index=pd.DatetimeIndex([], name="time"))
+
+    series = _build_window_regime_series(
+        btc, fng, fund, date(2025, 1, 1), date(2025, 1, 6)
+    )
+    assert (series["funding"] == 50).all()
+
+
+def test_empty_window_returns_empty_series():
+    btc = _btc_daily(date(2024, 1, 1), 400, direction="bull")
+    fng = _fng(date(2024, 1, 1), 400, 70)
+    fund = _funding(date(2024, 1, 1), 400, 0.0)
+
+    series = _build_window_regime_series(
+        btc, fng, fund, date(2025, 1, 1), date(2025, 1, 1)  # empty range
+    )
+    assert series.empty
+
+
+# --------------------------------------------------------------------------- #
+# _window_regime_tag — Residual 1 (Paso 0 → C, "composite_mean")
+# --------------------------------------------------------------------------- #
+
+
+def _series(composite_values, price=80, fng=70, funding=60, start=date(2025, 1, 1)):
+    idx = pd.date_range(pd.Timestamp(start), periods=len(composite_values), freq="D")
+    return pd.DataFrame(
+        {
+            "price": [price] * len(composite_values),
+            "fng": [fng] * len(composite_values),
+            "funding": [funding] * len(composite_values),
+            "composite": list(composite_values),
+        },
+        index=idx,
+    )
+
+
+def test_window_regime_tag_classifies_mean_composite_bull():
+    tag = _window_regime_tag(_series([70, 80, 90]))
+    assert tag["regime"] == "BULL"
+    assert tag["score"] == pytest.approx(80.0)
+    assert tag["method"] == "composite_mean"
+    assert tag["n_days"] == 3
+    assert set(tag["components"]) == {"price", "fng", "funding"}
+
+
+def test_window_regime_tag_neutral_when_mean_is_between():
+    tag = _window_regime_tag(_series([40, 50, 60]))
+    assert tag["regime"] == "NEUTRAL"
+    assert tag["score"] == pytest.approx(50.0)
+
+
+def test_window_regime_tag_none_for_empty_series():
+    assert _window_regime_tag(None) is None
+    assert _window_regime_tag(_series([])) is None
+
+
+# --------------------------------------------------------------------------- #
+# _per_regime_breakdown — Residual 2 (composite taxonomy, agreed in #536)
+# --------------------------------------------------------------------------- #
+
+
+def _trade(entry: datetime, pnl_usd: float, pnl_pct: float, exit_reason: str = "TP") -> dict:
+    return {
+        "entry_time": entry,
+        "pnl_usd": pnl_usd,
+        "pnl_pct": pnl_pct,
+        "exit_reason": exit_reason,
+    }
+
+
+def test_per_regime_buckets_trades_by_entry_day_composite():
+    # Day 1 BULL (90), day 2 BEAR (20), day 3 NEUTRAL (50).
+    series = _series([90, 20, 50], start=date(2025, 1, 1))
+    trades = [
+        _trade(datetime(2025, 1, 1, 12), 10.0, 1.0),   # → BULL
+        _trade(datetime(2025, 1, 2, 9), -5.0, -0.5),   # → BEAR
+        _trade(datetime(2025, 1, 3, 18), 2.0, 0.2),    # → NEUTRAL
+    ]
+    out = _per_regime_breakdown(trades, series)
+
+    assert out["BULL"]["trades"] == 1
+    assert out["BULL"]["total_pnl_usd"] == pytest.approx(10.0)
+    assert out["BULL"]["win_rate"] == pytest.approx(100.0)
+    assert out["BEAR"]["trades"] == 1
+    assert out["BEAR"]["total_pnl_usd"] == pytest.approx(-5.0)
+    assert out["BEAR"]["win_rate"] == pytest.approx(0.0)
+    assert out["NEUTRAL"]["trades"] == 1
+
+
+def test_per_regime_skips_open_trades():
+    series = _series([90, 90], start=date(2025, 1, 1))
+    trades = [
+        _trade(datetime(2025, 1, 1, 12), 10.0, 1.0, exit_reason="TP"),
+        _trade(datetime(2025, 1, 2, 12), 0.0, 0.0, exit_reason="OPEN"),
+    ]
+    out = _per_regime_breakdown(trades, series)
+    assert out["BULL"]["trades"] == 1  # OPEN trade not counted
+
+
+def test_per_regime_all_buckets_present_when_empty():
+    series = _series([90, 90])
+    out = _per_regime_breakdown([], series)
+    for regime in ("BULL", "BEAR", "NEUTRAL"):
+        assert out[regime]["trades"] == 0
+        assert out[regime]["total_pnl_usd"] == 0
+
+
+def test_per_regime_none_without_series():
+    assert _per_regime_breakdown([_trade(datetime(2025, 1, 1), 1.0, 0.1)], None) is None
+
+
+# --------------------------------------------------------------------------- #
+# Integration: evaluate_window wires regime_tag + per_regime when regime_data
+# is supplied; stays None (backward-compatible) when it is not.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeAutoTune:
+    """Minimal stand-in returning trades with the fields the regime layer
+    needs (entry_time, pnl_usd, pnl_pct, exit_reason)."""
+
+    def __init__(self, trades):
+        self._trades = trades
+        self.calls = []
+
+    def run_backtest_with_params(self, symbol, params, sim_start, sim_end, *, cutoff=None, app_config=None):
+        self.calls.append(symbol)
+        metrics = {"total_trades": len(self._trades), "net_pnl": 5.0}
+        return self._trades, metrics
+
+
+@pytest.fixture
+def patch_auto_tune(monkeypatch):
+    def _install(trades):
+        import sys
+        fake = _FakeAutoTune(trades)
+        monkeypatch.setitem(sys.modules, "auto_tune", fake)
+        return fake
+    return _install
+
+
+def _eval_window() -> Window:
+    return Window(
+        index=0,
+        train_start=date(2024, 1, 1),
+        train_end=date(2025, 1, 1),
+        test_start=date(2025, 1, 1),
+        test_end=date(2025, 2, 1),
+        warmup_gap_days=0,
+    )
+
+
+def _tuned_keep(symbol="BTCUSDT") -> dict:
+    return {
+        "results": {
+            symbol: {
+                "symbol": symbol,
+                "current_params": {"atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5},
+                "current_val_pnl": 0,
+                "proposed_params": None,
+                "proposal_detail": None,
+                "recommendation": "KEEP",
+            }
+        }
+    }
+
+
+def _regime_data(direction="bull", fng=80, rate=0.005) -> dict:
+    return {
+        "btc_daily": _btc_daily(date(2024, 1, 1), 500, direction=direction),
+        "fng_df": _fng(date(2024, 1, 1), 500, fng),
+        "funding_df": _funding(date(2024, 1, 1), 500, rate),
+    }
+
+
+def test_evaluate_window_populates_top_level_regime_tag_and_per_regime(patch_auto_tune):
+    patch_auto_tune([
+        _trade(datetime(2025, 1, 5, 12), 10.0, 1.0),
+        _trade(datetime(2025, 1, 20, 12), -3.0, -0.3),
+    ])
+    report = evaluate_window(
+        _eval_window(), _tuned_keep(), config={"symbol_overrides": {}},
+        regime_data=_regime_data(direction="bull"),
+    )
+
+    assert isinstance(report["regime_tag"], dict)
+    assert report["regime_tag"]["regime"] == "BULL"
+    assert report["regime_tag"]["method"] == "composite_mean"
+    assert isinstance(report["per_regime"], dict)
+    assert set(report["per_regime"]) == {"BULL", "BEAR", "NEUTRAL"}
+    # Both trades fall in the bull window → bucketed under BULL.
+    assert report["per_regime"]["BULL"]["trades"] == 2
+
+
+def test_per_symbol_regime_tag_is_retired(patch_auto_tune):
+    """The old per-symbol `regime_tag` placeholder is gone; regime lives at
+    the window level now."""
+    patch_auto_tune([_trade(datetime(2025, 1, 5, 12), 10.0, 1.0)])
+    report = evaluate_window(
+        _eval_window(), _tuned_keep(), config={"symbol_overrides": {}},
+        regime_data=_regime_data(),
+    )
+    entry = report["results"]["BTCUSDT"]
+    assert "regime_tag" not in entry
+    assert set(entry) == {"n_trades", "metrics", "error"}
+
+
+def test_no_regime_data_leaves_regime_fields_none(patch_auto_tune):
+    """Backward-compatible: without regime_data the harness performs no I/O
+    and leaves regime_tag / per_regime as None."""
+    patch_auto_tune([_trade(datetime(2025, 1, 5, 12), 10.0, 1.0)])
+    report = evaluate_window(
+        _eval_window(), _tuned_keep(), config={"symbol_overrides": {}},
+    )
+    assert report["regime_tag"] is None
+    assert report["per_regime"] is None
+
+
+def test_empty_test_range_carries_none_regime_fields(patch_auto_tune):
+    patch_auto_tune([])
+    window = Window(
+        index=1, train_start=date(2024, 1, 1), train_end=date(2025, 1, 1),
+        test_start=date(2025, 1, 1), test_end=date(2025, 1, 1),  # degenerate
+        warmup_gap_days=0,
+    )
+    report = evaluate_window(
+        window, _tuned_keep(), config={"symbol_overrides": {}},
+        regime_data=_regime_data(),
+    )
+    assert report["regime_tag"] is None
+    assert report["per_regime"] is None

--- a/walk_forward.py
+++ b/walk_forward.py
@@ -471,7 +471,271 @@ def _date_to_sim_datetime(d: date) -> datetime:
     return datetime(d.year, d.month, d.day, tzinfo=timezone.utc)
 
 
-def evaluate_window(window: Window, tuned: dict, config: dict) -> dict:
+# --------------------------------------------------------------------------- #
+# Per-window regime composite (#536, completes #276)
+# --------------------------------------------------------------------------- #
+#
+# Residual 1 — `regime_tag` for the window: a single BULL/BEAR/NEUTRAL tag.
+# Paso 0 (agreed in #536): the aggregation rule is **composite_mean** — build
+# the daily composite over the test window, then classify its mean. Composite
+# = 40% price + 30% F&G + 30% funding (mode='global' weights from
+# strategy.regime), reusing the production scorers so the window composite is
+# byte-identical to live regime detection.
+#
+# Residual 2 — `per_regime` breakdown: bucket the window's trades by the
+# composite regime active on each trade's entry day. Same taxonomy as the
+# window tag (agreed in #536) — one vocabulary across the whole report.
+#
+# Holdout safety (Non-Negotiable #2/#3): these helpers are pure — they read no
+# data source. The caller loads the three frames from NON-HOLDOUT origins
+# (`data/ohlcv.db`, `data/backtest/*.csv`); `compute_windows` bounds every
+# `test_end <= holdout_start`, so the composite only ever indexes pre-holdout
+# dates. No `open_holdout`, no `"holdout"` literal.
+
+# Composite weights and thresholds mirror strategy.regime mode='global'.
+_REGIME_W_PRICE = 0.40
+_REGIME_W_FNG = 0.30
+_REGIME_W_FUNDING = 0.30
+_REGIME_BULL_ABOVE = 60
+_REGIME_BEAR_BELOW = 40
+_REGIME_NEUTRAL_SCORE = 50  # F&G / funding fallback when history misses a day
+
+
+def _classify_regime_score(score: float) -> str:
+    """Map a 0-100 composite score to BULL/BEAR/NEUTRAL.
+
+    Thresholds mirror `strategy.regime._compute_local_regime`: strictly above
+    60 is BULL, strictly below 40 is BEAR, the closed band [40, 60] is NEUTRAL.
+    """
+    if score > _REGIME_BULL_ABOVE:
+        return "BULL"
+    if score < _REGIME_BEAR_BELOW:
+        return "BEAR"
+    return "NEUTRAL"
+
+
+def _normalize_daily_index(df):
+    """Return a copy of `df` with a tz-naive, sorted DatetimeIndex, or None
+    when the frame is empty / has no usable index."""
+    import pandas as pd  # noqa: PLC0415 — keep pandas out of import time
+    if df is None or len(df) == 0:
+        return None
+    out = df.copy()
+    idx = pd.DatetimeIndex(out.index)
+    if idx.tz is not None:
+        idx = idx.tz_localize(None)
+    out.index = idx
+    return out.sort_index()
+
+
+def _daily_value_series(df, col: str, agg: str = "last"):
+    """Collapse a frame to a tz-naive, day-indexed Series of `col`.
+
+    `agg` controls intra-day aggregation: 'last' for an already-daily series
+    (F&G), 'mean' for sub-daily samples (8h funding). Returns None when the
+    frame is empty or lacks the column.
+    """
+    import pandas as pd  # noqa: PLC0415
+    if df is None or len(df) == 0 or col not in getattr(df, "columns", []):
+        return None
+    s = df[col].copy()
+    idx = pd.DatetimeIndex(s.index)
+    if idx.tz is not None:
+        idx = idx.tz_localize(None)
+    s.index = idx
+    s = s.sort_index()
+    daily = s.resample("1D").mean() if agg == "mean" else s.resample("1D").last()
+    return daily.dropna()
+
+
+def _value_asof(series, day):
+    """Forward-filled value of `series` at/before `day`, or None."""
+    import pandas as pd  # noqa: PLC0415
+    if series is None or len(series) == 0:
+        return None
+    try:
+        val = series.asof(day)
+    except (TypeError, KeyError):
+        return None
+    if val is None or pd.isna(val):
+        return None
+    return val
+
+
+def _build_window_regime_series(btc_daily, fng_df, funding_df, test_start, test_end):
+    """Per-day composite regime score over ``[test_start, test_end)``.
+
+    Pure: takes already-loaded historical frames and returns a DataFrame
+    indexed by calendar day (left-inclusive of the test range) with columns
+    ``price``, ``fng``, ``funding``, ``composite``. Reads no data source.
+
+    - ``price``    : `strategy.regime._compute_price_score` on the BTC daily
+      history up to and including each day (lookback honoured; <200 bars
+      yields the production 100 fallback).
+    - ``fng``      : `_compute_fng_score` of the day's Fear & Greed value
+      (forward-filled; neutral 50 when history misses the day).
+    - ``funding``  : `_compute_funding_score` of the day's mean funding rate
+      (forward-filled; neutral 50 when history misses the day).
+    - ``composite``: 0.40*price + 0.30*fng + 0.30*funding (global weights).
+
+    Returns an empty DataFrame when the window has no days.
+    """
+    import pandas as pd  # noqa: PLC0415
+    from strategy.regime import (  # noqa: PLC0415
+        _compute_fng_score,
+        _compute_funding_score,
+        _compute_price_score,
+    )
+
+    # Degenerate test range → empty series. `date_range(s, s, inclusive="left")`
+    # still yields one element in pandas, so guard the empty/inverted case
+    # explicitly (mirrors `evaluate_window`'s `test_start >= test_end` check).
+    if pd.Timestamp(test_start) >= pd.Timestamp(test_end):
+        return pd.DataFrame(columns=["price", "fng", "funding", "composite"])
+
+    days = pd.date_range(
+        pd.Timestamp(test_start), pd.Timestamp(test_end), freq="D", inclusive="left"
+    )
+    if len(days) == 0:
+        return pd.DataFrame(columns=["price", "fng", "funding", "composite"])
+
+    btc = _normalize_daily_index(btc_daily)
+    fng_daily = _daily_value_series(fng_df, "fng", agg="last")
+    funding_daily = _daily_value_series(funding_df, "rate", agg="mean")
+
+    rows = []
+    for d in days:
+        price_score = _compute_price_score(btc.loc[:d]) if btc is not None else 100
+        fng_val = _value_asof(fng_daily, d)
+        funding_val = _value_asof(funding_daily, d)
+        fng_score = (
+            _compute_fng_score(int(fng_val)) if fng_val is not None
+            else _REGIME_NEUTRAL_SCORE
+        )
+        funding_score = (
+            _compute_funding_score(float(funding_val)) if funding_val is not None
+            else _REGIME_NEUTRAL_SCORE
+        )
+        composite = (
+            price_score * _REGIME_W_PRICE
+            + fng_score * _REGIME_W_FNG
+            + funding_score * _REGIME_W_FUNDING
+        )
+        rows.append((d, price_score, fng_score, funding_score, composite))
+
+    return pd.DataFrame(
+        rows, columns=["ts", "price", "fng", "funding", "composite"]
+    ).set_index("ts")
+
+
+def _window_regime_tag(regime_series):
+    """Residual 1: the window's regime_tag via the agreed rule (Paso 0 → C,
+    "composite_mean") — classify the mean of the daily composite.
+
+    Returns ``{regime, score, components, n_days, method}`` or None when the
+    series is empty / unavailable.
+    """
+    if regime_series is None or len(regime_series) == 0:
+        return None
+    mean_composite = float(regime_series["composite"].mean())
+    return {
+        "regime": _classify_regime_score(mean_composite),
+        "score": round(mean_composite, 2),
+        "components": {
+            "price": round(float(regime_series["price"].mean()), 2),
+            "fng": round(float(regime_series["fng"].mean()), 2),
+            "funding": round(float(regime_series["funding"].mean()), 2),
+        },
+        "n_days": int(len(regime_series)),
+        "method": "composite_mean",
+    }
+
+
+def _per_regime_breakdown(trades, regime_series):
+    """Residual 2: bucket closed trades by the composite regime active on
+    their entry day (same taxonomy as the window tag).
+
+    Returns ``{"BULL": {...}, "BEAR": {...}, "NEUTRAL": {...}}`` where each
+    bucket carries ``{trades, win_rate, avg_pnl_pct, total_pnl_usd}`` (mirrors
+    `backtest.classify_market_regime`'s per-bucket shape), or None when the
+    regime series is unavailable.
+    """
+    import pandas as pd  # noqa: PLC0415
+    if regime_series is None or len(regime_series) == 0:
+        return None
+
+    composite = regime_series["composite"]
+    buckets: dict[str, list] = {"BULL": [], "BEAR": [], "NEUTRAL": []}
+    for t in trades or []:
+        if t.get("exit_reason") == "OPEN":
+            continue
+        entry = t.get("entry_time")
+        if entry is None:
+            continue
+        ts = pd.Timestamp(entry)
+        if ts.tz is not None:
+            ts = ts.tz_localize(None)
+        score = _value_asof(composite, ts.normalize())
+        if score is None:
+            continue
+        buckets[_classify_regime_score(float(score))].append(t)
+
+    result = {}
+    for regime, regime_trades in buckets.items():
+        if not regime_trades:
+            result[regime] = {
+                "trades": 0, "win_rate": 0, "avg_pnl_pct": 0, "total_pnl_usd": 0,
+            }
+            continue
+        df_r = pd.DataFrame(regime_trades)
+        wins = df_r[df_r["pnl_usd"] > 0]
+        result[regime] = {
+            "trades": len(df_r),
+            "win_rate": round(len(wins) / len(df_r) * 100, 1),
+            "avg_pnl_pct": round(float(df_r["pnl_pct"].mean()), 2),
+            "total_pnl_usd": round(float(df_r["pnl_usd"].sum()), 2),
+        }
+    return result
+
+
+def _load_regime_data(app_config: dict | None = None) -> dict | None:
+    """Load the three historical series the regime composite needs, from
+    NON-HOLDOUT production sources. Returns ``{btc_daily, fng_df, funding_df}``
+    or None on any failure (regime_tag then degrades to None).
+
+    Sources (never the locked snapshot — Non-Negotiable #2/#3):
+      - BTC daily OHLCV ← `backtest.get_cached_data('BTCUSDT', '1d')`
+        → `data/ohlcv.db`
+      - Fear & Greed    ← `backtest.get_historical_fear_greed()`
+        → `data/backtest/fear_greed_history.csv`
+      - funding rate    ← `backtest.get_historical_funding_rate()`
+        → `data/backtest/btc_funding_rate_history.csv`
+    """
+    import backtest  # noqa: PLC0415
+    try:
+        btc_daily = backtest.get_cached_data("BTCUSDT", "1d")
+        if btc_daily is None or len(btc_daily) == 0:
+            log.warning(
+                "walk_forward: regime data load — empty BTC daily; "
+                "regime_tag disabled for this run"
+            )
+            return None
+        return {
+            "btc_daily": btc_daily,
+            "fng_df": backtest.get_historical_fear_greed(),
+            "funding_df": backtest.get_historical_funding_rate(),
+        }
+    except Exception as exc:  # noqa: BLE001 — regime is best-effort enrichment
+        log.warning(
+            "walk_forward: regime data load failed (%s): %s — regime_tag disabled",
+            type(exc).__name__, exc,
+        )
+        return None
+
+
+def evaluate_window(
+    window: Window, tuned: dict, config: dict, regime_data: dict | None = None
+) -> dict:
     """Evaluate per-symbol tuned params on the fold's **test range**.
 
     The train range was consumed during tuning (commit 3). The locked
@@ -490,6 +754,11 @@ def evaluate_window(window: Window, tuned: dict, config: dict) -> dict:
             consumes. Passed through to `run_backtest_with_params` so
             the standard `cfg + symbol_overrides` path stays active
             (time_limit + participation cap gates on).
+        regime_data: Optional dict ``{btc_daily, fng_df, funding_df}`` of
+            already-loaded NON-HOLDOUT historical frames. When provided, the
+            window's ``regime_tag`` and ``per_regime`` are computed from it;
+            when None (default) both stay None and no regime I/O runs. The
+            orchestrator loads it once and passes it down.
 
     Returns:
         A per-window report shaped::
@@ -503,20 +772,23 @@ def evaluate_window(window: Window, tuned: dict, config: dict) -> dict:
                     symbol: {
                         "n_trades": int,
                         "metrics": dict,     # projection of calculate_metrics
-                        "regime_tag": None,  # see Note below
                         "error": str | None, # populated on runner sentinel
                     },
                     ...
                 },
                 "skipped": [{"symbol": str, "reason": str}, ...],
+                "regime_tag": dict | None,   # window-level; see Note below
+                "per_regime": dict | None,   # window-level; see Note below
             }
 
-        ``regime_tag`` is always ``None`` here. The simulator emits
-        regime classification per-trade (see ``classify_market_regime``),
-        not a single tag per run. A fold-level summary would require an
-        aggregate decision (mode? majority?) the harness has not yet
-        agreed on; surfacing it now would invent semantics. Leave
-        ``None`` until a downstream commit chooses the rule.
+        ``regime_tag`` and ``per_regime`` are window-level (#536, completes
+        #276), populated only when ``regime_data`` is supplied; otherwise both
+        stay ``None`` and the function performs no regime I/O. ``regime_tag``
+        is the composite BULL/BEAR/NEUTRAL of the test window under the agreed
+        rule (Paso 0 → C, "composite_mean": classify the mean of the daily
+        40/30/30 price+F&G+funding composite). ``per_regime`` buckets the
+        window's trades by the composite regime on each trade's entry day —
+        same taxonomy as ``regime_tag``.
 
         ``skipped`` lists symbols whose tune dict had no usable params
         and whose evaluation was therefore skipped (no runner call).
@@ -544,6 +816,8 @@ def evaluate_window(window: Window, tuned: dict, config: dict) -> dict:
         "params": {},
         "results": {},
         "skipped": [],
+        "regime_tag": None,
+        "per_regime": None,
     }
 
     # Degenerate fold: empty test range. Return the envelope; do not
@@ -558,6 +832,7 @@ def evaluate_window(window: Window, tuned: dict, config: dict) -> dict:
 
     tune_results = tuned.get("results", {}) if isinstance(tuned, dict) else {}
 
+    all_trades: list[dict] = []
     for symbol, sym_tune in tune_results.items():
         params = _select_params_for_eval(sym_tune)
         if params is None or len(params) != len(_TUNED_PARAM_KEYS):
@@ -577,12 +852,35 @@ def evaluate_window(window: Window, tuned: dict, config: dict) -> dict:
             app_config=config,
         )
 
+        if trades:
+            all_trades.extend(trades)
+
         report["results"][symbol] = {
             "n_trades": len(trades) if trades else 0,
             "metrics": _project_metrics(metrics),
-            "regime_tag": None,  # see docstring — intentionally unset
             "error": metrics.get("error") if isinstance(metrics, dict) else None,
         }
+
+    # Window-level regime composite (#536). Best-effort enrichment: a failure
+    # here must not blacken an otherwise-valid fold. The helpers are pure; the
+    # frames in `regime_data` were loaded by the orchestrator from NON-HOLDOUT
+    # sources (Non-Negotiable #2/#3).
+    if regime_data is not None:
+        try:
+            series = _build_window_regime_series(
+                regime_data.get("btc_daily"),
+                regime_data.get("fng_df"),
+                regime_data.get("funding_df"),
+                window.test_start,
+                window.test_end,
+            )
+            report["regime_tag"] = _window_regime_tag(series)
+            report["per_regime"] = _per_regime_breakdown(all_trades, series)
+        except Exception as exc:  # noqa: BLE001 — regime is best-effort
+            log.warning(
+                "walk_forward: regime composite failed on window %d (%s): %s",
+                window.index, type(exc).__name__, exc,
+            )
 
     return report
 
@@ -671,6 +969,8 @@ def _fold_error_report(window: Window, phase: str, exc: BaseException) -> dict:
         "params": {},
         "results": {},
         "skipped": [],
+        "regime_tag": None,
+        "per_regime": None,
         "error": {
             "phase": phase,            # "tune" | "evaluate"
             "type": type(exc).__name__,
@@ -746,6 +1046,7 @@ def run_walk_forward(
     windows: list[Window],
     app_config: dict,
     ci_mode: bool = False,
+    load_regime: bool = False,
 ) -> WalkForwardRun:
     """Drive `tune_window` → `evaluate_window` over every fold in `windows`.
 
@@ -770,6 +1071,11 @@ def run_walk_forward(
             `evaluate_window` (and the resulting report shape) is
             unchanged; only the source of per-symbol params differs.
             Default False (production behaviour unchanged).
+        load_regime: When True, load the regime composite's NON-HOLDOUT
+            source frames once and pass them to every `evaluate_window`
+            so each fold carries a window-level `regime_tag` + `per_regime`
+            (#536). Default False keeps the orchestrator I/O-free for unit
+            tests; the CLI (`main`) opts in.
 
     Returns:
         A `WalkForwardRun` carrying the original window list and one
@@ -778,6 +1084,13 @@ def run_walk_forward(
     """
     if not windows:
         return WalkForwardRun(windows=[], window_reports=[])
+
+    # Load the regime composite's NON-HOLDOUT source frames once for the whole
+    # run — the orchestrator is the right layer to amortise the disk/CSV read
+    # across folds. Best-effort: on failure `regime_data` is None and every
+    # window's regime_tag degrades to None. Opt-in via `load_regime` so unit
+    # tests of the orchestrator stay I/O-free.
+    regime_data = _load_regime_data(app_config) if load_regime else None
 
     reports: list[dict] = []
     for window in windows:
@@ -795,7 +1108,7 @@ def run_walk_forward(
             continue
 
         try:
-            report = evaluate_window(window, tuned, app_config)
+            report = evaluate_window(window, tuned, app_config, regime_data=regime_data)
         except BaseException as exc:  # noqa: BLE001 — best-effort across folds
             log.warning(
                 "walk_forward: evaluate_window failed on window %d (%s): %s",
@@ -1480,7 +1793,9 @@ def main(argv: list[str] | None = None) -> int:
         # (stdout before the JSON marker) so a consumer can split on the
         # `=== walk-forward summary (JSON) ===` line.
         app_config = _load_app_config(args.config_path)
-        run = run_walk_forward(windows, app_config, ci_mode=args.ci_mode)
+        run = run_walk_forward(
+            windows, app_config, ci_mode=args.ci_mode, load_regime=True
+        )
         summary = aggregate_run_stats(run)
         print("=== walk-forward summary (JSON) ===")
         print(json.dumps(summary, indent=2, sort_keys=True, default=str))


### PR DESCRIPTION
## Qué

Cierra los **2 criterios residuales de #276** que dejó #534 (`85dc87f`), verificados contra el código. `Closes #276`. `Closes #536`.

### Paso 0 — decisión de metodología (acordada antes de codear)

¿Cómo se asigna **un** `regime_tag` a una ventana de muchas barras?

- **Residual 1 — regla de agregación: `composite_mean` (opción C).** El `regime_tag` de la ventana clasifica la **media** del composite diario `40% precio + 30% F&G + 30% funding` sobre la test window. Pesos y umbrales (`>60` BULL / `<40` BEAR) reusados *verbatim* de `strategy.regime` `mode='global'`.
- **Residual 2 — taxonomía del breakdown: composite (opción A).** Cada trade se clasifica por el composite de **su día de entrada** → buckets `BULL/BEAR/NEUTRAL`. Misma taxonomía que el `regime_tag` (un solo vocabulario en el reporte), en vez de reusar el `classify_market_regime` price-only (que habría mezclado `bull/bear/sideways` con `BULL/BEAR/NEUTRAL`).

## Cambios

- **`regime_tag` window-level**: promovido del placeholder per-symbol (siempre `None`) a campo top-level del reporte por-ventana. Forma: `{regime, score, components{price,fng,funding}, n_days, method:"composite_mean"}`.
- **`per_regime` window-level**: nuevo campo top-level; forma por bucket idéntica a `backtest.classify_market_regime` (`{trades, win_rate, avg_pnl_pct, total_pnl_usd}`).
- **Placeholder per-symbol `regime_tag` retirado** (docstring + `test_walk_forward_eval` actualizados).
- Helpers **puros** nuevos en `walk_forward.py` (`_classify_regime_score`, `_build_window_regime_series`, `_window_regime_tag`, `_per_regime_breakdown`, `_load_regime_data` + utilidades de índice/asof). Toman frames como argumentos y no leen ninguna fuente → testeables sin disco/red y estructuralmente incapaces de tocar el holdout.
- `evaluate_window` gana un kwarg opcional `regime_data` (default `None` → sin I/O de régimen, backward-compatible). `run_walk_forward` carga los frames **una vez** (opt-in `load_regime=True`, lo activa el CLI) y los pasa hacia abajo; los tests del orquestador siguen sin I/O.

## Holdout safety (Non-Negotiables #2/#3)

- Sourcing **NON-HOLDOUT**: `data/ohlcv.db` (BTC daily) + `data/backtest/*.csv` (F&G, funding) vía los loaders existentes de `backtest`. Nunca `open_holdout`, nunca el literal `"holdout"`.
- `compute_windows` ya acota `test_end <= holdout_start`, así que el composite solo indexa fechas **pre-holdout**.
- El path gated del holdout (`evaluate_winner_on_holdout`, #322) queda **intacto**. La bandera de holdout se auditó a fondo **antes** de codear (3 agentes, incluido el lente paranoico de holdout → SAFE).
- `tests/test_holdout_isolation.py` pasa **15/15**.

## Verificación

- **24 tests nuevos** en `tests/test_walk_forward_regime.py` (helpers puros + integración).
- Suite walk-forward completa: **118 verde**.
- Suite completa del repo: **2787 passed, 22 skipped**; 1 falla = flake pre-existente ortogonal (`test_http_reexport::test_load_proxy_from_env`, proxy env-var, no relacionado).
- Compile OK · `--dry-run` OK · **smoke real contra datos non-holdout**: `regime_tag = BULL score 72.56`, `per_regime` coherente.
- CI smoke (`walk-forward-smoke`) seguro: con zero-window, `main()` retorna antes del bloque `--execute`, así que `load_regime` no dispara I/O.

## Sample report

`docs/superpowers/specs/es/2026-05-29-walk-forward-harness-sample.md` actualizado **in-place** con los campos window-level — solo `n/a`; `method` es un string de contrato, **sin números fabricados** (Non-Negotiable #5).

## Dependencias

- Soft-dep con **#278** (deflated metrics): este residual va **antes** porque #278 extiende la misma salida por-ventana que `per_regime` toca. Evita rework.
- Deslinde de **#322** (holdout A.4-3): fuera de scope, no tocado.
