### PR TITLE
fix(frontend): send qty in open-position payload (fixes 422 qty required)

### DIFF
--- a/frontend/src/components/OpenPositionModal.test.tsx
+++ b/frontend/src/components/OpenPositionModal.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import OpenPositionModal from './OpenPositionModal';
+import type { SymbolStatus } from '../types';
+import * as api from '../api';
+
+// Regression for the production 422 "qty Field required": the backend
+// OpenPositionRequest requires `qty` (and forbids extra fields). The modal
+// computes qty = size/entry for display but must also SEND it.
+vi.mock('../api', () => ({
+  openPosition: vi.fn().mockResolvedValue({ ok: true, position: { id: 1 } }),
+}));
+
+function symbols(): SymbolStatus[] {
+  return [{
+    symbol: 'BTCUSDT', estado: 'ok', price: 50_000, lrc_pct: 20, score: 6,
+    señal: false, gatillo: true, ts: '2026-04-22T12:00:00Z',
+  } as SymbolStatus];
+}
+
+describe('OpenPositionModal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends qty (= size/entry) in the open-position payload', async () => {
+    render(
+      <OpenPositionModal
+        symbols={symbols()}
+        prefill={{ symbol: 'BTCUSDT', price: 50_000, sizeUsd: 1000 }}
+        onClose={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Abrir/ }));
+    await waitFor(() => expect(api.openPosition).toHaveBeenCalledTimes(1));
+
+    const payload = (api.openPosition as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.qty).toBeCloseTo(1000 / 50_000, 10);   // 0.02
+    expect(payload.qty).toBeGreaterThan(0);
+    expect(payload.entry_price).toBe(50_000);
+    expect(payload.size_usd).toBe(1000);
+    // qty * entry_price ≈ size_usd — the backend cross-field invariant.
+    expect(payload.qty * payload.entry_price).toBeCloseTo(payload.size_usd, 6);
+  });
+
+  it('blocks submit and does not call the API when capital is empty (qty would be 0)', async () => {
+    render(
+      <OpenPositionModal
+        symbols={symbols()}
+        prefill={{ symbol: 'BTCUSDT', price: 50_000 }}  // no sizeUsd → capital empty
+        onClose={() => {}}
+        onCreated={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Abrir/ }));
+    await waitFor(() =>
+      expect(screen.getByText(/capital.*mayor a 0/i)).toBeInTheDocument());
+    expect(api.openPosition).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/OpenPositionModal.tsx
+++ b/frontend/src/components/OpenPositionModal.tsx
@@ -66,6 +66,7 @@ const OpenPositionModal: React.FC<OpenPositionModalProps> = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!entry) { setError('El precio de entrada es requerido'); return; }
+    if (!size || qty <= 0) { setError('El capital (USD) debe ser mayor a 0'); return; }
     setSaving(true);
     setError(null);
     try {
@@ -73,6 +74,10 @@ const OpenPositionModal: React.FC<OpenPositionModalProps> = ({
         symbol,
         direction,
         entry_price: entry,
+        // qty is REQUIRED by the backend OpenPositionRequest (it forbids extra
+        // fields and cross-validates qty * entry_price ≈ size_usd). Send the
+        // full-precision computed value, not the rounded display value.
+        qty,
         sl_price:   sl || null,
         tp_price:   tp || null,
         size_usd:   size || null,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -235,6 +235,7 @@ export interface PositionCreatePayload {
   symbol:      string;
   direction?:  PositionDirection;
   entry_price: number;
+  qty:         number;            // REQUIRED by the backend OpenPositionRequest
   sl_price?:   number | null;
   tp_price?:   number | null;
   size_usd?:   number | null;


### PR DESCRIPTION
## Problem (production — operator blocked)

Opening a position from the UI failed with `422 BodyValidationError: {"type":"missing","loc":["qty"],"msg":"Field required"}` (input carried `symbol/direction/entry_price/sl_price/...` but no `qty`).

## Root cause

The backend `OpenPositionRequest` (`api/positions_birth.py:75`) requires `qty` and uses `extra="forbid"`. Cluster D (#471, 2026-05-26) deliberately removed the server-side `qty` fallback, making `qty` a hard contract field. But `OpenPositionModal` computed `qty = size/entry` only for the displayed "Cantidad" chip and never sent it — it sent `size_usd` instead. So every open-position attempt 422'd.

## Fix (frontend only — backend unchanged, no restart needed)

- `OpenPositionModal.tsx`: include `qty` (full-precision `size/entry`) in the payload, satisfying the backend's `qty * entry_price ≈ size_usd` cross-field invariant. Added a submit guard so capital (USD) must be `> 0`.
- `types.ts`: `qty` now required on `PositionCreatePayload`.
- `OpenPositionModal.test.tsx`: regression tests — payload carries `qty == size/entry` and `qty * entry_price ≈ size_usd`; submit blocked (no API call) when capital is empty.

## Verification

`tsc --noEmit` clean. `vitest run` → 133 passed (+2 new). Only one builder of `PositionCreatePayload` exists, so the now-required `qty` breaks no other caller.

Fixes the open-position 422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
