### PR TITLE
fix(db): read endpoints off the writer lock — fixes 500 'database is locked' on /positions + /capital

### DIFF
--- a/api/capital.py
+++ b/api/capital.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
 from db.capital import db_get_capital, db_upsert_capital
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 log = logging.getLogger("api.capital")
 
@@ -30,7 +30,11 @@ class CapitalPutBody(BaseModel):
 
 @router.get("", summary="Get current capital state for current tenant")
 def get_capital(tenant_id: int = Depends(get_current_tenant_id)):
-    with transaction() as con:
+    # READ via snapshot_connection (WAL-concurrent, query_only, NO BEGIN
+    # IMMEDIATE) — a read must not contend for the writer lock. Using
+    # transaction() here 500'd under the scanner's write burst (prod incident
+    # 2026-05-29). PUT /capital below keeps transaction() (it writes).
+    with snapshot_connection() as con:
         row = db_get_capital(con, tenant_id)
     if row is None:
         raise HTTPException(

--- a/api/positions.py
+++ b/api/positions.py
@@ -268,8 +268,13 @@ def list_positions(
     status: Optional[str] = Query("all", description="open | closed | all"),
     tenant_id: int = Depends(get_current_tenant_id),
 ):
-    # B.5 #258: tenant_id from JWT, never from request param/header/body
-    with transaction() as con:
+    # B.5 #258: tenant_id from JWT, never from request param/header/body.
+    # READ via snapshot_connection (WAL-concurrent, query_only, NO BEGIN
+    # IMMEDIATE) — NOT transaction(). transaction() takes the writer lock even
+    # for reads; under the scanner's write burst it 500'd with "database is
+    # locked" (prod incident 2026-05-29). A read must never contend for the
+    # writer lock.
+    with snapshot_connection() as con:
         positions = db_get_positions(con, status, tenant_id=tenant_id)
     return {"total": len(positions), "positions": positions}
 

--- a/db/connection.py
+++ b/db/connection.py
@@ -80,7 +80,15 @@ def _open_configured_connection() -> sqlite3.Connection:
     db_file = _resolve_db_file()
     con = sqlite3.connect(db_file, isolation_level=None)
     con.row_factory = _DictRow
-    con.execute("PRAGMA busy_timeout = 5000")
+    # busy_timeout raised 5000 -> 15000 after a production lock-contention
+    # incident (2026-05-29): the scanner's per-scan kill-switch decision burst
+    # (~80 BEGIN IMMEDIATE writes/cycle on a 460MB DB) held the writer lock long
+    # enough that read endpoints routed through transaction() (also
+    # BEGIN IMMEDIATE) timed out at 5s and returned 500. Read endpoints should
+    # use snapshot_connection() (WAL-concurrent, no writer lock) — this longer
+    # timeout is the safety net for the writes + any remaining BEGIN IMMEDIATE
+    # readers. Do NOT lower below 15000 without addressing the write-burst load.
+    con.execute("PRAGMA busy_timeout = 15000")
     return con
 
 

--- a/tests/db/test_transaction.py
+++ b/tests/db/test_transaction.py
@@ -247,3 +247,36 @@ def test_PrecheckConn_and_SnapshotConn_are_distinct_NewTypes():
         assert wrapped_b is con
     finally:
         con.close()
+
+
+def test_snapshot_read_succeeds_while_writer_holds_lock(fresh_db):
+    """Regression for the 2026-05-29 prod lock-contention incident.
+
+    A read via snapshot_connection() must succeed while another connection
+    holds the writer lock (BEGIN IMMEDIATE) — WAL permits concurrent readers.
+    The read endpoints (GET /positions, GET /capital) previously routed reads
+    through transaction() (which itself does BEGIN IMMEDIATE); under the
+    scanner's per-scan write burst they timed out and returned 500. A read must
+    never contend for the writer lock.
+    """
+    from db.connection import _open_configured_connection
+    from db.transaction import snapshot_connection
+
+    # Seed one committed row (visible to the snapshot read).
+    with transaction() as con:
+        con.execute("CREATE TABLE IF NOT EXISTS _lock_probe (id INTEGER PRIMARY KEY, v TEXT)")
+        con.execute("INSERT INTO _lock_probe (v) VALUES ('committed')")
+
+    # Hold the writer lock with an uncommitted write.
+    writer = _open_configured_connection()
+    writer.execute("BEGIN IMMEDIATE")
+    writer.execute("INSERT INTO _lock_probe (v) VALUES ('uncommitted')")
+    try:
+        # Must NOT block or raise "database is locked"; sees the committed
+        # snapshot (1 row), not the writer's pending row.
+        with snapshot_connection() as con:
+            n = con.execute("SELECT COUNT(*) FROM _lock_probe").fetchone()[0]
+        assert n == 1
+    finally:
+        writer.execute("ROLLBACK")
+        writer.close()


### PR DESCRIPTION
## Production incident (2026-05-29)

The operator's dashboard showed **all zeros** (0 positions, $0 equity) despite intact data. `GET /positions` and `GET /capital` were returning **500 `sqlite3.OperationalError: database is locked`** (confirmed in the service journal). The ticker/symbols endpoints worked, so it was specific to the per-tenant DB reads.

## Root cause

Both read endpoints route through `transaction()`, which issues `BEGIN IMMEDIATE` — acquiring the SQLite **writer lock even for a read**. The scanner writes ~80 kill-switch decisions per scan cycle (40 symbols × `v1` + `v2_shadow`), each its own `BEGIN IMMEDIATE` transaction, on a 460 MB DB where `kill_switch_decisions` has grown to ~199k rows. That write burst holds the writer lock long enough that a concurrent read's `BEGIN IMMEDIATE` exceeds `busy_timeout` (5 s) and raises "database is locked" → 500. The frontend's `fetchAll` swallows the 500, so the dashboard renders zeros. (Verified on prod: an 8-read probe showed intermittent 5 s timeouts during write bursts; the operator's data was always present under their tenant.)

This is not related to #538/#539 — the `trials` table doesn't even exist on prod.

## Fix

- **`api/positions.py::list_positions` and `api/capital.py::get_capital` read via `snapshot_connection()`** (WAL-concurrent, `query_only`, **no `BEGIN IMMEDIATE`**) instead of `transaction()`. With WAL, these reads never block on the writer — immune to write-burst length and table growth.
- **`db/connection.py`: `busy_timeout` 5000 → 15000** — safety net for the writes and any remaining `BEGIN IMMEDIATE` readers (e.g. `get_dashboard_state`). This matches the value hotpatched directly on prod to stabilize the incident; landing it here ensures a redeploy doesn't revert it.
- **Regression test** (`tests/db/test_transaction.py`): a `snapshot_connection()` read succeeds while another connection holds `BEGIN IMMEDIATE`.

## Verification
356 capital/positions/transaction/multi-tenant tests pass; the new regression test passes (16/16 in `test_transaction.py`).

## Follow-up (separate PR — not blocking)
- Route `get_dashboard_state` (and other per-tenant reads) off `BEGIN IMMEDIATE` too.
- Reduce kill-switch write load: batch the per-scan decision INSERTs into one transaction; add retention/pruning to `kill_switch_decisions` (~199k rows); consider gating `v2_shadow` shadow-logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
