### PR TITLE
ci(deploy): workflow_dispatch trigger + retrying health check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,11 @@ name: Deploy to Production
 on:
   push:
     branches: [main]
+  # Manual trigger: recover a deploy when the push event was not picked up by
+  # Actions (observed 2026-05-29 — the #540 squash-merge to main created the
+  # commit but no push-triggered run fired, a GitHub-side transient). Run with:
+  #   gh workflow run deploy.yml --ref main
+  workflow_dispatch:
 
 concurrency:
   group: deploy-production
@@ -103,12 +108,21 @@ jobs:
         env:
           HOST: ${{ secrets.DEPLOY_HOST }}
         run: |
-          sleep 15
-          if ! ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "curl -fsS http://localhost:8100/health"; then
-            echo "::error::Health check falló. Logs del servicio:"
-            ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "sudo journalctl -u trading-spacial -n 80 --no-pager"
-            exit 1
-          fi
+          # Poll up to ~60s: the service can take well over 15s to answer
+          # /health after restart on the large prod DB. The prior single-shot
+          # "sleep 15 + one curl" failed 5 of 6 recent deploys even when the
+          # rsync + restart had already succeeded — a false-red. Retry instead.
+          for i in $(seq 1 12); do
+            if ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "curl -fsS http://localhost:8100/health" >/dev/null 2>&1; then
+              echo "Health check passed (attempt ${i}/12)."
+              exit 0
+            fi
+            echo "Health check attempt ${i}/12 not ready; retrying in 5s..."
+            sleep 5
+          done
+          echo "::error::Health check failed after 12 attempts (~60s). Service logs:"
+          ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "sudo journalctl -u trading-spacial -n 80 --no-pager"
+          exit 1
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Why

Investigating why PR #540's merge did not deploy: the squash-merge created `c06e159` on `main` (confirmed remote HEAD) but **no push-triggered workflow ran** (0 check-runs on the commit; last push run was #539 at 17:11). Diagnosis:
- Workflows are all **active**; commit message has **no skip-ci token**; committer (`GitHub <noreply@github.com>`) is **identical** to the #538/#539 merges that *did* fire; `pull_request` events fired fine at 22:26–30.
- Conclusion: a **GitHub-side transient** — the `push` event for `c06e159` was not picked up by Actions. Nothing in the workflow config is wrong; there is no reproducible config bug to "fix". The proper engineering response is to make deploys **recoverable and reliable**, not to hack a re-push.

## Changes (both in `deploy.yml`)

1. **`workflow_dispatch` trigger** — a missed auto-deploy can now be re-run reliably: `gh workflow run deploy.yml --ref main`. No more depending solely on the push event.
2. **Retrying health check** — poll `/health` up to ~60s (12×5s) instead of a single curl after a 15s sleep. The single-shot check **false-failed 5 of the last 6 deploys** (the rsync + restart had already succeeded; the service just needed longer to answer on the large prod DB). This stops deploys showing red when they actually succeeded.

## After merge
Deploy current `main` (which already contains the #540 lock fix) via `gh workflow run deploy.yml --ref main` — proper pipeline deploy, no manual file edits on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)