### PR TITLE
fix(#494): batch 1 — dashboard GET endpoints off the writer lock

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 from api.config import load_config
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id, require_role
-from db.transaction import transaction
+from db.transaction import snapshot_connection
 
 log = logging.getLogger("api.health")
 
@@ -34,7 +34,8 @@ class ReactivateRequest(BaseModel):
 @router.get("/health/symbols", dependencies=[Depends(verify_api_key)])
 def get_health_symbols():
     """List current health state per symbol."""
-    with transaction() as con:
+    # READ via snapshot_connection (WAL-concurrent, no writer lock) — #494
+    with snapshot_connection() as con:
         rows = con.execute(
             """SELECT symbol, state, state_since, last_evaluated_at,
                       last_metrics_json, manual_override
@@ -52,7 +53,7 @@ def get_health_events(
     limit: int = Query(50, ge=1, le=500, description="Max rows to return (capped to prevent unbounded scans)"),
 ):
     """Transition history. Optionally filter by symbol."""
-    with transaction() as con:
+    with snapshot_connection() as con:
         if symbol:
             rows = con.execute(
                 """SELECT id, symbol, from_state, to_state, trigger_reason,
@@ -115,7 +116,7 @@ def health_check():
 
     # Database connectivity
     try:
-        with transaction() as con:
+        with snapshot_connection() as con:
             con.execute("SELECT 1")
         checks["database"] = "ok"
     except Exception as e:

--- a/api/signals.py
+++ b/api/signals.py
@@ -21,7 +21,7 @@ from api.config import load_config
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
 from api.telegram import build_telegram_message
-from db.transaction import transaction, snapshot_connection
+from db.transaction import snapshot_connection
 from db.signals import (
     get_latest_signal, get_latest_scan, get_scans, get_signals_summary, save_scan,
 )
@@ -262,7 +262,8 @@ def get_signals_performance(
     (tenant_id=NULL) are invisible. Each user sees their own performance
     tracking.
     """
-    with transaction() as con:
+    # READ via snapshot_connection (WAL-concurrent, no writer lock) — #494
+    with snapshot_connection() as con:
         # Solo señales completadas (24h de historia) — filtradas por tenant
         rows = con.execute(
             "SELECT * FROM signal_outcomes WHERE status = 'completed' AND tenant_id = ?",
@@ -320,7 +321,7 @@ def get_signals_performance(
 def latest_signal(
     symbol: Optional[str] = Query(None, description="Filtrar por par (ej: SOLUSDT)")
 ):
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = get_latest_signal(con, symbol)
     if not row:
         msg = f"Sin señales para {symbol}." if symbol else "Sin señales registradas."
@@ -353,7 +354,7 @@ def latest_signal(
 def latest_message(
     symbol: Optional[str] = Query(None, description="Filtrar por par")
 ):
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = get_latest_signal(con, symbol)
     if not row:
         return {"message": "Sin señales registradas aun."}
@@ -371,7 +372,7 @@ def latest_message(
 
 @router.get("/{scan_id}", summary="Detalle de un escaneo por ID")
 def signal_by_id(scan_id: int):
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute("SELECT * FROM scans WHERE id=?", (scan_id,)).fetchone()
     if not row:
         raise HTTPException(status_code=404, detail=f"Escaneo #{scan_id} no encontrado")

--- a/api/tune.py
+++ b/api/tune.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from api.config import load_config, CONFIG_FILE
 from api.deps import verify_api_key
 from auth.dependencies import require_role
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 log = logging.getLogger("api.tune")
 
@@ -27,7 +27,8 @@ router = APIRouter(prefix="/tune", tags=["tune"])
 @router.get("/latest", summary="Latest tune result")
 def tune_latest():
     """Returns the most recent tune_result row (with parsed results_json) or null."""
-    with transaction() as con:
+    # READ via snapshot_connection (WAL-concurrent, no writer lock) — #494
+    with snapshot_connection() as con:
         row = con.execute(
             "SELECT * FROM tune_results ORDER BY id DESC LIMIT 1"
         ).fetchone()

--- a/btc_api.py
+++ b/btc_api.py
@@ -431,7 +431,8 @@ def list_symbols():
     """Retorna el último escaneo de cada símbolo, ordenado por señal y score."""
     import json as _json  # noqa: PLC0415 — local import keeps the module-level surface unchanged
     symbols = _scanner_state.get("symbols_active") or get_active_symbols()
-    with transaction() as con:
+    # READ via snapshot_connection (WAL-concurrent, no writer lock) — #494
+    with snapshot_connection() as con:
         rows    = get_signals_summary(con)
     by_sym  = {r["symbol"]: r for r in rows}
     result  = []

--- a/health.py
+++ b/health.py
@@ -12,7 +12,7 @@ import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 
 log = logging.getLogger("health")
@@ -1040,11 +1040,10 @@ def get_dashboard_state(
     ks_cfg = (cfg.get("kill_switch") or {})
     now = datetime.now(timezone.utc)
 
-    # Task 8.5: open ONE transaction and thread `conn` through every helper.
+    # Task 8.5: open ONE connection and thread `conn` through every helper.
     # Previously each helper opened its own tx → nested-BEGIN-IMMEDIATE
-    # deadlock. db_get_capital is now also called inside the outer tx so it
-    # serializes against any concurrent capital write.
-    with transaction() as conn:
+    # deadlock. Using snapshot_connection (WAL-concurrent, no writer lock) — #494.
+    with snapshot_connection() as conn:
         from db.capital import db_get_capital
         capital = db_get_capital(conn, tenant_id)
         # Build symbol list: union of DEFAULT_SYMBOLS + any DB rows. This way

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -507,6 +507,42 @@ class TestAPIEndpoints:
         assert "symbols" in data
         assert "total" in data
 
+    def test_dashboard_read_endpoints_use_snapshot_not_writer_lock(
+        self, client, monkeypatch
+    ):
+        """Regression for #494 batch 1.
+
+        GET /symbols (and the other dashboard-polled read endpoints) must
+        use snapshot_connection(), not transaction() (BEGIN IMMEDIATE).
+        Concurrency proof: while a writer holds BEGIN IMMEDIATE the endpoint
+        must still return 200. Mirrors
+        tests/db/test_transaction.py::test_snapshot_read_succeeds_while_writer_holds_lock.
+        """
+        import btc_api
+        from db.connection import _open_configured_connection
+
+        # Hold the writer lock with an uncommitted write — simulates the
+        # scanner's per-scan write burst that caused the prod 500s.
+        writer = _open_configured_connection()
+        writer.execute("BEGIN IMMEDIATE")
+        writer.execute(
+            "INSERT INTO scans (ts, symbol, estado, señal, setup, price, "
+            "lrc_pct, rsi_1h, score, score_label, macro_ok, gatillo) "
+            "VALUES ('2026-01-01T00:00:00', 'BTCUSDT', 'test', 0, 0, "
+            "1.0, 0.0, 50.0, 0, 'test', 0, 0)"
+        )
+        try:
+            # GET /symbols uses snapshot_connection (WAL concurrent read);
+            # must NOT block or 500 even while writer holds the lock.
+            r = client.get("/symbols")
+            assert r.status_code == 200, (
+                f"/symbols returned {r.status_code} while writer held BEGIN IMMEDIATE — "
+                "endpoint is still using transaction() instead of snapshot_connection()"
+            )
+        finally:
+            writer.execute("ROLLBACK")
+            writer.close()
+
     def test_signals_filtro_symbol(self, client, sample_report):
         import btc_api
         btc_api.save_scan(sample_report)


### PR DESCRIPTION
## What & why

Part of #494 — Batch 1 of the read-endpoint sweep.

`transaction()` runs `BEGIN IMMEDIATE` (grabs the SQLite writer lock) even for pure reads. Under the scanner's per-scan write burst, read endpoints routed through it 500 with "database is locked" — the cause of the 2026-05-26 and 2026-05-29 prod incidents. `snapshot_connection()` is WAL-concurrent (`PRAGMA query_only=1`, no writer lock).

## Migrated — 10 pure-read dashboard-polled GET sites

All verified read-only by reading the full `with` block AND grepping every helper's definition (not guessed from names):

- `health.py` `get_dashboard_state` — the big one (dozens of SELECTs in one writer-lock block); full call tree walked, confirmed zero writes reachable
- `api/health.py` — `GET /health/symbols`, `GET /health/events`, `GET /health` (health probe)
- `btc_api.py` — `GET /symbols`
- `api/tune.py` — `GET /tune/latest`
- `api/signals.py` — `GET /signals/performance`, `/latest`, `/latest/message`, `/{scan_id}`

Write and read-then-write sites in these files stay on `transaction()`. Unused `transaction` imports dropped where the file no longer writes.

## Safety net

`snapshot_connection()` enforces `query_only=1` — any migrated site that actually writes raises `OperationalError` loudly in tests. None did.

## Tests

- Baseline (test_api.py + test_health_dashboard.py): 152 passed
- Post: **153 passed** (no failures)
- New regression test `test_dashboard_read_endpoints_use_snapshot_not_writer_lock` — mirrors the existing `test_snapshot_read_succeeds_while_writer_holds_lock`: holds a `BEGIN IMMEDIATE` writer lock, asserts `GET /symbols` still returns 200. RED before migration (OperationalError), GREEN after.

## Next batches (tracked in #494)
- Batch 2: agent + auth + notifications API reads
- Batch 3: scanner-loop + calibrator + shadow reads (highest care — overlaps the #397/#542 hot path; separate PR + concurrency test)
- Batch 4 (optional): CLI one-shot scripts (no contention — low priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
