### PR TITLE
fix(#494): batch 2 — agent/auth/notifications/prefs read endpoints off the writer lock

### DIFF
--- a/api/agent/circuit_breaker.py
+++ b/api/agent/circuit_breaker.py
@@ -31,7 +31,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from api.config import load_config
-from db.transaction import transaction
+from db.transaction import snapshot_connection
 
 log = logging.getLogger("api.agent.circuit_breaker")
 
@@ -103,7 +103,7 @@ def _global_spend_last_24h() -> float:
     """
     now = datetime.now(timezone.utc)
     cutoff = (now - timedelta(hours=24)).isoformat()
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             "SELECT COALESCE(SUM(cost_usd), 0) AS total "
             "FROM agent_conversations "

--- a/api/agent/history.py
+++ b/api/agent/history.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, Field
 
 from api.agent.audit import RETENTION_DAYS
 from auth.dependencies import get_current_tenant_id
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 log = logging.getLogger("api.agent.history")
 
@@ -221,7 +221,7 @@ def list_conversations(
     Pre-reg D.7: tenant_id from JWT, never from query/body.
     """
     now = _now_iso()
-    with transaction() as con:
+    with snapshot_connection() as con:
         # Parameters live in two buckets so the order in execute() lines
         # up with the placeholder order in the final SQL: JOIN clause
         # comes BEFORE WHERE, so any `?` in the JOIN must be earlier in
@@ -321,7 +321,7 @@ def get_messages(
     signed_payload is never persisted and therefore never returned.
     """
     now = _now_iso()
-    with transaction() as con:
+    with snapshot_connection() as con:
         meta = con.execute(
             "SELECT conversation_id, tenant_id, title, surface, pinned, expires_at "
             "FROM agent_conversation_meta WHERE conversation_id = ?",

--- a/api/agent/proposals.py
+++ b/api/agent/proposals.py
@@ -60,7 +60,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 log = logging.getLogger("api.agent.proposals")
 
@@ -305,7 +305,7 @@ def persist_proposal(
 def load_proposal_row(proposal_id: str) -> Optional[dict]:
     """Fetch the row from agent_side_effects. Returns None if absent.
     Caller compares result column to decide pending vs consumed."""
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             """SELECT id, tenant_id, conversation_id, ts, action, args_json,
                       idempotency_key, result, http_status, expires_at

--- a/api/agent/router.py
+++ b/api/agent/router.py
@@ -51,7 +51,7 @@ from api.agent.proposals import (
 from api.agent.streaming import sse_serialize
 from auth.dependencies import get_current_tenant_id, get_current_user, require_role
 from auth.models import User
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 log = logging.getLogger("api.agent.router")
 
@@ -504,7 +504,7 @@ def get_agent_metrics():
     cutoff_iso = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
     today_iso  = datetime.now(timezone.utc).date().isoformat() + "T00:00:00+00:00"
 
-    with transaction() as con:
+    with snapshot_connection() as con:
         today_row = con.execute(
             "SELECT "
             "  COUNT(*) AS turn_count, "

--- a/api/agent/tools/handlers.py
+++ b/api/agent/tools/handlers.py
@@ -30,7 +30,7 @@ import json
 import logging
 from typing import Any
 
-from db.transaction import transaction
+from db.transaction import snapshot_connection
 
 log = logging.getLogger("api.agent.tools.handlers")
 
@@ -91,7 +91,7 @@ def get_portfolio_overview(*, tenant_id: int) -> dict:
     from health import get_dashboard_state
     from api.config import load_config
 
-    with transaction() as con:
+    with snapshot_connection() as con:
         open_positions = db_get_positions(con, status="open", tenant_id=tenant_id)
     open_count = len(open_positions)
     total_notional = sum(float(p.get("size_usd") or 0) for p in open_positions)
@@ -121,7 +121,7 @@ def get_portfolio_overview(*, tenant_id: int) -> dict:
 def get_positions(*, tenant_id: int) -> dict:
     """Currently open positions, summarized."""
     from db.positions import db_get_positions
-    with transaction() as con:
+    with snapshot_connection() as con:
         rows = db_get_positions(con, status="open", tenant_id=tenant_id)
     return {"positions": [_position_to_summary(p) for p in rows]}
 
@@ -133,7 +133,7 @@ def get_position_detail(*, tenant_id: int, position_id: int) -> dict:
     row exists but doesn't belong to this tenant, return 'not_found' —
     never reveals existence cross-tenant.
     """
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             "SELECT * FROM positions WHERE id=? AND tenant_id=?",
             (position_id, tenant_id),
@@ -154,7 +154,7 @@ def get_symbols_with_signals(*, tenant_id: int, limit: int = 10) -> dict:  # noq
     than `limit` raw scan rows that may all be the same symbol.
     """
     from db.signals import get_latest_scan_per_symbol
-    with transaction() as con:
+    with snapshot_connection() as con:
         rows = get_latest_scan_per_symbol(con, limit=limit, only_signals=False)
     return {
         "symbols": [
@@ -176,7 +176,7 @@ def get_symbol_setup(*, tenant_id: int, symbol: str) -> dict:  # noqa: ARG001
     """
     from db.signals import get_scans
     norm = _normalize_symbol(symbol)
-    with transaction() as con:
+    with snapshot_connection() as con:
         rows = get_scans(con, limit=1, symbol=norm)
     if not rows:
         return {"error": "not_found"}
@@ -225,7 +225,7 @@ def get_recent_signals(*, tenant_id: int, limit: int = 10, since_hours: int = 24
     signal for every tenant; the per-user split lives in the dispatcher
     layer added in B.4 #257)."""
     from db.signals import get_scans
-    with transaction() as con:
+    with snapshot_connection() as con:
         rows = get_scans(con, limit=limit, only_signals=True, since_hours=since_hours)
     return {
         "signals": [
@@ -251,7 +251,7 @@ def get_closed_trades(*, tenant_id: int, window: str = "30d") -> dict:
     from datetime import datetime, timedelta, timezone
     from db.positions import db_get_positions
 
-    with transaction() as con:
+    with snapshot_connection() as con:
         if window == "all":
             rows = db_get_positions(con, status="closed", tenant_id=tenant_id)
         else:

--- a/api/agent/tools/propose_handlers.py
+++ b/api/agent/tools/propose_handlers.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from db.transaction import transaction
+from db.transaction import snapshot_connection
 
 from api.agent.proposals import (
     ACTION_APPLY_TUNE,
@@ -78,7 +78,7 @@ def propose_close_position(
     rationale:       str,
 ) -> dict:
     """Verify ownership, sign a close_position proposal, persist."""
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             "SELECT symbol, direction, status, entry_price, size_usd "
             "FROM positions WHERE id = ? AND tenant_id = ?",
@@ -126,7 +126,7 @@ def propose_reactivate_symbol(
     norm = symbol.upper().strip()
     if not norm.endswith("USDT"):
         norm = f"{norm}USDT"
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             "SELECT state FROM symbol_health WHERE symbol = ?",
             (norm,),

--- a/api/auth.py
+++ b/api/auth.py
@@ -78,7 +78,7 @@ from auth.tokens import (
     _access_minutes,
     _refresh_days,
 )
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -220,7 +220,7 @@ def _clear_auth_cookies(response: Response) -> None:
 
 
 def _user_by_email(email: str) -> Optional[User]:
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             """
             SELECT id, email, password_hash, role, is_active, created_at,
@@ -247,7 +247,7 @@ def _user_by_email(email: str) -> Optional[User]:
 def _password_hash_for_email(email: str) -> Optional[str]:
     """Fetch the bcrypt hash for an email. Used by login + change_password.
     Returns None if user does not exist."""
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             "SELECT password_hash FROM users WHERE email = ?", (email,)
         ).fetchone()
@@ -584,7 +584,7 @@ def change_password(
 def _hydrate_user(user_id: int) -> Optional[User]:
     """Refresh-flow user hydration. Mirrors the middleware helper but returns
     None if user is gone or deactivated (caller decides what to do)."""
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = con.execute(
             """
             SELECT id, email, role, is_active, created_at, password_changed_at,

--- a/api/kill_switch.py
+++ b/api/kill_switch.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from api.config import load_config, save_config
 from api.deps import verify_api_key
 from auth.dependencies import require_role
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 log = logging.getLogger("api.kill_switch")
 
@@ -87,7 +87,7 @@ def kill_switch_list_recommendations(
     """List auto-calibrator recommendations, latest first."""
     import json as _json
 
-    with transaction() as conn:
+    with snapshot_connection() as conn:
         sql = (
             "SELECT id, ts, triggered_by, slider_value, projected_pnl, "
             "projected_dd, status, applied_ts, applied_by, report_json "
@@ -151,7 +151,7 @@ def kill_switch_apply_recommendation(rec_id: int):
     from datetime import datetime, timezone
 
     try:
-        with transaction() as conn:
+        with snapshot_connection() as conn:
             row = conn.execute(
                 """SELECT id, status, slider_value
                    FROM kill_switch_recommendations WHERE id = ?""",
@@ -243,7 +243,7 @@ def kill_switch_ignore_recommendation(rec_id: int):
     from datetime import datetime, timezone
 
     try:
-        with transaction() as conn:
+        with snapshot_connection() as conn:
             row = conn.execute(
                 """SELECT id, status FROM kill_switch_recommendations WHERE id = ?""",
                 (rec_id,),

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 log = logging.getLogger("api.notifications")
 
@@ -39,7 +39,7 @@ def get_notifications(
     from notifier._storage import list_unread
     if not unread:
         # Full list (both read + unread) — direct query (list_unread filters on read_at).
-        with transaction() as con:
+        with snapshot_connection() as con:
             rows = con.execute(
                 """SELECT id, event_type, event_key, priority, payload_json,
                           channels_sent, delivery_status, sent_at, read_at, error_log
@@ -52,7 +52,7 @@ def get_notifications(
         cols = ("id", "event_type", "event_key", "priority", "payload_json",
                 "channels_sent", "delivery_status", "sent_at", "read_at", "error_log")
         return {"notifications": [dict(zip(cols, r)) for r in rows]}
-    with transaction() as con:
+    with snapshot_connection() as con:
         return {"notifications": list_unread(con, limit=limit, tenant_id=tenant_id)}
 
 

--- a/api/user_preferences.py
+++ b/api/user_preferences.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 from db.user_preferences import (
     db_get_user_preferences,
     db_upsert_user_preferences,
@@ -69,7 +69,7 @@ def _mask_token(token: str) -> str:
 
 @router.get("", summary="Get preferences for current tenant (defaults if unset)")
 def get_preferences(tenant_id: int = Depends(get_current_tenant_id)):
-    with transaction() as con:
+    with snapshot_connection() as con:
         row = db_get_user_preferences(con, tenant_id)
     if row is None:
         # Return sensible defaults — per pre-reg §3.2
@@ -150,7 +150,7 @@ def post_preferences_test(tenant_id: int = Depends(get_current_tenant_id)):
     """
     from notifier.channels.telegram import TelegramChannel  # noqa: PLC0415
 
-    with transaction() as con:
+    with snapshot_connection() as con:
         prefs = db_get_user_preferences(con, tenant_id) or {}
     notify_channels = prefs.get("notify_channels") or {}
 


### PR DESCRIPTION
## What & why

Part of #494 — Batch 2 of the read-endpoint sweep. Follows #544 (Batch 1, dashboard GETs).

`transaction()` runs `BEGIN IMMEDIATE` (writer lock) even for pure reads → 500 "database is locked" under the scanner's write burst. `snapshot_connection()` is WAL-concurrent (`query_only=1`, no writer lock). `query_only` makes any accidental write raise loudly — the safety net.

## Migrated — 18 pure-read API sites (agent / auth / notifications / preferences / kill-switch)

Each verified read-only by reading the full `with` block and grepping every helper's definition:

- **agent read-tools** (`api/agent/tools/handlers.py`, polled per turn): `get_portfolio_overview`, `get_positions`, `get_position_detail`, `get_symbols_with_signals`, `get_symbol_setup`, `get_recent_signals`, `get_closed_trades`
- **agent**: `GET /agent/conversations`, `GET /agent/conversations/{id}/messages`, `GET /agent/metrics`, `_global_spend_last_24h` (every turn), `load_proposal_row`, the two `propose_*` ownership-check reads
- **kill-switch**: `GET /kill_switch/recommendations` + the apply/ignore pre-check read blocks (the adjacent UPDATE blocks stay on `transaction()`)
- **notifications**: `GET /notifications` (both branches)
- **preferences**: `GET /preferences`, `POST /preferences/test`
- **auth**: `_user_by_email`, `_password_hash_for_email`, `_hydrate_user`

## Deliberately SKIPPED (left on `transaction()`)
- `auth.py` `refresh` / `lookup_refresh` — read block is tightly coupled to the token-rotation write flow; splitting it is risky, deferred.
- `user_preferences.py` `PUT /preferences` token-mask read — same function as the upsert.
- `kill_switch.py` apply/ignore UPDATE blocks — writes.

## Safety net + tests
- `query_only=1` would raise `OperationalError` on any migrated site that writes. None did.
- Suite (agent/auth/notifications/preferences/kill_switch selection): baseline **278 passed** → post **278 passed**, zero regressions.
- No new test needed — Batch 1 (#544) added the snapshot-under-writer-lock regression test.

## Remaining (tracked in #494)
- Batch 3: scanner-loop + calibrator + shadow reads (highest care — overlaps #397/#542 hot path; separate PR + concurrency test).
- Batch 4 (optional): CLI one-shot scripts (no contention — low priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
