### PR TITLE
fix(#494): batch 3 — scanner/calibrator/shadow read paths off the writer lock

### DIFF
--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -149,8 +149,9 @@ def _build_e5_cooldown(symbol: str, cfg: dict) -> dict:
 
     try:
         from db.positions import db_last_exit_ts  # noqa: PLC0415
-        from db.transaction import transaction  # noqa: PLC0415
-        with transaction() as con:
+        from db.transaction import snapshot_connection  # noqa: PLC0415
+        # Pure read — snapshot_connection (WAL-concurrent, no writer lock) — #494
+        with snapshot_connection() as con:
             last_exit_dt = db_last_exit_ts(con, symbol)
     except Exception as e:  # noqa: BLE001
         # Throttle: one log line per (symbol, exc-type) per process.

--- a/notifier/__init__.py
+++ b/notifier/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from db.transaction import transaction
+from db.transaction import transaction, snapshot_connection
 from notifier import dedupe, ratelimit
 from notifier._storage import record_delivery
 from notifier._templates import render
@@ -92,7 +92,8 @@ def notify(
         if tenant_id is not None else event.dedupe_key
     )
     window_seconds = _resolve_dedupe_window(event, cfg)
-    with transaction() as con:
+    # Pure read — snapshot_connection (WAL-concurrent, no writer lock) — #494
+    with snapshot_connection() as con:
         _should_send = dedupe.should_send(
             con, event.event_type, dedupe_key,
             window_seconds=window_seconds,

--- a/notifier/dispatch_per_user.py
+++ b/notifier/dispatch_per_user.py
@@ -15,7 +15,7 @@ import logging
 import sqlite3
 from typing import Any
 
-from db.transaction import transaction
+from db.transaction import transaction, snapshot_connection
 from db.user_preferences import db_get_user_preferences
 from notifier import notify
 from notifier.channels.base import DeliveryReceipt
@@ -77,7 +77,8 @@ def dispatch_signal_to_users(
     The downstream `notify()` call still owns its own transactions
     (file/network I/O — must not extend the DB lock).
     """
-    with transaction() as _users_con:
+    # Pure reads — snapshot_connection (WAL-concurrent, no writer lock) — #494
+    with snapshot_connection() as _users_con:
         users = _list_active_users(_users_con)
     if not users:
         log.debug("dispatch_signal_to_users: no active users — broadcast skipped")
@@ -86,7 +87,7 @@ def dispatch_signal_to_users(
     out: dict[int, list[DeliveryReceipt]] = {}
 
     for user in users:
-        with transaction() as inner_con:
+        with snapshot_connection() as inner_con:
             prefs = db_get_user_preferences(inner_con, user["id"])
         if prefs is None:
             symbol_filter = _DEFAULT_SYMBOL_FILTER

--- a/scanner/runtime.py
+++ b/scanner/runtime.py
@@ -30,7 +30,7 @@ from btc_scanner import scan
 from data import market_data as md
 from db.connection import backup_db
 from db.signals import get_signals_summary, save_scan
-from db.transaction import transaction
+from db.transaction import transaction, snapshot_connection
 from notifier import notify, SystemEvent
 
 log = logging.getLogger("scanner.runtime")
@@ -159,7 +159,8 @@ def check_pending_signal_outcomes(current_prices: dict[str, float]):
     """
     from datetime import datetime, timezone  # noqa: PLC0415
 
-    with transaction() as con:
+    # Pure read — snapshot_connection (WAL-concurrent, no writer lock) — #494
+    with snapshot_connection() as con:
         rows = con.execute("SELECT * FROM signal_outcomes WHERE status = 'pending'").fetchall()
 
     if not rows:
@@ -358,8 +359,8 @@ def scanner_loop(stop_event: threading.Event | None = None):
 
         # Actualizar data/symbols_status.json al final de cada ciclo
         try:
-            from db.transaction import transaction  # noqa: PLC0415
-            with transaction() as con:
+            # Pure read — snapshot_connection (WAL-concurrent, no writer lock) — #494
+            with snapshot_connection() as con:
                 rows = get_signals_summary(con)
             update_symbols_json(rows)
         except Exception as e:

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -242,8 +242,8 @@ def _persist_recommendation(
 
 def _load_last_recalibration_ts() -> str | None:
     """Return the latest ts from kill_switch_recommendations, or None."""
-    from db.transaction import transaction
-    with transaction() as conn:
+    from db.transaction import snapshot_connection
+    with snapshot_connection() as conn:
         row = conn.execute(
             "SELECT MAX(ts) FROM kill_switch_recommendations",
         ).fetchone()
@@ -252,9 +252,9 @@ def _load_last_recalibration_ts() -> str | None:
 
 def _count_recalibrations_today(now) -> int:
     """Count rows in kill_switch_recommendations persisted today (UTC)."""
-    from db.transaction import transaction
+    from db.transaction import snapshot_connection
     today_prefix = now.strftime("%Y-%m-%d")
-    with transaction() as conn:
+    with snapshot_connection() as conn:
         row = conn.execute(
             "SELECT COUNT(*) FROM kill_switch_recommendations WHERE ts LIKE ?",
             (today_prefix + "%",),
@@ -264,8 +264,8 @@ def _count_recalibrations_today(now) -> int:
 
 def _load_last_applied_recommendation() -> dict[str, Any] | None:
     """Return the most recent applied recommendation row as a dict, or None."""
-    from db.transaction import transaction
-    with transaction() as conn:
+    from db.transaction import snapshot_connection
+    with snapshot_connection() as conn:
         row = conn.execute(
             """SELECT id, ts, slider_value, projected_pnl, projected_dd,
                       status, applied_ts, applied_by, report_json
@@ -291,9 +291,9 @@ def _load_last_calibration_regime_score() -> float | None:
     field is missing.
     """
     import json
-    from db.transaction import transaction
+    from db.transaction import snapshot_connection
 
-    with transaction() as conn:
+    with snapshot_connection() as conn:
         row = conn.execute(
             """SELECT report_json FROM kill_switch_recommendations
                ORDER BY ts DESC, id DESC LIMIT 1""",
@@ -318,11 +318,11 @@ def _count_symbols_with_recent_alerts(window_hours: float) -> int:
     have per_symbol_tier='ALERT' OR portfolio_tier IN ('REDUCED','FROZEN').
     """
     from datetime import datetime, timedelta, timezone
-    from db.transaction import transaction
+    from db.transaction import snapshot_connection
 
     now = datetime.now(tz=timezone.utc)
     cutoff = (now - timedelta(hours=float(window_hours))).isoformat()
-    with transaction() as conn:
+    with snapshot_connection() as conn:
         row = conn.execute(
             """SELECT COUNT(DISTINCT symbol)
                FROM kill_switch_decisions
@@ -443,9 +443,10 @@ def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
             # when ANY tenant breaches them, not when the (meaningless) cross-
             # tenant aggregate does.
             from db.capital import db_list_active_tenant_ids
-            from db.transaction import transaction as _tx_for_tenants
+            from db.transaction import snapshot_connection as _snap_for_tenants
             # Task 5 (#446): `db_list_active_tenant_ids` now requires `con`.
-            with _tx_for_tenants() as _tenants_con:
+            # Pure SELECT — use snapshot_connection (WAL-concurrent, no writer lock) — #494
+            with _snap_for_tenants() as _tenants_con:
                 tenant_ids = db_list_active_tenant_ids(_tenants_con)
             if tenant_ids:
                 per_tenant_dd = [
@@ -585,8 +586,9 @@ def _compute_current_portfolio_dd(
             cap_row = db_get_capital(conn, tenant_id)
             opens = _load_open_positions(conn, tenant_id=tenant_id)
         else:
-            from db.transaction import transaction as _tx
-            with _tx() as _c:
+            from db.transaction import snapshot_connection as _snap
+            # Pure reads — use snapshot_connection (WAL-concurrent, no writer lock) — #494
+            with _snap() as _c:
                 cap_row = db_get_capital(_c, tenant_id)
                 opens = _load_open_positions(_c, tenant_id=tenant_id)
 

--- a/strategy/kill_switch_v2_optimizer.py
+++ b/strategy/kill_switch_v2_optimizer.py
@@ -21,10 +21,10 @@ _GRID_STEP = 5
 def _load_closed_positions_window(window_days: float, now) -> list[dict[str, Any]]:
     """Load closed positions with exit_ts within the last window_days, ordered by entry_ts."""
     from datetime import timedelta
-    from db.transaction import transaction
+    from db.transaction import snapshot_connection
 
     cutoff = (now - timedelta(days=float(window_days))).isoformat()
-    with transaction() as conn:
+    with snapshot_connection() as conn:
         rows = conn.execute(
             """SELECT symbol, entry_ts, exit_ts, exit_reason, pnl_usd
                FROM positions

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -101,9 +101,9 @@ def _load_recent_sl_timestamps(
 ) -> list[str]:
     """Load exit_ts of closed positions with exit_reason='SL' for a symbol within window."""
     from datetime import timedelta
-    from db.transaction import transaction
+    from db.transaction import snapshot_connection
     cutoff = (now - timedelta(hours=float(window_hours))).isoformat()
-    with transaction() as conn:
+    with snapshot_connection() as conn:
         rows = conn.execute(
             """SELECT exit_ts
                FROM positions
@@ -119,8 +119,8 @@ def _load_recent_sl_timestamps(
 
 def _load_v2_state(symbol: str) -> dict[str, Any]:
     """Load per-symbol v2 state. Returns keys with None defaults if row missing."""
-    from db.transaction import transaction
-    with transaction() as conn:
+    from db.transaction import snapshot_connection
+    with snapshot_connection() as conn:
         row = conn.execute(
             """SELECT velocity_cooldown_until, velocity_last_trigger_ts
                FROM kill_switch_v2_state
@@ -206,8 +206,8 @@ def _evaluate_velocity(symbol: str, cfg: dict[str, Any]) -> bool:
 
 def _load_closed_trades_for_symbol(symbol: str) -> list[dict[str, Any]]:
     """Load closed positions for a symbol with non-NULL exit_ts."""
-    from db.transaction import transaction
-    with transaction() as conn:
+    from db.transaction import snapshot_connection
+    with snapshot_connection() as conn:
         rows = conn.execute(
             """SELECT exit_ts, pnl_usd
                FROM positions
@@ -222,8 +222,8 @@ def _load_closed_trades_for_symbol(symbol: str) -> list[dict[str, Any]]:
 
 def _load_baseline(symbol: str) -> dict[str, Any] | None:
     """Load per-symbol baseline. Returns None if no row exists."""
-    from db.transaction import transaction
-    with transaction() as conn:
+    from db.transaction import snapshot_connection
+    with snapshot_connection() as conn:
         row = conn.execute(
             """SELECT baseline_wr, baseline_sigma, trades_count, computed_at
                FROM kill_switch_v2_baseline
@@ -426,8 +426,9 @@ def emit_shadow_decision(
         # double-counts and under-reports DD). Single source of truth:
         # kill_switch_v2.compute_portfolio_dd_from_ledger (same as the dashboard).
         from db.capital import db_get_capital
-        from db.transaction import transaction as _tx
-        with _tx() as _con:
+        from db.transaction import snapshot_connection as _snap
+        # Pure reads — use snapshot_connection (WAL-concurrent, no writer lock) — #494
+        with _snap() as _con:
             _capital_row = db_get_capital(_con, tenant_id)
             opens = _load_open_positions(_con, tenant_id=tenant_id)
         if _capital_row and _capital_row.get("balance") is not None:
@@ -458,8 +459,9 @@ def emit_shadow_decision(
         # B6: record portfolio-tier transitions for the dashboard
         try:
             from health import recent_portfolio_transitions, record_portfolio_transition
-            from db.transaction import transaction as _tx_for_pt
-            with _tx_for_pt() as _pt_con:
+            from db.transaction import snapshot_connection as _snap_for_pt, transaction as _tx_for_pt
+            # Pure read — snapshot_connection (WAL-concurrent, no writer lock) — #494
+            with _snap_for_pt() as _pt_con:
                 recent = recent_portfolio_transitions(_pt_con, limit=1)
             prev_tier = recent[0]["to_tier"] if recent else "NORMAL"
             if prev_tier != portfolio["tier"]:

--- a/tests/test_strategy_kill_switch_v2.py
+++ b/tests/test_strategy_kill_switch_v2.py
@@ -2785,3 +2785,66 @@ def test_dd_from_ledger_skips_symbol_without_price():
     )
     assert out["current_equity"] == pytest.approx(10_000.0)
     assert out["portfolio_dd"] == pytest.approx(0.0)
+
+
+# ── #494 Batch 3: concurrency regression ─────────────────────────────────────
+
+
+def test_scanner_read_succeeds_while_writer_holds_lock(tmp_path, monkeypatch):
+    """Batch 3 (#494): scanner/calibrator/shadow pure reads must NOT block
+    when the scanner's own write loop holds BEGIN IMMEDIATE.
+
+    Mirrors tests/db/test_transaction.py::test_snapshot_read_succeeds_while_writer_holds_lock
+    but exercises the migrated scanner-batch functions specifically:
+    _load_v2_state, _load_baseline, and _load_last_recalibration_ts.
+
+    A still-on-transaction() implementation raises 'database is locked';
+    snapshot_connection() reads the committed snapshot concurrently.
+    """
+    import btc_api
+    from db.connection import _open_configured_connection
+    from db.transaction import transaction as _tx
+    from strategy.kill_switch_v2_shadow import _load_v2_state, _load_baseline
+    from strategy.kill_switch_v2_calibrator import _load_last_recalibration_ts
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+
+    # Seed committed rows so reads return something meaningful.
+    with _tx() as con:
+        con.execute(
+            """INSERT OR IGNORE INTO kill_switch_v2_state
+               (symbol, velocity_cooldown_until, velocity_last_trigger_ts, updated_at)
+               VALUES ('BTCUSDT', NULL, NULL, '2026-01-01T00:00:00+00:00')"""
+        )
+        con.execute(
+            """INSERT OR IGNORE INTO kill_switch_v2_baseline
+               (symbol, baseline_wr, baseline_sigma, trades_count, computed_at)
+               VALUES ('BTCUSDT', 0.55, 0.3, 50, '2026-01-01T00:00:00+00:00')"""
+        )
+
+    # Hold the writer lock with an uncommitted write — simulates the scanner
+    # mid-write burst that caused the original lock-contention incident.
+    writer = _open_configured_connection()
+    writer.execute("BEGIN IMMEDIATE")
+    writer.execute(
+        "INSERT INTO kill_switch_v2_state "
+        "(symbol, velocity_cooldown_until, velocity_last_trigger_ts, updated_at) "
+        "VALUES ('ETHUSDT', NULL, NULL, '2026-01-01T00:00:00+00:00')"
+    )
+    try:
+        # All three must succeed (read committed snapshot) without raising.
+        state = _load_v2_state("BTCUSDT")
+        baseline = _load_baseline("BTCUSDT")
+        last_ts = _load_last_recalibration_ts()
+
+        assert state is not None, "_load_v2_state returned None"
+        assert baseline is not None, "_load_baseline returned None"
+        # _load_last_recalibration_ts returns None when no recommendations row — that's fine.
+        assert isinstance(last_ts, (str, type(None)))
+    finally:
+        writer.execute("ROLLBACK")
+        writer.close()


### PR DESCRIPTION
## What & why

Part of #494 — **Batch 3, the highest-risk batch.** Completes the read-endpoint sweep started in #544 (batch 1) and #545 (batch 2).

These sites run inside the **scanner + calibrator background threads** — the very writers whose per-scan burst caused the 2026-05-26 / 2026-05-29 lock-contention incidents — and several were just rewritten in #542 (the #397 ledger-DD fix). `transaction()` runs `BEGIN IMMEDIATE` (writer lock) even for reads; `snapshot_connection()` is WAL-concurrent (`query_only=1`, no writer lock). `query_only` makes any accidental write raise loudly — the safety net.

## Migrated — 19 pure-read hot-path sites

- **calibrator**: `_load_last_recalibration_ts`, `_count_recalibrations_today`, `_load_last_applied_recommendation`, `_load_last_calibration_regime_score`, `_count_symbols_with_recent_alerts`, tenant read in `kill_switch_calibrator_loop`, and the `conn=None` self-open branch of `_compute_current_portfolio_dd`
- **shadow**: `_load_recent_sl_timestamps`, `_load_v2_state`, `_load_closed_trades_for_symbol`, `_load_baseline`, `emit_shadow_decision` capital+positions read, `emit_shadow_decision` B6 transitions read
- **optimizer**: `_load_closed_positions_window`
- **scanner/runtime**: `check_pending_signal_outcomes` initial fetch, `scanner_loop` summary read
- **btc_scanner**: `_build_e5_cooldown`
- **notifier**: dedupe check + per-user users/prefs reads

## Three trap sites — handled surgically

1. `emit_shadow_decision`: the B6 transitions **read** → snapshot; the adjacent `record_portfolio_transition` **write** stays on `transaction()` (separate blocks, distinct aliases).
2. `check_pending_signal_outcomes`: the pending **fetch** → snapshot; the per-row **UPDATE** stays on `transaction()`.
3. `_compute_current_portfolio_dd`: only the `conn is None` self-open read migrated; the caller-passed-`conn` path untouched.

All 7 write sites verified still on `transaction()` (`_persist_recommendation`, `_mark_prior_pending_as_superseded`, `_upsert_v2_state`, `_upsert_baseline`, the B6 write, the scanner UPDATE, `record_delivery`).

## Tests
- Baseline 315 → **316 passed**, zero regressions.
- New concurrency test `test_scanner_read_succeeds_while_writer_holds_lock`: holds a real `BEGIN IMMEDIATE` writer lock with uncommitted data, asserts migrated scanner reads (`_load_v2_state`, `_load_baseline`, `_load_last_recalibration_ts`) succeed AND see the committed snapshot (not the uncommitted write) — RED before, GREEN after.

## #494 status after this PR
Batches 1–3 done → the API + scanner-loop read surface is off the writer lock. Remaining: Batch 4 (CLI one-shot scripts — no contention, optional/low priority). Plus the noted follow-ups: #543 (kill-switch fail-closed) and the kill_switch apply/ignore TOCTOU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
