### PR TITLE
fix(ks-v2): kill-switch live-DD fails closed (Closes #543)

### DIFF
--- a/.mex/patterns/computing-portfolio-dd.md
+++ b/.mex/patterns/computing-portfolio-dd.md
@@ -8,7 +8,7 @@ triggers:
   - "kill switch"
   - "compute_portfolio_dd_from_ledger"
   - "dd_formula_version"
-last_updated: 2026-05-30
+last_updated: 2026-05-31
 ---
 
 # Pattern: Computing live portfolio drawdown
@@ -52,6 +52,30 @@ Sign convention: `portfolio_dd` is **negative** when in drawdown. Zero when flat
 | `emit_shadow_decision` | `strategy/kill_switch_v2_shadow.py` |
 | `_compute_current_portfolio_dd` | `strategy/kill_switch_v2_calibrator.py` |
 | `get_dashboard_state` | `health.py` |
+
+### Fail-closed contract for live-DD reads (#543)
+
+`_compute_current_portfolio_dd(cfg, *, tenant_id, conn=None, strict=False)` is the
+helper safety callers go through. `0.0` means "no drawdown" — the **most
+permissive** answer for a circuit-breaker input — so a computation failure must
+never silently return it to a safety path. Two failure sub-classes, handled
+distinctly:
+
+- **Ledger read failure** (capital row / open positions unreadable): nothing can
+  be computed. `strict=True` **propagates** the exception so the caller fails
+  closed; `strict=False` (default, display callers) returns `0.0`.
+- **Price-snapshot / MTM failure**: the realized drawdown is ledger-derived and
+  price-independent. Degrade to the **ledger-only DD** `-(peak - balance)/peak` —
+  never `0.0`, never re-raise (even under `strict`). A transient price hiccup
+  must not erase a real drawdown (#397 class) nor freeze the system every tick.
+
+Caller posture:
+
+| Caller | `strict` | Rationale |
+|---|---|---|
+| `_is_portfolio_normal` (B5 auto-recovery gate) | `True` | outer guard returns `False` → blocks reactivation during a failure window |
+| degradation trigger loop (calibrator) | `True` | a failing tenant is **excluded** from the `min()`, never injected as a phantom `0.0` that masks others' real DD |
+| `get_dashboard_state` | `False` | display-only; a DB blip must not 500 the dashboard |
 
 ## Gotchas
 

--- a/docs/superpowers/plans/2026-05-31-543-killswitch-fail-closed.md
+++ b/docs/superpowers/plans/2026-05-31-543-killswitch-fail-closed.md
@@ -1,0 +1,83 @@
+# #543 — kill-switch live-DD fail-closed
+
+## Problem
+
+`_compute_current_portfolio_dd` (`strategy/kill_switch_v2_calibrator.py`) collapses
+**every** exception to `return 0.0`. `0.0` = "no drawdown" = the most permissive
+answer for a safety input, and it is indistinguishable from a genuinely healthy
+portfolio. On a DB hiccup / malformed capital row / price-snapshot failure the
+kill-switch sees health exactly when the system is least healthy. Fail-**open** on
+a safety organ. Surfaced by the #542 (#397) adversarial audit, Lens 4.
+
+## Consumers (verified)
+
+| Site | Function | Effect of phantom 0.0 | Posture needed |
+|---|---|---|---|
+| `calibrator.py:453` | degradation trigger (`min(per_tenant_dd)`) | 0.0 dominates `min` → trigger silent | fail-closed (exclude failing tenant) |
+| `health.py:432` | `_is_portfolio_normal` (B5 auto-recovery gate) | tier=NORMAL → reactivates PAUSED symbol during the failure window | **fail-closed (the dangerous one)** |
+| `health.py:1201` | `get_dashboard_state` no-capital display | 0.0 legitimate (fresh tenant) | unchanged (display) |
+
+`_is_portfolio_normal` already has an outer `try/except → return False`
+(fail-closed), but the helper swallows its own exception **before** that guard can
+see it. The phantom 0.0 leaks under an existing fail-closed guard.
+
+## Contract (approved: strict flag + raise)
+
+`_compute_current_portfolio_dd(cfg, *, tenant_id, conn=None, strict=False) -> float`
+
+Two failure sub-classes, handled distinctly:
+
+- **Phase 1 — ledger reads** (`db_get_capital`, `_load_open_positions`): cannot
+  compute anything. `strict=True` → re-raise (caller decides). `strict=False` →
+  `0.0` + `log.warning` (legacy display behavior preserved).
+- **Phase 2 — full DD with MTM** (`_snapshot_prices` + `compute_portfolio_dd_from_ledger`):
+  the realized DD is ledger-derived and does NOT depend on prices. A price-feed
+  outage must NOT erase a real drawdown (the #397 failure class). Degrade to
+  **ledger-only DD** = `-(peak - balance)/peak`, never `0.0`. This does NOT
+  re-raise even under `strict=True` — a transient price hiccup freezing the
+  system on every tick is worse than a one-tick MTM gap. Mirrors `get_dashboard_state`
+  (#542, health.py:1175-1191).
+
+Drop the docstring line "Returns 0.0 if anything fails (conservative — won't fire
+degradation trigger)" — that conservatism is backwards for a circuit breaker.
+
+## Callers
+
+- `health.py:432` `_is_portfolio_normal` → pass `strict=True`. Outer guard already
+  returns False → fail-closed for free. **The key fix.**
+- `calibrator.py:453` degradation trigger → wrap each per-tenant call in
+  try/except with `strict=True`; on error EXCLUDE that tenant from the `min()` and
+  `log.warning`. If the list empties after exclusions, `current_dd=0.0` (the
+  trigger emits a *recommendation*, not direct protection).
+- `health.py:1201` `get_dashboard_state` → leave `strict=False` (default). No
+  behavior change.
+
+## Tests (TDD, written first)
+
+`tests/test_strategy_kill_switch_v2_calibrator.py`:
+1. `test_compute_dd_strict_true_reraises_on_ledger_read_failure` — monkeypatch
+   `db.capital.db_get_capital` → raise; `strict=True` raises, `strict=False` → 0.0.
+2. `test_compute_dd_price_failure_degrades_to_ledger_only_not_zero` — capital
+   balance<peak, monkeypatch `_snapshot_prices` → raise; DD == ledger-only (≠ 0.0)
+   even with `strict=True`.
+
+`tests/test_health_probation.py`:
+3. `test_is_portfolio_normal_returns_false_when_dd_computation_fails` — seed 1
+   tenant capital, monkeypatch `_compute_current_portfolio_dd` → raise; assert
+   `_is_portfolio_normal(cfg) is False` (fail-closed).
+4. `test_degradation_trigger_excludes_failing_tenant` — calibrator loop with 2
+   tenants, one whose DD raises; the failing tenant is excluded, no phantom 0.0
+   injected into `min()`.
+
+## Out of scope
+
+- Shadow `emit_shadow_decision` outer try/except (writes nothing on failure —
+  that is already fail-safe: no decision row beats a wrong one).
+- Last-known-good DD caching (a heavier v2 enhancement; ledger-only degrade
+  already preserves realized DD without it).
+
+## Verify
+
+- `python -m pytest tests/test_strategy_kill_switch_v2_calibrator.py tests/test_health_probation.py -v`
+- Adversarial 4-lens audit (independent subagent, default-to-suspicion).
+- 1 PR. Merge requested separately (explicit per-op auth).

--- a/health.py
+++ b/health.py
@@ -429,7 +429,10 @@ def _is_portfolio_normal(cfg: dict[str, Any]) -> bool:
             ).fetchone()[0]
 
         for tid in tenant_ids:
-            portfolio_dd = _compute_current_portfolio_dd(cfg, tenant_id=tid)
+            # #543: strict=True so an unrecoverable DD read failure PROPAGATES to
+            # the outer guard (→ return False) instead of leaking a permissive
+            # 0.0 that would reactivate a PAUSED symbol during the failure window.
+            portfolio_dd = _compute_current_portfolio_dd(cfg, tenant_id=tid, strict=True)
             portfolio = evaluate_portfolio_tier(portfolio_dd, int(n_failures), cfg)
             if portfolio.get("tier") != "NORMAL":
                 return False

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -449,11 +449,24 @@ def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
             with _snap_for_tenants() as _tenants_con:
                 tenant_ids = db_list_active_tenant_ids(_tenants_con)
             if tenant_ids:
-                per_tenant_dd = [
-                    _compute_current_portfolio_dd(cfg, tenant_id=tid)
-                    for tid in tenant_ids
-                ]
-                current_dd = min(per_tenant_dd)  # most negative = worst DD
+                per_tenant_dd = []
+                for tid in tenant_ids:
+                    try:
+                        per_tenant_dd.append(
+                            _compute_current_portfolio_dd(
+                                cfg, tenant_id=tid, strict=True,
+                            )
+                        )
+                    except Exception as _dd_err:
+                        # #543: a tenant whose DD cannot be computed is EXCLUDED
+                        # from the degradation min() — never injected as a phantom
+                        # 0.0 that would mask the other tenants' real drawdown.
+                        log.warning(
+                            "portfolio DD failed for tenant_id=%s; excluding "
+                            "tenant from degradation eval: %s",
+                            tid, _dd_err, exc_info=True,
+                        )
+                current_dd = min(per_tenant_dd) if per_tenant_dd else 0.0
             else:
                 current_dd = 0.0
             last_applied = _load_last_applied_recommendation()
@@ -558,13 +571,28 @@ def _load_current_regime_score() -> float | None:
 
 
 def _compute_current_portfolio_dd(
-    cfg: dict[str, Any], *, tenant_id: int, conn=None,
+    cfg: dict[str, Any], *, tenant_id: int, conn=None, strict: bool = False,
 ) -> float:
     """Compute live portfolio DD from ledger balance + open-position MTM.
 
     Reuses kill_switch_v2.compute_portfolio_dd_from_ledger (ledger + open MTM;
     closed PnL already in balance — see #397).
-    Returns 0.0 if anything fails (conservative — won't fire degradation trigger).
+
+    Fail-closed contract (#543). Two failure sub-classes are handled distinctly:
+
+    - **Ledger read failure** (capital row / open positions): nothing can be
+      computed. With ``strict=True`` the exception PROPAGATES so a safety caller
+      (e.g. the B5 auto-recovery gate ``_is_portfolio_normal``, or the
+      degradation trigger) can fail closed instead of seeing a permissive
+      phantom ``0.0`` — ``0.0`` means "no drawdown", the most dangerous default
+      for a circuit-breaker input. With ``strict=False`` (the default, for
+      display callers such as ``get_dashboard_state``) it returns ``0.0``.
+    - **Price-snapshot / MTM failure**: the realized drawdown is ledger-derived
+      and does NOT depend on prices. A price-feed outage must not erase a real
+      drawdown (the #397 failure class). Degrade to the ledger-only DD,
+      ``-(peak - balance)/peak``, never ``0.0`` — and never re-raise (even under
+      ``strict``): a transient price hiccup freezing the system every tick is
+      worse than a one-tick MTM gap. Mirrors ``get_dashboard_state`` (#542).
 
     Per multi-tenant policy: `tenant_id` is required. The capital base is the
     tenant's ledger balance when present, falling back to cfg["capital_usd"]
@@ -574,6 +602,10 @@ def _compute_current_portfolio_dd(
     (e.g. get_dashboard_state, which owns an outer tx and would deadlock if
     inner helpers opened their own).
     """
+    # ── Phase 1: ledger reads (unrecoverable on failure) ────────────────────
+    # Imports live inside the try so an ImportError follows the same fail-closed
+    # contract as a ledger read (strict → propagate, lenient → 0.0) rather than
+    # escaping uncaught (#543 audit, Lens 4).
     try:
         from strategy.kill_switch_v2 import compute_portfolio_dd_from_ledger
         from strategy.kill_switch_v2_shadow import (
@@ -587,7 +619,7 @@ def _compute_current_portfolio_dd(
             opens = _load_open_positions(conn, tenant_id=tenant_id)
         else:
             from db.transaction import snapshot_connection as _snap
-            # Pure reads — use snapshot_connection (WAL-concurrent, no writer lock) — #494
+            # Pure reads — snapshot_connection (WAL-concurrent, no writer lock) — #494
             with _snap() as _c:
                 cap_row = db_get_capital(_c, tenant_id)
                 opens = _load_open_positions(_c, tenant_id=tenant_id)
@@ -599,7 +631,19 @@ def _compute_current_portfolio_dd(
             # No ledger row (pre-onboarding): cfg default, no peak history.
             balance = float(cfg.get("capital_usd", 1000.0))
             peak_balance = None
+    except Exception as e:
+        # #543: unrecoverable. strict callers fail closed (propagate); display
+        # callers keep the legacy permissive 0.0.
+        log.warning(
+            "compute_current_portfolio_dd ledger read failed for tenant_id=%s: %s",
+            tenant_id, e, exc_info=True,
+        )
+        if strict:
+            raise
+        return 0.0
 
+    # ── Phase 2: full DD with open-MTM; degrade to ledger-only on failure ────
+    try:
         result = compute_portfolio_dd_from_ledger(
             balance=balance,
             peak_balance=(float(peak_balance) if peak_balance is not None else None),
@@ -608,8 +652,20 @@ def _compute_current_portfolio_dd(
         )
         return float(result["portfolio_dd"])
     except Exception as e:
-        log.warning(
-            "compute_current_portfolio_dd failed for tenant_id=%s: %s",
-            tenant_id, e, exc_info=True,
+        # #543/#542: price-feed / MTM failure. The realized (ledger-only)
+        # drawdown is known and price-independent — keep it rather than erasing
+        # it with a 0.0. Never re-raise: a transient price hiccup must not
+        # freeze the system on every tick.
+        peak_eff = max(
+            (float(peak_balance) if peak_balance is not None else balance),
+            balance,
         )
-        return 0.0
+        ledger_only_dd = (
+            -((peak_eff - balance) / peak_eff) if peak_eff > 0 else 0.0
+        )
+        log.warning(
+            "compute_current_portfolio_dd MTM/price snapshot failed for "
+            "tenant_id=%s; degrading to ledger-only DD=%.4f: %s",
+            tenant_id, ledger_only_dd, e, exc_info=True,
+        )
+        return ledger_only_dd

--- a/tests/test_health_probation.py
+++ b/tests/test_health_probation.py
@@ -339,3 +339,36 @@ def test_evaluate_all_symbols_runs_auto_reactivate_for_each(tmp_db, monkeypatch)
         evaluate_all_symbols(cfg)
 
     assert calls == ["AAA", "BBB"]
+
+
+# ── #543: auto-recovery gate fails closed on DD computation failure ──────────
+
+
+def test_is_portfolio_normal_returns_false_when_dd_computation_fails(tmp_db, monkeypatch):
+    """#543: _is_portfolio_normal is the B5 auto-recovery gate. If the live-DD
+    computation hits an unrecoverable ledger-read failure (DB hiccup, malformed
+    capital), the gate must fail CLOSED (return False → block auto-recovery)
+    instead of seeing a permissive phantom 0.0 that reactivates a PAUSED symbol
+    during the failure window.
+
+    Regression: this monkeypatches the LOW-LEVEL ledger read (db_get_capital),
+    not the helper itself. With the pre-#543 swallow-to-0.0 behavior the helper
+    would return 0.0 → tier NORMAL → gate True (test FAILS). With the strict
+    contract the read failure propagates → the gate's outer guard returns False
+    (test PASSES). It pins the end-to-end fail-closed path, not just the guard."""
+    import db.capital as _cap
+    from db.capital import db_upsert_capital
+    from db.transaction import transaction
+    from health import _is_portfolio_normal
+
+    # At least one onboarded tenant so the gate enters its per-tenant loop.
+    with transaction() as con:
+        db_upsert_capital(con, 1, balance=8_000.0, peak_balance=10_000.0)
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated ledger read failure")
+
+    monkeypatch.setattr(_cap, "db_get_capital", _boom)
+
+    cfg = {"kill_switch": {"enabled": True, "v2": {}}}
+    assert _is_portfolio_normal(cfg) is False

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -405,6 +405,107 @@ def test_compute_current_portfolio_dd_does_not_double_count_closed_trades(fresh_
     assert dd == pytest.approx(-(10_400.0 - 10_200.0) / 10_400.0, abs=1e-6)
 
 
+# ── #543: _compute_current_portfolio_dd fail-closed contract ────────────────
+
+
+def test_compute_dd_strict_true_reraises_on_ledger_read_failure(fresh_db, monkeypatch):
+    """#543: a ledger-read failure (Phase 1) is unrecoverable — strict=True must
+    re-raise so the safety caller can fail closed, instead of collapsing to a
+    permissive 0.0. strict=False preserves the legacy display behavior (0.0)."""
+    import db.capital as _cap
+    from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
+
+    def _boom(*a, **k):
+        raise RuntimeError("simulated DB hiccup reading capital")
+
+    monkeypatch.setattr(_cap, "db_get_capital", _boom)
+    cfg = {"capital_usd": 1000.0}
+
+    # strict=True → propagate (caller decides; the gate fails closed).
+    with pytest.raises(RuntimeError):
+        _compute_current_portfolio_dd(cfg, tenant_id=1, strict=True)
+
+    # strict=False (default) → legacy permissive 0.0 for display callers.
+    assert _compute_current_portfolio_dd(cfg, tenant_id=1, strict=False) == 0.0
+
+
+def test_compute_dd_price_failure_degrades_to_ledger_only_not_zero(fresh_db, monkeypatch):
+    """#543: a price-snapshot failure (Phase 2) must NOT erase a real realized
+    drawdown. The ledger balance/peak are already known; degrade to ledger-only
+    DD = -(peak-balance)/peak, never 0.0 — even under strict=True (a transient
+    price hiccup must not freeze the system on every tick). Mirrors #542."""
+    from db.capital import db_upsert_capital
+    from db.transaction import transaction
+    import strategy.kill_switch_v2_shadow as _shadow
+    from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
+
+    with transaction() as con:
+        # balance 9000 below peak 10000 → realized DD of -10%.
+        db_upsert_capital(con, 1, balance=9_000.0, peak_balance=10_000.0)
+
+    def _price_boom():
+        raise RuntimeError("simulated price-feed outage")
+
+    monkeypatch.setattr(_shadow, "_snapshot_prices", _price_boom)
+    cfg = {"capital_usd": 1000.0}
+
+    expected = -(10_000.0 - 9_000.0) / 10_000.0  # -0.1 ledger-only
+
+    # Even strict=True degrades (does not re-raise) for the price-feed sub-class.
+    dd_strict = _compute_current_portfolio_dd(cfg, tenant_id=1, strict=True)
+    assert dd_strict == pytest.approx(expected, abs=1e-6)
+    assert dd_strict != 0.0
+
+    dd_lenient = _compute_current_portfolio_dd(cfg, tenant_id=1, strict=False)
+    assert dd_lenient == pytest.approx(expected, abs=1e-6)
+
+
+def test_degradation_trigger_excludes_failing_tenant(fresh_db, monkeypatch, caplog):
+    """#543: when one tenant's DD computation raises, the calibrator loop must
+    EXCLUDE that tenant from the degradation min() (not inject a phantom 0.0 that
+    masks the other tenants' drawdown), log the exclusion, and not crash."""
+    import logging
+    import threading
+    from db.capital import db_upsert_capital
+    from db.transaction import transaction
+    import strategy.kill_switch_v2_calibrator as cal
+
+    with transaction() as con:
+        db_upsert_capital(con, 1, balance=10_000.0, peak_balance=10_000.0)
+        db_upsert_capital(con, 2, balance=9_000.0, peak_balance=10_000.0)
+
+    def _fake_dd(cfg, *, tenant_id, conn=None, strict=False):
+        if tenant_id == 2:
+            raise RuntimeError("simulated DD failure for tenant 2")
+        return -0.02
+
+    # Isolate to the degradation path: silence the other three triggers so the
+    # loop neither persists a recommendation nor reads uninitialised state.
+    monkeypatch.setattr(cal, "_compute_current_portfolio_dd", _fake_dd)
+    monkeypatch.setattr(cal, "should_run_safety_net", lambda *a, **k: False)
+    monkeypatch.setattr(cal, "_load_current_regime_score", lambda: None)
+    monkeypatch.setattr(cal, "_load_last_calibration_regime_score", lambda: None)
+    monkeypatch.setattr(cal, "_count_symbols_with_recent_alerts", lambda *a, **k: 0)
+
+    stop_event = threading.Event()
+
+    def fake_wait(_seconds):
+        stop_event.set()
+        return True
+
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    cfg = {"kill_switch": {"v2": {"auto_calibrator": {}}}}
+
+    with caplog.at_level(logging.WARNING, logger="kill_switch_v2_calibrator"):
+        cal.kill_switch_calibrator_loop(lambda: cfg, stop_event=stop_event)
+
+    msgs = [r.getMessage() for r in caplog.records]
+    # The failing tenant was excluded with a warning; the loop did not crash.
+    assert any("excluding" in m.lower() and "tenant" in m.lower() for m in msgs), msgs
+    assert not any("iteration failed" in m for m in msgs), msgs
+
+
 # ── B4b.1: POST /kill_switch/recalibrate ────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

`_compute_current_portfolio_dd` (`strategy/kill_switch_v2_calibrator.py`) collapsed **every** exception to `return 0.0`. `0.0` = "no drawdown" = the most permissive answer for a circuit-breaker safety input — and indistinguishable from a genuinely healthy portfolio. On a DB hiccup / malformed capital row / price-feed outage the kill-switch saw health exactly when the system was least healthy. Fail-**open** on a safety organ. Surfaced by the #542 (#397) adversarial audit, Lens 4.

## Contract (fail-closed)

`_compute_current_portfolio_dd(cfg, *, tenant_id, conn=None, strict=False)` now splits into two failure sub-classes:

- **Phase 1 — ledger reads** (`db_get_capital`, `_load_open_positions`): unrecoverable. `strict=True` → **propagate** (caller fails closed); `strict=False` (default, display) → `0.0`.
- **Phase 2 — price/MTM** (`_snapshot_prices` + `compute_portfolio_dd_from_ledger`): the realized DD is ledger-derived and price-independent. Degrade to **ledger-only DD** `-(peak - balance)/peak`, never `0.0`, never re-raise (a transient price hiccup must not freeze the system every tick, nor erase a real DD — the #397 class). Mirrors `get_dashboard_state`'s #542 fallback.

## Callers

| Caller | `strict` | Why |
|---|---|---|
| `_is_portfolio_normal` (B5 auto-recovery gate) | `True` | outer guard returns `False` → blocks reactivating a PAUSED symbol during the failure window. **The key fix** — the phantom `0.0` previously leaked *under* this existing fail-closed guard. |
| degradation trigger loop (calibrator) | `True` | a failing tenant is **excluded** from the `min()`, never injected as a phantom `0.0` that masks the other tenants' real drawdown |
| `get_dashboard_state` | `False` (default) | display-only; a DB blip must not 500 the dashboard |

## Tests

4 new (TDD, red→green):
- `strict=True` re-raises on ledger-read failure; `strict=False` → `0.0`.
- price-snapshot failure degrades to ledger-only DD (≠ `0.0`) even under `strict`.
- degradation trigger excludes the failing tenant (no phantom `0.0` in `min()`).
- `_is_portfolio_normal` fails closed (regression patches the low-level `db_get_capital`, pinning the end-to-end path, not just the guard).

Regression: **278 tests pass** across the affected surface (calibrator, probation, shadow/core, dashboard, integration, API health + kill-switch parity).

## Audit

Independent adversarial 4-lens audit (default-to-suspicion): **GO**, no required fixes. The one point it raised — imports sitting outside the `try` — was already folded back inside so an `ImportError` follows the same fail-closed contract.

Closes #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)