### PR TITLE
fix(ks-v2): clamp degraded DD + alert on all-tenants-unreadable (#543 follow-up)

### DIFF
--- a/.mex/patterns/computing-portfolio-dd.md
+++ b/.mex/patterns/computing-portfolio-dd.md
@@ -77,6 +77,12 @@ Caller posture:
 | degradation trigger loop (calibrator) | `True` | a failing tenant is **excluded** from the `min()`, never injected as a phantom `0.0` that masks others' real DD |
 | `get_dashboard_state` | `False` | display-only; a DB blip must not 500 the dashboard |
 
+Two hardening details (#543 follow-up): the ledger-only degrade is **clamped at
+`-1.0`** (a negative balance would otherwise produce a sub-100% drawdown); and
+when the degradation loop finds **every** active tenant unreadable it emits one
+`log.error` (aggregate "blind safety input") rather than only the scattered
+per-tenant WARN lines — `current_dd` still falls back to `0.0`.
+
 ## Gotchas
 
 - **NEVER pass `closed_trades` to a live-path DD computation.** The anti-pattern is:

--- a/docs/superpowers/plans/2026-05-31-543-followup-dd-hardening.md
+++ b/docs/superpowers/plans/2026-05-31-543-followup-dd-hardening.md
@@ -1,0 +1,55 @@
+# #543 follow-up A — live-DD hardening (clamp + all-unreadable alert)
+
+Two non-blocking items the #543 adversarial audit raised. Same predicate as #543
+(robustness of the live-DD computation / degradation path). One PR.
+
+## Item 1 — clamp degraded DD at -1.0 (cosmetic)
+
+The Phase-2 ledger-only degrade in `_compute_current_portfolio_dd` computes
+`-(peak_eff - balance)/peak_eff`. With a NEGATIVE balance the raw ratio drops
+below `-1.0` (worse than a -100% total loss), which is nonsensical as a drawdown
+figure. Clamp to `max(-1.0, ledger_only_dd)`. Purely presentational — tier
+evaluation already treats anything past the threshold as FROZEN, so behaviour is
+unchanged; this just stops a sub-100% DD leaking into logs/dashboard.
+
+## Item 2 — log.error when ALL tenants' DD is unreadable
+
+Today, if every active tenant's DD raises, the degradation loop sets
+`current_dd = 0.0` and the degradation *recommendation* is silently suppressed —
+the only trace is scattered per-tenant WARN logs (one per tenant). Escalate the
+*aggregate* condition to a single, higher-severity line:
+
+- When there were active tenants but `per_tenant_dd` ended up empty (every tenant
+  raised) → emit one `log.error` for the tick, naming how many tenants were
+  unreadable. Severity bump from WARN→ERROR is the whole point: monitoring/alerting
+  keys off ERROR, and this is a real "the safety input is blind" condition.
+- **No counter, no Telegram, no threshold** (user decision): immediate, stateless,
+  restart-safe. A single transient hourly hiccup will log one ERROR; a persistent
+  outage logs one per tick. That noise is acceptable — an unreadable safety input
+  every tick *should* be loud.
+- The degradation behaviour is unchanged: `current_dd` still falls back to `0.0`
+  (the trigger only emits an operator-reviewed recommendation, not protection;
+  the real gate `_is_portfolio_normal` fails closed independently — #543).
+
+### Pieces
+
+- In `kill_switch_calibrator_loop`'s degradation branch: after the per-tenant
+  loop, `if tenant_ids and not per_tenant_dd: log.error(...)`. One added branch,
+  no new functions, no module state.
+
+## Tests (TDD)
+
+`tests/test_strategy_kill_switch_v2_calibrator.py`:
+1. `test_compute_dd_degrade_clamps_at_negative_one` — negative balance + price
+   failure → degraded DD == -1.0 (not < -1.0).
+2. `test_calibrator_logs_error_when_all_tenants_unreadable` — 2 tenants both
+   raising, one iteration → exactly one `log.error` naming the unreadable count;
+   loop does not crash; no recommendation persisted.
+3. `test_calibrator_no_error_when_some_tenant_readable` — 2 tenants, one readable
+   → no `log.error` (the aggregate condition didn't trigger).
+
+## Verify
+
+- `python -m pytest tests/test_strategy_kill_switch_v2_calibrator.py -q`
+- Regression across calibrator + probation + shadow/core.
+- Code review / light audit (safety loop). 1 PR, references #543. Merge separate.

--- a/strategy/kill_switch_v2_calibrator.py
+++ b/strategy/kill_switch_v2_calibrator.py
@@ -466,7 +466,22 @@ def kill_switch_calibrator_loop(cfg_fn, stop_event=None) -> None:
                             "tenant from degradation eval: %s",
                             tid, _dd_err, exc_info=True,
                         )
-                current_dd = min(per_tenant_dd) if per_tenant_dd else 0.0
+                if per_tenant_dd:
+                    current_dd = min(per_tenant_dd)  # most negative = worst DD
+                else:
+                    # #543 follow-up: EVERY active tenant's DD was unreadable.
+                    # current_dd falls back to 0.0 (the trigger only emits an
+                    # operator-reviewed recommendation, not protection — the real
+                    # gate _is_portfolio_normal fails closed independently). But a
+                    # blind safety input is an ERROR-level aggregate condition, not
+                    # just the scattered per-tenant WARN lines above.
+                    log.error(
+                        "portfolio DD unreadable for ALL %d active tenant(s); "
+                        "degradation recommendation suppressed this tick "
+                        "(current_dd=0.0)",
+                        len(tenant_ids),
+                    )
+                    current_dd = 0.0
             else:
                 current_dd = 0.0
             last_applied = _load_last_applied_recommendation()
@@ -663,6 +678,9 @@ def _compute_current_portfolio_dd(
         ledger_only_dd = (
             -((peak_eff - balance) / peak_eff) if peak_eff > 0 else 0.0
         )
+        # #543 follow-up: a negative balance pushes the raw ratio below -1.0
+        # (worse than a -100% total loss), nonsensical as a drawdown. Clamp.
+        ledger_only_dd = max(-1.0, ledger_only_dd)
         log.warning(
             "compute_current_portfolio_dd MTM/price snapshot failed for "
             "tenant_id=%s; degrading to ledger-only DD=%.4f: %s",

--- a/tests/test_strategy_kill_switch_v2_calibrator.py
+++ b/tests/test_strategy_kill_switch_v2_calibrator.py
@@ -506,6 +506,118 @@ def test_degradation_trigger_excludes_failing_tenant(fresh_db, monkeypatch, capl
     assert not any("iteration failed" in m for m in msgs), msgs
 
 
+# ── #543 follow-up A: degrade clamp + all-unreadable log.error ──────────────
+
+
+def test_compute_dd_degrade_clamps_at_negative_one(fresh_db, monkeypatch):
+    """#543 follow-up: a NEGATIVE balance would make the ledger-only degrade DD
+    drop below -1.0 (worse than a -100% total loss), which is nonsensical as a
+    drawdown figure. Clamp the degraded value at -1.0."""
+    from db.capital import db_upsert_capital
+    from db.transaction import transaction
+    import strategy.kill_switch_v2_shadow as _shadow
+    from strategy.kill_switch_v2_calibrator import _compute_current_portfolio_dd
+
+    with transaction() as con:
+        # balance below zero, peak 10000 -> raw degrade = -((10000-(-500))/10000)
+        # = -1.05, which must clamp to -1.0.
+        db_upsert_capital(con, 1, balance=-500.0, peak_balance=10_000.0)
+
+    def _price_boom():
+        raise RuntimeError("simulated price-feed outage")
+
+    monkeypatch.setattr(_shadow, "_snapshot_prices", _price_boom)
+    cfg = {"capital_usd": 1000.0}
+
+    dd = _compute_current_portfolio_dd(cfg, tenant_id=1, strict=True)
+    assert dd == pytest.approx(-1.0, abs=1e-9)
+    assert dd >= -1.0
+
+
+def test_calibrator_logs_error_when_all_tenants_unreadable(fresh_db, monkeypatch, caplog):
+    """#543 follow-up: when EVERY active tenant's DD raises, the degradation
+    recommendation is silently suppressed (current_dd falls back to 0.0). Escalate
+    the aggregate blind-safety-input condition to a single log.error naming the
+    count -- not just scattered per-tenant WARN lines."""
+    import logging
+    import threading
+    from db.capital import db_upsert_capital
+    from db.transaction import transaction
+    import strategy.kill_switch_v2_calibrator as cal
+
+    with transaction() as con:
+        db_upsert_capital(con, 1, balance=9_000.0, peak_balance=10_000.0)
+        db_upsert_capital(con, 2, balance=8_000.0, peak_balance=10_000.0)
+
+    def _all_boom(cfg, *, tenant_id, conn=None, strict=False):
+        raise RuntimeError(f"simulated DD failure for tenant {tenant_id}")
+
+    monkeypatch.setattr(cal, "_compute_current_portfolio_dd", _all_boom)
+    monkeypatch.setattr(cal, "should_run_safety_net", lambda *a, **k: False)
+    monkeypatch.setattr(cal, "_load_current_regime_score", lambda: None)
+    monkeypatch.setattr(cal, "_load_last_calibration_regime_score", lambda: None)
+    monkeypatch.setattr(cal, "_count_symbols_with_recent_alerts", lambda *a, **k: 0)
+
+    stop_event = threading.Event()
+
+    def fake_wait(_seconds):
+        stop_event.set()
+        return True
+
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+    cfg = {"kill_switch": {"v2": {"auto_calibrator": {}}}}
+
+    with caplog.at_level(logging.ERROR, logger="kill_switch_v2_calibrator"):
+        cal.kill_switch_calibrator_loop(lambda: cfg, stop_event=stop_event)
+
+    errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(errors) == 1, errors
+    # The error names the all-unreadable condition and the count (2 tenants).
+    assert "2" in errors[0]
+    assert "unreadable" in errors[0].lower() or "all" in errors[0].lower()
+
+
+def test_calibrator_no_error_when_some_tenant_readable(fresh_db, monkeypatch, caplog):
+    """#543 follow-up: if at least one tenant's DD is readable, the aggregate
+    all-unreadable condition does NOT fire -- no log.error."""
+    import logging
+    import threading
+    from db.capital import db_upsert_capital
+    from db.transaction import transaction
+    import strategy.kill_switch_v2_calibrator as cal
+
+    with transaction() as con:
+        db_upsert_capital(con, 1, balance=9_000.0, peak_balance=10_000.0)
+        db_upsert_capital(con, 2, balance=8_000.0, peak_balance=10_000.0)
+
+    def _one_boom(cfg, *, tenant_id, conn=None, strict=False):
+        if tenant_id == 2:
+            raise RuntimeError("simulated DD failure for tenant 2")
+        return -0.02
+
+    monkeypatch.setattr(cal, "_compute_current_portfolio_dd", _one_boom)
+    monkeypatch.setattr(cal, "should_run_safety_net", lambda *a, **k: False)
+    monkeypatch.setattr(cal, "_load_current_regime_score", lambda: None)
+    monkeypatch.setattr(cal, "_load_last_calibration_regime_score", lambda: None)
+    monkeypatch.setattr(cal, "_count_symbols_with_recent_alerts", lambda *a, **k: 0)
+    monkeypatch.setattr(cal, "_load_last_applied_recommendation", lambda: None)
+
+    stop_event = threading.Event()
+
+    def fake_wait(_seconds):
+        stop_event.set()
+        return True
+
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+    cfg = {"kill_switch": {"v2": {"auto_calibrator": {}}}}
+
+    with caplog.at_level(logging.ERROR, logger="kill_switch_v2_calibrator"):
+        cal.kill_switch_calibrator_loop(lambda: cfg, stop_event=stop_event)
+
+    errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors == [], errors
+
+
 # ── B4b.1: POST /kill_switch/recalibrate ────────────────────────────────────
 
 


### PR DESCRIPTION
Two non-blocking hardening items the **#543 adversarial audit** raised (same predicate as #543 — robustness of the live-DD computation / degradation path).

## Item 1 — clamp degraded DD at -1.0

The Phase-2 ledger-only degrade in `_compute_current_portfolio_dd` computes `-(peak_eff - balance)/peak_eff`. With a **negative balance** the raw ratio drops below `-1.0` (worse than a -100% total loss) — nonsensical as a drawdown figure. Clamp at `-1.0`. Purely presentational: tier evaluation already treats anything past the threshold as FROZEN, so behaviour is unchanged; this just stops a sub-100% DD leaking into logs/dashboard.

## Item 2 — log.error when ALL tenants' DD is unreadable

Today, if every active tenant's DD raises, the degradation loop sets `current_dd = 0.0` and the degradation *recommendation* is silently suppressed — the only trace is scattered per-tenant WARN lines. Now: when there were active tenants but `per_tenant_dd` ended up empty, emit **one `log.error`** naming the unreadable count. Severity bump WARN→ERROR is the point: monitoring keys off ERROR, and "the safety input is blind" is a real aggregate condition.

Stateless by design (no counter, no Telegram, no threshold): immediate, restart-safe. The degradation behaviour is unchanged — `current_dd` still falls back to `0.0`; the trigger only emits an operator-reviewed recommendation, and the real gate `_is_portfolio_normal` fails closed independently (#543).

## Tests

3 new (TDD red→green): clamp at -1.0 on negative balance; one `log.error` when all tenants unreadable; no `log.error` when at least one tenant readable. **281 regression tests green** (calibrator, probation, core, dashboard).

Follow-up to #543 (the TOCTOU item from the same audit ships separately — different predicate, concurrency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)