### PR TITLE
fix(api): kill-switch apply/ignore gate on atomic status UPDATE (Closes #550)

### DIFF
--- a/api/kill_switch.py
+++ b/api/kill_switch.py
@@ -181,29 +181,45 @@ def kill_switch_apply_recommendation(rec_id: int):
                 ),
             )
 
-        # Write config override. save_config only merges at kill_switch level
-        # (it replaces the entire v2 sub-dict), so do read-modify-write here to
-        # preserve other v2 keys (auto_calibrator, regime_adjustments, etc).
-        existing_cfg = load_config()
-        existing_v2 = (existing_cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
-        merged_v2 = {**existing_v2, "aggressiveness": slider_int}
-        save_config({"kill_switch": {"v2": merged_v2}})
-
-        # Update DB row
+        # #550: the atomic UPDATE is the authority — NOT the pre-check read above
+        # (which only fast-paths 404/400 + validates the slider). Guard with
+        # status='pending' and check rowcount so a concurrent ignore/apply/
+        # supersede landing in the pre-check -> write window cannot cause a config
+        # change for a recommendation that ends up not applied. The config write
+        # therefore runs ONLY after this request wins the transition.
         now_iso = datetime.now(tz=timezone.utc).isoformat()
         with transaction() as conn:
-            conn.execute(
+            cur = conn.execute(
                 """UPDATE kill_switch_recommendations
                    SET status = 'applied', applied_ts = ?, applied_by = 'operator'
-                   WHERE id = ?""",
+                   WHERE id = ? AND status = 'pending'""",
                 (now_iso, rec_id),
             )
+            if cur.rowcount == 0:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"recommendation {rec_id} was concurrently modified "
+                        "(apply/ignore/supersede); not applied"
+                    ),
+                )
             updated = conn.execute(
                 """SELECT id, ts, triggered_by, slider_value, projected_pnl,
                           projected_dd, status, applied_ts, applied_by, report_json
                    FROM kill_switch_recommendations WHERE id = ?""",
                 (rec_id,),
             ).fetchone()
+
+        # Side effect runs only after winning the atomic transition (#550).
+        # save_config only merges at kill_switch level (it replaces the entire v2
+        # sub-dict), so do read-modify-write here to preserve other v2 keys
+        # (auto_calibrator, regime_adjustments, etc). Residual: if this throws
+        # after the UPDATE commits, the row is 'applied' but the slider isn't
+        # persisted — a loud 500, single request, no silent double-apply.
+        existing_cfg = load_config()
+        existing_v2 = (existing_cfg.get("kill_switch", {}) or {}).get("v2", {}) or {}
+        merged_v2 = {**existing_v2, "aggressiveness": slider_int}
+        save_config({"kill_switch": {"v2": merged_v2}})
 
         log.warning(
             "Kill switch v2: operator applied recomendación id=%d slider=%d",
@@ -257,14 +273,25 @@ def kill_switch_ignore_recommendation(rec_id: int):
                 detail=f"recommendation {rec_id} is already {row[1]}",
             )
 
+        # #550: guard the UPDATE with status='pending' + rowcount so a stale
+        # pre-check cannot overwrite a recommendation the calibrator (or another
+        # operator) already transitioned.
         now_iso = datetime.now(tz=timezone.utc).isoformat()
         with transaction() as conn:
-            conn.execute(
+            cur = conn.execute(
                 """UPDATE kill_switch_recommendations
                    SET status = 'ignored', applied_ts = ?, applied_by = 'operator'
-                   WHERE id = ?""",
+                   WHERE id = ? AND status = 'pending'""",
                 (now_iso, rec_id),
             )
+            if cur.rowcount == 0:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"recommendation {rec_id} was concurrently modified; "
+                        "not ignored"
+                    ),
+                )
             updated = conn.execute(
                 """SELECT id, ts, triggered_by, slider_value, projected_pnl,
                           projected_dd, status, applied_ts, applied_by, report_json

--- a/docs/superpowers/plans/2026-05-31-550-killswitch-apply-toctou.md
+++ b/docs/superpowers/plans/2026-05-31-550-killswitch-apply-toctou.md
@@ -1,0 +1,55 @@
+# #550 — kill-switch apply/ignore TOCTOU
+
+Third #543-audit follow-up, split into its own PR (different predicate:
+concurrency on the admin endpoints, not the live-DD fail-closed contract).
+
+## Problem
+
+`api/kill_switch.py` apply (`kill_switch_apply_recommendation`) and ignore
+(`kill_switch_ignore_recommendation`):
+
+1. Pre-check read (`snapshot_connection`): 404 if missing, 400 if not pending.
+2. **apply** then `save_config(...)` — writes the slider to `config.json`.
+3. UPDATE (separate `transaction()`): `SET status=... WHERE id=?` — **no
+   `AND status='pending'`, no rowcount check.**
+
+The UPDATE has no concurrency guard, and in apply the config write precedes it,
+gated only on the stale pre-check. An `apply` racing an `ignore` (or the
+calibrator's `supersede`) lets both pass the pre-check; apply mutates config;
+both UPDATEs run unguarded (last writer wins). The row can end up `ignored` while
+the aggressiveness slider was already changed.
+
+## Fix
+
+Make the atomic UPDATE the authority; the config side effect runs only for the
+request that actually transitions the row.
+
+1. Pre-check stays (fast 404 / 400 + slider-range validation; not authoritative).
+2. Atomic UPDATE first: `... WHERE id=? AND status='pending'`; check `rowcount`.
+3. `rowcount == 0` -> **409 Conflict**; no config change.
+4. apply only: `save_config(...)` after winning the transition.
+
+Residual (documented): if `save_config` throws after the UPDATE commits, the row
+is `applied` but the slider isn't persisted — a loud 500, single request, no
+silent double-apply. File+DB atomicity would need a 2-phase commit we are not
+building.
+
+## Tests (TDD, red->green)
+
+`tests/test_api_kill_switch_parity.py`:
+- `test_apply_lost_race_returns_409_and_does_not_write_config` — seed a row, a
+  concurrent transition flips it to `ignored`, a faked `snapshot_connection`
+  still reports `pending`; the guarded UPDATE affects 0 rows -> 409 AND
+  `save_config` is never called. (Against the old unguarded code this returns 200
+  + writes config, so it fails on the old path.)
+- `test_ignore_lost_race_returns_409` — same for ignore (real row `applied`).
+
+The existing happy-path tests (`test_apply_recommendation_marks_applied_and_writes_config`,
+`test_apply_already_applied_returns_400`, `test_ignore_recommendation_marks_ignored`,
+`test_ignore_recommendation_not_found_returns_404`) regress the reorder.
+
+## Verify
+
+- `python -m pytest tests/test_api_kill_switch_parity.py -q` (13 pass).
+- 161 regression green (parity + calibrator + health dashboard + endpoints).
+- Independent review. 1 PR, Closes #550. Merge requested separately.

--- a/tests/test_api_kill_switch_parity.py
+++ b/tests/test_api_kill_switch_parity.py
@@ -75,3 +75,136 @@ def test_kill_switch_ignore_no_auth(client):
     """POST /kill_switch/recommendations/1/ignore without auth → 401."""
     r = client.post("/kill_switch/recommendations/1/ignore")
     assert r.status_code == 401
+
+
+# ── #550: apply/ignore TOCTOU — atomic UPDATE is the authority ───────────────
+#
+# These call the endpoint functions directly (no TestClient): the admin-role
+# dependency reads request.state.user from AuthMiddleware, which the parity
+# client cannot easily satisfy. Calling the handler directly exercises exactly
+# the apply/ignore body — the only thing #550 changes — and asserts the 409 the
+# guarded UPDATE produces on a lost race.
+
+
+@pytest.fixture
+def apidb(monkeypatch, tmp_path):
+    """Wire DB_FILE + config at the test DB and init the schema. No TestClient."""
+    db_path = tmp_path / "test.db"
+
+    import db.connection as dbconn
+    monkeypatch.setattr(dbconn, "DB_FILE", str(db_path))
+
+    import btc_api
+    monkeypatch.setattr(btc_api, "DB_FILE", str(db_path))
+
+    import api.config as _ac
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"api_key": "test-key"}))
+    monkeypatch.setattr(_ac, "CONFIG_FILE", str(config_path))
+    monkeypatch.setattr(_ac, "DEFAULTS_FILE", "/tmp/_nonexistent_defaults.json")
+    monkeypatch.setattr(_ac, "SECRETS_FILE", "/tmp/_nonexistent_secrets.json")
+    monkeypatch.setattr(btc_api, "CONFIG_FILE", str(config_path))
+
+    from db.schema import init_db
+    init_db()
+    return str(db_path)
+
+
+def _seed_recommendation(status, slider_value=50):
+    """Insert one recommendation row with the given status; return its id."""
+    from datetime import datetime, timezone
+    from db.transaction import transaction
+
+    now = datetime.now(tz=timezone.utc).isoformat()
+    with transaction() as conn:
+        cur = conn.execute(
+            """INSERT INTO kill_switch_recommendations
+                 (ts, triggered_by, slider_value, projected_pnl, projected_dd,
+                  status, applied_ts, applied_by, report_json)
+               VALUES (?, ?, ?, NULL, NULL, ?, NULL, NULL, ?)""",
+            (now, json.dumps(["manual"]), slider_value, status, json.dumps({})),
+        )
+        return int(cur.lastrowid)
+
+
+def _stale_pending_cm(rec_id, slider_value):
+    """Fake snapshot_connection() whose pre-check read reports the row as
+    'pending' — a stale read that lost the race to a concurrent transition. The
+    REAL row (seeded non-pending) is what the guarded UPDATE sees, so rowcount=0."""
+    class _Cur:
+        def fetchone(self_):
+            # (id, status, slider_value) matches the apply pre-check SELECT;
+            # ignore reads only (id, status) — extra field harmless.
+            return (rec_id, "pending", slider_value)
+
+    class _Conn:
+        def execute(self_, *a, **k):
+            return _Cur()
+
+    class _CM:
+        def __enter__(self_):
+            return _Conn()
+
+        def __exit__(self_, *exc):
+            return False
+
+    return lambda: _CM()
+
+
+def test_apply_lost_race_returns_409_and_does_not_write_config(apidb, monkeypatch):
+    """#550: a stale pre-check that still sees 'pending' must NOT write config
+    when the row was concurrently transitioned. The guarded UPDATE matches 0 rows
+    -> 409, and save_config is never called.
+
+    Against the pre-#550 code (config written first, unguarded UPDATE) this would
+    write config and mark 'applied' — so the test fails on the old path and
+    passes only with the atomic-gate fix."""
+    from fastapi import HTTPException
+    import api.kill_switch as ks
+
+    # A concurrent ignore already transitioned the real row.
+    rec_id = _seed_recommendation(status="ignored", slider_value=50)
+
+    called = {"save": False}
+    monkeypatch.setattr(ks, "save_config",
+                        lambda partial: called.__setitem__("save", True))
+    monkeypatch.setattr(ks, "snapshot_connection",
+                        _stale_pending_cm(rec_id, 50))
+
+    with pytest.raises(HTTPException) as exc:
+        ks.kill_switch_apply_recommendation(rec_id)
+    assert exc.value.status_code == 409, exc.value.detail
+    assert called["save"] is False, "config must not be written on a lost race"
+
+
+def test_ignore_lost_race_returns_409(apidb, monkeypatch):
+    """#550: ignore must also gate on the atomic UPDATE. A stale pre-check that
+    sees 'pending' raises 409 when the row was already transitioned."""
+    from fastapi import HTTPException
+    import api.kill_switch as ks
+
+    # A concurrent apply already transitioned the real row.
+    rec_id = _seed_recommendation(status="applied", slider_value=50)
+
+    monkeypatch.setattr(ks, "snapshot_connection",
+                        _stale_pending_cm(rec_id, 50))
+
+    with pytest.raises(HTTPException) as exc:
+        ks.kill_switch_ignore_recommendation(rec_id)
+    assert exc.value.status_code == 409, exc.value.detail
+
+
+def test_apply_happy_path_marks_applied_and_writes_config(apidb, monkeypatch):
+    """#550 regression: the uncontended apply still writes config with the right
+    slider and marks the row applied (the reorder did not break the success
+    path)."""
+    import api.kill_switch as ks
+
+    rec_id = _seed_recommendation(status="pending", slider_value=72)
+
+    saved = {}
+    monkeypatch.setattr(ks, "save_config", lambda partial: saved.update(partial))
+
+    out = ks.kill_switch_apply_recommendation(rec_id)
+    assert out["status"] == "applied"
+    assert saved["kill_switch"]["v2"]["aggressiveness"] == 72


### PR DESCRIPTION
Third follow-up from the **#543 audit** — split out because the predicate is different: concurrency on the admin apply/ignore endpoints, not the live-DD fail-closed contract.

## Problem

`api/kill_switch.py` apply/ignore:

1. Pre-check read (`snapshot_connection`): 404 if missing, 400 if not pending.
2. **apply** then `save_config(...)` writes the slider to `config.json`.
3. UPDATE (separate `transaction()`): `SET status=... WHERE id=?` — **no `AND status='pending'`, no rowcount check.**

The UPDATE has no concurrency guard, and in apply the config write precedes it, gated only on the stale pre-check. An `apply` racing an `ignore` (or the calibrator's `supersede`) lets both pass the pre-check; apply mutates config; both UPDATEs run unguarded. The row can end up `ignored` while the slider was already changed — the operator who ignored it sees no apply, yet config moved.

## Fix

Make the atomic UPDATE the authority; the config side effect runs only for the request that actually transitions the row.

1. Pre-check stays (fast 404 / 400 + slider validation; not authoritative).
2. Atomic UPDATE first: `... WHERE id=? AND status='pending'`; check `rowcount`.
3. `rowcount == 0` -> **409 Conflict**; no config change.
4. apply only: `save_config(...)` after winning the transition.

Residual (documented): if `save_config` throws after the UPDATE commits, the row is `applied` but the slider isn't persisted — a loud 500, single request, no silent double-apply. File+DB atomicity would need a 2-phase commit we are not building.

## Tests

2 new (TDD red->green): a stale pre-check that still sees `pending` while the real row is already decided returns **409** AND never calls `save_config`. The existing happy-path / already-decided tests regress the reorder. **161 regression green** (parity + calibrator + health dashboard + endpoints).

Closes #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)