### PR TITLE
Funding-carry tail-aware kill rule: PASS, but the kill adds no value

### DIFF
--- a/data/retune/2026-06-03-funding-carry-tail-kill/findings.md
+++ b/data/retune/2026-06-03-funding-carry-tail-kill/findings.md
@@ -1,0 +1,15 @@
+# Funding-carry tail-aware kill rule: VERDICT
+
+**Verdict: PASS**  (G1 in-sample: True, G2 out-of-sample: True)
+
+- Symbols used 9: BTCUSDT, ETHUSDT, ADAUSDT, AVAXUSDT, DOGEUSDT, UNIUSDT, XLMUSDT, RUNEUSDT, PENDLEUSDT
+- With-kill pooled net: 0.2706   No-kill pooled net: 0.2725
+- Kill vs no-kill net: mean delta -0.0018, CI95 [-0.0048, 0.0000], net_adds_value=False
+- Max-DD pooled ($): with-kill 150.06 vs no-kill 149.92, kill_lowers_dd=False
+- Post-2-shock pooled net: 0.0306  (shock_loss/ea 0.1200, kill-capped at K settlements)
+- K-sensitivity (descriptive): K=9: net 0.1739, kills 6.1; K=18: net 0.2679, kills 0.7; K=24: net 0.2706, kills 0.2; K=36: net 0.2720, kills 0.1
+
+Interpretation: kill adds value if net_adds_value (CI lo > 0) OR kill_lowers_dd; a PASS where
+the kill neither raises net nor lowers DD means the carry is already robust without it. Leverage 2x fixed.
+Scope: liquid universe, in-sample 2024-26 + 2 synthetic shocks. NOT production-deployable
+(rebalance #2, long-tail #3, live #4 are separate sub-projects).

--- a/data/retune/2026-06-03-funding-carry-tail-kill/per_symbol.json
+++ b/data/retune/2026-06-03-funding-carry-tail-kill/per_symbol.json
@@ -1,0 +1,74 @@
+[
+  {
+    "churn_cost": 30.463123519616833,
+    "net_no_kill": 0.3235278951190277,
+    "net_with_kill": 0.3235278951190277,
+    "n_kills": 0,
+    "symbol": "BTCUSDT",
+    "max_dd": 72.10151351067088
+  },
+  {
+    "churn_cost": 32.122622135180144,
+    "net_no_kill": 0.25412925539876113,
+    "net_with_kill": 0.25412925539876113,
+    "n_kills": 0,
+    "symbol": "ETHUSDT",
+    "max_dd": 54.49336729152992
+  },
+  {
+    "churn_cost": 77.15174560836292,
+    "net_no_kill": 0.19770273755355128,
+    "net_with_kill": 0.19770273755355128,
+    "n_kills": 0,
+    "symbol": "ADAUSDT",
+    "max_dd": 58.555112620448654
+  },
+  {
+    "churn_cost": 109.83978194524155,
+    "net_no_kill": 0.12671964395859453,
+    "net_with_kill": 0.12355681600246264,
+    "n_kills": 1,
+    "symbol": "AVAXUSDT",
+    "max_dd": 89.7152818244831
+  },
+  {
+    "churn_cost": 60.58282640638025,
+    "net_no_kill": 0.40150309965323816,
+    "net_with_kill": 0.40150309965323816,
+    "n_kills": 0,
+    "symbol": "DOGEUSDT",
+    "max_dd": 48.91219206645883
+  },
+  {
+    "churn_cost": 92.63031357468874,
+    "net_no_kill": 0.2623308635588113,
+    "net_with_kill": 0.2623308635588113,
+    "n_kills": 0,
+    "symbol": "UNIUSDT",
+    "max_dd": 10.019167306370946
+  },
+  {
+    "churn_cost": 264.04682825262785,
+    "net_no_kill": 0.10732203730559313,
+    "net_with_kill": 0.09398925521113204,
+    "n_kills": 1,
+    "symbol": "XLMUSDT",
+    "max_dd": 671.7947522343961
+  },
+  {
+    "churn_cost": 112.86075881597198,
+    "net_no_kill": 0.18999951265733092,
+    "net_with_kill": 0.18999951265733092,
+    "n_kills": 0,
+    "symbol": "RUNEUSDT",
+    "max_dd": 19.783245621940296
+  },
+  {
+    "churn_cost": 1253.99974256795,
+    "net_no_kill": 0.5890081502345849,
+    "net_with_kill": 0.5890081502345849,
+    "n_kills": 0,
+    "symbol": "PENDLEUSDT",
+    "max_dd": 325.19960332260644
+  }
+]

--- a/data/retune/2026-06-03-funding-carry-tail-kill/verdict.json
+++ b/data/retune/2026-06-03-funding-carry-tail-kill/verdict.json
@@ -1,0 +1,62 @@
+{
+  "verdict": {
+    "pass_g1": true,
+    "pass_g2": true,
+    "verdict": "PASS"
+  },
+  "kill_vs_nokill": {
+    "mean_delta": -0.001832845561176998,
+    "ci_lo": -0.0047956860266127966,
+    "ci_hi": 0.0,
+    "kill_adds_value": false
+  },
+  "with_kill_pooled": 0.2706386205987667,
+  "no_kill_pooled": 0.27247146615994366,
+  "post_shock_pooled": 0.030638620598766677,
+  "k_sensitivity": {
+    "9": {
+      "pooled_net": 0.1738529854732167,
+      "mean_kills": 6.111111111111111
+    },
+    "18": {
+      "pooled_net": 0.26793773949979177,
+      "mean_kills": 0.6666666666666666
+    },
+    "24": {
+      "pooled_net": 0.2706386205987667,
+      "mean_kills": 0.2222222222222222
+    },
+    "36": {
+      "pooled_net": 0.2719560084466207,
+      "mean_kills": 0.1111111111111111
+    }
+  },
+  "manifest": {
+    "experiment": "funding-carry-tail-kill",
+    "spec_commit": "9605758",
+    "kill_k": 24,
+    "n_shocks": 2,
+    "shock_loss_frac": 0.12,
+    "cost_model": {
+      "active_model": "v3",
+      "calibration_identity_hash": "1b616f742ed2eec7c00e09a78d2dd796dad79ba3d771175a39cda512d38c0d4d"
+    },
+    "symbols_used": [
+      "BTCUSDT",
+      "ETHUSDT",
+      "ADAUSDT",
+      "AVAXUSDT",
+      "DOGEUSDT",
+      "UNIUSDT",
+      "XLMUSDT",
+      "RUNEUSDT",
+      "PENDLEUSDT"
+    ],
+    "generated_utc": "2026-06-03T12:03:31.852341+00:00"
+  },
+  "max_dd_pooled": {
+    "with_kill": 150.06380397765614,
+    "no_kill": 149.91886988673423,
+    "kill_lowers_dd": false
+  }
+}

--- a/docs/superpowers/plans/2026-06-03-funding-carry-tail-kill.md
+++ b/docs/superpowers/plans/2026-06-03-funding-carry-tail-kill.md
@@ -1,0 +1,488 @@
+# Funding-Carry Tail-Aware Kill Rule — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-interval-mark funding accrual + a frozen funding-negative KILL rule to the (already-passing) funding carry, and gate whether the kill makes the carry survive an out-of-sample tail (2 synthetic shocks) net-positive while reporting whether the kill adds value vs no-kill.
+
+**Architecture:** Extends the existing `tools/funding_carry/` package (constants/ingest/simulate/evaluate/run from the PASS). Adds per-interval mark to `simulate.py`, a new `kill_rule.py` (negative-run detection + with-kill / no-kill equity simulators charging real v3 churn cost), kill-vs-no-kill + shock-injection + tail gate to `evaluate.py`, and a `run_kill.py` orchestrator. Reuses `backtest_costs.compute_trade_costs(model="v3", enable_funding=False)` and the populated `data/funding.db`.
+
+**Tech Stack:** Python 3, sqlite3, numpy, pytest. Reuses `backtest_costs` + the existing `tools/funding_carry` package.
+
+**Frozen pre-registration (spec `2026-06-03-funding-carry-tail-kill-design.md`, commit 9605758):**
+- per-interval mark: `Σ rate_i × mark_i × units` (mark from perp_klines at each settlement).
+- KILL: exit after K=24 consecutive `rate<0` settlements; re-enter on first `rate>=0`; no cooldown. Each IN-tramo charges one v3 round-trip (transaction-only). K frozen; K-sensitivity {9,18,24,36} is DESCRIPTIVE.
+- Gate: G1 = with-kill pooled net > 0 (in-sample); G2 = survives N_SHOCKS=2 synthetic shocks (0.5%/8h × 5d) injected at the 2 most-vulnerable points, kill firing during each, net-positive. Verdict PASS = G1 ∧ G2. Leverage 2.0 fixed (liquidation not the binding risk).
+- `$`-denominated. No holdout (#322), no live perps.
+
+**Note:** `data/funding.db` is already populated (11 symbols, 2646 funding + 21168 perp klines each). No network needed.
+
+---
+
+## File Structure
+
+- Modify `tools/funding_carry/constants.py` — add KILL_K, K_SENSITIVITY, N_SHOCKS, LEVERAGE, OUTPUT_DIR_KILL.
+- Modify `tools/funding_carry/simulate.py` — add `perp_mark_series`, `funding_pnl_per_interval`.
+- Create `tools/funding_carry/kill_rule.py` — `consecutive_negative_exit`, `simulate_with_kill`, `simulate_no_kill`.
+- Modify `tools/funding_carry/evaluate.py` — add `kill_vs_nokill`, `inject_shocks`, `gate_tail`, `verdict_kill`.
+- Create `tools/funding_carry/run_kill.py` — orchestrator → `data/retune/2026-06-03-funding-carry-tail-kill/`.
+- Modify `tests/test_funding_carry.py` — TDD for all new functions.
+
+Existing reused signatures (already in the package):
+`simulate.load_funding(funding_db, symbol, start_ms, end_ms) -> [(ts,rate)]`;
+`simulate.perp_price_at / spot_price_at / spot_liquidity`;
+`simulate.recost_four_legs(*, symbol, units, spot_price, perp_price, liq, holding_hours) -> float`;
+`constants.NOTIONAL, CANDIDATE_SYMBOLS, WINDOW_START, WINDOW_END, OHLCV_DB, FUNDING_DB, BOOTSTRAP_N, BOOTSTRAP_SEED, SHOCK_FUNDING_PER_8H, SHOCK_DAYS`.
+
+---
+
+## Task 1: New frozen constants
+
+**Files:** Modify `tools/funding_carry/constants.py`
+
+- [ ] **Step 1: Append the new constants**
+
+Append to `tools/funding_carry/constants.py`:
+```python
+# --- Tail-aware kill rule (sub-project #1, spec 9605758) ---
+KILL_K = 24                       # exit after this many consecutive negative settlements (~8d)
+K_SENSITIVITY = (9, 18, 24, 36)   # DESCRIPTIVE only — does NOT gate the verdict
+N_SHOCKS = 2                      # synthetic out-of-sample shocks (2022 = LUNA + FTX)
+LEVERAGE = 2.0                    # fixed conservative; liquidation needs ~50% adverse (not binding)
+OUTPUT_DIR_KILL = "data/retune/2026-06-03-funding-carry-tail-kill"
+```
+
+- [ ] **Step 2: Verify it imports**
+
+Run: `python -c "from tools.funding_carry.constants import KILL_K, K_SENSITIVITY, N_SHOCKS, LEVERAGE, OUTPUT_DIR_KILL; print(KILL_K, K_SENSITIVITY, N_SHOCKS, LEVERAGE)"`
+Expected: `24 (9, 18, 24, 36) 2 2.0`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/funding_carry/constants.py
+git commit -m "feat(funding-carry): kill-rule constants (K=24, 2 shocks, lev 2x)"
+```
+
+---
+
+## Task 2: Per-interval mark accrual
+
+**Files:** Modify `tools/funding_carry/simulate.py`; Test `tests/test_funding_carry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_funding_carry.py`:
+```python
+def test_perp_mark_series_lookup(tmp_path):
+    db = str(tmp_path / "f.db"); _mk_funding_db(db)   # perp close=100 at each hour
+    # funding times at 0, 28.8M, 57.6M ms -> last perp close at/<= each
+    marks = simulate.perp_mark_series(db, "BTCUSDT", [0, 28_800_000, 57_600_000])
+    assert marks == [pytest.approx(100.0)] * 3
+
+def test_funding_pnl_per_interval_uses_each_mark():
+    funding = [(0, 0.0001), (1, -0.0002)]
+    marks = [100.0, 200.0]    # mark doubles on the 2nd settlement
+    pnl = simulate.funding_pnl_per_interval(funding, marks=marks, units=2.0)
+    assert pnl == pytest.approx(0.0001 * 100.0 * 2.0 + (-0.0002) * 200.0 * 2.0)
+```
+
+- [ ] **Step 2: Run, confirm FAIL**
+
+Run: `python -m pytest tests/test_funding_carry.py -k "perp_mark_series or per_interval" -v`
+Expected: FAIL (no attribute).
+
+- [ ] **Step 3: Implement (append to simulate.py)**
+
+```python
+def perp_mark_series(funding_db: str, symbol: str, times_ms: list[int]) -> list[float]:
+    """Perp mark close at or before each funding settlement time (NaN if none)."""
+    return [perp_price_at(funding_db, symbol, t) for t in times_ms]
+
+
+def funding_pnl_per_interval(funding: list[tuple[int, float]], *, marks: list[float],
+                             units: float) -> float:
+    """Funding the short collects, marked PER SETTLEMENT: sum(rate_i * mark_i * units).
+    More accurate than the constant-entry-mark approximation (spec §2)."""
+    return sum(rate * mark * units for (_, rate), mark in zip(funding, marks))
+```
+
+- [ ] **Step 4: Run, confirm PASS**
+
+Run: `python -m pytest tests/test_funding_carry.py -k "perp_mark_series or per_interval" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/funding_carry/simulate.py tests/test_funding_carry.py
+git commit -m "feat(funding-carry): per-interval mark funding accrual"
+```
+
+---
+
+## Task 3: Kill-rule simulator (with-kill + no-kill)
+
+**Files:** Create `tools/funding_carry/kill_rule.py`; Test `tests/test_funding_carry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_funding_carry.py`:
+```python
+from tools.funding_carry import kill_rule
+
+def test_simulate_no_kill_one_tramo():
+    # all positive funding -> one continuous tramo, no kill, one round-trip cost.
+    funding = [(i, 0.0001) for i in range(10)]
+    marks = [100.0] * 10
+    r = kill_rule.simulate_no_kill(funding, marks=marks, units=2.0, rt_cost=5.0)
+    assert r["n_tramos"] == 1
+    assert r["churn_cost"] == pytest.approx(5.0)
+    assert r["net"] == pytest.approx(sum(0.0001 * 100.0 * 2.0 for _ in range(10)) - 5.0)
+    assert len(r["equity_curve"]) == 10          # cumulative, time-ordered
+
+def test_simulate_with_kill_exits_on_K_negatives():
+    # 3 positive, then K=3 negatives -> exit; then 2 positive -> re-enter.
+    funding = [(i, 0.0001) for i in range(3)] + [(i + 3, -0.0002) for i in range(3)] \
+              + [(i + 6, 0.0001) for i in range(2)]
+    marks = [100.0] * 8
+    r = kill_rule.simulate_with_kill(funding, marks=marks, units=2.0, rt_cost=5.0, k=3)
+    assert r["n_tramos"] == 2                     # initial IN + one re-entry
+    assert r["n_kills"] == 1
+    assert r["churn_cost"] == pytest.approx(10.0) # 2 tramos * 5.0
+
+def test_with_kill_no_negatives_equals_no_kill():
+    funding = [(i, 0.0001) for i in range(10)]
+    marks = [100.0] * 10
+    wk = kill_rule.simulate_with_kill(funding, marks=marks, units=2.0, rt_cost=5.0, k=3)
+    nk = kill_rule.simulate_no_kill(funding, marks=marks, units=2.0, rt_cost=5.0)
+    assert wk["net"] == pytest.approx(nk["net"])
+```
+
+- [ ] **Step 2: Run, confirm FAIL**
+
+Run: `python -m pytest tests/test_funding_carry.py -k "no_kill or with_kill" -v`
+Expected: FAIL (no module kill_rule).
+
+- [ ] **Step 3: Implement `tools/funding_carry/kill_rule.py`**
+
+```python
+"""Funding-negative KILL rule simulator (spec §3-§4). IN/OUT state machine over the
+per-settlement funding stream, charging one v3 round-trip per IN-tramo (churn is real).
+Pure functions — `rt_cost` (round-trip transaction cost) is passed in, computed by the
+caller via simulate.recost_four_legs."""
+from __future__ import annotations
+
+
+def _accrue(funding, marks, units, lo, hi):
+    """Sum funding over settlements [lo, hi) (a single IN-tramo)."""
+    return sum(funding[i][1] * marks[i] * units for i in range(lo, hi))
+
+
+def simulate_no_kill(funding, *, marks, units, rt_cost) -> dict:
+    """Continuous hold: one tramo over all settlements, one round-trip cost."""
+    n = len(funding)
+    gross = _accrue(funding, marks, units, 0, n)
+    eq, run = [], 0.0
+    for i in range(n):
+        run += funding[i][1] * marks[i] * units
+        eq.append(run)
+    return {"net": gross - rt_cost, "n_tramos": 1, "n_kills": 0,
+            "churn_cost": rt_cost, "equity_curve": eq}
+
+
+def simulate_with_kill(funding, *, marks, units, rt_cost, k) -> dict:
+    """IN/OUT machine. Exit after `k` consecutive rate<0 settlements; re-enter on the
+    first rate>=0. Each IN-tramo charges `rt_cost` (one round trip). Equity curve is the
+    cumulative time-ordered P&L (funding only; basis handled by the caller per tramo)."""
+    n = len(funding)
+    eq, run = [], 0.0
+    state, neg = "IN", 0
+    n_tramos = 1 if n else 0          # start IN
+    n_kills = 0
+    for i in range(n):
+        rate = funding[i][1]
+        if state == "IN":
+            run += rate * marks[i] * units
+            neg = neg + 1 if rate < 0 else 0
+            if neg >= k:
+                state, neg = "OUT", 0
+                n_kills += 1
+        elif rate >= 0:               # OUT and funding back positive -> re-enter
+            state = "IN"
+            n_tramos += 1
+        eq.append(run)
+    churn = rt_cost * n_tramos
+    return {"net": run - churn, "n_tramos": n_tramos, "n_kills": n_kills,
+            "churn_cost": churn, "equity_curve": eq}
+```
+
+- [ ] **Step 4: Run, confirm PASS**
+
+Run: `python -m pytest tests/test_funding_carry.py -k "no_kill or with_kill" -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/funding_carry/kill_rule.py tests/test_funding_carry.py
+git commit -m "feat(funding-carry): kill-rule simulator (with-kill + no-kill, churn-charged)"
+```
+
+---
+
+## Task 4: Kill-vs-no-kill + shock injection + tail gate
+
+**Files:** Modify `tools/funding_carry/evaluate.py`; Test `tests/test_funding_carry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_funding_carry.py`:
+```python
+def test_kill_vs_nokill_bootstrap_deterministic():
+    wk = [0.06, 0.05, 0.07, 0.04, 0.08, 0.05, 0.06, 0.05, 0.07]
+    nk = [0.05, 0.05, 0.06, 0.04, 0.07, 0.05, 0.05, 0.05, 0.06]
+    a = evaluate.kill_vs_nokill(wk, nk)
+    b = evaluate.kill_vs_nokill(wk, nk)
+    assert a["ci_lo"] == b["ci_lo"]                       # seeded
+    assert a["mean_delta"] == pytest.approx(sum(w - n for w, n in zip(wk, nk)) / len(wk))
+
+def test_inject_shocks_subtracts_worst_points():
+    # a flat-up equity; injecting 2 shocks of size 3.0 reduces the final by ~2*3.0 net.
+    eq = [1.0, 2.0, 3.0, 4.0, 5.0]
+    final = evaluate.inject_shocks(eq, n_shocks=2, shock_loss=3.0)
+    assert final == pytest.approx(5.0 - 2 * 3.0)
+
+def test_gate_tail_requires_both():
+    g = evaluate.gate_tail(with_kill_net_pooled=0.10, post_shock_net_pooled=0.02)
+    assert g["pass_g1"] and g["pass_g2"] and g["verdict"] == "PASS"
+    g2 = evaluate.gate_tail(with_kill_net_pooled=0.10, post_shock_net_pooled=-0.01)
+    assert g2["verdict"] == "FAIL"
+    g3 = evaluate.gate_tail(with_kill_net_pooled=-0.01, post_shock_net_pooled=0.02)
+    assert g3["verdict"] == "FAIL"
+```
+
+- [ ] **Step 2: Run, confirm FAIL**
+
+Run: `python -m pytest tests/test_funding_carry.py -k "kill_vs_nokill or inject_shocks or gate_tail" -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement (append to evaluate.py)**
+
+```python
+from .constants import N_SHOCKS, SHOCK_FUNDING_PER_8H, SHOCK_DAYS, SHOCK_INTERVALS_PER_DAY
+
+
+def kill_vs_nokill(with_kill: list[float], no_kill: list[float]) -> dict:
+    """Paired pooled delta (with_kill - no_kill) net return + bootstrap CI. Does the kill
+    add value net of churn? Positive mean_delta = kill helps."""
+    deltas = np.asarray([w - n for w, n in zip(with_kill, no_kill)], dtype=float)
+    rng = np.random.default_rng(BOOTSTRAP_SEED)
+    idx = rng.integers(0, len(deltas), size=(BOOTSTRAP_N, len(deltas)))
+    means = deltas[idx].mean(axis=1)
+    return {"mean_delta": float(deltas.mean()),
+            "ci_lo": float(np.percentile(means, 2.5)),
+            "ci_hi": float(np.percentile(means, 97.5)),
+            "kill_adds_value": bool(np.percentile(means, 2.5) > 0.0)}
+
+
+def inject_shocks(equity_curve: list[float], *, n_shocks: int, shock_loss: float) -> float:
+    """Final equity after subtracting `n_shocks` one-time losses of `shock_loss` each
+    (the synthetic out-of-sample tail; the kill caps each shock's bleed). Conservative:
+    applies the full loss n_shocks times to the realized final equity."""
+    final = equity_curve[-1] if equity_curve else 0.0
+    return final - n_shocks * shock_loss
+
+
+def gate_tail(*, with_kill_net_pooled: float, post_shock_net_pooled: float) -> dict:
+    """G1 = with-kill net survives in-sample (>0); G2 = survives N_SHOCKS (>=0). PASS = both."""
+    g1 = bool(with_kill_net_pooled > 0.0)
+    g2 = bool(post_shock_net_pooled >= 0.0)
+    return {"pass_g1": g1, "pass_g2": g2, "verdict": "PASS" if (g1 and g2) else "FAIL"}
+```
+
+- [ ] **Step 4: Run, confirm PASS**
+
+Run: `python -m pytest tests/test_funding_carry.py -k "kill_vs_nokill or inject_shocks or gate_tail" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/funding_carry/evaluate.py tests/test_funding_carry.py
+git commit -m "feat(funding-carry): kill-vs-nokill + shock injection + tail gate (G1/G2)"
+```
+
+---
+
+## Task 5: run_kill orchestrator + artifacts
+
+**Files:** Create `tools/funding_carry/run_kill.py`; Test `tests/test_funding_carry.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_funding_carry.py`:
+```python
+def test_run_kill_required_keys():
+    from tools.funding_carry import run_kill
+    rec = {"symbol": "BTCUSDT", "net_with_kill": 0.06, "net_no_kill": 0.05,
+           "n_kills": 1, "max_dd": 100.0, "churn_cost": 50.0}
+    assert run_kill.REQUIRED_KILL_KEYS <= set(rec.keys())
+```
+
+- [ ] **Step 2: Run, confirm FAIL**
+
+Run: `python -m pytest tests/test_funding_carry.py -k run_kill_required -v`
+Expected: FAIL (no module run_kill).
+
+- [ ] **Step 3: Implement `tools/funding_carry/run_kill.py`**
+
+```python
+"""Orchestrate the tail-aware kill-rule study end-to-end → verdict artifacts.
+
+Run: python -m tools.funding_carry.run_kill   (uses data/funding.db; no network)
+Reads funding.db + ohlcv.db (read-only). Writes only under OUTPUT_DIR_KILL. No holdout."""
+from __future__ import annotations
+import json
+import os
+from datetime import datetime, timezone
+import numpy as np
+
+from backtest_costs import calibration_identity_hash, load_calibration
+from . import simulate, evaluate, kill_rule
+from .constants import (OHLCV_DB, FUNDING_DB, OUTPUT_DIR_KILL, CANDIDATE_SYMBOLS,
+                        WINDOW_START, WINDOW_END, NOTIONAL, KILL_K, K_SENSITIVITY,
+                        N_SHOCKS, SHOCK_FUNDING_PER_8H, SHOCK_DAYS, SHOCK_INTERVALS_PER_DAY)
+from .run import _ms, _covered_symbols
+
+REQUIRED_KILL_KEYS = {"symbol", "net_with_kill", "net_no_kill", "n_kills", "max_dd", "churn_cost"}
+
+
+def _max_dd(equity_curve) -> float:
+    eq = np.asarray(equity_curve, dtype=float)
+    if len(eq) == 0:
+        return 0.0
+    return float((np.maximum.accumulate(eq) - eq).max())
+
+
+def _one_symbol(s, w0, w1, k):
+    funding = simulate.load_funding(FUNDING_DB, s, w0, w1)
+    if len(funding) < 2:
+        return None
+    times = [t for t, _ in funding]
+    marks = simulate.perp_mark_series(FUNDING_DB, s, times)
+    spot_e = simulate.spot_price_at(OHLCV_DB, s, times[0])
+    perp_e = simulate.perp_price_at(FUNDING_DB, s, times[0])
+    if any(np.isnan(x) for x in (spot_e, perp_e)) or any(np.isnan(m) for m in marks):
+        return None
+    units = NOTIONAL / spot_e
+    liq = simulate.spot_liquidity(OHLCV_DB, s, times[0])
+    rt = simulate.recost_four_legs(symbol=s, units=units, spot_price=spot_e,
+                                   perp_price=perp_e, liq=liq,
+                                   holding_hours=(times[-1] - times[0]) / 3_600_000)
+    wk = kill_rule.simulate_with_kill(funding, marks=marks, units=units, rt_cost=rt, k=k)
+    nk = kill_rule.simulate_no_kill(funding, marks=marks, units=units, rt_cost=rt)
+    return {"symbol": s, "net_with_kill": wk["net"] / NOTIONAL,
+            "net_no_kill": nk["net"] / NOTIONAL, "n_kills": wk["n_kills"],
+            "max_dd": _max_dd(wk["equity_curve"]), "churn_cost": wk["churn_cost"],
+            "equity_curve": wk["equity_curve"]}
+
+
+def main():
+    os.makedirs(OUTPUT_DIR_KILL, exist_ok=True)
+    w0, w1 = _ms(WINDOW_START), _ms(WINDOW_END)
+    symbols = _covered_symbols(FUNDING_DB, w0, w1)
+    recs = [r for r in (_one_symbol(s, w0, w1, KILL_K) for s in symbols) if r]
+
+    wk_ret = [r["net_with_kill"] for r in recs]
+    nk_ret = [r["net_no_kill"] for r in recs]
+    kvn = evaluate.kill_vs_nokill(wk_ret, nk_ret)
+    wk_pooled = float(np.mean(wk_ret)) if recs else 0.0
+    # G2: per-symbol, subtract N_SHOCKS one-time bleeds (kill caps each at K settlements
+    # of the shock rate); pooled post-shock net return.
+    shock_loss = KILL_K * SHOCK_FUNDING_PER_8H            # kill caps the bleed at K settlements
+    post = [evaluate.inject_shocks([NOTIONAL * r["net_with_kill"]], n_shocks=N_SHOCKS,
+                                   shock_loss=NOTIONAL * shock_loss) / NOTIONAL for r in recs]
+    post_pooled = float(np.mean(post)) if recs else 0.0
+    gate = evaluate.gate_tail(with_kill_net_pooled=wk_pooled, post_shock_net_pooled=post_pooled)
+
+    # descriptive K-sensitivity (does NOT gate)
+    ksens = {}
+    for k in K_SENSITIVITY:
+        rs = [r for r in (_one_symbol(s, w0, w1, k) for s in symbols) if r]
+        ksens[k] = {"pooled_net": float(np.mean([x["net_with_kill"] for x in rs])) if rs else 0.0,
+                    "mean_kills": float(np.mean([x["n_kills"] for x in rs])) if rs else 0.0}
+
+    cal = load_calibration()
+    out = {"verdict": gate, "kill_vs_nokill": kvn, "with_kill_pooled": wk_pooled,
+           "no_kill_pooled": float(np.mean(nk_ret)) if recs else 0.0,
+           "post_shock_pooled": post_pooled, "k_sensitivity": ksens,
+           "manifest": {"experiment": "funding-carry-tail-kill", "spec_commit": "9605758",
+                        "kill_k": KILL_K, "n_shocks": N_SHOCKS, "shock_loss_frac": shock_loss,
+                        "cost_model": {"active_model": cal.active_model,
+                                       "calibration_identity_hash": calibration_identity_hash(cal)},
+                        "symbols_used": [r["symbol"] for r in recs],
+                        "generated_utc": datetime.now(timezone.utc).isoformat()}}
+    slim = [{kk: r[kk] for kk in REQUIRED_KILL_KEYS} for r in recs]
+    with open(os.path.join(OUTPUT_DIR_KILL, "per_symbol.json"), "w") as f:
+        json.dump(slim, f, indent=2)
+    with open(os.path.join(OUTPUT_DIR_KILL, "verdict.json"), "w") as f:
+        json.dump(out, f, indent=2)
+    lines = [
+        "# Funding-carry tail-aware kill rule: VERDICT", "",
+        f"**Verdict: {gate['verdict']}**  (G1 in-sample: {gate['pass_g1']}, G2 out-of-sample: {gate['pass_g2']})", "",
+        f"- Symbols used {len(recs)}: {', '.join(r['symbol'] for r in recs)}",
+        f"- With-kill pooled net: {wk_pooled:.4f}   No-kill pooled net: {out['no_kill_pooled']:.4f}",
+        f"- Kill vs no-kill: mean delta {kvn['mean_delta']:.4f}, CI95 [{kvn['ci_lo']:.4f}, {kvn['ci_hi']:.4f}], adds_value={kvn['kill_adds_value']}",
+        f"- Post-{N_SHOCKS}-shock pooled net: {post_pooled:.4f}  (shock_loss/ea {shock_loss:.4f}, kill-capped at K settlements)",
+        f"- K-sensitivity (descriptive): " + "; ".join(f"K={k}: net {v['pooled_net']:.4f}, kills {v['mean_kills']:.1f}" for k, v in ksens.items()), "",
+        "Interpretation: kill ADDS value if mean delta > 0 (better net) or lowers max_dd; a PASS",
+        "where kill <= no-kill means the carry is already robust without the kill. Leverage 2x fixed.",
+        "Scope: liquid universe, in-sample 2024-26 + 2 synthetic shocks. NOT production-deployable",
+        "(rebalance #2, long-tail #3, live #4 are separate sub-projects).",
+    ]
+    with open(os.path.join(OUTPUT_DIR_KILL, "findings.md"), "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+    print(f"VERDICT: {gate['verdict']}  (G1={gate['pass_g1']} G2={gate['pass_g2']}, "
+          f"with-kill {wk_pooled:.4f} vs no-kill {out['no_kill_pooled']:.4f})")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the unit test + full suite**
+
+Run: `python -m pytest tests/test_funding_carry.py -q`
+Expected: ALL pass (existing 16 + Task2 2 + Task3 3 + Task4 3 + Task5 1 = 25). DO NOT run `run_kill.main` yet (Task 6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/funding_carry/run_kill.py tests/test_funding_carry.py
+git commit -m "feat(funding-carry): run_kill orchestrator + tail-kill artifacts"
+```
+
+---
+
+## Task 6: Execute + route (human-in-the-loop)
+
+**Files:** runtime — `data/retune/2026-06-03-funding-carry-tail-kill/`
+
+- [ ] **Step 1: Execute.** `python -m tools.funding_carry.run_kill` — prints `VERDICT: ...`, writes the 3 artifacts. (Uses the populated `data/funding.db`; no network.)
+- [ ] **Step 2: Read `findings.md` + `verdict.json`.** Confirm G1/G2, the kill-vs-no-kill delta (does the kill add value or just churn?), and the K-sensitivity (is K=24 robust or a knife-edge?).
+- [ ] **Step 3: `mex log`** the verdict + whether the kill adds value.
+- [ ] **Step 4: Route.** PASS + kill-adds-value → the kill is a real risk control; proceed to sub-project #2 (rebalance) or #3 (long-tail). PASS + kill-neutral → the liquid carry is already tail-robust without a kill (also a useful finding). FAIL → the liquid carry is too thin for tail-aware deployment at this size; re-evaluate sizing/leverage or go straight to the long-tail (#3) where the gross edge is larger. Update memory `edge-landscape-funding-carry`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §2 per-interval mark → Task 2. §3 kill rule (K=24, re-enter, churn) → Task 3. §4 with-kill/no-kill simulator → Task 3. §5 kill-vs-no-kill + K-sensitivity → Tasks 4-5. §6 gate G1∧G2 + shock injection → Tasks 4-5. §7 file structure → all. §8 NN (no holdout/live) → read-only sqlite + funding.db, no `open_holdout`/`simulate_strategy`/`PositionClosure`. §10 open questions resolved: strict `<0` breaks the run (Task 3 `neg = neg+1 if rate<0 else 0`); shocks applied to final equity per-symbol (Task 5 `inject_shocks`); basis per-tramo — see limitation below.
+
+**Known simplification (pre-declared):** the equity curve and net in `simulate_with_kill` track FUNDING only; basis P&L per tramo is omitted (basis was trivial in the v1 PASS: ~$10-50 vs ~$1800 funding, <3%). This keeps the kill simulator focused on the funding-tail it manages. If basis matters at deployment it is a #2 (rebalance) concern. The churn cost (the kill's real price) IS charged in full.
+
+**Placeholder scan:** none. K-sensitivity values are concrete; shock_loss = KILL_K × SHOCK_FUNDING_PER_8H is a derived constant, not a TODO.
+
+**Type consistency:** `simulate_with_kill`/`simulate_no_kill` both return dicts with `net, n_tramos, n_kills, churn_cost, equity_curve`. `kill_vs_nokill(with_kill, no_kill)` takes two return lists. `gate_tail(with_kill_net_pooled=, post_shock_net_pooled=)` kwargs match the call in `run_kill.main`. `inject_shocks(equity_curve, n_shocks=, shock_loss=)` matches. `recost_four_legs` reused with its existing signature. `_ms`/`_covered_symbols` imported from the existing `run.py`. `REQUIRED_KILL_KEYS` ⊆ the per-symbol record.
+
+**Note on G2:** `inject_shocks` is applied to a single-element list `[NOTIONAL * net_with_kill]` per symbol (the realized final $ net), subtracting `N_SHOCKS × NOTIONAL × shock_loss`. `shock_loss = KILL_K × SHOCK_FUNDING_PER_8H` models the kill capping each shock's bleed at K settlements (not the full SHOCK_DAYS) — the kill's whole purpose. Conservative: the realized in-sample net already absorbed real negative episodes; G2 adds 2 MORE worst-case shocks on top.

--- a/docs/superpowers/specs/2026-06-03-funding-carry-tail-kill-design.md
+++ b/docs/superpowers/specs/2026-06-03-funding-carry-tail-kill-design.md
@@ -1,0 +1,124 @@
+# Funding-Carry Tail-Aware Kill Rule — Design
+
+**Fecha:** 2026-06-03
+**Estado:** DISEÑO (pre-registro) — pendiente de revisión de Samuel antes del plan.
+**Lineaje:** funding carry = PASS ([[edge-landscape-funding-carry]], PR #557) → fork de diseño de estrategia → sub-proyecto #1 (de 4: riesgo tail-aware → rebalanceo → long-tail → live).
+**No dispara:** holdout #322. Sin perps live. Sin `PositionClosure`. Extiende `tools/funding_carry/` (reusa `data/funding.db`, cero ingest nuevo).
+
+---
+
+## §1 · Pregunta (congelada)
+
+El funding carry PASÓ (6.33%/año net-of-v3, CI[5.02,7.45], 9/9 líquidos positivos) pero Gate B2 fue **thin**: el carry anual (6.33%) < un solo shock (7.5%) = short-vol. La cola empírica 2024-26 (funding negativo 15–34% de los intervalos, rachas hasta 16d) **ya está absorbida** en ese +6.33%. La pregunta de #1:
+
+> Con (a) **per-interval mark** (precisión) y (b) una regla de **KILL por funding-negativo** pre-registrada, ¿el carry sobrevive net-positivo una cola **PEOR que 2024-26** (M shocks sintéticos out-of-sample), Y el kill **AÑADE valor** (mejor net y/o menor max-DD) vs no-kill, neto del costo de churn?
+
+Decide si el edge short-vol-thin se vuelve **tail-robusto y deployable**, o si el churn del kill se come el beneficio.
+
+---
+
+## §2 · Per-interval mark (corrección de precisión)
+
+El falsification v1 usó mark constante (entry) en el accrual — conservador (subestima funding en activos que aprecian). #1 lo corrige:
+
+- **funding_pnl con per-interval mark:** `Σ_i fundingRate_i × mark_i × units`, donde `mark_i` = perp mark close en (o antes de) `funding_time_i`, de `perp_klines`. units fijo (sin rebalanceo; eso es #2).
+- Da la **curva de equity real en el tiempo** (no solo el total) — necesaria para max-DD verdadero y para la simulación con-kill.
+- Probablemente **sube** el carry medido vs el v1 (el mark crece en el bull) → el PASS de Gate A es robusto a esto.
+
+---
+
+## §3 · KILL rule (PRE-REGISTRADA, K congelado)
+
+- **Estado:** la posición está IN o OUT. Empieza IN al inicio de cobertura del símbolo.
+- **Trigger de salida:** cerrar el carry cuando el funding lleva **≥ K = 24 settlements consecutivos negativo** (≈ 8 días a 8h). Ancla empírica: las caídas normales reversibles son cortas (el carry netó +6.33% absorbiéndolas); las peligrosas son inversiones sostenidas >1 semana (AVAX 16d, SOL 7d, XLM 8d). Un kill a 8d corta el episodio peligroso sin matar el carry normal.
+- **Re-entrada:** re-entrar (IN) en el primer settlement con funding ≥ 0 después de un kill. Sin cooldown (pre-declarado, el más simple).
+- **Costo de churn:** cada ciclo OUT→IN cobra v3 en las 4 patas de re-apertura + las 4 de la salida previa. El kill NO es gratis — el simulador lo cobra explícitamente.
+- **CONGELADO IRREVOCABLE:** K=24, re-entrada-on-positive, sin cooldown. Cambiar cualquiera = experimento nuevo. La sensibilidad de K {9,18,24,36} se reporta **descriptiva** (§5), NO decide el veredicto (anti-overfit, patrón confirmatorio del Brazo A).
+
+---
+
+## §4 · Simulador con-kill (núcleo)
+
+Por símbolo, sobre la ventana, con per-interval mark:
+
+```
+estado = IN; equity = 0; legs_open_at = entry
+para cada settlement i (en orden de tiempo):
+    si estado == IN:
+        equity += fundingRate_i × mark_i × units            # cobra/paga funding
+        si racha_negativa(i) >= K:                            # 24 settlements negativos
+            equity -= v3_close(symbol, units, spot_i, perp_i) # cierra (2 RT, transaction-only)
+            estado = OUT
+    si estado == OUT y fundingRate_i >= 0:
+        equity -= v3_open(symbol, units, spot_i, perp_i)      # re-abre
+        estado = IN
+al final: si IN, cobra v3_close (cierre final). Sumar basis_pnl(entry,exit) de los tramos IN.
+net = equity - costos_v3_totales ; net_return = net / NOTIONAL ; annualized por longitud.
+```
+- **Baseline no-kill:** el mismo símbolo con per-interval mark pero SIN la regla (hold continuo) — para el reporte kill-vs-no-kill (§5).
+- Reusa `backtest_costs.compute_trade_costs(model="v3", enable_funding=False)` (transaction-only; funding modelado explícito) y el liquidity proxy del v1.
+
+---
+
+## §5 · Reportes y comparación
+
+- **Por símbolo y pooled (equal-weight):** net_return anualizado **con-kill** y **no-kill**; max-DD de la curva de equity (per-interval mark, time-ordered); número de ciclos kill/re-entry; costo total de churn.
+- **kill-vs-no-kill:** Δ = net_with_kill − net_no_kill, pooled, con bootstrap CI (10k, seed congelado) sobre símbolos. ¿El kill mejora net? ¿reduce max-DD? (Un kill que baja DD pero también net es un trade-off explícito a reportar, no un FAIL.)
+- **Sensibilidad K {9,18,24,36}:** net+maxDD pooled por cada K — DESCRIPTIVO. No gatea. Muestra si K=24 es una elección robusta o un filo.
+
+---
+
+## §6 · Gate de supervivencia de cola (decide deployabilidad)
+
+- **G1 — supervivencia empírica:** con-kill, net pooled > 0 sobre 2024-26 (ya sabemos que el no-kill lo logra; G1 confirma que el kill no lo rompe por churn).
+- **G2 — supervivencia out-of-sample (el gate real):** inyectar **M = 2 shocks sintéticos** (2022 = LUNA+FTX = 2 en ~6 meses) magnitud `SHOCK_FUNDING_PER_8H × SHOCK_DAYS` (0.5%/8h × 5d) en los 2 peores momentos de la curva con-kill. **El kill DEBE dispararse durante el shock** (el shock ES funding negativo sostenido > K) — esa es su razón de ser. PASS_G2 = con-kill, net pooled tras los 2 shocks ≥ 0; el kill acota la pérdida de cada shock a ~K settlements de bleed (no los 5 días completos).
+- **Leverage:** constante conservadora **2x** pre-declarada → liquidación de la pata short necesita ~50% adverso, muy por encima de los moves de basis observados (la liquidación NO es el binding risk aquí; el funding-bleed sí, y el kill lo ataca). Modelado de margen explícito = sub-proyecto #2/#4, fuera de #1.
+
+**VEREDICTO #1:** PASS = G1 ∧ G2 (el carry con-kill sobrevive la cola peor-que-empírica, net-positivo). Reporta si el kill AÑADE valor (kill-vs-no-kill) — un PASS con kill que NO mejora a no-kill significa "el carry ya es robusto sin kill" (resultado válido). FAIL = el churn del kill rompe G1, o ni con kill sobrevive G2 (el carry líquido es too-thin para deployment tail-aware → re-evaluar tamaño/universo).
+
+$-denominado → esquiva el mirage sharpe.
+
+---
+
+## §7 · Estructura de archivos
+
+Extiende `tools/funding_carry/`:
+- `simulate.py` — añadir `funding_pnl_per_interval(funding, marks, units)` y `perp_mark_series(funding_db, symbol, times)` (lookup de mark por settlement).
+- `kill_rule.py` (NUEVO) — `negative_run_lengths`, `simulate_with_kill(funding, marks, units, symbol, ..., K)` → curva de equity + ciclos + costo churn; `simulate_no_kill(...)` baseline.
+- `evaluate.py` — añadir `kill_vs_nokill(...)`, `inject_shocks(equity_curve, M, ...)`, `gate_tail(...)` (G1∧G2) + `verdict_kill`.
+- `run_kill.py` (NUEVO) — orquestador → `data/retune/2026-06-03-funding-carry-tail-kill/{verdict,per_symbol,findings}.json|md`.
+- `constants.py` — añadir `KILL_K=24`, `K_SENSITIVITY=(9,18,24,36)`, `N_SHOCKS=2`, `LEVERAGE=2.0`.
+- `tests/test_funding_carry.py` — TDD: negative_run, per-interval funding, kill simulator (entra/sale/re-entra + churn), kill-vs-nokill, shock injection, gate G1∧G2, verdict.
+
+---
+
+## §8 · No-Negociables respetados
+
+- **NN#3 holdout:** sin `open_holdout`, sin `simulate_strategy` con frames de holdout. Reusa `data/funding.db` (pública) + spot. No toca #322 ni la señal.
+- **NN#1/#4:** N/A — backtest offline, sin posiciones live, sin la señal/RISK_PER_TRADE.
+
+---
+
+## §9 · Qué NO es / techo
+
+- **No** modela margen/liquidación explícito (palanca pasiva; #2/#4).
+- **No** rebalancea/rolea (units fijo; #2).
+- **No** toca el long-tail (#3).
+- **No** ejecuta live (#4).
+- In-sample 2024-26, 9 líquidos, un régimen. Un PASS de #1 dice "el kill hace el carry líquido tail-robusto in-sample contra 2 shocks sintéticos" — no "deployable en producción" (eso necesita #2-#4 + infra).
+
+---
+
+## §10 · Preguntas abiertas para el plan
+
+1. `racha_negativa`: ¿cuenta settlements con `rate < 0` estrictos, o incluye `rate == 0`? Diseño: estrictos `< 0` rompen la racha en `>= 0`. Confirmar.
+2. Posición de los 2 shocks G2: ¿los 2 peores drawdowns existentes, o 2 puntos equiespaciados? Diseño: los 2 settlements donde la curva con-kill tiene mayor vulnerabilidad (mayor equity acumulado a riesgo). Definir métrica exacta en el plan.
+3. basis_pnl con kill: cada tramo IN tiene su propio entry/exit basis. Diseño: sumar basis por-tramo. Confirmar la contabilidad en el plan.
+
+---
+
+## §11 · Historial
+
+| Fecha | Cambio | Autor |
+|---|---|---|
+| 2026-06-03 | Diseño de #1 (riesgo tail-aware) tras el PASS del funding carry. Per-interval mark + kill por funding-negativo (K=24/8d congelado) + gate de supervivencia (G1 empírico ∧ G2 2-shocks). Palanca primaria = kill (leverage 2x fijo). Reusa funding.db. | Claude Opus 4.8 + sssamuelll |

--- a/tests/test_funding_carry.py
+++ b/tests/test_funding_carry.py
@@ -172,3 +172,25 @@ def test_with_kill_no_negatives_equals_no_kill():
     wk = kill_rule.simulate_with_kill(funding, marks=marks, units=2.0, rt_cost=5.0, k=3)
     nk = kill_rule.simulate_no_kill(funding, marks=marks, units=2.0, rt_cost=5.0)
     assert wk["net"] == pytest.approx(nk["net"])
+
+
+def test_kill_vs_nokill_bootstrap_deterministic():
+    wk = [0.06, 0.05, 0.07, 0.04, 0.08, 0.05, 0.06, 0.05, 0.07]
+    nk = [0.05, 0.05, 0.06, 0.04, 0.07, 0.05, 0.05, 0.05, 0.06]
+    a = evaluate.kill_vs_nokill(wk, nk)
+    b = evaluate.kill_vs_nokill(wk, nk)
+    assert a["ci_lo"] == b["ci_lo"]
+    assert a["mean_delta"] == pytest.approx(sum(w - n for w, n in zip(wk, nk)) / len(wk))
+
+def test_inject_shocks_subtracts_worst_points():
+    eq = [1.0, 2.0, 3.0, 4.0, 5.0]
+    final = evaluate.inject_shocks(eq, n_shocks=2, shock_loss=3.0)
+    assert final == pytest.approx(5.0 - 2 * 3.0)
+
+def test_gate_tail_requires_both():
+    g = evaluate.gate_tail(with_kill_net_pooled=0.10, post_shock_net_pooled=0.02)
+    assert g["pass_g1"] and g["pass_g2"] and g["verdict"] == "PASS"
+    g2 = evaluate.gate_tail(with_kill_net_pooled=0.10, post_shock_net_pooled=-0.01)
+    assert g2["verdict"] == "FAIL"
+    g3 = evaluate.gate_tail(with_kill_net_pooled=-0.01, post_shock_net_pooled=0.02)
+    assert g3["verdict"] == "FAIL"

--- a/tests/test_funding_carry.py
+++ b/tests/test_funding_carry.py
@@ -194,3 +194,9 @@ def test_gate_tail_requires_both():
     assert g2["verdict"] == "FAIL"
     g3 = evaluate.gate_tail(with_kill_net_pooled=-0.01, post_shock_net_pooled=0.02)
     assert g3["verdict"] == "FAIL"
+
+def test_run_kill_required_keys():
+    from tools.funding_carry import run_kill
+    rec = {"symbol": "BTCUSDT", "net_with_kill": 0.06, "net_no_kill": 0.05,
+           "n_kills": 1, "max_dd": 100.0, "churn_cost": 50.0}
+    assert run_kill.REQUIRED_KILL_KEYS <= set(rec.keys())

--- a/tests/test_funding_carry.py
+++ b/tests/test_funding_carry.py
@@ -141,3 +141,30 @@ def test_funding_pnl_per_interval_uses_each_mark():
     marks = [100.0, 200.0]    # mark doubles on the 2nd settlement
     pnl = simulate.funding_pnl_per_interval(funding, marks=marks, units=2.0)
     assert pnl == pytest.approx(0.0001 * 100.0 * 2.0 + (-0.0002) * 200.0 * 2.0)
+
+from tools.funding_carry import kill_rule
+
+def test_simulate_no_kill_one_tramo():
+    funding = [(i, 0.0001) for i in range(10)]
+    marks = [100.0] * 10
+    r = kill_rule.simulate_no_kill(funding, marks=marks, units=2.0, rt_cost=5.0)
+    assert r["n_tramos"] == 1
+    assert r["churn_cost"] == pytest.approx(5.0)
+    assert r["net"] == pytest.approx(sum(0.0001 * 100.0 * 2.0 for _ in range(10)) - 5.0)
+    assert len(r["equity_curve"]) == 10
+
+def test_simulate_with_kill_exits_on_K_negatives():
+    funding = [(i, 0.0001) for i in range(3)] + [(i + 3, -0.0002) for i in range(3)] \
+              + [(i + 6, 0.0001) for i in range(2)]
+    marks = [100.0] * 8
+    r = kill_rule.simulate_with_kill(funding, marks=marks, units=2.0, rt_cost=5.0, k=3)
+    assert r["n_tramos"] == 2
+    assert r["n_kills"] == 1
+    assert r["churn_cost"] == pytest.approx(10.0)
+
+def test_with_kill_no_negatives_equals_no_kill():
+    funding = [(i, 0.0001) for i in range(10)]
+    marks = [100.0] * 10
+    wk = kill_rule.simulate_with_kill(funding, marks=marks, units=2.0, rt_cost=5.0, k=3)
+    nk = kill_rule.simulate_no_kill(funding, marks=marks, units=2.0, rt_cost=5.0)
+    assert wk["net"] == pytest.approx(nk["net"])

--- a/tests/test_funding_carry.py
+++ b/tests/test_funding_carry.py
@@ -130,3 +130,14 @@ def test_required_artifact_keys():
     rec = {"symbol": "BTCUSDT", "net_return_annual": 0.1, "net": 1000.0,
            "funding_pnl": 1200.0, "basis_pnl": 0.0, "cost_v3": 200.0}
     assert run.REQUIRED_SYMBOL_KEYS <= set(rec.keys())
+
+def test_perp_mark_series_lookup(tmp_path):
+    db = str(tmp_path / "f.db"); _mk_funding_db(db)   # perp close=100 at each hour
+    marks = simulate.perp_mark_series(db, "BTCUSDT", [0, 28_800_000, 57_600_000])
+    assert marks == [pytest.approx(100.0)] * 3
+
+def test_funding_pnl_per_interval_uses_each_mark():
+    funding = [(0, 0.0001), (1, -0.0002)]
+    marks = [100.0, 200.0]    # mark doubles on the 2nd settlement
+    pnl = simulate.funding_pnl_per_interval(funding, marks=marks, units=2.0)
+    assert pnl == pytest.approx(0.0001 * 100.0 * 2.0 + (-0.0002) * 200.0 * 2.0)

--- a/tests/test_funding_carry.py
+++ b/tests/test_funding_carry.py
@@ -161,6 +161,10 @@ def test_simulate_with_kill_exits_on_K_negatives():
     assert r["n_tramos"] == 2
     assert r["n_kills"] == 1
     assert r["churn_cost"] == pytest.approx(10.0)
+    assert len(r["equity_curve"]) == 8                 # one point per settlement, kills included
+    # 3 pos (+0.06) + 3 neg accrued through the kill (-0.12) + 1 post-reentry pos (+0.02) = -0.04
+    # gross; the re-entry tick (i=6) is NOT collected; net = gross - churn 10.0
+    assert r["net"] == pytest.approx(-0.04 - 10.0)
 
 def test_with_kill_no_negatives_equals_no_kill():
     funding = [(i, 0.0001) for i in range(10)]

--- a/tools/funding_carry/constants.py
+++ b/tools/funding_carry/constants.py
@@ -25,3 +25,10 @@ FAPI_FUNDING = "https://fapi.binance.com/fapi/v1/fundingRate"
 OHLCV_DB = "data/ohlcv.db"        # spot klines (reused)
 FUNDING_DB = "data/funding.db"    # produced by ingest
 OUTPUT_DIR = "data/retune/2026-06-03-funding-carry-falsification"
+
+# --- Tail-aware kill rule (sub-project #1, spec 9605758) ---
+KILL_K = 24                       # exit after this many consecutive negative settlements (~8d)
+K_SENSITIVITY = (9, 18, 24, 36)   # DESCRIPTIVE only — does NOT gate the verdict
+N_SHOCKS = 2                      # synthetic out-of-sample shocks (2022 = LUNA + FTX)
+LEVERAGE = 2.0                    # fixed conservative; liquidation needs ~50% adverse (not binding)
+OUTPUT_DIR_KILL = "data/retune/2026-06-03-funding-carry-tail-kill"

--- a/tools/funding_carry/evaluate.py
+++ b/tools/funding_carry/evaluate.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import numpy as np
 from .constants import (BOOTSTRAP_N, BOOTSTRAP_SEED, SHOCK_FUNDING_PER_8H,
-                        SHOCK_DAYS, SHOCK_INTERVALS_PER_DAY)
+                        SHOCK_DAYS, SHOCK_INTERVALS_PER_DAY, N_SHOCKS)
 
 
 def gate_a(annual_returns: list[float]) -> dict:
@@ -40,3 +40,34 @@ def verdict(a: dict, b2: dict) -> dict:
     """PASS iff Gate A and Gate B2 both pass (spec §7). $-denominated, no mirage."""
     v = "PASS" if (a.get("pass_a") and b2.get("pass_b2")) else "FAIL"
     return {"verdict": v, "pass_a": bool(a.get("pass_a")), "pass_b2": bool(b2.get("pass_b2"))}
+
+
+from .constants import N_SHOCKS, SHOCK_FUNDING_PER_8H, SHOCK_DAYS, SHOCK_INTERVALS_PER_DAY
+
+
+def kill_vs_nokill(with_kill: list[float], no_kill: list[float]) -> dict:
+    """Paired pooled delta (with_kill - no_kill) net return + bootstrap CI. Does the kill
+    add value net of churn? Positive mean_delta = kill helps."""
+    deltas = np.asarray([w - n for w, n in zip(with_kill, no_kill)], dtype=float)
+    rng = np.random.default_rng(BOOTSTRAP_SEED)
+    idx = rng.integers(0, len(deltas), size=(BOOTSTRAP_N, len(deltas)))
+    means = deltas[idx].mean(axis=1)
+    return {"mean_delta": float(deltas.mean()),
+            "ci_lo": float(np.percentile(means, 2.5)),
+            "ci_hi": float(np.percentile(means, 97.5)),
+            "kill_adds_value": bool(np.percentile(means, 2.5) > 0.0)}
+
+
+def inject_shocks(equity_curve: list[float], *, n_shocks: int, shock_loss: float) -> float:
+    """Final equity after subtracting `n_shocks` one-time losses of `shock_loss` each
+    (the synthetic out-of-sample tail; the kill caps each shock's bleed). Conservative:
+    applies the full loss n_shocks times to the realized final equity."""
+    final = equity_curve[-1] if equity_curve else 0.0
+    return final - n_shocks * shock_loss
+
+
+def gate_tail(*, with_kill_net_pooled: float, post_shock_net_pooled: float) -> dict:
+    """G1 = with-kill net survives in-sample (>0); G2 = survives N_SHOCKS (>=0). PASS = both."""
+    g1 = bool(with_kill_net_pooled > 0.0)
+    g2 = bool(post_shock_net_pooled >= 0.0)
+    return {"pass_g1": g1, "pass_g2": g2, "verdict": "PASS" if (g1 and g2) else "FAIL"}

--- a/tools/funding_carry/evaluate.py
+++ b/tools/funding_carry/evaluate.py
@@ -42,8 +42,6 @@ def verdict(a: dict, b2: dict) -> dict:
     return {"verdict": v, "pass_a": bool(a.get("pass_a")), "pass_b2": bool(b2.get("pass_b2"))}
 
 
-from .constants import N_SHOCKS, SHOCK_FUNDING_PER_8H, SHOCK_DAYS, SHOCK_INTERVALS_PER_DAY
-
 
 def kill_vs_nokill(with_kill: list[float], no_kill: list[float]) -> dict:
     """Paired pooled delta (with_kill - no_kill) net return + bootstrap CI. Does the kill

--- a/tools/funding_carry/kill_rule.py
+++ b/tools/funding_carry/kill_rule.py
@@ -1,0 +1,48 @@
+"""Funding-negative KILL rule simulator (spec §3-§4). IN/OUT state machine over the
+per-settlement funding stream, charging one v3 round-trip per IN-tramo (churn is real).
+Pure functions — `rt_cost` (round-trip transaction cost) is passed in, computed by the
+caller via simulate.recost_four_legs."""
+from __future__ import annotations
+
+
+def _accrue(funding, marks, units, lo, hi):
+    """Sum funding over settlements [lo, hi) (a single IN-tramo)."""
+    return sum(funding[i][1] * marks[i] * units for i in range(lo, hi))
+
+
+def simulate_no_kill(funding, *, marks, units, rt_cost) -> dict:
+    """Continuous hold: one tramo over all settlements, one round-trip cost."""
+    n = len(funding)
+    gross = _accrue(funding, marks, units, 0, n)
+    eq, run = [], 0.0
+    for i in range(n):
+        run += funding[i][1] * marks[i] * units
+        eq.append(run)
+    return {"net": gross - rt_cost, "n_tramos": 1, "n_kills": 0,
+            "churn_cost": rt_cost, "equity_curve": eq}
+
+
+def simulate_with_kill(funding, *, marks, units, rt_cost, k) -> dict:
+    """IN/OUT machine. Exit after `k` consecutive rate<0 settlements; re-enter on the
+    first rate>=0. Each IN-tramo charges `rt_cost` (one round trip). Equity curve is the
+    cumulative time-ordered P&L (funding only; basis handled by the caller per tramo)."""
+    n = len(funding)
+    eq, run = [], 0.0
+    state, neg = "IN", 0
+    n_tramos = 1 if n else 0          # start IN
+    n_kills = 0
+    for i in range(n):
+        rate = funding[i][1]
+        if state == "IN":
+            run += rate * marks[i] * units
+            neg = neg + 1 if rate < 0 else 0
+            if neg >= k:
+                state, neg = "OUT", 0
+                n_kills += 1
+        elif rate >= 0:               # OUT and funding back positive -> re-enter
+            state = "IN"
+            n_tramos += 1
+        eq.append(run)
+    churn = rt_cost * n_tramos
+    return {"net": run - churn, "n_tramos": n_tramos, "n_kills": n_kills,
+            "churn_cost": churn, "equity_curve": eq}

--- a/tools/funding_carry/kill_rule.py
+++ b/tools/funding_carry/kill_rule.py
@@ -13,20 +13,28 @@ def _accrue(funding, marks, units, lo, hi):
 def simulate_no_kill(funding, *, marks, units, rt_cost) -> dict:
     """Continuous hold: one tramo over all settlements, one round-trip cost."""
     n = len(funding)
-    gross = _accrue(funding, marks, units, 0, n)
+    assert len(marks) == n, f"marks/funding length mismatch: {len(marks)} vs {n}"
     eq, run = [], 0.0
     for i in range(n):
         run += funding[i][1] * marks[i] * units
         eq.append(run)
-    return {"net": gross - rt_cost, "n_tramos": 1, "n_kills": 0,
-            "churn_cost": rt_cost, "equity_curve": eq}
+    churn = rt_cost if n else 0.0          # no cost on an empty series (symmetry w/ with_kill)
+    return {"net": run - churn, "n_tramos": 1 if n else 0, "n_kills": 0,
+            "churn_cost": churn, "equity_curve": eq}
 
 
 def simulate_with_kill(funding, *, marks, units, rt_cost, k) -> dict:
     """IN/OUT machine. Exit after `k` consecutive rate<0 settlements; re-enter on the
     first rate>=0. Each IN-tramo charges `rt_cost` (one round trip). Equity curve is the
-    cumulative time-ordered P&L (funding only; basis handled by the caller per tramo)."""
+    cumulative time-ordered P&L (funding only; basis handled by the caller per tramo).
+
+    Settlement convention (matches spec §4 pseudocode): funding is collected only for
+    settlements where the position is IN *at the charge*. The kill tick (the Kth negative)
+    IS collected then we exit; the re-entry tick (the first rate>=0 while OUT) is NOT
+    collected — we re-enter after observing the positive and collect from the next
+    settlement on. Tiny, symmetric, and intentional."""
     n = len(funding)
+    assert len(marks) == n, f"marks/funding length mismatch: {len(marks)} vs {n}"
     eq, run = [], 0.0
     state, neg = "IN", 0
     n_tramos = 1 if n else 0          # start IN
@@ -39,7 +47,7 @@ def simulate_with_kill(funding, *, marks, units, rt_cost, k) -> dict:
             if neg >= k:
                 state, neg = "OUT", 0
                 n_kills += 1
-        elif rate >= 0:               # OUT and funding back positive -> re-enter
+        elif rate >= 0:               # OUT and funding back positive -> re-enter (not collected)
             state = "IN"
             n_tramos += 1
         eq.append(run)

--- a/tools/funding_carry/run_kill.py
+++ b/tools/funding_carry/run_kill.py
@@ -10,11 +10,14 @@ import numpy as np
 
 from backtest_costs import calibration_identity_hash, load_calibration
 from . import simulate, evaluate, kill_rule
-from .constants import (OHLCV_DB, FUNDING_DB, OUTPUT_DIR_KILL, CANDIDATE_SYMBOLS,
+from .constants import (OHLCV_DB, FUNDING_DB, OUTPUT_DIR_KILL,
                         WINDOW_START, WINDOW_END, NOTIONAL, KILL_K, K_SENSITIVITY,
-                        N_SHOCKS, SHOCK_FUNDING_PER_8H, SHOCK_DAYS, SHOCK_INTERVALS_PER_DAY)
+                        N_SHOCKS, SHOCK_FUNDING_PER_8H)
 from .run import _ms, _covered_symbols
 
+# G2 shock model (spec §6): a SUSTAINED negative episode longer than KILL_K; the kill fires
+# at K settlements, capping each shock's bleed at KILL_K * SHOCK_FUNDING_PER_8H. (SHOCK_DAYS
+# from the falsification's 5-day B2 is a DIFFERENT shock model and is intentionally unused here.)
 REQUIRED_KILL_KEYS = {"symbol", "net_with_kill", "net_no_kill", "n_kills", "max_dd", "churn_cost"}
 
 
@@ -44,8 +47,9 @@ def _one_symbol(s, w0, w1, k):
     nk = kill_rule.simulate_no_kill(funding, marks=marks, units=units, rt_cost=rt)
     return {"symbol": s, "net_with_kill": wk["net"] / NOTIONAL,
             "net_no_kill": nk["net"] / NOTIONAL, "n_kills": wk["n_kills"],
-            "max_dd": _max_dd(wk["equity_curve"]), "churn_cost": wk["churn_cost"],
-            "equity_curve": wk["equity_curve"]}
+            "max_dd": _max_dd(wk["equity_curve"]),                 # $ (funding-equity DD)
+            "max_dd_no_kill": _max_dd(nk["equity_curve"]),        # $
+            "churn_cost": wk["churn_cost"], "equity_curve": wk["equity_curve"]}
 
 
 def main():
@@ -80,6 +84,9 @@ def main():
                                        "calibration_identity_hash": calibration_identity_hash(cal)},
                         "symbols_used": [r["symbol"] for r in recs],
                         "generated_utc": datetime.now(timezone.utc).isoformat()}}
+    dd_wk = float(np.mean([r["max_dd"] for r in recs])) if recs else 0.0
+    dd_nk = float(np.mean([r["max_dd_no_kill"] for r in recs])) if recs else 0.0
+    out["max_dd_pooled"] = {"with_kill": dd_wk, "no_kill": dd_nk, "kill_lowers_dd": bool(dd_wk < dd_nk)}
     slim = [{kk: r[kk] for kk in REQUIRED_KILL_KEYS} for r in recs]
     with open(os.path.join(OUTPUT_DIR_KILL, "per_symbol.json"), "w") as f:
         json.dump(slim, f, indent=2)
@@ -90,11 +97,12 @@ def main():
         f"**Verdict: {gate['verdict']}**  (G1 in-sample: {gate['pass_g1']}, G2 out-of-sample: {gate['pass_g2']})", "",
         f"- Symbols used {len(recs)}: {', '.join(r['symbol'] for r in recs)}",
         f"- With-kill pooled net: {wk_pooled:.4f}   No-kill pooled net: {out['no_kill_pooled']:.4f}",
-        f"- Kill vs no-kill: mean delta {kvn['mean_delta']:.4f}, CI95 [{kvn['ci_lo']:.4f}, {kvn['ci_hi']:.4f}], adds_value={kvn['kill_adds_value']}",
+        f"- Kill vs no-kill net: mean delta {kvn['mean_delta']:.4f}, CI95 [{kvn['ci_lo']:.4f}, {kvn['ci_hi']:.4f}], net_adds_value={kvn['kill_adds_value']}",
+        f"- Max-DD pooled ($): with-kill {dd_wk:.2f} vs no-kill {dd_nk:.2f}, kill_lowers_dd={dd_wk < dd_nk}",
         f"- Post-{N_SHOCKS}-shock pooled net: {post_pooled:.4f}  (shock_loss/ea {shock_loss:.4f}, kill-capped at K settlements)",
         f"- K-sensitivity (descriptive): " + "; ".join(f"K={k}: net {v['pooled_net']:.4f}, kills {v['mean_kills']:.1f}" for k, v in ksens.items()), "",
-        "Interpretation: kill ADDS value if mean delta > 0 (better net) or lowers max_dd; a PASS",
-        "where kill <= no-kill means the carry is already robust without the kill. Leverage 2x fixed.",
+        "Interpretation: kill adds value if net_adds_value (CI lo > 0) OR kill_lowers_dd; a PASS where",
+        "the kill neither raises net nor lowers DD means the carry is already robust without it. Leverage 2x fixed.",
         "Scope: liquid universe, in-sample 2024-26 + 2 synthetic shocks. NOT production-deployable",
         "(rebalance #2, long-tail #3, live #4 are separate sub-projects).",
     ]

--- a/tools/funding_carry/run_kill.py
+++ b/tools/funding_carry/run_kill.py
@@ -1,0 +1,108 @@
+"""Orchestrate the tail-aware kill-rule study end-to-end → verdict artifacts.
+
+Run: python -m tools.funding_carry.run_kill   (uses data/funding.db; no network)
+Reads funding.db + ohlcv.db (read-only). Writes only under OUTPUT_DIR_KILL. No holdout."""
+from __future__ import annotations
+import json
+import os
+from datetime import datetime, timezone
+import numpy as np
+
+from backtest_costs import calibration_identity_hash, load_calibration
+from . import simulate, evaluate, kill_rule
+from .constants import (OHLCV_DB, FUNDING_DB, OUTPUT_DIR_KILL, CANDIDATE_SYMBOLS,
+                        WINDOW_START, WINDOW_END, NOTIONAL, KILL_K, K_SENSITIVITY,
+                        N_SHOCKS, SHOCK_FUNDING_PER_8H, SHOCK_DAYS, SHOCK_INTERVALS_PER_DAY)
+from .run import _ms, _covered_symbols
+
+REQUIRED_KILL_KEYS = {"symbol", "net_with_kill", "net_no_kill", "n_kills", "max_dd", "churn_cost"}
+
+
+def _max_dd(equity_curve) -> float:
+    eq = np.asarray(equity_curve, dtype=float)
+    if len(eq) == 0:
+        return 0.0
+    return float((np.maximum.accumulate(eq) - eq).max())
+
+
+def _one_symbol(s, w0, w1, k):
+    funding = simulate.load_funding(FUNDING_DB, s, w0, w1)
+    if len(funding) < 2:
+        return None
+    times = [t for t, _ in funding]
+    marks = simulate.perp_mark_series(FUNDING_DB, s, times)
+    spot_e = simulate.spot_price_at(OHLCV_DB, s, times[0])
+    perp_e = simulate.perp_price_at(FUNDING_DB, s, times[0])
+    if any(np.isnan(x) for x in (spot_e, perp_e)) or any(np.isnan(m) for m in marks):
+        return None
+    units = NOTIONAL / spot_e
+    liq = simulate.spot_liquidity(OHLCV_DB, s, times[0])
+    rt = simulate.recost_four_legs(symbol=s, units=units, spot_price=spot_e,
+                                   perp_price=perp_e, liq=liq,
+                                   holding_hours=(times[-1] - times[0]) / 3_600_000)
+    wk = kill_rule.simulate_with_kill(funding, marks=marks, units=units, rt_cost=rt, k=k)
+    nk = kill_rule.simulate_no_kill(funding, marks=marks, units=units, rt_cost=rt)
+    return {"symbol": s, "net_with_kill": wk["net"] / NOTIONAL,
+            "net_no_kill": nk["net"] / NOTIONAL, "n_kills": wk["n_kills"],
+            "max_dd": _max_dd(wk["equity_curve"]), "churn_cost": wk["churn_cost"],
+            "equity_curve": wk["equity_curve"]}
+
+
+def main():
+    os.makedirs(OUTPUT_DIR_KILL, exist_ok=True)
+    w0, w1 = _ms(WINDOW_START), _ms(WINDOW_END)
+    symbols = _covered_symbols(FUNDING_DB, w0, w1)
+    recs = [r for r in (_one_symbol(s, w0, w1, KILL_K) for s in symbols) if r]
+
+    wk_ret = [r["net_with_kill"] for r in recs]
+    nk_ret = [r["net_no_kill"] for r in recs]
+    kvn = evaluate.kill_vs_nokill(wk_ret, nk_ret)
+    wk_pooled = float(np.mean(wk_ret)) if recs else 0.0
+    shock_loss = KILL_K * SHOCK_FUNDING_PER_8H
+    post = [evaluate.inject_shocks([NOTIONAL * r["net_with_kill"]], n_shocks=N_SHOCKS,
+                                   shock_loss=NOTIONAL * shock_loss) / NOTIONAL for r in recs]
+    post_pooled = float(np.mean(post)) if recs else 0.0
+    gate = evaluate.gate_tail(with_kill_net_pooled=wk_pooled, post_shock_net_pooled=post_pooled)
+
+    ksens = {}
+    for k in K_SENSITIVITY:
+        rs = [r for r in (_one_symbol(s, w0, w1, k) for s in symbols) if r]
+        ksens[k] = {"pooled_net": float(np.mean([x["net_with_kill"] for x in rs])) if rs else 0.0,
+                    "mean_kills": float(np.mean([x["n_kills"] for x in rs])) if rs else 0.0}
+
+    cal = load_calibration()
+    out = {"verdict": gate, "kill_vs_nokill": kvn, "with_kill_pooled": wk_pooled,
+           "no_kill_pooled": float(np.mean(nk_ret)) if recs else 0.0,
+           "post_shock_pooled": post_pooled, "k_sensitivity": ksens,
+           "manifest": {"experiment": "funding-carry-tail-kill", "spec_commit": "9605758",
+                        "kill_k": KILL_K, "n_shocks": N_SHOCKS, "shock_loss_frac": shock_loss,
+                        "cost_model": {"active_model": cal.active_model,
+                                       "calibration_identity_hash": calibration_identity_hash(cal)},
+                        "symbols_used": [r["symbol"] for r in recs],
+                        "generated_utc": datetime.now(timezone.utc).isoformat()}}
+    slim = [{kk: r[kk] for kk in REQUIRED_KILL_KEYS} for r in recs]
+    with open(os.path.join(OUTPUT_DIR_KILL, "per_symbol.json"), "w") as f:
+        json.dump(slim, f, indent=2)
+    with open(os.path.join(OUTPUT_DIR_KILL, "verdict.json"), "w") as f:
+        json.dump(out, f, indent=2)
+    lines = [
+        "# Funding-carry tail-aware kill rule: VERDICT", "",
+        f"**Verdict: {gate['verdict']}**  (G1 in-sample: {gate['pass_g1']}, G2 out-of-sample: {gate['pass_g2']})", "",
+        f"- Symbols used {len(recs)}: {', '.join(r['symbol'] for r in recs)}",
+        f"- With-kill pooled net: {wk_pooled:.4f}   No-kill pooled net: {out['no_kill_pooled']:.4f}",
+        f"- Kill vs no-kill: mean delta {kvn['mean_delta']:.4f}, CI95 [{kvn['ci_lo']:.4f}, {kvn['ci_hi']:.4f}], adds_value={kvn['kill_adds_value']}",
+        f"- Post-{N_SHOCKS}-shock pooled net: {post_pooled:.4f}  (shock_loss/ea {shock_loss:.4f}, kill-capped at K settlements)",
+        f"- K-sensitivity (descriptive): " + "; ".join(f"K={k}: net {v['pooled_net']:.4f}, kills {v['mean_kills']:.1f}" for k, v in ksens.items()), "",
+        "Interpretation: kill ADDS value if mean delta > 0 (better net) or lowers max_dd; a PASS",
+        "where kill <= no-kill means the carry is already robust without the kill. Leverage 2x fixed.",
+        "Scope: liquid universe, in-sample 2024-26 + 2 synthetic shocks. NOT production-deployable",
+        "(rebalance #2, long-tail #3, live #4 are separate sub-projects).",
+    ]
+    with open(os.path.join(OUTPUT_DIR_KILL, "findings.md"), "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+    print(f"VERDICT: {gate['verdict']}  (G1={gate['pass_g1']} G2={gate['pass_g2']}, "
+          f"with-kill {wk_pooled:.4f} vs no-kill {out['no_kill_pooled']:.4f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/funding_carry/simulate.py
+++ b/tools/funding_carry/simulate.py
@@ -125,3 +125,15 @@ def spot_liquidity(ohlcv_db: str, symbol: str, ts_ms: int) -> float:
     if len(rows) < 120:
         return float("nan")
     return sum(c * v / 60.0 for c, v in rows) / len(rows)
+
+
+def perp_mark_series(funding_db: str, symbol: str, times_ms: list[int]) -> list[float]:
+    """Perp mark close at or before each funding settlement time (NaN if none)."""
+    return [perp_price_at(funding_db, symbol, t) for t in times_ms]
+
+
+def funding_pnl_per_interval(funding: list[tuple[int, float]], *, marks: list[float],
+                             units: float) -> float:
+    """Funding the short collects, marked PER SETTLEMENT: sum(rate_i * mark_i * units).
+    More accurate than the constant-entry-mark approximation (spec §2)."""
+    return sum(rate * mark * units for (_, rate), mark in zip(funding, marks))

--- a/tools/funding_carry/simulate.py
+++ b/tools/funding_carry/simulate.py
@@ -136,4 +136,6 @@ def funding_pnl_per_interval(funding: list[tuple[int, float]], *, marks: list[fl
                              units: float) -> float:
     """Funding the short collects, marked PER SETTLEMENT: sum(rate_i * mark_i * units).
     More accurate than the constant-entry-mark approximation (spec §2)."""
+    assert len(marks) == len(funding), \
+        f"marks/funding length mismatch: {len(marks)} vs {len(funding)}"
     return sum(rate * mark * units for (_, rate), mark in zip(funding, marks))

--- a/tools/funding_carry/simulate.py
+++ b/tools/funding_carry/simulate.py
@@ -128,8 +128,22 @@ def spot_liquidity(ohlcv_db: str, symbol: str, ts_ms: int) -> float:
 
 
 def perp_mark_series(funding_db: str, symbol: str, times_ms: list[int]) -> list[float]:
-    """Perp mark close at or before each funding settlement time (NaN if none)."""
-    return [perp_price_at(funding_db, symbol, t) for t in times_ms]
+    """Perp mark close at or before each funding settlement time (NaN if none).
+
+    One query + a pointer walk over the (ascending) klines — O(K+T), not one DB round
+    trip per settlement (the naive version did ~2.6k connections/symbol)."""
+    if not times_ms:
+        return []
+    with closing(sqlite3.connect(f"file:{funding_db}?mode=ro", uri=True)) as con:
+        kl = con.execute(
+            "SELECT open_time, close FROM perp_klines WHERE symbol=? AND open_time<=? "
+            "ORDER BY open_time", (symbol, max(times_ms))).fetchall()
+    out, j, last = [], 0, float("nan")
+    for t in times_ms:                         # times_ms is ascending (funding order)
+        while j < len(kl) and kl[j][0] <= t:
+            last = float(kl[j][1]); j += 1
+        out.append(last)
+    return out
 
 
 def funding_pnl_per_interval(funding: list[tuple[int, float]], *, marks: list[float],


### PR DESCRIPTION
@
## What

Sub-project #1 of the funding-carry strategy-design fork (after the carry PASS, #557). Adds **per-interval-mark** funding accrual + a frozen **funding-negative KILL rule** (exit after K=24 consecutive negative settlements / ~8d, re-enter on positive) to the carry, and gates tail survival: G1 (with-kill net stays positive in-sample) + G2 (survives 2 synthetic out-of-sample sustained shocks, kill-capped at K). Extends `tools/funding_carry/`; reuses the populated `data/funding.db`.

## Verdict: **PASS** — but the headline is what we learned, not the seal

**1. Per-interval mark ~doubled the measured carry** (27% total vs 15% constant-mark v1). The v1 approximation was conservative; the real carry is ~2×. This is what lets **G2 pass** (27% − 24% two-shock = +3%, a thin margin).

**2. The funding-negative kill adds NO value — we falsified the kill-as-keystone hypothesis.**
- Kill vs no-kill net: mean delta **−0.0018**, CI95 [−0.0048, 0.0000] (never helps, at best neutral). `kill_lowers_dd=False`.
- At K=24 the kill fires on only **2 of 9** symbols.
- K-sensitivity: K=9 (twitchy) **destroys** value (17% vs 27%, churn + missed reversions); K≥18 is inert.
- Liquid negative-funding runs are short and mean-reverting → exiting costs churn and misses the rebound.

**Conclusion:** the liquid carry is already tail-robust **without** a kill. The tail that matters is not the gradual funding-negative bleed (absorbed) but the catastrophic shock — and a funding-persistence kill is too slow for that. **The real tail lever is sizing/leverage (sub-project #2), not the kill.** Honest science: we tested the chosen lever and it was the wrong one.

## How / safety

- Subagent-driven, two-stage review per group; TDD (25 tests). Reviews caught: re-entry settlement convention (documented), length asserts, a perf issue (perp_mark_series ~2.6k connections/symbol → one query + walk), dead imports, a prose-vs-computed mismatch in the artifact.
- `git diff main...` confined to `tools/funding_carry/`, `tests/`, `docs/`, `data/retune/`. `backtest_costs` untouched. **No holdout** (#322), no live perps, no `PositionClosure`.

## Route

PASS but kill discarded → sub-project #2 redirected from "rebalance" to **sizing tail-aware** (the G2 +3% margin is thin at full size). The kill stays as documented negative space.

Artifact: `data/retune/2026-06-03-funding-carry-tail-kill/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@