### PR TITLE
chore(tests): fast parallel local gate (pytest-xdist) + Windows-only proxy test fix

### DIFF
--- a/.mex/context/setup.md
+++ b/.mex/context/setup.md
@@ -58,10 +58,22 @@ docker compose up --build  # Frontend at :3000, backend at :8000
 ## Tests
 
 ```bash
-python -m pytest tests/ -v
+# FAST local gate (default for dev loops): parallel + skip network-marked tests.
+# ~49s for ~3100 tests on a 24-core box. Same selection CI's Backend job runs.
+python -m pytest tests/ -m "not network" -n auto -q
+
+python -m pytest tests/ -v                  # FULL serial suite — runs the network-marked
+                                            # full backtests over data/ohlcv.db (705 MB,
+                                            # local-only): HOURS. Run deliberately, not by default.
 python -m pytest tests/test_scanner.py -v   # Scanner logic only
 python -m pytest tests/test_api.py -v       # API endpoints only
 ```
+
+`-n auto` needs `pytest-xdist` (in `requirements-dev.txt`). The slow set is the
+`network`-marked modules (`test_backtest_with_costs`, `test_backtest_smoke_*`,
+`test_backtest_refactor_parity`, `test_auto_tune_max_date::...`) — they fetch live
+data on cache miss and replay multi-year backtests; CI never runs them (marker +
+missing ohlcv.db).
 
 ## Windows Automation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,11 @@ python btc_api.py          # REST API at http://localhost:8000
 python btc_scanner.py      # Standalone scanner (runs once, used by API)
 python watchdog.py         # Process supervisor (Windows only)
 
-# Tests
-python -m pytest tests/ -v
+# Tests — DEFAULT to the fast parallel gate (same selection as CI's Backend job;
+# ~49s on this machine). The bare `pytest tests/` runs network-marked multi-year
+# backtests over the local 705 MB ohlcv.db: HOURS. Only run those deliberately.
+python -m pytest tests/ -m "not network" -n auto -q
+python -m pytest tests/ -v                  # FULL suite incl. slow network-marked backtests
 python -m pytest tests/test_scanner.py -v
 python -m pytest tests/test_api.py -v
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,9 @@
 -r requirements.txt
 
 pytest>=8.0
+# Parallel test execution (`-n auto`) — the fast local gate. CI runs serial
+# (2 vCPUs, no gain); locally on many cores this cuts the suite to <1 min.
+pytest-xdist>=3.5
 # httpx is what fastapi.testclient uses internally for its HTTP simulation.
 # It's not a transitive dep of fastapi itself.
 httpx>=0.27

--- a/tests/test_http_reexport.py
+++ b/tests/test_http_reexport.py
@@ -22,13 +22,18 @@ def test_rate_limit_enforces_min_interval():
 
 
 def test_load_proxy_from_env(monkeypatch):
-    """HTTPS_PROXY env var takes precedence."""
+    """HTTPS_PROXY env var takes precedence.
+
+    Order matters: delenv BEFORE setenv. On Windows os.environ is
+    case-insensitive, so delenv("https_proxy") after setenv("HTTPS_PROXY", ...)
+    deletes the variable just set — the test passed on Linux CI but failed
+    locally on Windows."""
     from infra import http
 
-    monkeypatch.setenv("HTTPS_PROXY", "socks5://test:1080")
     monkeypatch.delenv("HTTP_PROXY", raising=False)
     monkeypatch.delenv("https_proxy", raising=False)
     monkeypatch.delenv("http_proxy", raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "socks5://test:1080")
 
     proxy = http._load_proxy()
     assert proxy == {"http": "socks5://test:1080", "https": "socks5://test:1080"}


### PR DESCRIPTION
## Fast parallel local test gate + Windows-only proxy test fix

Two small orthogonal dev-ergonomics fixes, found while shipping #561:

### 1. Fast local gate (pytest-xdist)

The bare `python -m pytest tests/` runs the `network`-marked modules (`test_backtest_with_costs`, `test_backtest_smoke_*`, `test_backtest_refactor_parity`, `test_auto_tune_max_date::test_*`) which replay multi-year backtests against the local 705 MB `ohlcv.db` and fetch live exchange data on cache miss — **2+ hours locally**. CI never runs them (`-m "not network"` + the db is gitignored so the skipif fires).

Measured today on this 24-core box:

| Command | Result |
|---|---|
| `pytest tests/` (bare) | killed after 2h, still running |
| `pytest tests/ -m "not network" -n auto` | **3118 passed in 48.56s** |

Changes: `pytest-xdist>=3.5` in `requirements-dev.txt`; the fast command documented as the dev default in `CLAUDE.md` and `.mex/context/setup.md`, with the bare invocation flagged as deliberate-only. No CI change (2 vCPUs, serial is fine there; same test selection either way).

### 2. `test_load_proxy_from_env` — broken on Windows only

`os.environ` is case-insensitive on Windows, so `monkeypatch.delenv("https_proxy")` placed *after* `setenv("HTTPS_PROXY", ...)` deleted the variable the test had just set. Passed on Linux CI, failed on every local Windows run. Fix: delenv before setenv (correct on both platforms) + explanatory docstring.

Verified: `tests/test_http_reexport.py` 2/2 green locally; fast gate 3118/3118 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
