### PR TITLE
fix(celda4): print ASCII en dry-run (cp1252 / U+2229)

### DIFF
--- a/tools/celda4_stat_arb/run.py
+++ b/tools/celda4_stat_arb/run.py
@@ -184,7 +184,7 @@ def main(argv: list[str] | None = None, *, db_path: str = DB_PATH,
         if args.dry_run:
             with open(os.path.join(output_dir, "fingerprint.json"), "w", encoding="utf-8") as f:
                 json.dump(fingerprint, f, indent=2)
-            print(f"[dry-run] fingerprint: {fingerprint['n_members']} símbolos panel∩perps")
+            print(f"[dry-run] fingerprint: {fingerprint['n_members']} simbolos panel x perps")  # ASCII: cp1252
             return {"dry_run": True, "fingerprint": fingerprint}
 
         cutoffs_full = derive_tier_cutoffs(db_path)


### PR DESCRIPTION
Fix cosmetico de 1 linea: el print del dry-run usaba el caracter U+2229 que la consola Windows cp1252 no encodea (tercer caso del mismo patron en la sesion). El dry-run computo el fingerprint correctamente (146 simbolos panel x perps, ventana 2021-01-01..2025-04-30) y solo murio imprimiendo.