### PR TITLE
Monitor de realizacion per-tenant: la cuenta real como evidencia (q2 incluido)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ SIGNAL_*.txt
 # Private live production trade data (real positions/P&L) â€” diagnostic inputs
 data/retune/2026-06-01-cost-model-diagnosis/live_trades.json
 data/retune/2026-06-01-cost-model-diagnosis/per_trade.json
+
+# Realizacion per-tenant — data familiar sensible, el tool se versiona, la data no
+data/realizacion/

--- a/tests/test_tenant_realization.py
+++ b/tests/test_tenant_realization.py
@@ -1,0 +1,62 @@
+"""Tests offline del monitor de realización per-tenant (cómputo puro)."""
+from __future__ import annotations
+
+from tools.tenant_realization.report import compute_report
+
+
+def _pos(pnl_usd, pnl_pct, reason="TIME_LIMIT_HIT", size=1000.0, exit_ts="2026-06-01T12:00:00"):
+    return {"symbol": "X", "direction": "SHORT", "size_usd": size,
+            "pnl_usd": pnl_usd, "pnl_pct": pnl_pct, "exit_reason": reason,
+            "entry_ts": "2026-06-01T00:00:00", "exit_ts": exit_ts}
+
+
+def test_totales_y_retorno_sobre_desplegado():
+    r = compute_report([_pos(10.0, 1.0), _pos(-5.0, -0.5)])
+    assert r["n_trades"] == 2
+    assert r["pnl_total_usd"] == 5.0
+    assert r["capital_desplegado_usd"] == 2000.0
+    assert r["retorno_sobre_desplegado_pct"] == 0.25
+    assert r["wins"] == 1
+
+
+def test_descomposicion_q2_manual_vs_senal():
+    r = compute_report([
+        _pos(80.0, 8.0, reason="MANUAL"),
+        _pos(10.0, 1.0, reason="TP_HIT"),
+        _pos(10.0, 1.0, reason="SL_HIT"),
+    ])
+    q2 = r["descomposicion_q2"]
+    assert q2["manual"]["n"] == 1 and q2["manual"]["pnl_usd"] == 80.0
+    assert q2["señal"]["n"] == 2 and q2["señal"]["pnl_usd"] == 20.0
+    assert q2["fraccion_manual_del_pnl"] == 0.8
+
+
+def test_ci_incluye_cero_es_ruido():
+    # media positiva pero n chico y sigma grande -> no significativo
+    r = compute_report([_pos(5, 2.0), _pos(-4, -1.5), _pos(3, 1.0)])
+    assert r["per_trade_pct"]["significativo"] is False
+    lo, hi = r["per_trade_pct"]["ci95"]
+    assert lo < 0 < hi
+
+
+def test_ci_significativo_cuando_consistente():
+    # 40 trades todos +1% con variacion minima -> CI lo > 0
+    poss = [_pos(10, 1.0 + 0.01 * (i % 3)) for i in range(40)]
+    r = compute_report(poss)
+    assert r["per_trade_pct"]["significativo"] is True
+    assert r["per_trade_pct"]["ci95"][0] > 0
+
+
+def test_agrupacion_semanal_iso():
+    r = compute_report([
+        _pos(1.0, 0.1, exit_ts="2026-05-21T10:00:00"),  # W21
+        _pos(2.0, 0.2, exit_ts="2026-05-30T10:00:00"),  # W22
+        _pos(3.0, 0.3, exit_ts="2026-06-01T10:00:00"),  # W23
+    ])
+    assert set(r["por_semana_iso"]) == {"2026-W21", "2026-W22", "2026-W23"}
+    assert r["por_semana_iso"]["2026-W23"]["pnl_usd"] == 3.0
+
+
+def test_pnl_cero_no_divide():
+    r = compute_report([_pos(0.0, 0.0)])
+    assert r["descomposicion_q2"]["fraccion_manual_del_pnl"] is None

--- a/tools/tenant_realization/__init__.py
+++ b/tools/tenant_realization/__init__.py
@@ -1,0 +1,12 @@
+"""Monitor de realización per-tenant: la cuenta real como evidencia de primera clase.
+
+Lee (read-only, vía ssh) las posiciones cerradas de un tenant en el signals.db
+de producción y produce el reporte que convierte "le va bien/mal" en un número
+con intervalo: P&L real, retorno sobre capital desplegado (no sobre el balance
+nocional de la plataforma), descomposición señal-vs-salida-manual (el hallazgo
+q2), y el CI del per-trade acumulándose.
+
+Contexto: 2026-06-06 — capital familiar real corre el mundo direccional desde
+2026-05-21 sin instrumentar; el balance de la plataforma ($10k) es nocional,
+las operaciones y P&L en $ son reales (Binance).
+"""

--- a/tools/tenant_realization/report.py
+++ b/tools/tenant_realization/report.py
@@ -1,0 +1,143 @@
+"""Reporte de realización de un tenant — read-only sobre el server de producción.
+
+Usage: python -m tools.tenant_realization.report [--tenant 2] [--host atrium-aws]
+
+Fetch: una sola llamada ssh → sqlite3 (mode=ro) → filas JSON de posiciones
+cerradas del tenant. Cómputo local puro (testeable offline con fixtures).
+Artefacto: data/realizacion/tenant<id>_<fecha>.json (gitignoreado — data
+familiar sensible; el TOOL se versiona, la data no).
+
+Métricas honestas:
+- pnl_total_usd y retorno sobre capital DESPLEGADO (Σ size de cada trade,
+  secuencial) — no sobre el balance nocional de la plataforma.
+- Descomposición por exit_reason: MANUAL (criterio del operador, el hallazgo
+  q2) vs señal (SL/TP/TIME_LIMIT).
+- CI95 del pnl_pct por trade (t aproximada) — el número que decide cuándo
+  esto deja de ser ruido.
+"""
+from __future__ import annotations
+import argparse
+import json
+import math
+import pathlib
+import subprocess
+import time
+
+PROD_DB = "/var/www/trading/signals.db"
+OUTPUT_DIR = "data/realizacion"
+MANUAL_REASONS = {"MANUAL"}
+
+_QUERY = (
+    "SELECT json_group_array(json_object("
+    "'symbol', symbol, 'direction', direction, 'size_usd', size_usd,"
+    "'pnl_usd', pnl_usd, 'pnl_pct', pnl_pct, 'exit_reason', exit_reason,"
+    "'entry_ts', entry_ts, 'exit_ts', exit_ts)) "
+    "FROM positions WHERE tenant_id={tenant} AND status='closed' "
+    "AND pnl_usd IS NOT NULL"
+)
+
+
+def fetch_positions(tenant: int, host: str) -> list[dict]:
+    """One read-only ssh round-trip → list of closed-position dicts."""
+    sql = _QUERY.format(tenant=int(tenant))
+    cmd = ["ssh", "-o", "ConnectTimeout=15", "-o", "BatchMode=yes", host,
+           f"sqlite3 'file:{PROD_DB}?mode=ro' \"{sql};\""]
+    out = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if out.returncode != 0:
+        raise RuntimeError(f"ssh/sqlite3 fallo: {out.stderr.strip()}")
+    return json.loads(out.stdout.strip())
+
+
+def _mean_std(xs: list[float]) -> tuple[float, float]:
+    n = len(xs)
+    if n == 0:
+        return 0.0, 0.0
+    mu = sum(xs) / n
+    var = sum((x - mu) ** 2 for x in xs) / n
+    return mu, math.sqrt(var)
+
+
+def compute_report(positions: list[dict]) -> dict:
+    """Pure function: positions → reporte. Testeable offline."""
+    n = len(positions)
+    pnl_total = sum(p["pnl_usd"] for p in positions)
+    deployed = sum(p["size_usd"] or 0.0 for p in positions)
+    pcts = [p["pnl_pct"] for p in positions if p["pnl_pct"] is not None]
+    mu, sigma = _mean_std(pcts)
+    se = sigma / math.sqrt(len(pcts)) if pcts else 0.0
+    ci_lo, ci_hi = mu - 1.96 * se, mu + 1.96 * se
+
+    manual = [p for p in positions if p["exit_reason"] in MANUAL_REASONS]
+    señal = [p for p in positions if p["exit_reason"] not in MANUAL_REASONS]
+    pnl_manual = sum(p["pnl_usd"] for p in manual)
+    pnl_señal = sum(p["pnl_usd"] for p in señal)
+
+    semanas: dict[str, dict] = {}
+    for p in sorted(positions, key=lambda x: x["exit_ts"] or ""):
+        wk = _iso_week(p["exit_ts"])
+        s = semanas.setdefault(wk, {"n": 0, "pnl_usd": 0.0})
+        s["n"] += 1
+        s["pnl_usd"] = round(s["pnl_usd"] + p["pnl_usd"], 2)
+
+    return {
+        "n_trades": n,
+        "pnl_total_usd": round(pnl_total, 2),
+        "capital_desplegado_usd": round(deployed, 2),
+        "retorno_sobre_desplegado_pct": round(100 * pnl_total / deployed, 3) if deployed else None,
+        "wins": sum(1 for p in positions if p["pnl_usd"] > 0),
+        "per_trade_pct": {
+            "media": round(mu, 4), "sigma": round(sigma, 4),
+            "ci95": [round(ci_lo, 4), round(ci_hi, 4)],
+            "significativo": bool(ci_lo > 0 or ci_hi < 0),
+        },
+        "descomposicion_q2": {
+            "manual": {"n": len(manual), "pnl_usd": round(pnl_manual, 2)},
+            "señal": {"n": len(señal), "pnl_usd": round(pnl_señal, 2)},
+            "fraccion_manual_del_pnl": round(pnl_manual / pnl_total, 3) if pnl_total else None,
+        },
+        "por_semana_iso": semanas,
+    }
+
+
+def _iso_week(ts: str | None) -> str:
+    if not ts:
+        return "?"
+    import datetime
+    d = datetime.date.fromisoformat(ts[:10])
+    y, w, _ = d.isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tenant", type=int, default=2)
+    ap.add_argument("--host", default="atrium-aws")
+    args = ap.parse_args()
+
+    positions = fetch_positions(args.tenant, args.host)
+    report = compute_report(positions)
+    report["tenant_id"] = args.tenant
+    report["generado_utc"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    report["fuente"] = f"{args.host}:{PROD_DB} (read-only)"
+
+    out = pathlib.Path(OUTPUT_DIR)
+    out.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%d", time.gmtime())
+    path = out / f"tenant{args.tenant}_{stamp}.json"
+    path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    pt = report["per_trade_pct"]
+    q2 = report["descomposicion_q2"]
+    print(f"tenant {args.tenant}: {report['n_trades']} trades, "
+          f"P&L ${report['pnl_total_usd']} sobre ${report['capital_desplegado_usd']} desplegados "
+          f"({report['retorno_sobre_desplegado_pct']}%)")
+    print(f"per-trade: {pt['media']}% CI95 {pt['ci95']} -> "
+          f"{'SIGNIFICATIVO' if pt['significativo'] else 'aun ruido'}")
+    print(f"q2: manual {q2['manual']['n']} trades = ${q2['manual']['pnl_usd']} "
+          f"({q2['fraccion_manual_del_pnl']} del total) vs señal {q2['señal']['n']} = ${q2['señal']['pnl_usd']}")
+    print(f"artefacto: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Monitor de realización per-tenant (read-only)

**Contexto (2026-06-06):** capital familiar real corre el sistema direccional desde 2026-05-21 (tenant 2) sin instrumentar como evidencia. El balance de plataforma es nocional por defecto; las operaciones y P&L en $ son reales (Binance). Este PR convierte "le va bien/mal" en un número con intervalo.

### Qué hace

`python -m tools.tenant_realization.report --tenant 2` — una llamada ssh read-only al `signals.db` de producción → cómputo local puro:

- P&L real en $ y **retorno sobre capital DESPLEGADO** (no sobre el balance ficticio de la plataforma).
- **Descomposición q2**: salidas MANUAL (criterio del operador — el único edge con CI≠0 que el proyecto ha medido) vs salidas por señal (SL/TP/TIME_LIMIT).
- **CI95 del per-trade** con flag de significancia — el número que decide cuándo la cuenta deja de ser ruido.
- Agregado semanal ISO para la lectura recurrente (junto al shadow de carry).

### Primera medición (31 trades, 2026-05-21→06-05)

+$138.31 sobre $21.4k desplegados (0.65%) · per-trade +0.44% CI95 [−0.23, +1.11] = **aún ruido** (consistente con el hallazgo señal-gross-flat del programa) · **q2 confirmado direccionalmente: 2 salidas MANUAL = 63% del P&L**.

### Contratos

- Read-only estricto (`mode=ro` vía ssh); cero escritura en el sistema vivo.
- `data/realizacion/` **gitignoreado** — data familiar sensible; el tool se versiona, la data no.
- Cómputo puro testeable offline: 6 tests (totales, q2, CI ruido/significativo, semanas ISO, división por cero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
