### PR TITLE
feat(positions): eje control_domain — fundacion posiciones EXTERNAL (v0.1)

### DIFF
--- a/api/agent/tools/handlers.py
+++ b/api/agent/tools/handlers.py
@@ -92,7 +92,11 @@ def get_portfolio_overview(*, tenant_id: int) -> dict:
     from api.config import load_config
 
     with snapshot_connection() as con:
-        open_positions = db_get_positions(con, status="open", tenant_id=tenant_id)
+        # control_domain='INTERNAL': el copiloto solo gobierna posiciones del
+        # sistema; no presenta EXTERNAL como actuable (no puede cerrarlas) — CD-1.
+        open_positions = db_get_positions(
+            con, status="open", tenant_id=tenant_id, control_domain="INTERNAL"
+        )
     open_count = len(open_positions)
     total_notional = sum(float(p.get("size_usd") or 0) for p in open_positions)
 
@@ -119,10 +123,17 @@ def get_portfolio_overview(*, tenant_id: int) -> dict:
 
 
 def get_positions(*, tenant_id: int) -> dict:
-    """Currently open positions, summarized."""
+    """Currently open positions, summarized.
+
+    control_domain='INTERNAL': EXTERNAL positions (opened outside the system)
+    are not shown as the copilot's governable positions — it cannot close them
+    (CD-1). They surface in the operator's own view (v0.1.5), not here.
+    """
     from db.positions import db_get_positions
     with snapshot_connection() as con:
-        rows = db_get_positions(con, status="open", tenant_id=tenant_id)
+        rows = db_get_positions(
+            con, status="open", tenant_id=tenant_id, control_domain="INTERNAL"
+        )
     return {"positions": [_position_to_summary(p) for p in rows]}
 
 

--- a/api/positions.py
+++ b/api/positions.py
@@ -153,8 +153,14 @@ def check_position_stops(
     pos_list_to_close: list[tuple[int, float, str]] = []
 
     with transaction() as con:
+        # control_domain='INTERNAL': el auto-cierre (SL/TP/TIME) es un ACTUADOR
+        # del sistema. Una posición EXTERNAL (abierta por fuera, p.ej. en Binance)
+        # se observa pero NUNCA se actúa — CD-1. Sin este filtro el scanner
+        # cerraría el ledger de una posición que sigue viva en el broker
+        # (spec 2026-06-09-posiciones-externas §4.1).
         rows = con.execute(
-            "SELECT * FROM positions WHERE symbol=? AND status='open'",
+            "SELECT * FROM positions "
+            "WHERE symbol=? AND status='open' AND control_domain='INTERNAL'",
             (symbol.upper(),),
         ).fetchall()
         pos_list = [dict(r) for r in rows]
@@ -427,11 +433,20 @@ def delete_position(
     # serialize against any concurrent operator edit of the same row.
     with transaction() as con:
         row = con.execute(
-            "SELECT id FROM positions WHERE id=? AND tenant_id=?",
+            "SELECT control_domain FROM positions WHERE id=? AND tenant_id=?",
             (pos_id, tenant_id),
         ).fetchone()
         if not row:
             raise HTTPException(status_code=404, detail=f"Posicion #{pos_id} no encontrada")
+        if row[0] == "EXTERNAL":
+            # CD-5: una EXTERNAL corrió y tiene P&L; cancelarla (outcome nulo)
+            # corrompería su EpisodioDeConducción. El sistema no la lleva a
+            # cancelled ni a closed; solo el operador la cierra vía
+            # PositionClosure(USER) tras cerrar en Binance (spec §4, HIGH #7).
+            raise HTTPException(
+                status_code=409,
+                detail=f"Posicion #{pos_id} es EXTERNAL; no se puede cancelar desde el sistema (ciérrala en Binance)",
+            )
         con.execute("UPDATE positions SET status='cancelled' WHERE id=?", (pos_id,))
     update_positions_json()
     return {"ok": True, "message": f"Posicion #{pos_id} cancelada"}

--- a/db/positions.py
+++ b/db/positions.py
@@ -106,10 +106,14 @@ def db_last_exit_ts(
 
     Task 8 (#446): `con` is now mandatory positional first arg.
     """
+    # control_domain='INTERNAL': el cooldown gobierna las ENTRADAS del sistema.
+    # Cerrar una posición EXTERNAL (papá cierra su bag en Binance) no debe
+    # pausar las señales INTERNAL del símbolo — CD-1 (spec §4, HIGH #11).
     if tenant_id is None:
         row = con.execute(
             "SELECT exit_ts FROM positions "
             "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
+            "AND control_domain='INTERNAL' "
             "ORDER BY exit_ts DESC LIMIT 1",
             (symbol.upper(),),
         ).fetchone()
@@ -117,7 +121,7 @@ def db_last_exit_ts(
         row = con.execute(
             "SELECT exit_ts FROM positions "
             "WHERE symbol=? AND status='closed' AND exit_ts IS NOT NULL "
-            "AND tenant_id=? "
+            "AND tenant_id=? AND control_domain='INTERNAL' "
             "ORDER BY exit_ts DESC LIMIT 1",
             (symbol.upper(), tenant_id),
         ).fetchone()
@@ -137,11 +141,18 @@ def db_get_positions(
     status: Optional[str] = None,
     tenant_id: Optional[int] = None,
     since: Optional[str] = None,
+    control_domain: Optional[str] = None,
 ) -> list:
-    """List positions, optionally filtered by status, tenant_id, and since.
+    """List positions, optionally filtered by status, tenant_id, since, and
+    control_domain.
 
     Per B.5: when tenant_id is None (default), returns all rows (legacy).
     When tenant_id is int, filters strict to that tenant.
+
+    `control_domain`: opt-in filter ('INTERNAL' / 'EXTERNAL'). Default None =
+    no filter, so the general listing (the /positions API and the v0.1.5 view)
+    sees EXTERNAL rows. System-risk/actuator callers (the agent context) pass
+    'INTERNAL' to exclude positions the system cannot govern — CD-1.
 
     `since`: ISO 8601 string. When provided, filters to rows with
     `exit_ts >= since` for status='closed' (the typical use — windowed
@@ -159,6 +170,9 @@ def db_get_positions(
     if tenant_id is not None:
         clauses.append("tenant_id=?")
         params.append(tenant_id)
+    if control_domain is not None:
+        clauses.append("control_domain=?")
+        params.append(control_domain)
     if since is not None:
         # Use exit_ts when filtering closed trades (the historial case);
         # otherwise entry_ts. Both columns are ISO 8601 strings so a

--- a/db/positions_schema.py
+++ b/db/positions_schema.py
@@ -142,6 +142,12 @@ CANONICAL_POSITIONS_COLUMNS: tuple[ColumnSpec, ...] = (
     ColumnSpec("atr_entry", "REAL"),
     ColumnSpec("be_mult", "REAL"),
     ColumnSpec("tenant_id", "INTEGER"),
+    # control_domain: provenance/control axis. INTERNAL (system-born, system
+    # may actuate) vs EXTERNAL (opened outside, observed-only). Added by
+    # _migrate_control_domain after all table recreations. NOT NULL DEFAULT
+    # 'INTERNAL' so every pre-existing row is INTERNAL (behavior preserved).
+    # Spec: 2026-06-09-posiciones-externas-control-domain-spec.md.
+    ColumnSpec("control_domain", "TEXT", nullable=False, default="'INTERNAL'"),
 )
 
 

--- a/db/schema.py
+++ b/db/schema.py
@@ -426,6 +426,15 @@ def init_db() -> None:
         _migrate_unique_open_scan(con_d)
         _migrate_idempotency_keys(con_d)
 
+    # control_domain axis (posiciones EXTERNAL — spec
+    # 2026-06-09-posiciones-externas-control-domain). Runs AFTER all table
+    # recreations so the column is never dropped by a later recreate. Fresh DB:
+    # the recreations build positions without it → this ALTER adds it. Prod
+    # (already migrated): the recreations skip (idempotent) → this ALTER adds
+    # it. PRAGMA-guarded for idempotency.
+    with transaction() as con_cd:
+        _migrate_control_domain(con_cd)
+
 
 # Per-user tables that need a tenant_id column (Epic B B.1).
 # kill_switch_* tables intentionally NOT in this list — kept global for B.1
@@ -812,6 +821,37 @@ def backfill_tenant(
         )
         affected[table] = cursor.rowcount
     return affected
+
+
+def _migrate_control_domain(con: sqlite3.Connection) -> None:
+    """Add `control_domain` to positions (INTERNAL default / EXTERNAL).
+
+    Distingue posiciones nacidas DEL sistema (INTERNAL — el sistema tiene
+    camino de control: PositionClosure, check_position_stops) de las abiertas
+    POR FUERA (EXTERNAL — observadas, nunca actuadas). `positions` confundía
+    dos ejes que coincidían por accidente: provenance (de dónde vino) y control
+    (quién actúa); esta columna los separa.
+
+    Idempotente: PRAGMA-guarded ADD COLUMN (NO try/except — un ALTER fallido en
+    la BEGIN IMMEDIATE marcaría la tx como abortable). NOT NULL DEFAULT
+    'INTERNAL' rellena toda fila existente, así que el comportamiento de las
+    filas previas se preserva (todas son INTERNAL).
+
+    Spec: docs/superpowers/specs/es/2026-06-09-posiciones-externas-control-domain-spec.md (REV 2 §2).
+    """
+    cols = {
+        row[1]
+        for row in con.execute("PRAGMA table_info(positions)").fetchall()
+    }
+    if "control_domain" not in cols:
+        con.execute(
+            "ALTER TABLE positions ADD COLUMN control_domain TEXT NOT NULL "
+            "DEFAULT 'INTERNAL'"
+        )
+        log.info(
+            "DB migration: added control_domain column to positions "
+            "(default INTERNAL)"
+        )
 
 
 def _migrate_qty_not_null(con: sqlite3.Connection) -> None:

--- a/docs/superpowers/specs/es/2026-06-09-posiciones-externas-control-domain-spec.md
+++ b/docs/superpowers/specs/es/2026-06-09-posiciones-externas-control-domain-spec.md
@@ -1,0 +1,111 @@
+# Spec — Posiciones EXTERNAL: el eje `control_domain` (REV 2)
+
+**Fecha:** 2026-06-09 · **REV 2** (tras roast de Adrian: 5 BLOCKER / 4 HIGH / 4 MEDIUM, todos direccionados). **Estado:** PROPUESTO.
+**Tipo:** integración de modelo de dominio. **Alcance partido** (decisión de Samuel): **v0.1 = FUNDACIÓN** (objetivo viernes 2026-06-12), **v0.1.5 = VISTA** (fast-follow), **v0.2 = plano vivo**.
+**Origen:** papá (tenant 2) hizo 2 operaciones LONG por fuera del sistema (Binance), sin SL, las aguanta underwater; NO están en la base.
+**Funda:** junta del roster 2026-06-09 (Voronov/Halberg/Adrian/Null Vale/Richter/Cassian, sin Axiom-0) + roast de Adrian sobre REV 1.
+**Relacionado:** `2026-06-09-integracion-eje-conducta-spec.md`, `2026-06-08-panel-disciplina-suerte-aware-spec.md`.
+
+---
+
+## REV 2 — qué cambió (changelog del roast)
+
+El error raíz de REV 1: razonó contra el **stub** del esquema (`db/schema.py:170-190`), no contra el esquema VIVO (los CHECK reales los instalan las migraciones que **recrean** la tabla, `schema.py:1132-1403`; el canon lo congela `db/positions_schema.py`). REV 2 razona contra el esquema vivo y cierra:
+
+1. **B1 — exención sistemática, no de un consumidor.** `control_domain='INTERNAL'` debe filtrar TODOS los lectores de `status='open'` que tocan riesgo/actuador, no solo `check_position_stops` (§4).
+2. **B2 — la columna entra al canon + a la recreación.** `control_domain` se añade a `CANONICAL_POSITIONS_COLUMNS` y a las `CREATE TABLE positions_new` de las migraciones que recrean, o una recreación posterior la borra (§2).
+3. **B3 — camino de nacimiento declarado.** Las EXTERNAL nacen por un registrador one-shot dedicado (no por el INSERT de señal `db_create_position_sql`, que no escribe la columna) (§3).
+4. **B4 — `scan_id=NULL` para EXTERNAL.** Resuelve la colisión con el índice único `(tenant_id, scan_id) WHERE status='open'` y es semánticamente correcto: sin linkage de señal del sistema (§3).
+5. **B5 — `qty>0` se mantiene; "no autoritativa" es sobre Binance, no sobre el CHECK.** La fila cumple el constraint duro (los valores de papá son >0); "espejo no autoritativo" describe la correspondencia-con-Binance (concern de v0.2), no debilita el CHECK (§3).
+6. Decisiones de Samuel bakeadas: ETH entry `2026-06-02T11:11`; aviso de horizonte = **flag pull en la vista, NO push Telegram**; vista **self-tenant — la ve papá en su cuenta** (multitenant, JWT), Samuel monitorea por el export read-only.
+
+---
+
+## 0. Qué es / qué NO es
+Declara el eje `control_domain` y registra de forma SEGURA 2 posiciones que el sistema observa pero no controla. v0.1 NO construye la vista roja ni el P&L (eso es v0.1.5). NO cierra nada. NO lee precio vivo. NO reconcilia con Binance. NO promete edge.
+
+## 1. El hallazgo (Voronov) — `positions` confundía provenance y control
+`positions` mezcló dos semánticas que coincidían por accidente: **provenance** (de dónde nació el hecho) y **control** (si el sistema puede actuar). Toda fila fue provenance-interno ⟹ control-interno. `check_position_stops` lo encarna: `WHERE status='open'` → cierra; asume *estar-en-la-tabla ⟹ autorización-para-actuar*. Las ops de papá rompen la coincidencia: **provenance EXTERNO, control CERO**. No es un estado del lifecycle — es una columna que siempre fue constante implícita.
+
+**Ley de orquestación:** observación y control son ejes independientes. El sistema representa lo que ve sin afirmar que puede actuar, y rehúsa todo actuador cuya autorización no esté presente.
+
+## 2. La columna `control_domain` (cierra B2)
+`positions.control_domain TEXT NOT NULL DEFAULT 'INTERNAL'`, dominio `{INTERNAL, EXTERNAL}`.
+- **Canon:** añadir a `CANONICAL_POSITIONS_COLUMNS` (`db/positions_schema.py:124-145`) — pasa de 20 a 21 columnas; actualizar el test de canonicalidad con justificación en el PR.
+- **Recreación:** añadir `control_domain TEXT NOT NULL DEFAULT 'INTERNAL'` a cada `CREATE TABLE positions_new` de las migraciones que recrean (`_migrate_qty_not_null`, `_migrate_qty_positive`, `_migrate_tenant_id_not_null`, `_migrate_direction_enum`) y a sus `TARGET_COLS`, **o** una recreación posterior la borra. Idempotente (PRAGMA-guarded ALTER en el stub para DBs ya migradas).
+- Backfill: el `DEFAULT 'INTERNAL'` cubre toda fila existente; ninguna es EXTERNAL salvo registro explícito (§3).
+
+## 3. Registro de las 2 operaciones EXTERNAL (cierra B3/B4/B5)
+**Camino de nacimiento:** un registrador one-shot dedicado (`tools/register_external_position.py` o equivalente), NO el INSERT de señal. Escribe explícitamente `control_domain='EXTERNAL'`. Idempotente (no duplica si ya existe por `(tenant_id, symbol, entry_ts)`).
+
+| Campo | BTC | ETH |
+|---|---|---|
+| `tenant_id` | 2 | 2 |
+| `direction` | LONG | LONG |
+| `status` | open | open |
+| `control_domain` | EXTERNAL | EXTERNAL |
+| `entry_price` | 64390 | 1700 |
+| `entry_ts` | 2026-06-04T00:56 | 2026-06-02T11:11 |
+| `qty` | 0.01967 | 0.448 |
+| `size_usd` | qty×entry = **1266.55** | qty×entry = **761.60** |
+| `sl_price` / `tp_price` | NULL / NULL | NULL / NULL |
+| `scan_id` | **NULL** | **NULL** |
+
+- **`scan_id=NULL` (B4):** evita la colisión con `idx_positions_open_scan_unique` y es correcto — no hubo linkage de señal del sistema. Consecuencia coherente con el spec-conducta §4.2: `apertura_discrecional=true` (fue manual). *Matiz (Richter): papá "siguió una señal" pero ejecutó por fuera; ese acto ("siguió-pero-ejecutó-afuera") es un tipo de conducta más rico que el modelo aún no nombra — diferido. `control_domain='EXTERNAL'` es la señal más fuerte y ortogonal: "ejecutado fuera del sistema", no solo "sin scan_id".*
+- **`size_usd` (cierra MEDIUM #12):** registrado como `qty×entry_price` para que las proyecciones de conducta (`size_usd`, `costo_piso`) no nazcan NO-DISPONIBLE.
+- **`qty>0` (B5):** los valores reportados cumplen el CHECK vivo; la fila es válida. "No autoritativa" = no verificada contra el fill real de Binance (correspondencia, v0.2), NO una debilidad del constraint.
+
+## 4. Exención sistemática del control (cierra B1 + HIGH #11)
+**Regla:** todo lector de `status='open'` que alimente un ACTUADOR del sistema o su MATEMÁTICA DE RIESGO/COOLDOWN debe filtrar `control_domain='INTERNAL'`. La VISTA (v0.1.5) lee EXTERNAL a propósito. Consumidores a tocar (verificados por Adrian):
+
+| Consumidor | Archivo | Acción |
+|---|---|---|
+| Auto-cierre SL/TP/TIME | `api/positions.py:155-263` (`check_position_stops`) | `… AND control_domain='INTERNAL'` en el SELECT de Fase 1 (predicado SQL, no flag en memoria — evita race) |
+| MTM / `P(ruina)` / `τ_b` | `strategy/kill_switch_v2_shadow.py:65-88` (`_load_open_positions`) | excluir EXTERNAL del MTM de riesgo |
+| Cooldown del scanner | `db/positions.py` (`db_last_exit_ts`) | excluir EXTERNAL: cerrar la op de papá NO debe pausar señales INTERNAL del símbolo |
+| Contexto del agente/copiloto | `api/agent/tools/handlers.py:95,125` | el copiloto NO debe tratar una EXTERNAL como posición gobernable (no proponer cierre que no puede ejecutar) |
+| `rule_a_check` (diagnóstico) | `tools/rule_a_check.py:93` | excluir EXTERNAL del análisis de reglas del sistema |
+
+**Patrón recomendado:** un helper único (p.ej. `INTERNAL_OPEN_PREDICATE = "status='open' AND control_domain='INTERNAL'"`) reusado, para que un futuro consumidor no olvide el filtro. (Voronov: el control nunca debió derivarse de la presencia; este helper hace explícita la autorización.)
+
+**No-cierre:** una EXTERNAL nunca entra a `pos_list_to_close`. No-negociable #1 intacto: el único camino a `REALIZED` sigue siendo `PositionClosure`; EXTERNAL solo lo toma vía `PositionClosure(USER)` cuando papá cierra en Binance y reconcilia.
+
+**Cancelación (cierra HIGH #7):** el endpoint `DELETE` (`api/positions.py:435`, `→ cancelled`) debe **rechazar** `control_domain='EXTERNAL'` (409): una EXTERNAL corrió y tiene P&L; `cancelled` (outcome nulo) corrompería su `EpisodioDeConducción`.
+
+## 5. La vista (v0.1.5 — fast-follow, decisiones LOCKED)
+DIFERIDA del viernes, pero con el contrato congelado:
+- **Self-tenant — la ve papá en su cuenta** (decisión de Samuel; multitenant, `tenant_id` del JWT, NUNCA de param — cierra HIGH #6/IDOR). Samuel monitorea por el export read-only (`tools/tenant_export`), no por un endpoint cross-tenant.
+- **El "rojo" se parte** (no-mezcla): rojo-de-conducta = VIOLACIÓN tipable (`sin_stop` = `sl_price IS NULL`; `past_time_horizon`) — legible sin precio. Separado del **P&L snapshot** (outcome/suerte), etiquetado *"no realizado, al momento de cargar; el ledger no es tu saldo en Binance"*, tipo `RUIDO`. Nunca rojo-porque-pierde. (Corrección: "abrió sin señal" NO es violación; el rojo afirma solo `sin_stop` + `past_time_horizon`.)
+- **Aviso de horizonte = flag PULL en la vista** (decisión de Samuel; NO push Telegram — coherente con panel §6 pull-only). `past_time_horizon` = **derivado read-only, NO persistido** (cierra HIGH #8/Q2). Cuando `time_limit_hours[símbolo]` es `None` → `NO-DISPONIBLE`, no `false` (cierra MEDIUM #10, consistente con `costo_piso`).
+- **P&L snapshot (cierra HIGH #9/LOW #14):** fuente = último `scans.price` del símbolo vía `snapshot_connection` (read-only, evita el lock del scanner). `mark_ts` explícito + banda de staleness (umbral a fijar, sugerido 2× scan_interval); si no hay precio reciente o falta → mostrar `"—"` con razón, NO un número stale disfrazado de actual.
+
+## 6. Contrato de runtime (Halberg)
+- Exención = predicado SQL en cada SELECT (§4), no flag en memoria.
+- P&L: SOLO `snapshot_connection`; CERO roll-in a capital.
+- El sistema NUNCA escribe `closed` ni `cancelled` sobre una EXTERNAL por su cuenta.
+- Idempotencia del registro y de la migración de columna.
+
+## 7. Alcance
+- **v0.1 (viernes 06-12):** columna `control_domain` (canon + recreación + ALTER idempotente); exención sistemática en los 5 consumidores; rechazo de DELETE sobre EXTERNAL; registro one-shot de las 2 ops. **Resultado: las ops están en el ledger, NO contaminan riesgo/cooldown/agente, NO se auto-cierran.** (Papá aún no ve la vista — esa es v0.1.5.)
+- **v0.1.5 (fast-follow):** la vista self-tenant (rojo-de-violación + flag `past_time_horizon` + P&L snapshot etiquetado).
+- **v0.2:** plano vivo `CONDUCTING` persistido, objeto cross-mundo INV-5, MAE/MFE, mark continuo, botón de cierre, reconciliación real ledger↔Binance, primitiva de correspondencia (Richter).
+
+## 8. Invariantes
+- **CD-1.** Ningún actuador del sistema ni su matemática de riesgo/cooldown toca una EXTERNAL (auto-cierre, ratchet SL, roll-in capital, MTM de ruina, cooldown, propuesta del agente).
+- **CD-2.** El P&L no-realizado de una EXTERNAL es `outcome` efímero tipo `RUIDO`; no persiste, no roda a capital, no se co-renderiza con la conducta.
+- **CD-3.** El rojo afirma SOLO violaciones tipables pre-declaradas (`sin_stop`, `past_time_horizon`), nunca el signo del P&L.
+- **CD-4.** La fila EXTERNAL es espejo no-autoritativo de Binance; ninguna lectura la trata como verdad sobre el broker.
+- **CD-5.** Cierre solo vía `PositionClosure(USER)` (papá); el sistema nunca lleva una EXTERNAL a `REALIZED` ni a `CANCELLED`.
+- **CD-6.** `control_domain` está en el canon y sobrevive toda recreación de tabla; el default `INTERNAL` preserva el comportamiento de toda fila existente.
+
+## 9. Consistencia cross-documento
+- Spec-conducta §4.2 (`apertura_discrecional ← scan_id IS NULL`): consistente — EXTERNAL lleva `scan_id=NULL` ⟹ `apertura_discrecional=true` (correcto, fue manual). `control_domain='EXTERNAL'` es señal ortogonal más fuerte ("ejecutado fuera"); no se rellena scan_id (eso borraría la conducta — Adrian #13).
+- El tipo de conducta "siguió-señal-pero-ejecutó-afuera" queda DIFERIDO (no hay campo; el modelo aún no lo nombra — Richter).
+
+## 10. Preguntas abiertas (residuales para el build)
+1. Umbral exacto de staleness del P&L snapshot (sugerido 2× scan_interval) — v0.1.5.
+2. ¿El registrador one-shot es un script en `tools/` o un comando admin? (recomendado: script idempotente versionado.)
+3. ¿`scans.price` es la fuente canónica del último precio, o hay una cache de runtime preferible? — v0.1.5.
+
+## 11. Kill del spec
+Si una verificación encuentra que (a) el P&L se co-renderiza con la conducta, (b) el sistema escribe `closed`/`cancelled` sobre una EXTERNAL, (c) el rojo afirma una violación sin regla pre-declarada, (d) la exención queda fuera del SELECT (race), o (e) un consumidor de riesgo lee EXTERNAL sin filtro — esa pieza se corta o re-tipa antes de codificar.

--- a/strategy/kill_switch_v2_shadow.py
+++ b/strategy/kill_switch_v2_shadow.py
@@ -48,11 +48,14 @@ def _load_closed_trades(conn, *, tenant_id: int) -> list[dict[str, Any]]:
     `db.capital.db_list_active_tenant_ids()` and call this loader once per
     tenant. Aggregating across tenants implicitly is not allowed.
     """
+    # control_domain='INTERNAL': los baselines de riesgo del kill-switch se
+    # computan solo de trades del sistema. Un cierre EXTERNAL (posición de papá
+    # cerrada en Binance) no es un trade del sistema — CD-1 (spec §4).
     rows = conn.execute(
         """SELECT symbol, exit_ts, pnl_usd
            FROM positions
            WHERE status = 'closed' AND exit_ts IS NOT NULL
-             AND tenant_id = ?
+             AND tenant_id = ? AND control_domain = 'INTERNAL'
            ORDER BY exit_ts""",
         (tenant_id,),
     ).fetchall()
@@ -67,10 +70,13 @@ def _load_open_positions(conn, *, tenant_id: int) -> list[dict[str, Any]]:
 
     See `_load_closed_trades` for the multi-tenant policy rationale.
     """
+    # control_domain='INTERNAL': el MTM / P(ruina) del kill-switch no debe
+    # ver una posición EXTERNAL que el sistema no controla — CD-1 (spec §4).
     rows = conn.execute(
         """SELECT symbol, entry_price, qty, direction
            FROM positions
-           WHERE status = 'open' AND tenant_id = ?""",
+           WHERE status = 'open' AND tenant_id = ?
+             AND control_domain = 'INTERNAL'""",
         (tenant_id,),
     ).fetchall()
     # NOTE: qty is intentionally NOT coerced to 0.0 here. Legacy unmeasurable

--- a/tests/_baselines/positions.json
+++ b/tests/_baselines/positions.json
@@ -5,6 +5,7 @@
         {
           "atr_entry": null,
           "be_mult": null,
+          "control_domain": "INTERNAL",
           "direction": "LONG",
           "entry_price": 50000.0,
           "entry_ts": "2026-01-15T10:05:00Z",
@@ -42,6 +43,7 @@
         {
           "atr_entry": null,
           "be_mult": null,
+          "control_domain": "INTERNAL",
           "direction": "LONG",
           "entry_price": 50000.0,
           "entry_ts": "2026-01-15T10:05:00Z",
@@ -72,6 +74,7 @@
       "position": {
         "atr_entry": null,
         "be_mult": null,
+        "control_domain": "INTERNAL",
         "direction": "LONG",
         "entry_price": 3000.0,
         "entry_ts": "2026-04-27T17:05:48.172642+00:00",
@@ -106,6 +109,7 @@
       "position": {
         "atr_entry": null,
         "be_mult": null,
+        "control_domain": "INTERNAL",
         "direction": "LONG",
         "entry_price": 50000.0,
         "entry_ts": "2026-01-15T10:05:00Z",

--- a/tests/test_control_domain.py
+++ b/tests/test_control_domain.py
@@ -1,0 +1,85 @@
+"""Tests del eje `control_domain` en positions (INTERNAL vs EXTERNAL).
+
+Spec: docs/superpowers/specs/es/2026-06-09-posiciones-externas-control-domain-spec.md (REV 2).
+
+`control_domain` distingue posiciones nacidas DEL sistema (INTERNAL, el sistema
+las gobierna) de las abiertas POR FUERA (EXTERNAL, el sistema observa pero no
+actúa). v0.1 = fundación: la columna + la exención sistemática.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+
+
+def _fresh_db(tmp_path) -> sqlite3.Connection:
+    """init_db() sobre una DB fresca (mismo patrón que test_canonical_positions_schema)."""
+    db_path = tmp_path / "control_domain.db"
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        import btc_api
+        original = btc_api.DB_FILE
+        btc_api.DB_FILE = str(db_path)
+        try:
+            from db.schema import init_db
+            init_db()
+            return sqlite3.connect(str(db_path))
+        finally:
+            btc_api.DB_FILE = original
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+
+
+def test_positions_has_control_domain_column(tmp_path):
+    """Una DB fresca tiene `control_domain TEXT NOT NULL DEFAULT 'INTERNAL'`."""
+    con = _fresh_db(tmp_path)
+    try:
+        cols = {r[1]: r for r in con.execute("PRAGMA table_info(positions)").fetchall()}
+    finally:
+        con.close()
+    assert "control_domain" in cols, "falta la columna control_domain en positions"
+    # PRAGMA table_info: (cid, name, type, notnull, dflt_value, pk)
+    _, _, ctype, notnull, dflt, _ = cols["control_domain"]
+    assert ctype == "TEXT", f"tipo esperado TEXT, vivo {ctype!r}"
+    assert notnull == 1, "control_domain debe ser NOT NULL"
+    assert dflt == "'INTERNAL'", f"default esperado 'INTERNAL', vivo {dflt!r}"
+
+
+def test_insert_without_control_domain_defaults_internal(tmp_path):
+    """Un INSERT que NO menciona control_domain (todos los paths existentes)
+    cae a INTERNAL — el comportamiento de las filas previas se preserva."""
+    con = _fresh_db(tmp_path)
+    try:
+        con.execute(
+            "INSERT INTO positions "
+            "(symbol, direction, status, entry_price, entry_ts, qty, tenant_id) "
+            "VALUES ('BTCUSDT', 'LONG', 'open', 1.0, '2026-01-01T00:00:00', 1.0, 1)"
+        )
+        con.commit()
+        val = con.execute("SELECT control_domain FROM positions").fetchone()[0]
+    finally:
+        con.close()
+    assert val == "INTERNAL"
+
+
+def test_migration_idempotent_second_init(tmp_path):
+    """Correr init_db dos veces no rompe ni duplica la columna (idempotencia)."""
+    con = _fresh_db(tmp_path)  # primer init_db ya corrió dentro del helper
+    con.close()
+    # Segundo init_db sobre la misma DB.
+    import btc_api
+    from db.schema import init_db
+    db_path = tmp_path / "control_domain.db"
+    original = btc_api.DB_FILE
+    btc_api.DB_FILE = str(db_path)
+    try:
+        init_db()  # no debe lanzar
+    finally:
+        btc_api.DB_FILE = original
+    con = sqlite3.connect(str(db_path))
+    try:
+        cd_cols = [r for r in con.execute("PRAGMA table_info(positions)").fetchall()
+                   if r[1] == "control_domain"]
+    finally:
+        con.close()
+    assert len(cd_cols) == 1, "control_domain no debe duplicarse en el segundo init_db"

--- a/tests/test_control_domain_exemption.py
+++ b/tests/test_control_domain_exemption.py
@@ -1,0 +1,201 @@
+"""Exención sistemática de posiciones EXTERNAL (control_domain) — fundación 2/2.
+
+CD-1: ningún actuador del sistema ni su matemática de riesgo/cooldown toca una
+posición EXTERNAL. Verifica los 6 consumidores de `status='open'` que Adrian
+enumeró + el rechazo de DELETE.
+
+Spec: docs/superpowers/specs/es/2026-06-09-posiciones-externas-control-domain-spec.md (REV 2 §4).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures / helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def db_and_cfg(tmp_path, monkeypatch):
+    """Fresh DB wired into every connection source + overridable config."""
+    db_path = str(tmp_path / "cd_exempt.db")
+    import db.connection as dbconn
+    import btc_api
+    import api.positions as _pos_mod
+
+    monkeypatch.setattr(dbconn, "DB_FILE", db_path)
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    cfg_holder: dict = {"cfg": {}}
+    monkeypatch.setattr(_pos_mod, "load_config", lambda: cfg_holder["cfg"])
+    from strategy import _validators
+    monkeypatch.setattr(_validators, "_validator_warned", set())
+
+    def set_cfg(cfg: dict):
+        cfg_holder["cfg"] = cfg
+
+    return db_path, set_cfg
+
+
+def _insert(con, *, symbol="BTCUSDT", direction="LONG", status="open",
+            control_domain="INTERNAL", entry_price=65000.0, entry_ts=None,
+            sl_price=None, tp_price=None, qty=1.0, tenant_id=2,
+            exit_ts=None, pnl_usd=None):
+    if entry_ts is None:
+        entry_ts = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc).isoformat()
+    cur = con.execute(
+        """INSERT INTO positions
+               (symbol, direction, status, entry_price, entry_ts, sl_price,
+                tp_price, qty, tenant_id, control_domain, exit_ts, pnl_usd)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (symbol, direction, status, entry_price, entry_ts, sl_price,
+         tp_price, qty, tenant_id, control_domain, exit_ts, pnl_usd),
+    )
+    return cur.lastrowid
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. check_position_stops — el landmine: NO auto-cierra una EXTERNAL
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_check_position_stops_skips_external(db_and_cfg):
+    """Una EXTERNAL muy vencida NO se auto-cierra; una INTERNAL gemela SÍ."""
+    import btc_api
+    from db.transaction import transaction
+
+    _, set_cfg = db_and_cfg
+    set_cfg({"symbol_overrides": {"BTCUSDT": {"time_limit_hours": 5}}})
+
+    old = (datetime.now(timezone.utc) - timedelta(hours=200)).isoformat()
+    with transaction() as con:
+        ext_id = _insert(con, control_domain="EXTERNAL", entry_ts=old)
+        int_id = _insert(con, control_domain="INTERNAL", entry_ts=old)
+
+    btc_api.check_position_stops("BTCUSDT", 65500.0)
+
+    with transaction() as con:
+        ext = con.execute("SELECT status FROM positions WHERE id=?", (ext_id,)).fetchone()[0]
+        intl = con.execute("SELECT status FROM positions WHERE id=?", (int_id,)).fetchone()[0]
+    assert ext == "open", "EXTERNAL no debe auto-cerrarse por TIME_LIMIT"
+    assert intl == "closed", "la INTERNAL gemela SÍ debe cerrarse (control: el filtro discrimina)"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. db_last_exit_ts — el cooldown ignora cierres EXTERNAL
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_db_last_exit_ts_ignores_external(db_and_cfg):
+    """Un cierre EXTERNAL no debe contar como último exit del símbolo (cooldown)."""
+    from db.transaction import transaction
+    from db.positions import db_last_exit_ts
+
+    with transaction() as con:
+        _insert(con, status="closed", control_domain="EXTERNAL",
+                exit_ts=datetime(2026, 6, 1, tzinfo=timezone.utc).isoformat(), pnl_usd=-10.0)
+        result = db_last_exit_ts(con, "BTCUSDT")
+    assert result is None, "un cierre EXTERNAL no debe fijar el cooldown system-wide"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. kill_switch_v2_shadow — MTM/riesgo excluye EXTERNAL (open + closed)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_shadow_load_open_excludes_external(db_and_cfg):
+    from db.transaction import transaction
+    from strategy.kill_switch_v2_shadow import _load_open_positions
+
+    with transaction() as con:
+        _insert(con, status="open", control_domain="EXTERNAL", tenant_id=2)
+        _insert(con, status="open", control_domain="INTERNAL", tenant_id=2)
+        loaded = _load_open_positions(con, tenant_id=2)
+    assert len(loaded) == 1, "el MTM del kill-switch no debe ver la EXTERNAL"
+
+
+def test_shadow_load_closed_excludes_external(db_and_cfg):
+    from db.transaction import transaction
+    from strategy.kill_switch_v2_shadow import _load_closed_trades
+
+    with transaction() as con:
+        _insert(con, status="closed", control_domain="EXTERNAL", tenant_id=2,
+                exit_ts="2026-06-01T00:00:00+00:00", pnl_usd=-5.0)
+        _insert(con, status="closed", control_domain="INTERNAL", tenant_id=2,
+                exit_ts="2026-06-02T00:00:00+00:00", pnl_usd=3.0)
+        loaded = _load_closed_trades(con, tenant_id=2)
+    assert len(loaded) == 1, "los baselines del kill-switch no deben incluir cierres EXTERNAL"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. db_get_positions — filtro opcional control_domain (lo usa el agente)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_db_get_positions_control_domain_filter(db_and_cfg):
+    from db.transaction import transaction
+    from db.positions import db_get_positions
+
+    with transaction() as con:
+        _insert(con, status="open", control_domain="EXTERNAL", tenant_id=2)
+        _insert(con, status="open", control_domain="INTERNAL", tenant_id=2)
+        internal_only = db_get_positions(con, status="open", tenant_id=2, control_domain="INTERNAL")
+        all_rows = db_get_positions(con, status="open", tenant_id=2)
+    assert len(internal_only) == 1, "el filtro INTERNAL debe excluir EXTERNAL"
+    assert len(all_rows) == 2, "sin filtro, el listado general (la vista) ve ambas"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Agente — get_positions no presenta EXTERNAL como gobernable
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_agent_get_positions_excludes_external(db_and_cfg):
+    from db.transaction import transaction
+    from api.agent.tools.handlers import get_positions
+
+    with transaction() as con:
+        _insert(con, status="open", control_domain="EXTERNAL", tenant_id=2)
+        _insert(con, status="open", control_domain="INTERNAL", tenant_id=2)
+
+    result = get_positions(tenant_id=2)
+    assert len(result["positions"]) == 1, "el copiloto no debe ver la EXTERNAL como posición suya"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. DELETE rechaza EXTERNAL (no se cancela lo que corrió y tiene P&L)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_delete_position_rejects_external(tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+    import db.connection as dbconn
+    import btc_api
+
+    db_path = str(tmp_path / "del.db")
+    monkeypatch.setattr(dbconn, "DB_FILE", db_path)
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    btc_api.init_db()
+
+    from db.transaction import transaction
+    with transaction() as con:
+        ext_id = _insert(con, status="open", control_domain="EXTERNAL", tenant_id=99)
+
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"api_key": "test-key"}))
+    import api.config as _ac
+    for mod, attr in ((btc_api, "CONFIG_FILE"), (_ac, "CONFIG_FILE"),
+                      (btc_api, "DEFAULTS_FILE"), (_ac, "DEFAULTS_FILE"),
+                      (btc_api, "SECRETS_FILE"), (_ac, "SECRETS_FILE")):
+        val = str(cfg_path) if "CONFIG" in attr else str(tmp_path / f"no_{attr}.json")
+        monkeypatch.setattr(mod, attr, val, raising=False)
+
+    from btc_api import app
+    client = TestClient(app)
+    r = client.delete(f"/positions/{ext_id}", headers={"X-API-Key": "test-key"})
+    assert r.status_code == 409, f"DELETE de EXTERNAL debe ser 409; got {r.status_code} {r.text}"

--- a/tests/test_register_external_position.py
+++ b/tests/test_register_external_position.py
@@ -1,0 +1,67 @@
+"""Tests del registrador one-shot de posiciones EXTERNAL.
+
+Camino de nacimiento dedicado (NO el INSERT de señal): registra una posición
+abierta POR FUERA del sistema como control_domain='EXTERNAL', scan_id=NULL,
+size_usd=qty×entry. Idempotente. Spec REV 2 §3.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+
+@pytest.fixture
+def con(tmp_path):
+    db_path = tmp_path / "reg.db"
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        import btc_api
+        original = btc_api.DB_FILE
+        btc_api.DB_FILE = str(db_path)
+        try:
+            from db.schema import init_db
+            init_db()
+        finally:
+            btc_api.DB_FILE = original
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+    c = sqlite3.connect(str(db_path))
+    c.row_factory = sqlite3.Row
+    yield c
+    c.close()
+
+
+def test_register_external_creates_external_row(con):
+    from tools.register_external_position import register_external
+
+    row = register_external(
+        con, tenant_id=2, symbol="BTCUSDT", direction="LONG",
+        qty=0.01967, entry_price=64390.0, entry_ts="2026-06-04T00:56:00+00:00",
+    )
+    con.commit()
+    assert row is not None
+    assert row["control_domain"] == "EXTERNAL"
+    assert row["scan_id"] is None
+    assert row["status"] == "open"
+    assert row["sl_price"] is None and row["tp_price"] is None
+    assert row["size_usd"] == pytest.approx(0.01967 * 64390.0)
+    assert row["tenant_id"] == 2
+
+
+def test_register_external_idempotent(con):
+    from tools.register_external_position import register_external
+
+    kw = dict(tenant_id=2, symbol="ETHUSDT", direction="LONG", qty=0.448,
+              entry_price=1700.0, entry_ts="2026-06-02T11:11:00+00:00")
+    first = register_external(con, **kw)
+    con.commit()
+    second = register_external(con, **kw)
+    con.commit()
+    assert first is not None, "primer registro crea la fila"
+    assert second is None, "segundo registro es no-op (idempotente)"
+    n = con.execute(
+        "SELECT COUNT(*) FROM positions WHERE symbol='ETHUSDT' AND control_domain='EXTERNAL'"
+    ).fetchone()[0]
+    assert n == 1, "no debe duplicar la posición EXTERNAL"

--- a/tools/register_external_position.py
+++ b/tools/register_external_position.py
@@ -1,0 +1,109 @@
+"""Registrador one-shot de una posición EXTERNAL (abierta por fuera del sistema).
+
+Camino de nacimiento dedicado para posiciones que el operador abrió en el broker
+(p.ej. Binance) sin pasar por la señal del sistema: las marca
+`control_domain='EXTERNAL'` para que el sistema las OBSERVE pero nunca las actúe
+(no auto-cierre, no MTM de riesgo, no cooldown, no propuesta del copiloto — CD-1).
+
+NO usa el INSERT de señal (`db_create_position_sql`): aquella ruta es para
+posiciones INTERNAL nacidas de un scan. Esta escribe `control_domain='EXTERNAL'`,
+`scan_id=NULL` (no hubo señal del sistema), `size_usd=qty×entry_price`, sin SL/TP.
+
+Idempotente por (tenant_id, symbol, entry_ts, control_domain='EXTERNAL').
+
+PRECONDICIÓN: el código con la columna `control_domain` + la exención debe estar
+DESPLEGADO en el destino ANTES de correr esto. Si se registra en un servidor que
+aún corre el código viejo (sin la exención), el scanner viejo auto-cerraría la
+fila — el orden es deploy → register.
+
+Usage (en el servidor, contra el DB_FILE configurado = prod):
+    python -m tools.register_external_position --tenant 2 --symbol BTCUSDT \
+        --direction LONG --qty 0.01967 --entry-price 64390 \
+        --entry-ts 2026-06-04T00:56:00+00:00
+
+Spec: docs/superpowers/specs/es/2026-06-09-posiciones-externas-control-domain-spec.md (REV 2 §3).
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+
+
+def register_external(
+    con: sqlite3.Connection,
+    *,
+    tenant_id: int,
+    symbol: str,
+    direction: str,
+    qty: float,
+    entry_price: float,
+    entry_ts: str,
+) -> dict | None:
+    """Registra una posición EXTERNAL. Devuelve la fila creada, o None si ya
+    existía (idempotente). El caller posee la transacción y el commit."""
+    symbol = symbol.upper()
+    direction = direction.upper()
+    existing = con.execute(
+        "SELECT id FROM positions "
+        "WHERE tenant_id=? AND symbol=? AND entry_ts=? AND control_domain='EXTERNAL'",
+        (tenant_id, symbol, entry_ts),
+    ).fetchone()
+    if existing is not None:
+        return None
+
+    size_usd = round(qty * entry_price, 4)
+    cur = con.execute(
+        """INSERT INTO positions
+               (scan_id, symbol, direction, status, entry_price, entry_ts,
+                sl_price, tp_price, size_usd, qty, tenant_id, control_domain)
+           VALUES (NULL, ?, ?, 'open', ?, ?, NULL, NULL, ?, ?, ?, 'EXTERNAL')""",
+        (symbol, direction, entry_price, entry_ts, size_usd, qty, tenant_id),
+    )
+    cur2 = con.execute("SELECT * FROM positions WHERE id=?", (cur.lastrowid,))
+    cols = [d[0] for d in cur2.description]
+    return dict(zip(cols, cur2.fetchone()))
+
+
+def main() -> int:
+    from db.transaction import transaction
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tenant", type=int, required=True)
+    ap.add_argument("--symbol", required=True)
+    ap.add_argument("--direction", default="LONG", choices=["LONG", "SHORT"])
+    ap.add_argument("--qty", type=float, required=True)
+    ap.add_argument("--entry-price", type=float, required=True)
+    ap.add_argument("--entry-ts", required=True, help="ISO 8601, p.ej. 2026-06-04T00:56:00+00:00")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="no escribe; reporta qué haría")
+    args = ap.parse_args()
+
+    with transaction() as con:
+        con.row_factory = sqlite3.Row
+        if args.dry_run:
+            existing = con.execute(
+                "SELECT id FROM positions WHERE tenant_id=? AND symbol=? "
+                "AND entry_ts=? AND control_domain='EXTERNAL'",
+                (args.tenant, args.symbol.upper(), args.entry_ts),
+            ).fetchone()
+            size = round(args.qty * args.entry_price, 4)
+            verb = "ya existe (no-op)" if existing else f"crearía EXTERNAL size_usd={size}"
+            print(f"[dry-run] {args.symbol.upper()} {args.direction} qty={args.qty} "
+                  f"@ {args.entry_price} ({args.entry_ts}) → {verb}")
+            # No commit en dry-run: deshacer cualquier estado de la tx.
+            raise SystemExit(0)
+        row = register_external(
+            con, tenant_id=args.tenant, symbol=args.symbol,
+            direction=args.direction, qty=args.qty,
+            entry_price=args.entry_price, entry_ts=args.entry_ts,
+        )
+    if row is None:
+        print(f"{args.symbol.upper()} @ {args.entry_ts}: ya registrada (no-op).")
+    else:
+        print(f"Registrada EXTERNAL #{row['id']}: {row['symbol']} {row['direction']} "
+              f"qty={row['qty']} @ {row['entry_price']} size_usd={row['size_usd']}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Qué

Introduce el eje **`control_domain`** en `positions` (`INTERNAL` default · `EXTERNAL`) y la **exención sistemática** que hace seguro registrar posiciones que el operador abrió POR FUERA del sistema (broker) y aguanta. Fundación v0.1 — la **vista roja self-tenant** (rojo-de-violación + P&L snapshot etiquetado) es el fast-follow v0.1.5.

## Por qué (el hallazgo)

`positions` confundía dos ejes que coincidían por accidente histórico: **provenance** (de dónde vino el hecho) y **control** (si el sistema puede actuar). `check_position_stops` lo tenía cableado (`status='open'` → cierra). La primera posición con **provenance externo / control cero** rompe la coincidencia: el scanner cerraría el ledger de una posición que sigue viva en el broker. Roster 2026-06-09 (Voronov, Halberg, Adrian, Null Vale, Richter, Cassian) + roast de Adrian (5 BLOCKER cerrados, razonando contra el esquema VIVO, no el stub).

## Cambios (3 commits, TDD)

1. **Esquema** — columna `control_domain` vía `_migrate_control_domain` (ALTER idempotente POST-recreaciones; cubre DB fresca y prod ya-migrada) + entrada en `CANONICAL_POSITIONS_COLUMNS` (guard de drift). El API la expone como `INTERNAL` para toda fila existente (baseline actualizado).
2. **Exención sistemática (CD-1)** — los 6 consumidores de posiciones abiertas que Adrian enumeró excluyen EXTERNAL: auto-cierre SL/TP/TIME (el landmine), cooldown (`db_last_exit_ts`), MTM + baselines del kill-switch shadow, listado del copiloto, y el endpoint de borrado responde 409 sobre EXTERNAL. `db_get_positions` gana un filtro opcional `control_domain` (None = la vista y el listado general ven ambas).
3. **Registrador** — `tools/register_external_position.py`, genérico + idempotente + `--dry-run`.

Diferido: `tools/rule_a_check` (diagnóstico offline, no actuador — fuera de la regla del párrafo 4 del spec).

## Tests

14 tests nuevos (cada uno falló primero). Gate completo: **3250 passed, 1 skipped** (selección no-network, paralela).

## Secuencia POST-merge (orden ESTRICTO — no en este PR)

1. **Deploy a prod** (el server crea la columna y activa la exención).
2. **Recién entonces** correr el registrador con las 2 operaciones de papá (tenant 2). Si se registran antes del deploy, el scanner viejo las auto-cierra.

## Spec

`docs/superpowers/specs/es/2026-06-09-posiciones-externas-control-domain-spec.md` (REV 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
