### PR TITLE
feat(tools): set_capital — fija el equity real de un tenant (reset de peak)

### DIFF
--- a/tests/test_set_capital.py
+++ b/tests/test_set_capital.py
@@ -1,0 +1,63 @@
+"""Tests del tool set_capital — fija el equity REAL de un tenant con reset de peak.
+
+El reset del peak es la parte de seguridad: bajar el balance dejando el peak
+viejo (nocional, más alto) haría que el sistema calcule un drawdown falso enorme
+y dispare el kill-switch. set_capital pone balance=peak=equity, dd=0.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+
+@pytest.fixture
+def con(tmp_path):
+    db_path = tmp_path / "cap.db"
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        import btc_api
+        orig = btc_api.DB_FILE
+        btc_api.DB_FILE = str(db_path)
+        try:
+            from db.schema import init_db
+            init_db()
+        finally:
+            btc_api.DB_FILE = orig
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+    c = sqlite3.connect(str(db_path))
+    c.row_factory = sqlite3.Row
+    yield c
+    c.close()
+
+
+def test_set_capital_resets_peak_and_dd(con):
+    """Sobre un row nocional con peak alto, fijar equity resetea peak y DD."""
+    from db.capital import db_upsert_capital
+    from tools.set_capital import set_capital
+
+    db_upsert_capital(con, 2, balance=10095.54, peak_balance=10138.31,
+                      max_drawdown_pct=0.42)
+    con.commit()
+
+    row = set_capital(con, tenant_id=2, equity=2026.0)
+    con.commit()
+
+    assert row["balance"] == 2026.0
+    assert row["peak_balance"] == 2026.0, (
+        "peak debe resetear al nuevo equity; dejar el viejo daría DD falso ~80%"
+    )
+    assert row["max_drawdown_pct"] == 0.0
+
+
+def test_set_capital_creates_if_absent(con):
+    """Tenant sin row de capital: lo crea con balance=peak=equity, dd=0."""
+    from tools.set_capital import set_capital
+
+    row = set_capital(con, tenant_id=7, equity=500.0)
+    con.commit()
+    assert row["balance"] == 500.0
+    assert row["peak_balance"] == 500.0
+    assert row["max_drawdown_pct"] == 0.0

--- a/tools/set_capital.py
+++ b/tools/set_capital.py
@@ -1,0 +1,71 @@
+"""Fija el equity REAL de un tenant en la tabla `capital`.
+
+El balance que la plataforma muestra es NOCIONAL ($10k de arranque + roll-in de
+P&L de trades INTERNAL). Para reflejar la cuenta real del operador (p.ej. el
+total en Binance de papá), este tool fija balance = equity y **resetea el peak
+al mismo valor** con drawdown 0.
+
+El reset del peak NO es opcional: `db_upsert_capital` preserva el peak viejo si
+no se le pasa uno. Bajar el balance dejando el peak nocional (más alto) haría que
+el sistema calcule un drawdown enorme (p.ej. (10138-2026)/10138 ≈ 80%) y dispare
+el kill-switch de portafolio. Por eso peak=equity, dd=0 (baseline real fresco).
+
+Usa la función legítima `db.capital.db_upsert_capital` (NO SQL crudo).
+
+Usage (en el server, contra el DB_FILE de prod):
+    python -m tools.set_capital --tenant 2 --equity 2026 [--dry-run]
+
+Nota de semántica: a partir de aquí el balance es real; los cierres de trades
+INTERNAL futuros rodarán su P&L sobre este valor. Las posiciones EXTERNAL no
+ruedan a capital (CD-1). Re-correr el tool con el equity actualizado de Binance
+es el flujo previsto (el saldo real se mueve).
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+
+from db.capital import db_upsert_capital
+
+
+def set_capital(con: sqlite3.Connection, *, tenant_id: int, equity: float) -> dict:
+    """balance=peak=equity, dd=0. Baseline real fresco (reset de peak obligatorio).
+    El caller posee la transacción y el commit."""
+    return db_upsert_capital(
+        con,
+        tenant_id,
+        balance=float(equity),
+        peak_balance=float(equity),
+        max_drawdown_pct=0.0,
+    )
+
+
+def main() -> int:
+    from db.capital import db_get_capital
+    from db.transaction import transaction
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tenant", type=int, required=True)
+    ap.add_argument("--equity", type=float, required=True)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="no escribe; reporta el antes y el después propuesto")
+    args = ap.parse_args()
+
+    with transaction() as con:
+        before = db_get_capital(con, args.tenant)
+        if args.dry_run:
+            print(f"[dry-run] tenant {args.tenant}: antes={before}")
+            print(f"[dry-run] -> balance={args.equity} peak={args.equity} dd=0.0")
+            raise SystemExit(0)
+        row = set_capital(con, tenant_id=args.tenant, equity=args.equity)
+
+    print(f"capital tenant {args.tenant}: antes balance="
+          f"{before['balance'] if before else None} peak="
+          f"{before['peak_balance'] if before else None}")
+    print(f"capital tenant {args.tenant}: ahora balance={row['balance']} "
+          f"peak={row['peak_balance']} dd={row['max_drawdown_pct']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Qué

Tool reutilizable `tools/set_capital.py` para fijar el **equity real** de un tenant en la tabla `capital`, con **reset de peak** y drawdown 0.

## Por qué

El `balance` de `capital` es **nocional** ($10k de arranque + roll-in de P&L de trades INTERNAL). No refleja la cuenta real del operador (p.ej. el total en Binance de papá, ~2026 USDT vs los ~$10,095 nocionales que muestra hoy). Este tool fija `balance = equity` y resetea `peak_balance = equity`, `max_drawdown_pct = 0`.

**El reset del peak no es opcional:** `db_upsert_capital` preserva el peak viejo si no se le pasa uno. Bajar el balance dejando el peak nocional (más alto) haría que el sistema calcule un drawdown enorme (≈80%) y dispare el kill-switch de portafolio. Por eso el tool fuerza `peak = equity`, `dd = 0` (baseline real fresco).

## Cómo

- `set_capital(con, *, tenant_id, equity)` usa la función legítima `db.capital.db_upsert_capital` (no SQL crudo).
- CLI con `--dry-run`. Reusable: el equity real se mueve, se re-corre con el valor actualizado.
- Las posiciones EXTERNAL no ruedan a capital (CD-1); los cierres INTERNAL futuros sí rodarán su P&L sobre el nuevo balance.

## Tests

2 tests (reset de peak + creación si ausente). Gate completo: **3252 passed, 1 skipped**.

## Post-merge

Correr en el server (post auto-deploy): `python -m tools.set_capital --tenant 2 --equity <real> --dry-run` y luego sin `--dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
