### PR TITLE
fix(positions): control_domain sobrevive las recreaciones de tabla (incidente bolsas papa)

### DIFF
--- a/db/schema.py
+++ b/db/schema.py
@@ -1078,6 +1078,7 @@ def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
             atr_entry   REAL,
             be_mult     REAL,
             tenant_id   INTEGER,
+            control_domain TEXT NOT NULL DEFAULT 'INTERNAL',
             CHECK (qty IS NOT NULL OR status = 'legacy_unmeasurable')
         )
         """
@@ -1089,9 +1090,15 @@ def _migrate_qty_not_null(con: sqlite3.Connection) -> None:
         "entry_ts", "sl_price", "tp_price", "size_usd", "qty",
         "exit_price", "exit_ts", "exit_reason", "pnl_usd", "pnl_pct",
         "notes", "atr_entry", "be_mult", "tenant_id",
+        "control_domain",
     ]
     select_expressions = [
-        col if col in existing_cols else "NULL"
+        # control_domain: NOT NULL DEFAULT 'INTERNAL' — si la fila previa no lo
+        # tiene (DB fresca, primera recreación), cae a 'INTERNAL', no a NULL
+        # (que violaría el NOT NULL). Si lo tiene, COPIA el valor (preserva
+        # EXTERNAL a través de la cascada de recreaciones — incidente 2026-06-09).
+        col if col in existing_cols
+        else ("'INTERNAL'" if col == "control_domain" else "NULL")
         for col in TARGET_COLS
     ]
     insert_sql = (
@@ -1197,6 +1204,7 @@ def _migrate_qty_positive(con: sqlite3.Connection) -> None:
             atr_entry   REAL,
             be_mult     REAL,
             tenant_id   INTEGER,
+            control_domain TEXT NOT NULL DEFAULT 'INTERNAL',
             CHECK ((qty IS NOT NULL AND qty > 0) OR status = 'legacy_unmeasurable')
         )
         """
@@ -1206,9 +1214,15 @@ def _migrate_qty_positive(con: sqlite3.Connection) -> None:
         "entry_ts", "sl_price", "tp_price", "size_usd", "qty",
         "exit_price", "exit_ts", "exit_reason", "pnl_usd", "pnl_pct",
         "notes", "atr_entry", "be_mult", "tenant_id",
+        "control_domain",
     ]
     select_expressions = [
-        col if col in existing_cols else "NULL"
+        # control_domain: NOT NULL DEFAULT 'INTERNAL' — si la fila previa no lo
+        # tiene (DB fresca, primera recreación), cae a 'INTERNAL', no a NULL
+        # (que violaría el NOT NULL). Si lo tiene, COPIA el valor (preserva
+        # EXTERNAL a través de la cascada de recreaciones — incidente 2026-06-09).
+        col if col in existing_cols
+        else ("'INTERNAL'" if col == "control_domain" else "NULL")
         for col in TARGET_COLS
     ]
     insert_sql = (
@@ -1309,6 +1323,7 @@ def _migrate_tenant_id_not_null(con: sqlite3.Connection) -> None:
             atr_entry   REAL,
             be_mult     REAL,
             tenant_id   INTEGER,
+            control_domain TEXT NOT NULL DEFAULT 'INTERNAL',
             CHECK ((qty IS NOT NULL AND qty > 0) OR status = 'legacy_unmeasurable'),
             CHECK (tenant_id IS NOT NULL OR status IN ('legacy_unmeasurable', 'legacy_no_tenant'))
         )
@@ -1319,9 +1334,15 @@ def _migrate_tenant_id_not_null(con: sqlite3.Connection) -> None:
         "entry_ts", "sl_price", "tp_price", "size_usd", "qty",
         "exit_price", "exit_ts", "exit_reason", "pnl_usd", "pnl_pct",
         "notes", "atr_entry", "be_mult", "tenant_id",
+        "control_domain",
     ]
     select_expressions = [
-        col if col in existing_cols else "NULL"
+        # control_domain: NOT NULL DEFAULT 'INTERNAL' — si la fila previa no lo
+        # tiene (DB fresca, primera recreación), cae a 'INTERNAL', no a NULL
+        # (que violaría el NOT NULL). Si lo tiene, COPIA el valor (preserva
+        # EXTERNAL a través de la cascada de recreaciones — incidente 2026-06-09).
+        col if col in existing_cols
+        else ("'INTERNAL'" if col == "control_domain" else "NULL")
         for col in TARGET_COLS
     ]
     insert_sql = (
@@ -1444,6 +1465,7 @@ def _migrate_direction_enum(con: sqlite3.Connection) -> None:
             atr_entry   REAL,
             be_mult     REAL,
             tenant_id   INTEGER,
+            control_domain TEXT NOT NULL DEFAULT 'INTERNAL',
             CHECK ((qty IS NOT NULL AND qty > 0) OR status = 'legacy_unmeasurable'),
             CHECK (tenant_id IS NOT NULL OR status IN ('legacy_unmeasurable', 'legacy_no_tenant')),
             CHECK (direction IN ('LONG', 'SHORT') OR status = 'legacy_unmeasurable')
@@ -1455,9 +1477,15 @@ def _migrate_direction_enum(con: sqlite3.Connection) -> None:
         "entry_ts", "sl_price", "tp_price", "size_usd", "qty",
         "exit_price", "exit_ts", "exit_reason", "pnl_usd", "pnl_pct",
         "notes", "atr_entry", "be_mult", "tenant_id",
+        "control_domain",
     ]
     select_expressions = [
-        col if col in existing_cols else "NULL"
+        # control_domain: NOT NULL DEFAULT 'INTERNAL' — si la fila previa no lo
+        # tiene (DB fresca, primera recreación), cae a 'INTERNAL', no a NULL
+        # (que violaría el NOT NULL). Si lo tiene, COPIA el valor (preserva
+        # EXTERNAL a través de la cascada de recreaciones — incidente 2026-06-09).
+        col if col in existing_cols
+        else ("'INTERNAL'" if col == "control_domain" else "NULL")
         for col in TARGET_COLS
     ]
     insert_sql = (

--- a/tests/test_control_domain.py
+++ b/tests/test_control_domain.py
@@ -83,3 +83,44 @@ def test_migration_idempotent_second_init(tmp_path):
     finally:
         con.close()
     assert len(cd_cols) == 1, "control_domain no debe duplicarse en el segundo init_db"
+
+
+def test_external_survives_reinit_recreations(tmp_path):
+    """Una posición EXTERNAL sobrevive a un segundo init_db.
+
+    Regresión del incidente 2026-06-09: las 4 migraciones recrean la tabla
+    positions en cada boot (cascada de CHECKs) y borraban control_domain →
+    re-default a INTERNAL → la exención dejaba de proteger las bolsas de papá
+    y el scanner las auto-cerraba. control_domain DEBE viajar dentro de las
+    recreaciones (CREATE + TARGET_COLS), no re-añadirse por ALTER después.
+    """
+    con = _fresh_db(tmp_path)
+    con.execute(
+        "INSERT INTO positions (symbol,direction,status,entry_price,entry_ts,"
+        "qty,tenant_id,control_domain) VALUES "
+        "('BTCUSDT','LONG','open',64390,'2026-06-04T00:56:00+00:00',0.01967,2,'EXTERNAL')"
+    )
+    con.commit()
+    con.close()
+
+    import btc_api
+    from db.schema import init_db
+    db_path = tmp_path / "control_domain.db"
+    orig = btc_api.DB_FILE
+    btc_api.DB_FILE = str(db_path)
+    try:
+        init_db()  # simula un deploy restart → corre las recreaciones de tabla
+    finally:
+        btc_api.DB_FILE = orig
+
+    con = sqlite3.connect(str(db_path))
+    try:
+        cd = con.execute(
+            "SELECT control_domain FROM positions WHERE symbol='BTCUSDT'"
+        ).fetchone()[0]
+    finally:
+        con.close()
+    assert cd == "EXTERNAL", (
+        "las recreaciones de init_db resetearon EXTERNAL a INTERNAL (el wipe que "
+        "auto-cerró las bolsas de papá)"
+    )


### PR DESCRIPTION
## Incidente

Tras desplegar el eje `control_domain` (#575) y registrar 2 posiciones EXTERNAL de papá, un deploy posterior **reseteó todas a INTERNAL** → la exención dejó de protegerlas → el scanner las auto-cerró (TIME_LIMIT fantasma; Binance sigue con ellas; P&L falso −$78.59 rodado a capital).

## Causa raíz (confirmada en logs)

Las 4 migraciones (`_migrate_qty_not_null`, `_migrate_qty_positive`, `_migrate_tenant_id_not_null`, `_migrate_direction_enum`) **recrean la tabla `positions` en CADA boot** — cascada: cada una stripea los CHECK de las otras, re-disparándolas. `control_domain` se añadía por ALTER **después** de las recreaciones, así que cada deploy lo borraba y lo re-defaulteaba a `INTERNAL`, perdiendo el marcado EXTERNAL. Es el **blocker B2 que Adrian marcó** en el roast del spec (y que se desestimó por asumir que las recreaciones se saltaban en prod — los logs prueban que NO).

## Fix

`control_domain` viaja **DENTRO de las 4 recreaciones** (en cada `CREATE TABLE positions_new` + sus `TARGET_COLS`), con fallback `'INTERNAL'` (no `NULL`) para DB fresca. Así se **preserva** a través de la cascada en vez de re-defaultearse. El `_migrate_control_domain` ALTER queda como backstop inofensivo.

## Test

`test_external_survives_reinit_recreations`: marca una posición EXTERNAL, corre `init_db` de nuevo (simula el deploy restart → las recreaciones), y asserta que sigue EXTERNAL. Falla sin el fix (reproduce el wipe), pasa con él. Gate **3257 passed, 1 skipped**.

## Post-merge (recovery, fuera de este PR)

Re-registrar las 2 bolsas de papá como EXTERNAL (sobrevivirán ya), revertir el P&L falso del capital, y manejar los cierres fantasma #35/#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
