### PR TITLE
feat(frontend): P&L no realizado en vivo por posicion

### DIFF
--- a/frontend/src/components/PositionsView.tsx
+++ b/frontend/src/components/PositionsView.tsx
@@ -68,6 +68,19 @@ function currentPriceFor(p: Position, symbols: SymbolStatus[]): number {
   return p.entry_price * (1 + (p.pnl_pct ?? 0) / 100);
 }
 
+// P&L NO REALIZADO en vivo de una posición abierta, marcado a `currentPrice`.
+// `pnl_usd`/`pnl_pct` están NULL hasta el cierre (solo se setean al cerrar),
+// así que una abierta mostraría $0.00 — lo computamos contra el precio actual.
+function livePnlFor(p: Position, currentPrice: number): { usd: number; pct: number } {
+  const qty = p.qty ?? 0;
+  const isLong = p.direction === 'LONG';
+  const diff = isLong ? (currentPrice - p.entry_price) : (p.entry_price - currentPrice);
+  return {
+    usd: diff * qty,
+    pct: p.entry_price > 0 ? (diff / p.entry_price) * 100 : 0,
+  };
+}
+
 // ── Main ─────────────────────────────────────────────────────
 
 const PositionsView: React.FC<PositionsViewProps> = ({
@@ -75,11 +88,11 @@ const PositionsView: React.FC<PositionsViewProps> = ({
   onOpenSymbol, onAbrirPosicion, onAskAgent, onEditSlTp, onClosePosition,
   mobile = false,
 }) => {
-  const winningPos = positions.filter((p) => (p.pnl_pct ?? 0) > 0).length;
-  const losingPos  = positions.filter((p) => (p.pnl_pct ?? 0) < 0).length;
+  const winningPos = positions.filter((p) => livePnlFor(p, currentPriceFor(p, symbols)).usd > 0).length;
+  const losingPos  = positions.filter((p) => livePnlFor(p, currentPriceFor(p, symbols)).usd < 0).length;
 
   const metrics = useMemo(() => {
-    const pnlOpen   = positions.reduce((a, p) => a + (p.pnl_usd ?? 0), 0);
+    const pnlOpen   = positions.reduce((a, p) => a + livePnlFor(p, currentPriceFor(p, symbols)).usd, 0);
     const pnlClosed = closedRecent7d.reduce((a, p) => a + (p.pnl_usd ?? 0), 0);
     const wins      = closedRecent7d.filter((p) => (p.pnl_usd ?? 0) > 0).length;
     const losses    = closedRecent7d.length - wins;
@@ -245,8 +258,9 @@ const PositionCard: React.FC<PositionCardProps> = ({
   position: p, currentPrice, onView, onAskAgent, onEditSlTp, onClosePosition,
 }) => {
   const isLong  = p.direction === 'LONG';
-  const pnlPct  = p.pnl_pct ?? 0;
-  const pnlAbs  = p.pnl_usd ?? 0;
+  // P&L no realizado en vivo (abierta): contra el precio actual, no el
+  // pnl_usd/pnl_pct guardado (NULL hasta el cierre).
+  const { usd: pnlAbs, pct: pnlPct } = livePnlFor(p, currentPrice);
   const tone: 'bull' | 'bear' = pnlAbs >= 0 ? 'bull' : 'bear';
   const insight = useMemo(() => getPositionInsight(p, currentPrice), [p, currentPrice]);
 


### PR DESCRIPTION
## Qué

Cada posición abierta ahora muestra su **P&L no realizado en vivo** (verde/rojo), marcado al precio actual — no $0.00.

## Por qué

`PositionCard` mostraba `p.pnl_usd` / `p.pnl_pct`, que están **NULL hasta el cierre** (solo se setean al cerrar). Así, toda posición abierta mostraba $0.00 — desconectado del equity total, que sí está en vivo. (Las bolsas EXTERNAL de papá se veían "en cero" en vez de su pérdida/ganancia real.)

## Cómo

Puro frontend. `currentPriceFor(p, symbols)` ya trae el `live_price` por símbolo. Nuevo helper `livePnlFor(p, currentPrice)` computa `(precio − entrada) × qty × signo`. Se usa en:
- `PositionCard` (el % y el $ por posición, verde/rojo).
- El hero "P&L abierto" (suma en vivo, antes $0).
- Los conteos ganando/perdiendo.

La data (entrada, qty, dirección, live_price) ya estaba disponible — no hubo cambio de backend.

## Tests

Frontend tsc + vitest (135 passed) + build verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
