### PR TITLE
fix(auth): login resiliente a contención del writer-lock (incidente login 500)

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -28,8 +28,11 @@ the cookie.
 """
 from __future__ import annotations
 
+import logging
 import os
 import secrets
+import sqlite3
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -82,6 +85,25 @@ from db.transaction import snapshot_connection, transaction
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+log = logging.getLogger("api.auth")
+
+# ── Writer-lock resilience (prod incident 2026-06-10) ────────────────────────
+# Auth writes share SQLite's single writer lock with the background scanner
+# (same process, same signals.db). During slow/cold scan cycles the scanner's
+# write bursts held the lock long enough that login's BEGIN IMMEDIATE writes
+# timed out and 500-ed for every tenant. We use a short per-attempt busy_timeout
+# + a few retries so an interactive login rides out a burst (bounded worst-case
+# latency) instead of failing; the cosmetic last_login write is best-effort.
+_AUTH_WRITE_BUSY_TIMEOUT_MS = 2000
+_AUTH_WRITE_RETRIES = 4
+_AUTH_WRITE_BACKOFF_SEC = 0.25
+
+
+def _is_db_locked(exc: BaseException) -> bool:
+    """True for SQLite 'database is locked' (transient writer-lock contention),
+    distinguished from real errors (missing table/column) which must surface."""
+    return isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc).lower()
 
 
 # ─── Schemas ────────────────────────────────────────────────────────────────
@@ -255,11 +277,41 @@ def _password_hash_for_email(email: str) -> Optional[str]:
 
 
 def _update_last_login(user_id: int) -> None:
-    with transaction() as con:
-        con.execute(
-            "UPDATE users SET last_login_at = ? WHERE id = ?",
-            (datetime.now(timezone.utc).isoformat(), user_id),
-        )
+    """Best-effort: last_login_at is cosmetic. A writer-lock timeout (scanner
+    contention) must NEVER fail authentication (prod incident 2026-06-10)."""
+    try:
+        with transaction(busy_timeout_ms=_AUTH_WRITE_BUSY_TIMEOUT_MS) as con:
+            con.execute(
+                "UPDATE users SET last_login_at = ? WHERE id = ?",
+                (datetime.now(timezone.utc).isoformat(), user_id),
+            )
+    except sqlite3.OperationalError as exc:
+        if not _is_db_locked(exc):
+            raise
+        log.warning("last_login_at update skipped (DB writer-lock busy): %s", exc)
+
+
+def _persist_refresh_token(user: User, *, user_agent, ip) -> str:
+    """Critical login write. Retries on transient 'database is locked' so a
+    background scanner write-burst does not 500 the login. Bounded worst-case
+    wait (~9.5s); the common case succeeds on the first attempt with no delay.
+    A non-lock error is not retried — it surfaces immediately."""
+    last_exc: Optional[sqlite3.OperationalError] = None
+    for attempt in range(_AUTH_WRITE_RETRIES):
+        try:
+            with transaction(busy_timeout_ms=_AUTH_WRITE_BUSY_TIMEOUT_MS) as con:
+                return create_refresh_token(con, user, user_agent=user_agent, ip=ip)
+        except sqlite3.OperationalError as exc:
+            if not _is_db_locked(exc):
+                raise
+            last_exc = exc
+            log.warning(
+                "refresh-token write contended (attempt %d/%d): %s",
+                attempt + 1, _AUTH_WRITE_RETRIES, exc,
+            )
+            time.sleep(_AUTH_WRITE_BACKOFF_SEC * (attempt + 1))
+    assert last_exc is not None  # loop ran ≥1 time
+    raise last_exc
 
 
 # ─── Routes ─────────────────────────────────────────────────────────────────
@@ -344,8 +396,7 @@ def login(request: Request, response: Response, body: LoginRequest):
     _update_last_login(user.id)
 
     access_token = create_access_token(user)
-    with transaction() as con:
-        refresh_token = create_refresh_token(con, user, user_agent=ua, ip=ip)
+    refresh_token = _persist_refresh_token(user, user_agent=ua, ip=ip)
     csrf_token = secrets.token_urlsafe(32)
 
     _set_auth_cookies(

--- a/api/auth.py
+++ b/api/auth.py
@@ -294,8 +294,9 @@ def _update_last_login(user_id: int) -> None:
 def _persist_refresh_token(user: User, *, user_agent, ip) -> str:
     """Critical login write. Retries on transient 'database is locked' so a
     background scanner write-burst does not 500 the login. Bounded worst-case
-    wait (~9.5s); the common case succeeds on the first attempt with no delay.
-    A non-lock error is not retried — it surfaces immediately."""
+    wait ~9.5s (4×2s busy_timeout + 0.25/0.5/0.75s backoffs), blocking one
+    threadpool worker; the common case succeeds on the first attempt with no
+    delay. A non-lock error is not retried — it surfaces immediately."""
     last_exc: Optional[sqlite3.OperationalError] = None
     for attempt in range(_AUTH_WRITE_RETRIES):
         try:
@@ -309,7 +310,8 @@ def _persist_refresh_token(user: User, *, user_agent, ip) -> str:
                 "refresh-token write contended (attempt %d/%d): %s",
                 attempt + 1, _AUTH_WRITE_RETRIES, exc,
             )
-            time.sleep(_AUTH_WRITE_BACKOFF_SEC * (attempt + 1))
+            if attempt < _AUTH_WRITE_RETRIES - 1:  # no backoff after the last try
+                time.sleep(_AUTH_WRITE_BACKOFF_SEC * (attempt + 1))
     assert last_exc is not None  # loop ran ≥1 time
     raise last_exc
 

--- a/db/connection.py
+++ b/db/connection.py
@@ -69,13 +69,18 @@ class _DictRow(tuple):
         return self._mapping.keys()
 
 
-def _open_configured_connection() -> sqlite3.Connection:
+def _open_configured_connection(busy_timeout_ms: int = 15000) -> sqlite3.Connection:
     """Open a configured sqlite3.Connection.
 
     PRIVATE. Use db.transaction.transaction() for all data access.
 
     isolation_level=None disables Python's implicit transaction management
     so transaction() can drive BEGIN/COMMIT/ROLLBACK explicitly.
+
+    `busy_timeout_ms` defaults to 15000 (see comment below). Interactive
+    endpoints that retry on contention (e.g. auth writes, prod incident
+    2026-06-10) pass a shorter per-attempt timeout so total latency stays
+    bounded across retries instead of blocking 15s on a single attempt.
     """
     db_file = _resolve_db_file()
     con = sqlite3.connect(db_file, isolation_level=None)
@@ -88,7 +93,7 @@ def _open_configured_connection() -> sqlite3.Connection:
     # use snapshot_connection() (WAL-concurrent, no writer lock) — this longer
     # timeout is the safety net for the writes + any remaining BEGIN IMMEDIATE
     # readers. Do NOT lower below 15000 without addressing the write-burst load.
-    con.execute("PRAGMA busy_timeout = 15000")
+    con.execute(f"PRAGMA busy_timeout = {int(busy_timeout_ms)}")
     return con
 
 

--- a/db/transaction.py
+++ b/db/transaction.py
@@ -34,10 +34,13 @@ SnapshotConn = NewType("SnapshotConn", sqlite3.Connection)
 
 
 @contextmanager
-def transaction() -> Iterator[sqlite3.Connection]:
+def transaction(busy_timeout_ms: int | None = None) -> Iterator[sqlite3.Connection]:
     """Open a connection, BEGIN IMMEDIATE, COMMIT on success, ROLLBACK on exception, ALWAYS close.
 
-    The yielded sqlite3.Connection has dict-row factory and PRAGMA busy_timeout=5000.
+    The yielded sqlite3.Connection has dict-row factory and PRAGMA busy_timeout
+    (default 15000 ms; see db.connection). `busy_timeout_ms` lets an interactive
+    caller that retries on contention use a shorter per-attempt timeout so total
+    latency stays bounded across retries (auth writes, prod incident 2026-06-10).
 
     Caller contract:
     - MAY use con.execute / executemany / executescript / cursor.
@@ -58,7 +61,11 @@ def transaction() -> Iterator[sqlite3.Connection]:
       (sqlite may have already aborted the tx on certain errors), the
       original exception is preserved and ROLLBACK's error is logged at DEBUG.
     """
-    con = _open_configured_connection()
+    con = (
+        _open_configured_connection()
+        if busy_timeout_ms is None
+        else _open_configured_connection(busy_timeout_ms)
+    )
     try:
         con.execute("BEGIN IMMEDIATE")
         try:

--- a/tests/test_auth_lock_resilience.py
+++ b/tests/test_auth_lock_resilience.py
@@ -1,0 +1,116 @@
+"""Regression: login must survive SQLite writer-lock contention.
+
+Prod incident 2026-06-10: the background scanner (same process, same
+`signals.db`) monopolised the single SQLite writer lock during slow/cold scan
+cycles. Login's two `BEGIN IMMEDIATE` writes — `_update_last_login` (cosmetic)
+and the refresh-token INSERT (critical) — timed out and raised
+`sqlite3.OperationalError: database is locked`, which fell through to a 500
+for EVERY tenant. Traceback died at api/auth.py:344 `_update_last_login`.
+
+Fix contract:
+- `_update_last_login` is best-effort: a writer-lock timeout must NEVER fail
+  authentication (last_login_at is cosmetic).
+- the refresh-token write retries on transient "database is locked" so an
+  interactive login rides out a scanner write-burst instead of 500-ing.
+- a NON-lock DB error is NOT swallowed (real bugs must still surface).
+"""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timezone
+
+import pytest
+
+from auth.password import hash_password
+
+
+def _create_user(client, email, password, role="admin") -> int:
+    from db.transaction import transaction
+
+    now = datetime.now(timezone.utc).isoformat()
+    with transaction() as con:
+        cur = con.execute(
+            "INSERT INTO users (email, password_hash, role, is_active, "
+            "created_at, password_changed_at) VALUES (?, ?, ?, 1, ?, ?)",
+            (email.lower(), hash_password(password), role, now, now),
+        )
+        return int(cur.lastrowid)
+
+
+def _login(client, email, password):
+    return client.post("/auth/login", json={"email": email, "password": password})
+
+
+_PW = "correct horse battery staple"
+
+
+def test_login_survives_transient_writer_lock(unauthed_client, monkeypatch):
+    """Scanner holds the writer lock for the last_login write + the first
+    refresh-token attempts; login must still succeed (best-effort + retry)."""
+    _create_user(unauthed_client, "lock1@example.com", _PW)
+
+    import api.auth
+
+    real_tx = api.auth.transaction
+    state = {"n": 0}
+
+    @contextmanager
+    def contended_tx(*args, **kwargs):
+        state["n"] += 1
+        # Calls: 1 = _update_last_login, 2..3 = refresh-token attempts 1..2.
+        # All contended; the lock frees by the refresh-token's 3rd attempt.
+        if state["n"] <= 3:
+            raise sqlite3.OperationalError("database is locked")
+        with real_tx(*args, **kwargs) as con:
+            yield con
+
+    monkeypatch.setattr(api.auth, "transaction", contended_tx)
+
+    resp = _login(unauthed_client, "lock1@example.com", _PW)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["user"]["email"] == "lock1@example.com"
+
+
+def test_login_succeeds_when_only_last_login_is_contended(unauthed_client, monkeypatch):
+    """Best-effort: a writer-lock timeout on the cosmetic last_login write
+    must not fail login; the critical refresh-token write still runs."""
+    _create_user(unauthed_client, "lock2@example.com", _PW)
+
+    import api.auth
+
+    real_tx = api.auth.transaction
+    state = {"n": 0}
+
+    @contextmanager
+    def first_call_locked(*args, **kwargs):
+        state["n"] += 1
+        if state["n"] == 1:  # only the last_login write
+            raise sqlite3.OperationalError("database is locked")
+        with real_tx(*args, **kwargs) as con:
+            yield con
+
+    monkeypatch.setattr(api.auth, "transaction", first_call_locked)
+
+    resp = _login(unauthed_client, "lock2@example.com", _PW)
+    assert resp.status_code == 200, resp.text
+
+
+def test_login_does_not_swallow_non_lock_db_errors(unauthed_client, monkeypatch):
+    """A real (non-lock) DB error must surface, not be hidden by the
+    lock-resilience handling."""
+    _create_user(unauthed_client, "lock3@example.com", _PW)
+
+    import api.auth
+
+    @contextmanager
+    def broken_tx(*args, **kwargs):
+        raise sqlite3.OperationalError("no such table: users")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(api.auth, "transaction", broken_tx)
+
+    # The non-lock error must NOT be swallowed — it propagates (surfaces as a
+    # 500). TestClient (raise_server_exceptions=True) re-raises it here.
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        _login(unauthed_client, "lock3@example.com", _PW)


### PR DESCRIPTION
## Incidente
Login devolvía **500 para todos los tenants**. Traceback de prod: `api/auth.py:344 _update_last_login → transaction → BEGIN IMMEDIATE → sqlite3.OperationalError: database is locked`.

## Causa raíz (confirmada: traceback + journal del server)
El scanner corre en el **mismo proceso** y comparte **una sola** `signals.db` (655 MB). En ciclos de scan lentos/fríos (red a Binance ~3 min/símbolo → ciclos de ~24 min vs ~21s normales), su actividad de escritura **monopoliza el único writer-lock** de SQLite. Las dos escrituras `BEGIN IMMEDIATE` del login timean (15s) → excepción sin manejar → 500. **Mismo class que 2026-05-29** (documentado en `db/connection.py:83-91`); reincide porque la DB creció (460→655 MB).

## Qué arregla este PR (login)
- `_update_last_login` → **best-effort** (campo cosmético; un lock-timeout nunca debe tumbar la auth).
- `_persist_refresh_token` → **retry acotado** ante `database is locked`, con `busy_timeout` corto por intento (worst-case ~9.5s; caso común = primer intento, 0 delay).
- `transaction()` / `_open_configured_connection()` → param opcional `busy_timeout_ms` (default 15000, **backward-compatible**; verificado contra todos los callers).
- Un error **no-lock** (p.ej. `no such table`) se propaga; no se traga.

## Alcance honesto (NO es el fix completo)
- `/refresh`, `/logout`, `change_password` hacen escrituras con el **mismo** writer-lock → comparten la vulnerabilidad. **Fuera de este PR** (el incidente reportado fue login). **Follow-up recomendado.**
- **El fix sistémico real** (que cura a todos): reducir la presión de escritura del scanner / por qué los ciclos se ponen fríos. Issue aparte.

## Tests / verificación
- `tests/test_auth_lock_resilience.py` (nuevo): reproduce la contención — retry + best-effort + no-tragar-errores-reales.
- Gate `pytest -m "not network" -n auto`: **3259 passed, 1 skipped**. Único rojo: `test_login_constant_time_within_150ms` — **flake de timing** bajo `-n auto` (pasa **3/3** aislado; el código nuevo vive en la ruta de login EXITOSO, ese test mide rutas de FALLO). No introducido por este PR.
- Revisión adversarial independiente: sin regresión de seguridad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)