### PR TITLE
hotfix(dossier): el prompt de extracción especifica el esquema JSON exacto

### DIFF
--- a/research/dossier.py
+++ b/research/dossier.py
@@ -29,9 +29,18 @@ _DOMINIOS = {
 
 EXTRACTION_PROMPT = (
     "Sos un EXTRACTOR de hechos, no un analista. Te doy contenido web con sus "
-    "URLs. Llená el JSON del esquema SOLO con hechos presentes en el contenido, "
-    "y para cada hecho poné en `fuente` la URL exacta de donde lo sacaste. Si un "
-    "hecho no está en el contenido, omitilo (no lo inventes). "
+    "URLs. Devolvé UN JSON con EXACTAMENTE estas claves (sin agregar otras):\n"
+    '{"equipo": [{"nombre": "", "rol": "", "enlaces": [], "fuente": "URL"}], '
+    '"equipo_identificado": true, '
+    '"presencia": {"sitio_web": {"url": "", "activo": "si|no|desconocido", "fuente": "URL"}, '
+    '"github": {...}, "twitter": {...}, "telegram_discord": {...}, "whitepaper": {...}}, '
+    '"actividad": {"ultimo_commit_github": {"valor": "", "fuente": "URL"}, '
+    '"ultimo_release": {...}, "ultimo_post_anuncio": {...}}, '
+    '"financiacion": [{"descripcion": "ronda/monto/inversores", "fecha": "", "fuente": "URL"}], '
+    '"hitos": [{"descripcion": "", "fecha": "", "fuente": "URL"}]}\n'
+    "Para cada hecho, `fuente` DEBE ser la URL EXACTA, copiada tal cual, de uno de "
+    "los bloques `URL:` que te di. Si un hecho no está en el contenido, omitilo (no "
+    "lo inventes); omití también las claves de presencia/actividad que no encuentres. "
     "PROHIBIDO: opinar, evaluar, recomendar, predecir, calificar el proyecto, o "
     "agregar cualquier campo que no esté en el esquema. Devolvé SOLO el JSON."
 )

--- a/tests/test_dossier_build.py
+++ b/tests/test_dossier_build.py
@@ -96,3 +96,12 @@ def test_extract_no_dict_es_no_disponible():
         return ["esto no es un dict"]   # crudo.get(...) → AttributeError
     d = build_dossier("ADAUSDT", exa_search=_exa_ok, extract_fn=extract)
     assert d.estado_general == "no_disponible"
+
+
+def test_prompt_incluye_el_esquema_objetivo():
+    # Regresión: DeepSeek necesita las claves EXACTAS del esquema en el prompt, o
+    # inventa su propia estructura (devolvió {"hechos": ...} → todo opaco en prod).
+    p = EXTRACTION_PROMPT
+    for clave in ("equipo", "equipo_identificado", "presencia", "actividad",
+                  "financiacion", "hitos"):
+        assert f'"{clave}"' in p, f"el prompt debe especificar la clave {clave!r}"


### PR DESCRIPTION
## Summary

Hotfix descubierto en la validación end-to-end de C en prod (#586). El dossier de Cardano (ADA) salía **`opaco`** pese a que Exa devolvía 8 resultados excelentes (73 KB de Wikipedia de Hoskinson/Cardano, etc.).

**Causa raíz:** el `EXTRACTION_PROMPT` decía "llená el JSON del esquema" pero **nunca le pasaba el esquema** a DeepSeek. Sin la estructura objetivo, DeepSeek inventaba su propia forma (`{"hechos": ...}` con `equipo=null`), así que `crudo.get("equipo")` era `None` y todo se descartaba → `opaco`. Los tests con red mockeada no lo atrapaban porque el `extract_fn` mock devolvía la estructura correcta a mano.

**Fix:** el prompt ahora incluye el esquema JSON exacto (claves `equipo`/`equipo_identificado`/`presencia`/`actividad`/`financiacion`/`hitos` con sus sub-formas) y refuerza que `fuente` debe ser la URL exacta copiada de los bloques de Exa (para el candado anti-alucinación).

**Validado contra Exa+DeepSeek reales** en el servidor antes de mergear: ADA ahora extrae **9 miembros del equipo** (Charles Hoskinson co-fundador de IOHK/Cardano, Jeremy Wood, etc.), todos con fuentes que matchean el url_set de Exa → el candado los acepta.

Test de regresión añadido: el prompt debe contener las claves del esquema (si alguien las quita, el test falla).

## Test Plan

- [x] `python -m pytest tests/test_dossier_build.py -q` → 9 passed (8 previos + regresión)
- [x] Validación con red real: ADA pasa de `opaco` (0 hechos) a extraer 9 miembros del equipo con fuentes ancladas
- [ ] Post-merge: re-correr el dossier de ADA vía el endpoint (con auth) y confirmar `estado_general: rastreable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)