### PR TITLE
feat: El Instrumento Fase 3a — el lazo vivo (pull-only)

### DIFF
--- a/api/plan.py
+++ b/api/plan.py
@@ -6,11 +6,14 @@ from __future__ import annotations
 
 import json
 import logging
-import sqlite3
+import requests
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 
+from api.deps import verify_api_key
+from api.levels import BinanceUnavailable
 from auth.dependencies import get_current_tenant_id
 from screener.sr_levels import detect_levels
 from instrument.plan import derive_plan
@@ -20,6 +23,12 @@ from db.transaction import snapshot_connection, transaction
 
 log = logging.getLogger("api.plan")
 router = APIRouter(tags=["plan"])
+
+
+class PlanConfirmRequest(BaseModel):
+    symbol: str
+    entry_price: float
+    position_id: int | None = None
 
 
 def _zonas_now(symbol: str) -> list[dict]:
@@ -59,19 +68,30 @@ def construir_hechos(*, rungs_llenos: list, be_movido: bool, estado_vivo: str,
 @router.get("/plan/derive/{symbol}", summary="Deriva el plan desde D.1 (NO persiste)")
 def derive(symbol: str, entry_price: float = Query(...)) -> dict:
     """El operador revisa el plan antes de confirmarlo. NO escribe nada."""
-    zonas = _zonas_now(symbol.upper())
+    symbol = symbol.upper()[:20]
+    try:
+        zonas = _zonas_now(symbol)
+    except (requests.RequestException, BinanceUnavailable, RuntimeError) as e:
+        log.warning("PLAN_DERIVE_NO_DISPONIBLE symbol=%s causa=%s", symbol, e)
+        raise HTTPException(status_code=503, detail="Binance no disponible — reintentá")
     return _plan_payload(derive_plan(zonas, entry_price))
 
 
-@router.post("/plan/confirm", summary="Confirma el plan revisado → crea la fila viva")
-def confirm(payload: dict, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
+@router.post("/plan/confirm", dependencies=[Depends(verify_api_key)],  # TODO(auth-cleanup): añadir require_role("admin") cuando se barra el resto de writes
+             summary="Confirma el plan revisado → crea la fila viva")
+def confirm(req: PlanConfirmRequest, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
     """El operador confirma en frío. Crea la fila lifecycle_states. La red (D.1)
     corre FUERA de la tx corta del insert."""
-    symbol = str(payload["symbol"]).upper()
-    entry_price = float(payload["entry_price"])
-    position_id = payload.get("position_id")
+    symbol = req.symbol.upper()[:20]
+    entry_price = req.entry_price
+    position_id = req.position_id
 
-    zonas = _zonas_now(symbol)
+    try:
+        zonas = _zonas_now(symbol)
+    except (requests.RequestException, BinanceUnavailable, RuntimeError) as e:
+        log.warning("PLAN_DERIVE_NO_DISPONIBLE symbol=%s causa=%s", symbol, e)
+        raise HTTPException(status_code=503, detail="Binance no disponible — reintentá")
+
     plan = derive_plan(zonas, entry_price)
     state = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=plan.sl_price)
     now = datetime.now(timezone.utc).isoformat()
@@ -88,9 +108,8 @@ def confirm(payload: dict, tenant_id: int = Depends(get_current_tenant_id)) -> d
 def vista(symbol: str, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
     """PULL: el estado vivo. Hechos, nunca instrucciones. Sin plan activo →
     estado_vivo None (la UI muestra 'sin plan')."""
-    symbol = symbol.upper()
+    symbol = symbol.upper()[:20]
     with snapshot_connection() as con:
-        con.row_factory = sqlite3.Row
         row = db_get_active_state(con, tenant_id=tenant_id, symbol=symbol)
     if row is None:
         return {"symbol": symbol, "estado_vivo": None}

--- a/api/plan.py
+++ b/api/plan.py
@@ -1,0 +1,109 @@
+"""API del plan vivo (instrumento F3a) — gate (derive/confirm) + vista (pull).
+
+PULL-ONLY: ningún endpoint emite push ni instrucción. Read-only sobre positions;
+escribe solo lifecycle_states. La red (D.1) corre fuera de tx. Spec §4/§6/§9."""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+
+from auth.dependencies import get_current_tenant_id
+from screener.sr_levels import detect_levels
+from instrument.plan import derive_plan
+from instrument.lifecycle import LifecycleState
+from db.lifecycle_states import db_put_state, db_get_active_state, plan_from_json
+from db.transaction import snapshot_connection, transaction
+
+log = logging.getLogger("api.plan")
+router = APIRouter(tags=["plan"])
+
+
+def _zonas_now(symbol: str) -> list[dict]:
+    """Zonas de D.1 con velas diarias hasta ahora (red, fuera de tx). Aislado
+    para mockear; reutiliza el fetch del endpoint de niveles."""
+    from api.levels import _fetch_daily_bars
+    return detect_levels(_fetch_daily_bars(symbol))
+
+
+def _plan_payload(plan) -> dict:
+    return {"entry": plan.entry_price,
+            "sl_plan": plan.sl_price,
+            "rungs": [{"tp_price": r.tp_price, "size_frac": r.size_frac} for r in plan.rungs],
+            "runner_frac": plan.runner_frac,
+            "entry_zone": plan.entry_zone}
+
+
+def construir_hechos(*, rungs_llenos: list, be_movido: bool, estado_vivo: str,
+                     sl_actual, sl_plan) -> list[str]:
+    """HECHOS de 𝓕ₜ — lo que ES verdad. NUNCA instrucciones (Axiom-0, spec §0).
+    Sin imperativos: el instrumento queda fuera del término que mide."""
+    hechos: list[str] = []
+    if estado_vivo == "incierto":
+        hechos.append("transición sin confirmar — revisá en Binance")
+    for i in sorted(rungs_llenos):
+        hechos.append(f"TP{i + 1} se llenó")
+    if be_movido:
+        hechos.append("tu SL está en break-even")
+    elif sl_actual is not None and sl_plan is not None:
+        if sl_actual <= sl_plan * (1 + 1e-9):
+            hechos.append("tu SL sigue debajo de la zona")
+        else:
+            hechos.append("tu SL está por encima del nivel del plan")
+    return hechos
+
+
+@router.get("/plan/derive/{symbol}", summary="Deriva el plan desde D.1 (NO persiste)")
+def derive(symbol: str, entry_price: float = Query(...)) -> dict:
+    """El operador revisa el plan antes de confirmarlo. NO escribe nada."""
+    zonas = _zonas_now(symbol.upper())
+    return _plan_payload(derive_plan(zonas, entry_price))
+
+
+@router.post("/plan/confirm", summary="Confirma el plan revisado → crea la fila viva")
+def confirm(payload: dict, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
+    """El operador confirma en frío. Crea la fila lifecycle_states. La red (D.1)
+    corre FUERA de la tx corta del insert."""
+    symbol = str(payload["symbol"]).upper()
+    entry_price = float(payload["entry_price"])
+    position_id = payload.get("position_id")
+
+    zonas = _zonas_now(symbol)
+    plan = derive_plan(zonas, entry_price)
+    state = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=plan.sl_price)
+    now = datetime.now(timezone.utc).isoformat()
+
+    with transaction() as con:
+        db_put_state(con, position_id=position_id, symbol=symbol, tenant_id=tenant_id,
+                     estado_vivo="activo", plan=plan, state=state, entry_price=entry_price,
+                     qty_original=None, events=[], prev_observed=[], prev_qty=None,
+                     confirmed_at=now, updated_at=now)
+    return {"symbol": symbol, "estado_vivo": "activo", "plan": _plan_payload(plan)}
+
+
+@router.get("/plan/{symbol}", summary="Estado vivo del plan (pull, solo hechos)")
+def vista(symbol: str, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
+    """PULL: el estado vivo. Hechos, nunca instrucciones. Sin plan activo →
+    estado_vivo None (la UI muestra 'sin plan')."""
+    symbol = symbol.upper()
+    with snapshot_connection() as con:
+        con.row_factory = sqlite3.Row
+        row = db_get_active_state(con, tenant_id=tenant_id, symbol=symbol)
+    if row is None:
+        return {"symbol": symbol, "estado_vivo": None}
+    plan = plan_from_json(row["plan_json"])
+    rungs_llenos = json.loads(row["rungs_llenos_json"])
+    hechos = construir_hechos(rungs_llenos=rungs_llenos, be_movido=bool(row["be_movido"]),
+                              estado_vivo=row["estado_vivo"], sl_actual=row["sl_actual"],
+                              sl_plan=plan.sl_price)
+    return {
+        "symbol": symbol, "estado_vivo": row["estado_vivo"],
+        "plan": _plan_payload(plan),
+        "realidad": {"fase": row["fase"], "rungs_llenos": rungs_llenos,
+                     "sl_actual": row["sl_actual"], "be_movido": bool(row["be_movido"]),
+                     "size_restante_frac": row["size_restante_frac"]},
+        "hechos": hechos,
+    }

--- a/api/plan.py
+++ b/api/plan.py
@@ -86,6 +86,14 @@ def confirm(req: PlanConfirmRequest, tenant_id: int = Depends(get_current_tenant
     entry_price = req.entry_price
     position_id = req.position_id
 
+    if position_id is not None:
+        with snapshot_connection() as con:
+            r = con.execute("SELECT origin FROM positions WHERE id=? AND tenant_id=?",
+                            (position_id, tenant_id)).fetchone()
+        if r is not None and r[0] == "AUTO_DERIVED":
+            raise HTTPException(status_code=422,
+                                detail="posición AUTO_DERIVED no admite plan de conducta (BNC-12)")
+
     try:
         zonas = _zonas_now(symbol)
     except (requests.RequestException, BinanceUnavailable, RuntimeError) as e:

--- a/btc_api.py
+++ b/btc_api.py
@@ -90,6 +90,7 @@ from api.agent.history import router as agent_history_router
 from api.valleys import router as valleys_router
 from api.dossier import router as dossier_router
 from api.levels import router as levels_router
+from api.plan import router as plan_router
 from btc_scanner import scan  # noqa: F401 — patch("btc_api.scan", ...) in test_api.py line 421
 from data import market_data as md  # used directly at line 145; patch.object(btc_api.md) in test_api.py
 # DB_FILE: monkeypatched as btc_api.DB_FILE by ~25 test files to redirect SQLite path
@@ -310,6 +311,7 @@ app.include_router(agent_history_router)
 app.include_router(valleys_router)
 app.include_router(dossier_router)
 app.include_router(levels_router)
+app.include_router(plan_router)
 
 
 @app.get("/", summary="Bienvenida y estado general")

--- a/db/lifecycle_states.py
+++ b/db/lifecycle_states.py
@@ -10,6 +10,15 @@ import sqlite3
 from instrument.plan import Plan, Rung
 from instrument.lifecycle import LifecycleState
 
+# Columnas explícitas (mismo patrón que db/conduct_episodes.py _COLS).
+# Incluye close_reason para que los callers reciban dicts independientes
+# del row_factory configurado en la conexión.
+_COLS = ("id, position_id, symbol, tenant_id, estado_vivo, plan_json, "
+         "entry_price, qty_original, fase, rungs_llenos_json, "
+         "consumed_orders_json, sl_actual, be_movido, size_restante_frac, "
+         "close_reason, events_json, prev_observed_json, prev_qty, "
+         "confirmed_at, updated_at")
+
 
 def plan_to_json(plan: Plan) -> str:
     return json.dumps({
@@ -22,10 +31,13 @@ def plan_to_json(plan: Plan) -> str:
 
 def plan_from_json(s: str) -> Plan:
     d = json.loads(s)
-    rungs = tuple(Rung(tp_price=r["tp_price"], size_frac=r["size_frac"],
-                       zona_origen=r["zona_origen"]) for r in d["rungs"])
-    return Plan(entry_price=d["entry_price"], entry_zone=d["entry_zone"],
-                sl_price=d["sl_price"], rungs=rungs, runner_frac=d["runner_frac"])
+    try:
+        rungs = tuple(Rung(tp_price=r["tp_price"], size_frac=r["size_frac"],
+                           zona_origen=r["zona_origen"]) for r in d["rungs"])
+        return Plan(entry_price=d["entry_price"], entry_zone=d["entry_zone"],
+                    sl_price=d["sl_price"], rungs=rungs, runner_frac=d["runner_frac"])
+    except KeyError as e:
+        raise ValueError(f"plan_from_json: campo faltante {e} en el plan almacenado") from e
 
 
 def state_to_row(state: LifecycleState) -> dict:
@@ -35,18 +47,18 @@ def state_to_row(state: LifecycleState) -> dict:
         "consumed_orders_json": json.dumps(sorted(state.consumed_order_ids)),
         "sl_actual": state.sl_actual, "be_movido": int(state.be_movido),
         "size_restante_frac": state.size_restante_frac,
+        "close_reason": state.close_reason,
     }
 
 
-def state_from_row(row) -> LifecycleState:
-    def g(key):
-        return row[key]
+def state_from_row(row: dict) -> LifecycleState:
     return LifecycleState(
-        plan_id=0, fase=g("fase"),
-        rungs_llenos=frozenset(json.loads(g("rungs_llenos_json"))),
-        consumed_order_ids=frozenset(json.loads(g("consumed_orders_json"))),
-        sl_actual=g("sl_actual"), be_movido=bool(g("be_movido")),
-        size_restante_frac=g("size_restante_frac"),
+        plan_id=0, fase=row["fase"],
+        rungs_llenos=frozenset(json.loads(row["rungs_llenos_json"])),
+        consumed_order_ids=frozenset(json.loads(row["consumed_orders_json"])),
+        sl_actual=row["sl_actual"], be_movido=bool(row["be_movido"]),
+        size_restante_frac=row["size_restante_frac"],
+        close_reason=row["close_reason"],
     )
 
 
@@ -54,32 +66,42 @@ def db_put_state(con: sqlite3.Connection, *, position_id, symbol, tenant_id, est
                  plan, state, entry_price, qty_original, events, prev_observed, prev_qty,
                  confirmed_at, updated_at) -> None:
     r = state_to_row(state)
+    # Supersede cualquier fila activa/incierta previa para el mismo (tenant, symbol)
+    # de modo que db_list_active nunca devuelva dos filas para el mismo símbolo.
+    con.execute(
+        "UPDATE lifecycle_states SET estado_vivo='cerrado', updated_at=? "
+        "WHERE tenant_id=? AND symbol=? AND estado_vivo IN ('activo','incierto')",
+        (updated_at, tenant_id, symbol))
     con.execute(
         """INSERT INTO lifecycle_states
            (position_id, symbol, tenant_id, estado_vivo, plan_json, entry_price,
             qty_original, fase, rungs_llenos_json, consumed_orders_json, sl_actual,
-            be_movido, size_restante_frac, events_json, prev_observed_json, prev_qty,
-            confirmed_at, updated_at)
-           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+            be_movido, size_restante_frac, close_reason, events_json,
+            prev_observed_json, prev_qty, confirmed_at, updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         (position_id, symbol, tenant_id, estado_vivo, plan_to_json(plan), entry_price,
          qty_original, r["fase"], r["rungs_llenos_json"], r["consumed_orders_json"],
-         r["sl_actual"], r["be_movido"], r["size_restante_frac"], json.dumps(events),
-         json.dumps(prev_observed), prev_qty, confirmed_at, updated_at))
+         r["sl_actual"], r["be_movido"], r["size_restante_frac"], r["close_reason"],
+         json.dumps(events), json.dumps(prev_observed), prev_qty, confirmed_at, updated_at))
 
 
 def db_get_active_state(con: sqlite3.Connection, *, tenant_id: int, symbol: str):
     cur = con.execute(
-        "SELECT * FROM lifecycle_states WHERE tenant_id=? AND symbol=? "
+        f"SELECT {_COLS} FROM lifecycle_states WHERE tenant_id=? AND symbol=? "
         "AND estado_vivo IN ('activo','incierto') ORDER BY confirmed_at DESC LIMIT 1",
         (tenant_id, symbol))
-    return cur.fetchone()
+    cols = [c[0] for c in cur.description]
+    row = cur.fetchone()
+    return dict(zip(cols, row)) if row else None
 
 
-def db_list_active(con: sqlite3.Connection, *, tenant_id: int) -> list:
+def db_list_active(con: sqlite3.Connection, *, tenant_id: int) -> list[dict]:
     cur = con.execute(
-        "SELECT * FROM lifecycle_states WHERE tenant_id=? AND estado_vivo IN ('activo','incierto')",
+        f"SELECT {_COLS} FROM lifecycle_states "
+        "WHERE tenant_id=? AND estado_vivo IN ('activo','incierto')",
         (tenant_id,))
-    return cur.fetchall()
+    cols = [c[0] for c in cur.description]
+    return [dict(zip(cols, row)) for row in cur.fetchall()]
 
 
 def db_update_state(con: sqlite3.Connection, *, row_id, estado_vivo, state, events,
@@ -88,8 +110,9 @@ def db_update_state(con: sqlite3.Connection, *, row_id, estado_vivo, state, even
     con.execute(
         """UPDATE lifecycle_states SET estado_vivo=?, fase=?, rungs_llenos_json=?,
                consumed_orders_json=?, sl_actual=?, be_movido=?, size_restante_frac=?,
-               events_json=?, prev_observed_json=?, prev_qty=?, updated_at=?
+               close_reason=?, events_json=?, prev_observed_json=?, prev_qty=?,
+               updated_at=?
            WHERE id=?""",
         (estado_vivo, r["fase"], r["rungs_llenos_json"], r["consumed_orders_json"],
-         r["sl_actual"], r["be_movido"], r["size_restante_frac"], json.dumps(events),
-         json.dumps(prev_observed), prev_qty, updated_at, row_id))
+         r["sl_actual"], r["be_movido"], r["size_restante_frac"], r["close_reason"],
+         json.dumps(events), json.dumps(prev_observed), prev_qty, updated_at, row_id))

--- a/db/lifecycle_states.py
+++ b/db/lifecycle_states.py
@@ -1,0 +1,95 @@
+"""Domicilio del estado vivo del plan (instrumento F3a) — serialización + SQL.
+
+Serializa Plan/LifecycleState ↔ JSON (frozensets ↔ listas) y persiste una fila
+por plan activo. Helpers SQL puros (reciben `con`). Spec §3."""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from instrument.plan import Plan, Rung
+from instrument.lifecycle import LifecycleState
+
+
+def plan_to_json(plan: Plan) -> str:
+    return json.dumps({
+        "entry_price": plan.entry_price, "entry_zone": plan.entry_zone,
+        "sl_price": plan.sl_price, "runner_frac": plan.runner_frac,
+        "rungs": [{"tp_price": r.tp_price, "size_frac": r.size_frac,
+                   "zona_origen": r.zona_origen} for r in plan.rungs],
+    })
+
+
+def plan_from_json(s: str) -> Plan:
+    d = json.loads(s)
+    rungs = tuple(Rung(tp_price=r["tp_price"], size_frac=r["size_frac"],
+                       zona_origen=r["zona_origen"]) for r in d["rungs"])
+    return Plan(entry_price=d["entry_price"], entry_zone=d["entry_zone"],
+                sl_price=d["sl_price"], rungs=rungs, runner_frac=d["runner_frac"])
+
+
+def state_to_row(state: LifecycleState) -> dict:
+    return {
+        "fase": state.fase,
+        "rungs_llenos_json": json.dumps(sorted(state.rungs_llenos)),
+        "consumed_orders_json": json.dumps(sorted(state.consumed_order_ids)),
+        "sl_actual": state.sl_actual, "be_movido": int(state.be_movido),
+        "size_restante_frac": state.size_restante_frac,
+    }
+
+
+def state_from_row(row) -> LifecycleState:
+    def g(key):
+        return row[key]
+    return LifecycleState(
+        plan_id=0, fase=g("fase"),
+        rungs_llenos=frozenset(json.loads(g("rungs_llenos_json"))),
+        consumed_order_ids=frozenset(json.loads(g("consumed_orders_json"))),
+        sl_actual=g("sl_actual"), be_movido=bool(g("be_movido")),
+        size_restante_frac=g("size_restante_frac"),
+    )
+
+
+def db_put_state(con: sqlite3.Connection, *, position_id, symbol, tenant_id, estado_vivo,
+                 plan, state, entry_price, qty_original, events, prev_observed, prev_qty,
+                 confirmed_at, updated_at) -> None:
+    r = state_to_row(state)
+    con.execute(
+        """INSERT INTO lifecycle_states
+           (position_id, symbol, tenant_id, estado_vivo, plan_json, entry_price,
+            qty_original, fase, rungs_llenos_json, consumed_orders_json, sl_actual,
+            be_movido, size_restante_frac, events_json, prev_observed_json, prev_qty,
+            confirmed_at, updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (position_id, symbol, tenant_id, estado_vivo, plan_to_json(plan), entry_price,
+         qty_original, r["fase"], r["rungs_llenos_json"], r["consumed_orders_json"],
+         r["sl_actual"], r["be_movido"], r["size_restante_frac"], json.dumps(events),
+         json.dumps(prev_observed), prev_qty, confirmed_at, updated_at))
+
+
+def db_get_active_state(con: sqlite3.Connection, *, tenant_id: int, symbol: str):
+    cur = con.execute(
+        "SELECT * FROM lifecycle_states WHERE tenant_id=? AND symbol=? "
+        "AND estado_vivo IN ('activo','incierto') ORDER BY confirmed_at DESC LIMIT 1",
+        (tenant_id, symbol))
+    return cur.fetchone()
+
+
+def db_list_active(con: sqlite3.Connection, *, tenant_id: int) -> list:
+    cur = con.execute(
+        "SELECT * FROM lifecycle_states WHERE tenant_id=? AND estado_vivo IN ('activo','incierto')",
+        (tenant_id,))
+    return cur.fetchall()
+
+
+def db_update_state(con: sqlite3.Connection, *, row_id, estado_vivo, state, events,
+                    prev_observed, prev_qty, updated_at) -> None:
+    r = state_to_row(state)
+    con.execute(
+        """UPDATE lifecycle_states SET estado_vivo=?, fase=?, rungs_llenos_json=?,
+               consumed_orders_json=?, sl_actual=?, be_movido=?, size_restante_frac=?,
+               events_json=?, prev_observed_json=?, prev_qty=?, updated_at=?
+           WHERE id=?""",
+        (estado_vivo, r["fase"], r["rungs_llenos_json"], r["consumed_orders_json"],
+         r["sl_actual"], r["be_movido"], r["size_restante_frac"], json.dumps(events),
+         json.dumps(prev_observed), prev_qty, updated_at, row_id))

--- a/db/schema.py
+++ b/db/schema.py
@@ -1915,6 +1915,7 @@ def _migrate_lifecycle_states(con: sqlite3.Connection) -> None:
                sl_actual            REAL,
                be_movido            INTEGER NOT NULL,
                size_restante_frac   REAL,
+               close_reason         TEXT,
                events_json          TEXT    NOT NULL DEFAULT '[]',
                prev_observed_json   TEXT,
                prev_qty             REAL,
@@ -1923,6 +1924,16 @@ def _migrate_lifecycle_states(con: sqlite3.Connection) -> None:
                UNIQUE (tenant_id, symbol, confirmed_at)
            )"""
     )
+    # Migración idempotente: ADD COLUMN close_reason si la tabla ya existía sin ella.
+    # PRAGMA-guarded (NOT try/except) para que la tx BEGIN IMMEDIATE no quede
+    # marcada como abortable si la columna ya existe (patrón Serrano HIGH 1).
+    ls_cols = {
+        row[1]
+        for row in con.execute("PRAGMA table_info(lifecycle_states)").fetchall()
+    }
+    if "close_reason" not in ls_cols:
+        con.execute("ALTER TABLE lifecycle_states ADD COLUMN close_reason TEXT")
+        log.info("_migrate_lifecycle_states: added close_reason column to lifecycle_states")
     con.execute(
         "CREATE INDEX IF NOT EXISTS idx_lifecycle_states_tenant "
         "ON lifecycle_states(tenant_id, estado_vivo)"

--- a/db/schema.py
+++ b/db/schema.py
@@ -458,6 +458,10 @@ def init_db() -> None:
     with transaction() as con_ce:
         _migrate_conduct_episodes(con_ce)
 
+    # lifecycle_states: domicilio del estado vivo del plan (instrumento F3a).
+    with transaction() as con_ls:
+        _migrate_lifecycle_states(con_ls)
+
 
 # Per-user tables that need a tenant_id column (Epic B B.1).
 # kill_switch_* tables intentionally NOT in this list — kept global for B.1
@@ -1883,3 +1887,44 @@ def _migrate_conduct_episodes(con: sqlite3.Connection) -> None:
         "ON conduct_episodes(tenant_id)"
     )
     log.info("_migrate_conduct_episodes: conduct_episodes table + index ensured.")
+
+
+def _migrate_lifecycle_states(con: sqlite3.Connection) -> None:
+    """Tabla lifecycle_states — domicilio del estado vivo del plan (instrumento F3a).
+
+    Una fila por plan activo del operador: el Plan confirmado (la ley) + la
+    LifecycleState incremental + el último snapshot observado (para el delta del
+    detector). Escrita por el gate y el tracker; read-only sobre positions.
+    Idempotente: CREATE TABLE IF NOT EXISTS.
+
+    Spec: docs/superpowers/specs/es/2026-06-13-instrumento-fase3a-lazo-vivo-design.md §3.
+    """
+    con.execute(
+        """CREATE TABLE IF NOT EXISTS lifecycle_states (
+               id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+               position_id          INTEGER,
+               symbol               TEXT    NOT NULL,
+               tenant_id            INTEGER NOT NULL,
+               estado_vivo          TEXT    NOT NULL CHECK (estado_vivo IN ('activo','cerrado','incierto')),
+               plan_json            TEXT    NOT NULL,
+               entry_price          REAL    NOT NULL,
+               qty_original         REAL,
+               fase                 TEXT    NOT NULL,
+               rungs_llenos_json    TEXT    NOT NULL,
+               consumed_orders_json TEXT    NOT NULL,
+               sl_actual            REAL,
+               be_movido            INTEGER NOT NULL,
+               size_restante_frac   REAL,
+               events_json          TEXT    NOT NULL DEFAULT '[]',
+               prev_observed_json   TEXT,
+               prev_qty             REAL,
+               confirmed_at         TEXT    NOT NULL,
+               updated_at           TEXT    NOT NULL,
+               UNIQUE (tenant_id, symbol, confirmed_at)
+           )"""
+    )
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lifecycle_states_tenant "
+        "ON lifecycle_states(tenant_id, estado_vivo)"
+    )
+    log.info("_migrate_lifecycle_states: lifecycle_states table + index ensured.")

--- a/docs/superpowers/plans/2026-06-13-instrumento-fase3a-lazo-vivo.md
+++ b/docs/superpowers/plans/2026-06-13-instrumento-fase3a-lazo-vivo.md
@@ -1,0 +1,994 @@
+# El Instrumento — Fase 3a (el lazo vivo, pull-only) · Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construir el acompañante en vivo pull-only: sigue una posición real contra el plan confirmado (detector de transiciones desde `observed_orders`), persiste el estado vivo, lo expone por pull, y mide conducta al cierre — sin push, sin instrucción, sin tocar el cierre.
+
+**Architecture:** Un detector puro (`instrument/tracker.py`) que deriva eventos de snapshots de `observed_orders` + qty y avanza la máquina de F1; un domicilio `lifecycle_states` (tabla + helpers + serialización en `db/lifecycle_states.py`); endpoints de gate y vista (`api/plan.py`); y un hook de I/O en `tools/sync_binance_spot.py` que corre tras el sync, más la conducta al cierre vía `compute_conduct` de F1.
+
+**Tech Stack:** Python 3.12 (`dataclasses`, `json`), FastAPI, pytest. Reutiliza F1 (`instrument/lifecycle.py`, `instrument/plan.py`, `instrument/conduct.py`) y `screener/sr_levels.py` (D.1).
+
+**Spec:** `docs/superpowers/specs/es/2026-06-13-instrumento-fase3a-lazo-vivo-design.md`.
+
+**Branch:** `feat/instrumento-fase3a-lazo-vivo` (ya creada).
+
+**Frontera dura:** read-only sobre `positions`, sin `PositionClosure`, sin escribir `closed`, **sin push, sin instrucción**. Escribe solo `lifecycle_states` + `conduct_episodes`.
+
+---
+
+## File Structure
+
+| Archivo | Responsabilidad |
+|---|---|
+| `instrument/tracker.py` (crear) | `detect_transitions` (puro) + `advance_live` (puro). |
+| `db/lifecycle_states.py` (crear) | Serialización `Plan`/`LifecycleState` ↔ JSON + helpers SQL del domicilio. |
+| `db/schema.py` (modificar) | Migración `lifecycle_states`. |
+| `api/plan.py` (crear) | `GET /plan/derive/{symbol}`, `POST /plan/confirm`, `GET /plan/{symbol}` + el constructor de `hechos` (anti-imperativo). |
+| `btc_api.py` (modificar) | Registrar el router de `plan`. |
+| `tools/sync_binance_spot.py` (modificar) | Hook: tras el sync, correr `advance_live` sobre las filas activas + conducta al cierre. |
+| `tests/test_instrument_tracker.py`, `tests/test_lifecycle_states.py`, `tests/test_plan_api.py` (crear) | Tests. |
+
+---
+
+### Task 1: `detect_transitions` — el detector puro
+
+**Files:**
+- Create: `instrument/tracker.py`
+- Test: `tests/test_instrument_tracker.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_instrument_tracker.py
+"""Tests del detector/tracker en vivo (instrumento F3a). Puro: sin red, sin DB. Spec §5."""
+from instrument.plan import derive_plan
+from instrument.lifecycle import LifecycleState
+from instrument.tracker import detect_transitions
+
+
+def _z(tipo, bajo, alto, centro):
+    return {"tipo": tipo, "precio_bajo": bajo, "precio_alto": alto,
+            "centro": centro, "toques": 3, "confluencia_redondo": []}
+
+
+def _plan():
+    zonas = [_z("soporte", 94, 96, 95),
+             _z("resistencia", 104, 106, 105),
+             _z("resistencia", 109, 111, 110)]
+    return derive_plan(zonas, entry_price=100.0)
+
+
+def _armed(p, **kw):
+    return LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=p.sl_price, **kw)
+
+
+def _tp(price, oid, qty=1.0):
+    return {"kind": "TP", "price": price, "qty": qty, "order_id": oid}
+
+
+def _sl(price, oid, qty=1.0):
+    return {"kind": "SL", "price": price, "qty": qty, "order_id": oid}
+
+
+def test_tp_desaparece_con_caida_de_qty_es_rung_filled():
+    p = _plan()
+    prev = [_tp(105, 11), _sl(p.sl_price, 99)]
+    curr = [_sl(p.sl_price, 99)]                  # el TP de 105 ya no está
+    evs = detect_transitions(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=0.5)
+    rung = [e for e in evs if e["tipo"] == "RUNG_FILLED"]
+    assert len(rung) == 1 and rung[0]["rung_index"] == 0 and rung[0]["order_id"] == "11"
+
+
+def test_tp_desaparece_sin_caida_de_qty_es_cancelacion():
+    p = _plan()
+    prev = [_tp(105, 11), _sl(p.sl_price, 99)]
+    curr = [_sl(p.sl_price, 99)]
+    evs = detect_transitions(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=1.0)  # qty igual
+    assert not any(e["tipo"] == "RUNG_FILLED" for e in evs)   # cancelación, no fill
+
+
+def test_rung_idempotente_por_order_id():
+    p = _plan()
+    prev = [_tp(105, 11)]
+    curr = []
+    st = _armed(p, consumed_order_ids=frozenset({"11"}))
+    evs = detect_transitions(p, st, prev, curr, prev_qty=1.0, curr_qty=0.5)
+    assert not any(e["tipo"] == "RUNG_FILLED" for e in evs)   # ya consumido
+
+
+def test_sl_cambia_a_entry_es_sl_moved():
+    p = _plan()
+    prev = [_sl(p.sl_price, 99)]
+    curr = [_sl(p.entry_price, 99)]
+    evs = detect_transitions(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=1.0)
+    sl = [e for e in evs if e["tipo"] == "SL_MOVED"]
+    assert len(sl) == 1 and sl[0]["nuevo_sl"] == p.entry_price
+
+
+def test_qty_cero_es_stop_hit():
+    p = _plan()
+    evs = detect_transitions(p, _armed(p), [_sl(p.sl_price, 99)], [], prev_qty=1.0, curr_qty=0.0)
+    assert any(e["tipo"] == "STOP_HIT" for e in evs)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_instrument_tracker.py -v`
+Expected: FAIL `ModuleNotFoundError: No module named 'instrument.tracker'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# instrument/tracker.py
+"""Tracker en vivo del instrumento (F3a) — puro, sin red, sin DB.
+
+Deriva eventos de transición de los snapshots de observed_orders + qty y avanza
+la máquina de F1. HONESTO sobre la resolución: un TP que desaparece pudo llenarse
+(qty baja) o cancelarse (qty igual); la ambigüedad no se inventa. Idempotente por
+order_id. Spec §5. NO emite alertas, NO instruye — solo deriva hechos."""
+from __future__ import annotations
+
+from instrument.lifecycle import LifecycleState, step
+
+_TOL = 0.005   # 0.5%: proximidad de precio observado ↔ nivel del plan
+_EPS = 1e-9
+
+
+def _close(a: float, b: float) -> bool:
+    return b != 0 and abs(a - b) / abs(b) <= _TOL
+
+
+def detect_transitions(plan, state: LifecycleState, prev_observed: list[dict],
+                       curr_observed: list[dict], prev_qty: float,
+                       curr_qty: float) -> list[dict]:
+    """Snapshots de observed_orders (prev/curr) + qty → eventos para step(). Puro."""
+    proc = "observado"
+    events: list[dict] = []
+    curr_ids = {o["order_id"] for o in curr_observed}
+    qty_dropped = curr_qty < prev_qty - _EPS
+
+    # 1. RUNG_FILLED: TP que estaba y ya no, matchea un rung no-lleno, + qty bajó.
+    if qty_dropped:
+        for o in prev_observed:
+            oid = str(o["order_id"])
+            if o.get("kind") != "TP" or o["order_id"] in curr_ids:
+                continue
+            if oid in state.consumed_order_ids:
+                continue
+            for i, r in enumerate(plan.rungs):
+                if i in state.rungs_llenos:
+                    continue
+                if _close(o["price"], r.tp_price):
+                    events.append({"tipo": "RUNG_FILLED", "order_id": oid,
+                                   "rung_index": i, "procedencia": proc})
+                    break
+
+    # 2. SL_MOVED: el SL observado cambió de precio entre snapshots.
+    prev_sl = next((o for o in prev_observed if o.get("kind") == "SL"), None)
+    curr_sl = next((o for o in curr_observed if o.get("kind") == "SL"), None)
+    if prev_sl and curr_sl and not _close(prev_sl["price"], curr_sl["price"]):
+        events.append({"tipo": "SL_MOVED", "nuevo_sl": float(curr_sl["price"]),
+                       "procedencia": proc})
+
+    # 3. Cierre: qty → 0.
+    if curr_qty <= 1e-8:
+        events.append({"tipo": "STOP_HIT", "procedencia": proc})
+
+    return events
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_instrument_tracker.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add instrument/tracker.py tests/test_instrument_tracker.py
+git commit -m "feat(instrument): detect_transitions — eventos desde snapshots de observed_orders (idempotente, honesto)"
+```
+
+---
+
+### Task 2: `advance_live` — avanzar la máquina + detectar cierre
+
+**Files:**
+- Modify: `instrument/tracker.py`
+- Test: `tests/test_instrument_tracker.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_instrument_tracker.py — añadir
+from instrument.tracker import advance_live
+
+
+def test_advance_live_aplica_rung_y_avanza():
+    p = _plan()
+    prev = [_tp(105, 11), _sl(p.sl_price, 99)]
+    curr = [_sl(p.sl_price, 99)]
+    new, events = advance_live(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=0.5)
+    assert 0 in new.rungs_llenos
+    assert "11" in new.consumed_order_ids
+    assert any(e["tipo"] == "RUNG_FILLED" for e in events)
+    assert new.fase == "RUNNING"
+
+
+def test_advance_live_cierre_lleva_a_closed():
+    p = _plan()
+    new, events = advance_live(p, _armed(p), [_sl(p.sl_price, 99)], [],
+                               prev_qty=1.0, curr_qty=0.0)
+    assert new.fase == "CLOSED"
+    assert new.close_reason in ("SL_HIT", "BE_HIT")
+
+
+def test_advance_live_sin_cambios_no_avanza():
+    p = _plan()
+    obs = [_sl(p.sl_price, 99)]
+    new, events = advance_live(p, _armed(p), obs, obs, prev_qty=1.0, curr_qty=1.0)
+    assert events == []
+    assert new.fase == "CONFIRMED"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_instrument_tracker.py -k advance_live -v`
+Expected: FAIL `ImportError: cannot import name 'advance_live'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# instrument/tracker.py — añadir al final
+def advance_live(plan, state: LifecycleState, prev_observed: list[dict],
+                 curr_observed: list[dict], prev_qty: float,
+                 curr_qty: float) -> tuple[LifecycleState, list[dict]]:
+    """Detecta transiciones y avanza la máquina. Devuelve (estado_nuevo, eventos).
+    Puro: compone detect_transitions + step de F1. Spec §6."""
+    events = detect_transitions(plan, state, prev_observed, curr_observed,
+                                prev_qty, curr_qty)
+    for e in events:
+        state = step(state, e, plan)
+        if state.fase == "CLOSED":
+            break
+    return state, events
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_instrument_tracker.py -v`
+Expected: PASS (8 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add instrument/tracker.py tests/test_instrument_tracker.py
+git commit -m "feat(instrument): advance_live — compone detección + máquina de F1 → estado nuevo + eventos"
+```
+
+---
+
+### Task 3: domicilio `lifecycle_states` — serialización + tabla + helpers
+
+**Files:**
+- Create: `db/lifecycle_states.py`
+- Modify: `db/schema.py` (migración idempotente, patrón de `_migrate_conduct_episodes`)
+- Test: `tests/test_lifecycle_states.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_lifecycle_states.py
+"""Tests del domicilio lifecycle_states (instrumento F3a). Spec §3."""
+import sqlite3
+
+from instrument.plan import derive_plan
+from instrument.lifecycle import LifecycleState
+from db.lifecycle_states import (
+    plan_to_json, plan_from_json, state_to_row, state_from_row,
+    db_put_state, db_get_active_state,
+)
+
+
+def _z(tipo, bajo, alto, centro):
+    return {"tipo": tipo, "precio_bajo": bajo, "precio_alto": alto,
+            "centro": centro, "toques": 3, "confluencia_redondo": []}
+
+
+def _plan():
+    return derive_plan([_z("soporte", 94, 96, 95), _z("resistencia", 104, 106, 105)],
+                       entry_price=100.0)
+
+
+def test_plan_json_roundtrip():
+    p = _plan()
+    p2 = plan_from_json(plan_to_json(p))
+    assert p2.entry_price == p.entry_price
+    assert [r.tp_price for r in p2.rungs] == [r.tp_price for r in p.rungs]
+    assert p2.sl_price == p.sl_price and p2.runner_frac == p.runner_frac
+
+
+def test_state_row_roundtrip_preserva_frozensets():
+    s = LifecycleState(plan_id=0, fase="RUNNING",
+                       rungs_llenos=frozenset({0}), consumed_order_ids=frozenset({"11"}),
+                       sl_actual=99.0, be_movido=True, size_restante_frac=0.5)
+    s2 = state_from_row(state_to_row(s))
+    assert s2.rungs_llenos == frozenset({0})
+    assert s2.consumed_order_ids == frozenset({"11"})
+    assert s2.be_movido is True and s2.fase == "RUNNING"
+
+
+def _con():
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.execute("""
+        CREATE TABLE lifecycle_states (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, position_id INTEGER,
+            symbol TEXT NOT NULL, tenant_id INTEGER NOT NULL,
+            estado_vivo TEXT NOT NULL CHECK (estado_vivo IN ('activo','cerrado','incierto')),
+            plan_json TEXT NOT NULL, entry_price REAL NOT NULL, qty_original REAL,
+            fase TEXT NOT NULL, rungs_llenos_json TEXT NOT NULL,
+            consumed_orders_json TEXT NOT NULL, sl_actual REAL, be_movido INTEGER NOT NULL,
+            size_restante_frac REAL, events_json TEXT NOT NULL DEFAULT '[]',
+            prev_observed_json TEXT, prev_qty REAL,
+            confirmed_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            UNIQUE (tenant_id, symbol, confirmed_at))""")
+    return con
+
+
+def test_put_y_get_active():
+    con = _con()
+    p = _plan()
+    s = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=p.sl_price)
+    db_put_state(con, position_id=7, symbol="BTCUSDT", tenant_id=2, estado_vivo="activo",
+                 plan=p, state=s, entry_price=100.0, qty_original=1.0, events=[],
+                 prev_observed=[], prev_qty=1.0, confirmed_at="2026-06-13T00:00:00+00:00",
+                 updated_at="2026-06-13T00:00:00+00:00")
+    row = db_get_active_state(con, tenant_id=2, symbol="BTCUSDT")
+    assert row is not None and row["symbol"] == "BTCUSDT" and row["estado_vivo"] == "activo"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_lifecycle_states.py -v`
+Expected: FAIL `ModuleNotFoundError: No module named 'db.lifecycle_states'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `db/lifecycle_states.py`:
+
+```python
+"""Domicilio del estado vivo del plan (instrumento F3a) — serialización + SQL.
+
+Serializa Plan/LifecycleState ↔ JSON (frozensets ↔ listas) y persiste una fila
+por plan activo. Helpers SQL puros (reciben `con`). Spec §3."""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from instrument.plan import Plan, Rung
+from instrument.lifecycle import LifecycleState
+
+
+def plan_to_json(plan: Plan) -> str:
+    return json.dumps({
+        "entry_price": plan.entry_price, "entry_zone": plan.entry_zone,
+        "sl_price": plan.sl_price, "runner_frac": plan.runner_frac,
+        "rungs": [{"tp_price": r.tp_price, "size_frac": r.size_frac,
+                   "zona_origen": r.zona_origen} for r in plan.rungs],
+    })
+
+
+def plan_from_json(s: str) -> Plan:
+    d = json.loads(s)
+    rungs = tuple(Rung(tp_price=r["tp_price"], size_frac=r["size_frac"],
+                       zona_origen=r["zona_origen"]) for r in d["rungs"])
+    return Plan(entry_price=d["entry_price"], entry_zone=d["entry_zone"],
+                sl_price=d["sl_price"], rungs=rungs, runner_frac=d["runner_frac"])
+
+
+def state_to_row(state: LifecycleState) -> dict:
+    return {
+        "fase": state.fase,
+        "rungs_llenos_json": json.dumps(sorted(state.rungs_llenos)),
+        "consumed_orders_json": json.dumps(sorted(state.consumed_order_ids)),
+        "sl_actual": state.sl_actual, "be_movido": int(state.be_movido),
+        "size_restante_frac": state.size_restante_frac,
+    }
+
+
+def state_from_row(row) -> LifecycleState:
+    g = row.__getitem__ if hasattr(row, "__getitem__") else row.get
+    return LifecycleState(
+        plan_id=0, fase=g("fase"),
+        rungs_llenos=frozenset(json.loads(g("rungs_llenos_json"))),
+        consumed_order_ids=frozenset(json.loads(g("consumed_orders_json"))),
+        sl_actual=g("sl_actual"), be_movido=bool(g("be_movido")),
+        size_restante_frac=g("size_restante_frac"),
+        close_reason=(g("close_reason") if _has(row, "close_reason") else None),
+    )
+
+
+def _has(row, key) -> bool:
+    try:
+        row[key]
+        return True
+    except (KeyError, IndexError):
+        return False
+
+
+def db_put_state(con: sqlite3.Connection, *, position_id, symbol, tenant_id, estado_vivo,
+                 plan, state, entry_price, qty_original, events, prev_observed, prev_qty,
+                 confirmed_at, updated_at) -> None:
+    r = state_to_row(state)
+    con.execute(
+        """INSERT INTO lifecycle_states
+           (position_id, symbol, tenant_id, estado_vivo, plan_json, entry_price,
+            qty_original, fase, rungs_llenos_json, consumed_orders_json, sl_actual,
+            be_movido, size_restante_frac, events_json, prev_observed_json, prev_qty,
+            confirmed_at, updated_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (position_id, symbol, tenant_id, estado_vivo, plan_to_json(plan), entry_price,
+         qty_original, r["fase"], r["rungs_llenos_json"], r["consumed_orders_json"],
+         r["sl_actual"], r["be_movido"], r["size_restante_frac"], json.dumps(events),
+         json.dumps(prev_observed), prev_qty, confirmed_at, updated_at))
+
+
+def db_get_active_state(con: sqlite3.Connection, *, tenant_id: int, symbol: str):
+    cur = con.execute(
+        "SELECT * FROM lifecycle_states WHERE tenant_id=? AND symbol=? "
+        "AND estado_vivo IN ('activo','incierto') ORDER BY confirmed_at DESC LIMIT 1",
+        (tenant_id, symbol))
+    return cur.fetchone()
+
+
+def db_list_active(con: sqlite3.Connection, *, tenant_id: int) -> list:
+    cur = con.execute(
+        "SELECT * FROM lifecycle_states WHERE tenant_id=? AND estado_vivo IN ('activo','incierto')",
+        (tenant_id,))
+    return cur.fetchall()
+
+
+def db_update_state(con: sqlite3.Connection, *, row_id, estado_vivo, state, events,
+                    prev_observed, prev_qty, updated_at) -> None:
+    r = state_to_row(state)
+    con.execute(
+        """UPDATE lifecycle_states SET estado_vivo=?, fase=?, rungs_llenos_json=?,
+               consumed_orders_json=?, sl_actual=?, be_movido=?, size_restante_frac=?,
+               events_json=?, prev_observed_json=?, prev_qty=?, updated_at=?
+           WHERE id=?""",
+        (estado_vivo, r["fase"], r["rungs_llenos_json"], r["consumed_orders_json"],
+         r["sl_actual"], r["be_movido"], r["size_restante_frac"], json.dumps(events),
+         json.dumps(prev_observed), prev_qty, updated_at, row_id))
+```
+
+> **Nota:** `state_from_row` no reconstruye `close_reason` salvo que la fila lo traiga; el domicilio no tiene columna `close_reason` (la fase CLOSED + `estado_vivo='cerrado'` lo cubren). El parámetro `close_reason` queda None al rehidratar para el tracker, que solo avanza estados activos. Si el quality review pide persistir `close_reason`, es una columna trivial.
+
+Then add the migration to `db/schema.py` (mirror `_migrate_conduct_episodes`, ~line 1846). New function `_migrate_lifecycle_states`:
+
+```python
+def _migrate_lifecycle_states(con: sqlite3.Connection) -> None:
+    """Tabla lifecycle_states — domicilio del estado vivo del plan (instrumento F3a).
+
+    Una fila por plan activo del operador: el Plan confirmado (la ley) + la
+    LifecycleState incremental + el último snapshot observado (para el delta del
+    detector). Escrita por el gate y el tracker; read-only sobre positions.
+    Idempotente: CREATE TABLE IF NOT EXISTS.
+
+    Spec: docs/superpowers/specs/es/2026-06-13-instrumento-fase3a-lazo-vivo-design.md §3.
+    """
+    con.execute(
+        """CREATE TABLE IF NOT EXISTS lifecycle_states (
+               id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+               position_id          INTEGER,
+               symbol               TEXT    NOT NULL,
+               tenant_id            INTEGER NOT NULL,
+               estado_vivo          TEXT    NOT NULL CHECK (estado_vivo IN ('activo','cerrado','incierto')),
+               plan_json            TEXT    NOT NULL,
+               entry_price          REAL    NOT NULL,
+               qty_original         REAL,
+               fase                 TEXT    NOT NULL,
+               rungs_llenos_json    TEXT    NOT NULL,
+               consumed_orders_json TEXT    NOT NULL,
+               sl_actual            REAL,
+               be_movido            INTEGER NOT NULL,
+               size_restante_frac   REAL,
+               events_json          TEXT    NOT NULL DEFAULT '[]',
+               prev_observed_json   TEXT,
+               prev_qty             REAL,
+               confirmed_at         TEXT    NOT NULL,
+               updated_at           TEXT    NOT NULL,
+               UNIQUE (tenant_id, symbol, confirmed_at)
+           )"""
+    )
+    con.execute(
+        "CREATE INDEX IF NOT EXISTS idx_lifecycle_states_tenant "
+        "ON lifecycle_states(tenant_id, estado_vivo)"
+    )
+    log.info("_migrate_lifecycle_states: lifecycle_states table + index ensured.")
+```
+
+Wire its call in its own `with transaction()` block right after the `_migrate_conduct_episodes` block (mirror that block's style):
+
+```python
+    # lifecycle_states: domicilio del estado vivo del plan (instrumento F3a).
+    with transaction() as con_ls:
+        _migrate_lifecycle_states(con_ls)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_lifecycle_states.py -v`
+Expected: PASS (3 passed)
+
+Then verify the migration applies: `python -m pytest tests/ -m "not network" -n auto -q -k "schema or migration or lifecycle_states"` → green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/lifecycle_states.py db/schema.py tests/test_lifecycle_states.py
+git commit -m "feat(db): domicilio lifecycle_states — serialización Plan/estado + tabla + helpers"
+```
+
+---
+
+### Task 4: gate — `GET /plan/derive/{symbol}` + `POST /plan/confirm`
+
+**Files:**
+- Create: `api/plan.py`
+- Test: `tests/test_plan_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_plan_api.py
+"""Tests de los endpoints del plan vivo (instrumento F3a). Spec §4/§6."""
+import os
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.plan import router
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _zonas():
+    return [{"tipo": "soporte", "precio_bajo": 94, "precio_alto": 96, "centro": 95,
+             "toques": 3, "confluencia_redondo": []},
+            {"tipo": "resistencia", "precio_bajo": 104, "precio_alto": 106, "centro": 105,
+             "toques": 3, "confluencia_redondo": []}]
+
+
+def test_derive_devuelve_plan_sin_persistir():
+    with patch("api.plan._zonas_now", return_value=_zonas()):
+        r = _app().get("/plan/derive/BTCUSDT?entry_price=100")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["entry"] == 100.0
+    assert [rg["tp_price"] for rg in body["rungs"]] == [105.0]
+    assert body["sl_plan"] == 94.0 * (1 - 0.01)
+
+
+def test_confirm_crea_la_fila(monkeypatch, tmp_path):
+    import btc_api
+    monkeypatch.setattr(btc_api, "DB_FILE", str(tmp_path / "d.db"))
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        from db.schema import init_db
+        init_db()
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+    with patch("api.plan._zonas_now", return_value=_zonas()), \
+         patch("api.plan._caller_tenant", return_value=2):
+        r = _app().post("/plan/confirm", json={"symbol": "BTCUSDT", "entry_price": 100.0})
+    assert r.status_code == 200 and r.json()["estado_vivo"] == "activo"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_plan_api.py -v`
+Expected: FAIL `ModuleNotFoundError: No module named 'api.plan'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# api/plan.py
+"""API del plan vivo (instrumento F3a) — gate (derive/confirm) + vista (pull).
+
+PULL-ONLY: ningún endpoint emite push ni instrucción. Read-only sobre positions;
+escribe solo lifecycle_states. La red (D.1) corre fuera de tx. Spec §4/§6/§9."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Query, Request
+
+from screener.sr_levels import detect_levels
+from instrument.plan import derive_plan
+from db.lifecycle_states import db_put_state, db_get_active_state
+from db.transaction import snapshot_connection, transaction
+
+log = logging.getLogger("api.plan")
+router = APIRouter(tags=["plan"])
+
+
+def _zonas_now(symbol: str) -> list[dict]:
+    """Zonas de D.1 con velas diarias hasta ahora (red, fuera de tx). Aislado
+    para mockear; reutiliza el fetch del endpoint de niveles."""
+    from api.levels import _fetch_daily_bars
+    return detect_levels(_fetch_daily_bars(symbol))
+
+
+def _caller_tenant(request: Request) -> int:
+    """tenant_id del caller (mismo mecanismo que el resto de la API per-tenant)."""
+    return int(getattr(request.state, "tenant_id", 0) or 0)
+
+
+def _plan_payload(plan) -> dict:
+    return {"entry": plan.entry_price,
+            "sl_plan": plan.sl_price,
+            "rungs": [{"tp_price": r.tp_price, "size_frac": r.size_frac} for r in plan.rungs],
+            "runner_frac": plan.runner_frac,
+            "entry_zone": plan.entry_zone}
+
+
+@router.get("/plan/derive/{symbol}", summary="Deriva el plan desde D.1 (NO persiste)")
+def derive(symbol: str, entry_price: float = Query(...)) -> dict:
+    """El operador revisa el plan antes de confirmarlo. NO escribe nada."""
+    zonas = _zonas_now(symbol.upper())
+    return _plan_payload(derive_plan(zonas, entry_price))
+
+
+@router.post("/plan/confirm", summary="Confirma el plan revisado → crea la fila viva")
+def confirm(payload: dict, request: Request) -> dict:
+    """El operador confirma en frío (su juicio + fundamentales entran aquí). Crea
+    la fila lifecycle_states. La red (D.1) corre fuera de la tx corta del insert."""
+    symbol = str(payload["symbol"]).upper()
+    entry_price = float(payload["entry_price"])
+    position_id = payload.get("position_id")
+    tenant_id = _caller_tenant(request)
+
+    zonas = _zonas_now(symbol)                       # red, fuera de tx
+    plan = derive_plan(zonas, entry_price)
+    from instrument.lifecycle import LifecycleState
+    state = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=plan.sl_price)
+    now = datetime.now(timezone.utc).isoformat()
+
+    with transaction() as con:
+        db_put_state(con, position_id=position_id, symbol=symbol, tenant_id=tenant_id,
+                     estado_vivo="activo", plan=plan, state=state, entry_price=entry_price,
+                     qty_original=None, events=[], prev_observed=[], prev_qty=None,
+                     confirmed_at=now, updated_at=now)
+    return {"symbol": symbol, "estado_vivo": "activo", "plan": _plan_payload(plan)}
+```
+
+> **Nota sobre `_caller_tenant`:** el test lo mockea. En runtime debe derivar el tenant del request igual que el resto de la API per-tenant (revisá cómo `api/positions.py` u otro endpoint per-tenant obtiene `tenant_id` del request/JWT y replicá ese mecanismo exacto en `_caller_tenant` en vez del placeholder `request.state.tenant_id`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_plan_api.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/plan.py tests/test_plan_api.py
+git commit -m "feat(api): gate del plan vivo — GET /plan/derive (preview) + POST /plan/confirm"
+```
+
+---
+
+### Task 5: vista `GET /plan/{symbol}` (pull, anti-imperativo) + registrar router
+
+**Files:**
+- Modify: `api/plan.py`
+- Modify: `btc_api.py` (registrar el router, junto a los demás)
+- Test: `tests/test_plan_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_plan_api.py — añadir
+from api.plan import construir_hechos
+
+
+def test_hechos_no_contienen_imperativos():
+    # los hechos afirman lo que ES, nunca instruyen.
+    hechos = construir_hechos(rungs_llenos=[0], be_movido=True, estado_vivo="activo",
+                              sl_actual=100.0, sl_plan=93.06)
+    texto = " ".join(hechos).lower()
+    for imperativo in ("mové", "movete", "cerrá", "vendé", "comprá", "mueve", "cierra"):
+        assert imperativo not in texto
+
+
+def test_hechos_reportan_tp1_y_be():
+    hechos = construir_hechos(rungs_llenos=[0], be_movido=True, estado_vivo="activo",
+                              sl_actual=100.0, sl_plan=93.06)
+    texto = " ".join(hechos).lower()
+    assert "tp1" in texto and "break-even" in texto
+
+
+def test_vista_router_registrado():
+    import btc_api
+    rutas = {getattr(r, "path", None) for r in btc_api.app.routes}
+    assert "/plan/{symbol}" in rutas
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_plan_api.py -k "hechos or router" -v`
+Expected: FAIL (`construir_hechos` no existe / ruta no registrada)
+
+- [ ] **Step 3: Write minimal implementation**
+
+En `api/plan.py`, añadir el constructor de hechos y la vista:
+
+```python
+def construir_hechos(*, rungs_llenos: list, be_movido: bool, estado_vivo: str,
+                     sl_actual, sl_plan) -> list[str]:
+    """HECHOS de 𝓕ₜ — lo que ES verdad. NUNCA instrucciones (Axiom-0, spec §0).
+    Sin imperativos: el instrumento queda fuera del término que mide."""
+    hechos: list[str] = []
+    if estado_vivo == "incierto":
+        hechos.append("transición sin confirmar — revisá en Binance")
+    for i in sorted(rungs_llenos):
+        hechos.append(f"TP{i + 1} se llenó")
+    if be_movido:
+        hechos.append("tu SL está en break-even")
+    elif sl_actual is not None and sl_plan is not None:
+        if sl_actual <= sl_plan * (1 + 1e-9):
+            hechos.append("tu SL sigue debajo de la zona")
+        else:
+            hechos.append("tu SL está por encima del nivel del plan")
+    return hechos
+
+
+@router.get("/plan/{symbol}", summary="Estado vivo del plan (pull, solo hechos)")
+def vista(symbol: str, request: Request) -> dict:
+    """PULL: el estado vivo. Hechos, nunca instrucciones. Si no hay plan activo,
+    estado_vivo None (la UI muestra 'sin plan')."""
+    symbol = symbol.upper()
+    tenant_id = _caller_tenant(request)
+    with snapshot_connection() as con:
+        con.row_factory = __import__("sqlite3").Row
+        row = db_get_active_state(con, tenant_id=tenant_id, symbol=symbol)
+    if row is None:
+        return {"symbol": symbol, "estado_vivo": None}
+    import json
+    from db.lifecycle_states import plan_from_json
+    plan = plan_from_json(row["plan_json"])
+    rungs_llenos = json.loads(row["rungs_llenos_json"])
+    hechos = construir_hechos(rungs_llenos=rungs_llenos, be_movido=bool(row["be_movido"]),
+                              estado_vivo=row["estado_vivo"], sl_actual=row["sl_actual"],
+                              sl_plan=plan.sl_price)
+    return {
+        "symbol": symbol, "estado_vivo": row["estado_vivo"],
+        "plan": _plan_payload(plan),
+        "realidad": {"fase": row["fase"], "rungs_llenos": rungs_llenos,
+                     "sl_actual": row["sl_actual"], "be_movido": bool(row["be_movido"]),
+                     "size_restante_frac": row["size_restante_frac"]},
+        "hechos": hechos,
+    }
+```
+
+En `btc_api.py`, tras `from api.levels import router as levels_router`:
+```python
+from api.plan import router as plan_router
+```
+Y tras `app.include_router(levels_router)`:
+```python
+app.include_router(plan_router)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_plan_api.py -v`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/plan.py btc_api.py tests/test_plan_api.py
+git commit -m "feat(api): vista pull del plan vivo (solo hechos, anti-imperativo) + registrar router"
+```
+
+---
+
+### Task 6: conducta al cierre — `finalize_conduct` (puro)
+
+**Files:**
+- Modify: `instrument/tracker.py`
+- Test: `tests/test_instrument_tracker.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_instrument_tracker.py — añadir
+from instrument.tracker import finalize_conduct
+
+
+def test_finalize_conduct_al_cierre():
+    p = _plan()
+    # secuencia de eventos vivos: TP1, SL→BE, STOP_HIT
+    events = [
+        {"tipo": "RUNG_FILLED", "order_id": "11", "rung_index": 0, "procedencia": "observado"},
+        {"tipo": "SL_MOVED", "nuevo_sl": p.entry_price, "procedencia": "observado"},
+        {"tipo": "STOP_HIT", "procedencia": "observado"},
+    ]
+    from instrument.lifecycle import LifecycleState, step
+    st = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=p.sl_price)
+    for e in events:
+        st = step(st, e, p)
+    c = finalize_conduct(p, events, st, entry_price=100.0,
+                         entry_ts="2026-06-10T00:00:00+00:00",
+                         exit_ts="2026-06-12T00:00:00+00:00")
+    assert c["adherencia_be"] is True
+    assert c["rungs_honrados"] == 1
+    assert c["procedencia"] == "observado"
+    assert "hold_hours" in c
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_instrument_tracker.py -k finalize -v`
+Expected: FAIL `ImportError: cannot import name 'finalize_conduct'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# instrument/tracker.py — añadir al final
+from instrument.conduct import compute_conduct
+
+
+def finalize_conduct(plan, events: list[dict], final_state, *, entry_price: float,
+                     entry_ts: str, exit_ts: str) -> dict:
+    """Conducta al cierre con el libro de fills vivo (la comparación que F2
+    difirió). Campo por campo contra el plan, procedencia 'observado'. NO PnL.
+    Spec §7."""
+    return compute_conduct(plan, events, final_state, entry_price=entry_price,
+                           entry_ts=entry_ts, exit_ts=exit_ts, procedencia="observado")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_instrument_tracker.py -v`
+Expected: PASS (9 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add instrument/tracker.py tests/test_instrument_tracker.py
+git commit -m "feat(instrument): finalize_conduct — conducta al cierre con fills vivos (sin PnL)"
+```
+
+---
+
+### Task 7: el hook de I/O — correr el tracker tras el sync
+
+**Files:**
+- Modify: `tools/sync_binance_spot.py` (añadir el paso del tracker tras el reconcile)
+- Test: `network`-marcado (smoke); la lógica pura ya está cubierta por Tasks 1/2/6
+
+**Context:** Read `tools/sync_binance_spot.py::sync_tenant` (~line 47). It runs the read-only reconcile + applies `observed_orders` outside any tx, then short tx writes. ADD a step AFTER that: for each active `lifecycle_states` row of the tenant, read the position's current qty (read-only) + the fresh `observed_orders` for that symbol, call `advance_live`, and persist via `db_update_state`. When `advance_live` returns a CLOSED state, call `finalize_conduct` and persist the episode via `db_put_episode` (from `db/conduct_episodes.py`), and set `estado_vivo='cerrado'`. ALL read-only on positions; the only writes are `lifecycle_states` + `conduct_episodes`. Network (Binance reads) stays OUTSIDE any transaction.
+
+- [ ] **Step 1: Write the wiring**
+
+Add a function `track_live(tenant_id)` to `tools/sync_binance_spot.py` and call it at the end of `sync_tenant` (after the reconcile writes). Use the existing helpers to read `observed_orders` for a symbol (read how `apply_observed_orders` / the v0.3 read path queries them, and mirror the read). Structure:
+
+```python
+def track_live(tenant_id: int) -> dict:
+    """Tras el sync: avanza el estado vivo de cada plan activo desde los
+    observed_orders frescos + la qty real. Read-only sobre positions; escribe
+    lifecycle_states + (al cierre) conduct_episodes. Sin push, sin PositionClosure."""
+    import json
+    import sqlite3
+    from datetime import datetime, timezone
+
+    from db.transaction import snapshot_connection, transaction
+    from db.lifecycle_states import (
+        db_list_active, db_update_state, plan_from_json, state_from_row,
+    )
+    from db.conduct_episodes import db_put_episode
+    from instrument.tracker import advance_live, finalize_conduct
+
+    now = datetime.now(timezone.utc).isoformat()
+    with snapshot_connection() as con:
+        con.row_factory = sqlite3.Row
+        activos = [dict(r) for r in db_list_active(con, tenant_id=tenant_id)]
+
+    avanzados = cerrados = 0
+    for row in activos:
+        symbol = row["symbol"]
+        with snapshot_connection() as con:
+            con.row_factory = sqlite3.Row
+            pos = con.execute(
+                "SELECT qty FROM positions WHERE symbol=? AND tenant_id=? "
+                "AND status='open' AND control_domain='EXTERNAL' LIMIT 1",
+                (symbol, tenant_id)).fetchone()
+            obs_rows = con.execute(
+                "SELECT kind, price, qty, order_id FROM observed_orders "
+                "WHERE tenant_id=? AND symbol=?", (tenant_id, symbol)).fetchall()
+        if pos is None:
+            continue
+        curr_qty = float(pos["qty"] or 0.0)
+        curr_observed = [dict(o) for o in obs_rows]
+        plan = plan_from_json(row["plan_json"])
+        state = state_from_row(row)
+        prev_observed = json.loads(row["prev_observed_json"] or "[]")
+        prev_qty = row["prev_qty"] if row["prev_qty"] is not None else curr_qty
+        prev_events = json.loads(row["events_json"] or "[]")
+
+        new_state, new_events = advance_live(plan, state, prev_observed, curr_observed,
+                                             prev_qty, curr_qty)
+        all_events = prev_events + new_events
+        if new_state.fase == "CLOSED":
+            conduct = finalize_conduct(plan, all_events, new_state,
+                                       entry_price=row["entry_price"],
+                                       entry_ts=row["confirmed_at"], exit_ts=now)
+            with transaction() as con:
+                db_put_episode(con, position_id=row["position_id"], symbol=symbol,
+                               tenant_id=tenant_id, entry_ts=row["confirmed_at"],
+                               exit_ts=now, conduct=conduct, plan_json=row["plan_json"],
+                               reproduced=True, created_ts=now)
+                db_update_state(con, row_id=row["id"], estado_vivo="cerrado",
+                                state=new_state, events=all_events,
+                                prev_observed=curr_observed, prev_qty=curr_qty, updated_at=now)
+            cerrados += 1
+        else:
+            with transaction() as con:
+                db_update_state(con, row_id=row["id"], estado_vivo=row["estado_vivo"],
+                                state=new_state, events=all_events,
+                                prev_observed=curr_observed, prev_qty=curr_qty, updated_at=now)
+            avanzados += 1
+    return {"avanzados": avanzados, "cerrados": cerrados}
+```
+
+Then call `track_live(tenant_id)` at the end of `sync_tenant` (after the reconcile block) and include its result in `sync_tenant`'s returned report dict (e.g. `report["track_live"] = track_live(tenant_id)`). Read the end of `sync_tenant` and wire it in following the existing return-dict shape.
+
+- [ ] **Step 2: Add a `network`-marked smoke test**
+
+```python
+# tests/test_instrument_tracker.py — añadir
+import pytest
+
+
+@pytest.mark.network
+def test_track_live_smoke():
+    # corre sobre el tenant real; no asierta valores vivos, solo que no revienta.
+    from tools.sync_binance_spot import track_live
+    res = track_live(2)
+    assert "avanzados" in res and "cerrados" in res
+```
+
+- [ ] **Step 3: Run the pure tests + fast gate**
+
+Run: `python -m pytest tests/test_instrument_tracker.py tests/test_lifecycle_states.py tests/test_plan_api.py -m "not network" -v`
+Expected: green.
+
+Run: `python -m pytest tests/ -m "not network" -n auto -q`
+Expected: no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/sync_binance_spot.py tests/test_instrument_tracker.py
+git commit -m "feat(instrument): track_live — el tracker corre tras el sync (read-only, conducta al cierre)"
+```
+
+---
+
+## Verificación final
+
+- [ ] **Puros + DB + endpoints:** `python -m pytest tests/test_instrument_tracker.py tests/test_lifecycle_states.py tests/test_plan_api.py -m "not network" -v` → todo verde.
+- [ ] **Gate rápido (CI):** `python -m pytest tests/ -m "not network" -n auto -q` → sin regresiones.
+- [ ] **Anti-imperativo:** confirmar que el test `test_hechos_no_contienen_imperativos` pasa — la vista nunca instruye.
+- [ ] **Frontera dura:** grep de `api/plan.py`, `instrument/tracker.py`, `tools/sync_binance_spot.py` (el bloque nuevo) → cero `PositionClosure`, cero `UPDATE positions`, cero push/notify. Solo escribe `lifecycle_states` + `conduct_episodes`.
+- [ ] **Vivo (deliberado, red + DB):** con el API corriendo, `POST /plan/confirm` un símbolo de papá, correr el sync, y `GET /plan/{symbol}` → ver el estado vivo con hechos. Ese es el entregable de F3a: el instrumento acompañando una posición real, en pull, sin instruir.

--- a/docs/superpowers/specs/es/2026-06-13-instrumento-fase3a-lazo-vivo-design.md
+++ b/docs/superpowers/specs/es/2026-06-13-instrumento-fase3a-lazo-vivo-design.md
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS lifecycle_states (
     sl_actual           REAL,
     be_movido           INTEGER NOT NULL,    -- 0/1
     size_restante_frac  REAL,
+    events_json         TEXT    NOT NULL DEFAULT '[]',  -- audit de eventos vivos (para conducta al cierre)
     prev_observed_json  TEXT,               -- último snapshot de observed_orders (para el delta)
     prev_qty            REAL,
     confirmed_at        TEXT    NOT NULL,

--- a/docs/superpowers/specs/es/2026-06-13-instrumento-fase3a-lazo-vivo-design.md
+++ b/docs/superpowers/specs/es/2026-06-13-instrumento-fase3a-lazo-vivo-design.md
@@ -1,0 +1,132 @@
+# El Instrumento — Fase 3a (el lazo vivo, pull-only) · Diseño
+
+**Fecha:** 2026-06-13
+**Rama:** `feat/instrumento-fase3a-lazo-vivo`
+**Parte de:** el instrumento completo (`docs/superpowers/specs/es/2026-06-12-instrumento-lifecycle-conducta-design.md`), Fase 3 de §3/§9. F3b (tarjeta de selección A+C+D.1) es un subsistema aparte, después.
+
+## §0 — Qué es F3a, y el invariante que lo gobierna
+
+F3a es el **acompañante en vivo**: sigue una posición REAL del operador contra el plan que confirmó, y al cierre mide su conducta `i` con el libro de fills vivo (la comparación plan-vs-conducta que F2 difirió honestamente). Es el tercer y último refutador de la falsación progresiva (F1 envelope → F2 simulación → **F3 fills vivos**).
+
+**El invariante (revelado por Axiom-0 sobre el deadlock push/pull):**
+
+> El instrumento solo tiene unidades mientras permanezca **FUERA del término que mide**. Medir `i` exige que `i` nazca en el operador.
+
+De ahí la decisión central de F3a: el instrumento **emite hechos observables, NUNCA instrucciones de conducta**. Mostrar "TP1 se llenó" es espejo (refleja `𝓕ₜ`). Decir "mové el SL a BE" es autoría (el instrumento se vuelve co-fuente del acto `i` y mediría su propio eco — gemelo no escrito de INV-1). El instrumento jamás dice qué hacer.
+
+**Canal (decidido por el operador, honrando un lock):** **pull-only.** El hecho vive en una vista consultable; **cero push**. Esto honra el candado LOCKED CD-3/CD-5 de `docs/superpowers/specs/es/2026-06-09-posiciones-externas-control-domain-spec.md` §5 ("flag PULL en la vista, NO push Telegram" para posiciones EXTERNAL) sin tocarlo. Beneficio estructural: sin canal de push, no hay trampa de atención ni pendiente hacia un botón "cerrar" que violaría CD-1/CD-5. El operador mira cuando ÉL decide; la ley D.1 que confirmó en frío vive en la vista, no en una alarma.
+
+## §1 — Frontera dura
+
+- **Read-only sobre `positions`.** F3a nunca escribe `positions.status`, nunca llama `PositionClosure`. El cierre lo confirma el humano (CD-5).
+- **CD-1 respetado:** las posiciones de Binance son EXTERNAL; F3a las observa, jamás las actúa.
+- **Sin push, sin instrucción.** Solo hechos, vía pull.
+- **Escribe solo a:** la tabla nueva `lifecycle_states` (estado vivo) y, al cierre, a `conduct_episodes` (el ledger de F1).
+- **BNC-12:** opera sobre posiciones `origin IN ('SIGNAL','OPERATOR')` (AUTO_DERIVED nunca es conducta).
+
+## §2 — Arquitectura
+
+El estado vivo del plan por fin tiene domicilio (lo que F1 difirió, lo que Halberg reclamó).
+
+| Pieza | Archivo | Responsabilidad |
+|---|---|---|
+| Domicilio | `db/lifecycle_states.py` + migración | Una fila por plan activo: plan + `LifecycleState` incremental + último snapshot observado. |
+| Gate (preview) | `api/plan.py` → `GET /plan/derive/{symbol}` | Deriva el plan desde D.1 + entry y lo devuelve para revisión — NO persiste. |
+| Gate (confirmar) | `api/plan.py` → `POST /plan/confirm` | El operador confirma el plan revisado → crea la fila `lifecycle_states`. |
+| Detector | `instrument/tracker.py` → `detect_transitions(...)` | **Puro.** Snapshot observado previo vs actual + qty → eventos. Idempotente, honesto sobre ambigüedad. |
+| Tracker | `instrument/tracker.py` → `advance_live(...)` + el hook de I/O | Corre **después** de `binance_sync`: lee posición EXTERNAL + `observed_orders`, detecta, avanza la máquina (`step`), persiste. **Cero alertas.** |
+| Vista | `api/plan.py` → `GET /plan/{symbol}` | Pull: estado vivo (plan vs realidad + conducta hasta ahora). |
+| Conducta al cierre | el tracker, al llegar a CLOSED | `compute_conduct` con los fills vivos → `conduct_episodes`. |
+
+## §3 — Domicilio: tabla `lifecycle_states`
+
+Una fila por plan activo del operador. Idempotente (CREATE TABLE IF NOT EXISTS), mismo estilo que `conduct_episodes`/`observed_orders`.
+
+```sql
+CREATE TABLE IF NOT EXISTS lifecycle_states (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    position_id         INTEGER,
+    symbol              TEXT    NOT NULL,
+    tenant_id           INTEGER NOT NULL,
+    estado_vivo         TEXT    NOT NULL CHECK (estado_vivo IN ('activo','cerrado','incierto')),
+    plan_json           TEXT    NOT NULL,   -- el Plan confirmado (la ley)
+    entry_price         REAL    NOT NULL,
+    qty_original        REAL,               -- qty al confirmar (base del % restante)
+    fase                TEXT    NOT NULL,    -- PLANNED|CONFIRMED|RUNNING|CLOSED
+    rungs_llenos_json   TEXT    NOT NULL,    -- [0,1,...]
+    consumed_orders_json TEXT   NOT NULL,    -- [order_id,...] (idempotencia)
+    sl_actual           REAL,
+    be_movido           INTEGER NOT NULL,    -- 0/1
+    size_restante_frac  REAL,
+    prev_observed_json  TEXT,               -- último snapshot de observed_orders (para el delta)
+    prev_qty            REAL,
+    confirmed_at        TEXT    NOT NULL,
+    updated_at          TEXT    NOT NULL,
+    UNIQUE (tenant_id, symbol, confirmed_at)
+);
+```
+
+Helpers SQL puros (reciben `con`): `db_put_lifecycle_state`, `db_get_active_state(con, tenant_id, symbol)`, `db_list_active(con, tenant_id)`, `db_update_lifecycle_state`. La serialización `LifecycleState ↔ fila` vive en helpers dedicados (frozensets ↔ JSON listas).
+
+## §4 — El gate (`POST /plan/confirm`)
+
+1. El operador (UI/CLI) pide derivar: el endpoint reconstruye las zonas de D.1 (`detect_levels` sobre velas diarias hasta ahora), `derive_plan(zonas, entry_price)`, y devuelve el plan **para revisión** (no lo persiste todavía).
+2. El operador **confirma** (su juicio + gate de fundamentales entran aquí, en frío): `POST /plan/confirm {symbol, entry_price, position_id?}` → crea la fila `lifecycle_states` con `estado_vivo='activo'`, `fase='CONFIRMED'`, `sl_actual=plan.sl_price`, `qty_original` de la posición. La red (D.1) corre **fuera** de la tx; el insert va en una tx corta.
+3. No per-tenant cross-talk: la fila lleva `tenant_id` del caller (validado como en el resto de la API).
+
+## §5 — El detector de transiciones (`detect_transitions`, puro)
+
+`detect_transitions(plan, state, prev_observed, curr_observed, prev_qty, curr_qty) -> list[dict]`. Puro: sin red, sin DB. `*_observed` = listas de `{kind, price, qty, order_id}` (forma de `observed_orders`). Devuelve eventos para la máquina de F1.
+
+`observed_orders` es un snapshot de órdenes ABIERTAS (DELETE+reinsert); un TP que desaparece pudo **llenarse** o **cancelarse** — el snapshot solo no distingue. Las reglas, honestas sobre su resolución:
+
+1. **RUNG_FILLED:** un `order_id` TP presente en `prev_observed`, **ausente** en `curr_observed`, que matchea por proximidad de precio (`_close` 0.5%) a un rung NO en `state.rungs_llenos`, **Y** `curr_qty < prev_qty` (la posición bajó) → `RUNG_FILLED(rung_index, order_id)`. Idempotente: si `order_id ∈ consumed_orders`, no-op.
+2. **Cancelación (no fill):** TP `order_id` que desaparece **sin** caída de qty → cancelación; **no** se emite evento.
+3. **SL_MOVED:** el SL observado cuyo `price` cambió de `prev` a `curr` a ≈ `entry_price` → `SL_MOVED(entry)`. (Si cambió a otro precio: también `SL_MOVED` con el nuevo SL — el campo de conducta `sl_respetado` lo juzgará al cierre.)
+4. **STOP_HIT / cierre:** `curr_qty ≈ 0` (con credencial ACTIVE) → `STOP_HIT` si el último SL observado matchea el cierre, o señal de cierre a confirmar (CD-5). El tracker marca `estado_vivo='cerrado'`; el sistema NO escribe `positions.status='closed'`.
+5. **Ambigüedad irresoluble** (no se puede matchear el delta a una transición conocida) → **no se avanza**; el tracker marca `estado_vivo='incierto'` y lo expone en la vista. El detector **no inventa** (misma honestidad que el envelope de F1/F2). El operador puede reconciliar a mano; F3b/futuro puede leer el trade history de Binance para desambiguar fill-vs-cancel con certeza (DEFER).
+
+## §6 — El tracker (I/O) y la vista (pull)
+
+**Tracker** (`advance_live`): corre **después** de `binance_sync` en el mismo ciclo (consume su salida; no compite por escrituras a `positions` — solo escribe `lifecycle_states`). Para cada fila activa: lee la posición + `observed_orders` frescos, llama `detect_transitions`, aplica los eventos por `step` (F1), persiste el estado nuevo + `prev_observed`/`prev_qty`. Si llega a CLOSED → §7.
+
+**Vista** (`GET /plan/{symbol}`, pull): devuelve el estado vivo, hechos contra el plan — sin instrucción:
+```jsonc
+{ "symbol": "BTCUSDT", "estado_vivo": "activo",
+  "plan": { "entry": .., "sl_plan": .., "rungs": [..], "runner_frac": .. },
+  "realidad": { "fase": "RUNNING", "rungs_llenos": [0], "sl_actual": .., "be_movido": true,
+                "size_restante_frac": 0.5 },
+  "hechos": ["TP1 se llenó", "tu SL está en break-even", "tu SL sigue debajo de la zona"] }
+```
+Los `hechos` son afirmaciones de `𝓕ₜ` (lo que ES verdad), **nunca** instrucciones. `estado_vivo:"incierto"` → un hecho honesto: "transición sin confirmar — revisá en Binance".
+
+## §7 — Conducta al cierre (la comparación que F2 difirió)
+
+Al llegar a CLOSED, ahora SÍ hay conducta **observada legítima** (los fills reales del libro vivo). El tracker corre `compute_conduct(plan, events, final_state, ...)` de F1 — **campo por campo** contra el plan confirmado: `entry_en_zona`, `sl_respetado` (¿ensanchaste el SL?, lo dice `observed_orders`), `adherencia_be` (¿moviste a BE tras TP1?), `rungs_honrados`, `escalono`, `cierre_en_plan`, `hold_hours` — con procedencia `observado`. Persiste a `conduct_episodes` (el ledger de F1). **NO una resta de PnL** (el veto de F2 sigue en pie): hechos de conducta, no rentabilidad.
+
+## §8 — Pruebas
+
+**Puras** (`tests/test_instrument_tracker.py`, sin red/DB):
+- `detect_transitions`: TP desaparece + qty baja → `RUNG_FILLED` (idempotente por order_id); TP desaparece sin caída de qty → **sin** evento (cancelación); SL cambia a ≈entry → `SL_MOVED`/BE; qty→0 → cierre; delta no-matcheable → sin evento (incierto).
+- serialización `LifecycleState ↔ fila` (round-trip de frozensets ↔ JSON).
+- conducta al cierre: una secuencia de snapshots vivos → `compute_conduct` produce los campos esperados.
+
+**DB** (`tests/test_lifecycle_states.py`): roundtrip de helpers, CHECK de `estado_vivo`, migración real vía `init_db()`, filtro por tenant.
+
+**Endpoints** (`tests/test_plan_api.py`): `POST /plan/confirm` crea la fila (D.1 mockeada); `GET /plan/{symbol}` devuelve el estado; los `hechos` no contienen ningún imperativo (regex anti-instrucción: sin "mové/movete/cerrá/vendé/comprá").
+
+**Tracker** (smoke `network`-marcado): un ciclo sobre datos reales.
+
+## §9 — Invariantes preservados
+- **El instrumento queda fuera del término que mide** (Axiom-0): solo hechos, nunca instrucciones. Test anti-imperativo en la vista.
+- **Pull-only:** sin push; honra CD-3/CD-5. Sin canal de salida en caliente.
+- **Frontera dura:** read-only sobre `positions`, sin `PositionClosure`, sin escribir `closed` (CD-5). Escribe solo `lifecycle_states` + `conduct_episodes`.
+- **CD-1 / BNC-12:** EXTERNAL observado nunca actuado; conducta solo SIGNAL/OPERATOR.
+- **Honestidad sobre la resolución:** ambigüedad del snapshot → `incierto`, no se inventa.
+- **Sin PnL:** la conducta al cierre es campo-por-campo, no resta de retorno (veto F2 vigente).
+
+## §10 — Fuera de alcance (defer / delete)
+- **Push de cualquier tipo** — DELETE (decisión del operador + lock CD-3/CD-5).
+- **Trade history de Binance para fill-vs-cancel con certeza** — DEFER (el snapshot-delta+qty es la resolución honesta de v1; el trade history desambigua los `incierto` en una iteración futura).
+- **F3b — tarjeta de selección compuesta A+C+D.1** — subsistema aparte, su propio spec.
+- **Follow-ups de pureza F1** (tolerancia float en BE detection, contrato de `events` en compute_conduct) — se atienden al cablear el tracker si tocan el camino vivo.

--- a/instrument/tracker.py
+++ b/instrument/tracker.py
@@ -21,18 +21,24 @@ def detect_transitions(plan, state: LifecycleState, prev_observed: list[dict],
                        curr_observed: list[dict], prev_qty: float,
                        curr_qty: float) -> list[dict]:
     """Snapshots de observed_orders (prev/curr) + qty → eventos para step(). Puro."""
+    if state.fase == "CLOSED":
+        return []   # terminal: no se re-emiten eventos sobre un estado cerrado
+
     proc = "observado"
     events: list[dict] = []
-    curr_ids = {o["order_id"] for o in curr_observed}
+    curr_ids = {str(o["order_id"]) for o in curr_observed}   # normaliza a str (consistente con consumed_order_ids)
     qty_dropped = curr_qty < prev_qty - _EPS
 
     if qty_dropped:
         for o in prev_observed:
             oid = str(o["order_id"])
-            if o.get("kind") != "TP" or o["order_id"] in curr_ids:
+            if o.get("kind") != "TP" or oid in curr_ids:
                 continue
             if oid in state.consumed_order_ids:
                 continue
+            # Asume precios de TP distintos por rung (vienen de zonas de resistencia
+            # distintas). break tras el primer match: con rungs a <0.5% podría
+            # mis-atribuir, pero derive_plan no produce rungs tan juntos.
             for i, r in enumerate(plan.rungs):
                 if i in state.rungs_llenos:
                     continue

--- a/instrument/tracker.py
+++ b/instrument/tracker.py
@@ -1,0 +1,76 @@
+"""Tracker en vivo del instrumento (F3a) — puro, sin red, sin DB.
+
+Deriva eventos de transición de los snapshots de observed_orders + qty y avanza
+la máquina de F1. HONESTO sobre la resolución: un TP que desaparece pudo llenarse
+(qty baja) o cancelarse (qty igual); la ambigüedad no se inventa. Idempotente por
+order_id. Spec §5. NO emite alertas, NO instruye — solo deriva hechos."""
+from __future__ import annotations
+
+from instrument.conduct import compute_conduct
+from instrument.lifecycle import LifecycleState, step
+
+_TOL = 0.005   # 0.5%: proximidad de precio observado ↔ nivel del plan
+_EPS = 1e-9
+
+
+def _close(a: float, b: float) -> bool:
+    return b != 0 and abs(a - b) / abs(b) <= _TOL
+
+
+def detect_transitions(plan, state: LifecycleState, prev_observed: list[dict],
+                       curr_observed: list[dict], prev_qty: float,
+                       curr_qty: float) -> list[dict]:
+    """Snapshots de observed_orders (prev/curr) + qty → eventos para step(). Puro."""
+    proc = "observado"
+    events: list[dict] = []
+    curr_ids = {o["order_id"] for o in curr_observed}
+    qty_dropped = curr_qty < prev_qty - _EPS
+
+    if qty_dropped:
+        for o in prev_observed:
+            oid = str(o["order_id"])
+            if o.get("kind") != "TP" or o["order_id"] in curr_ids:
+                continue
+            if oid in state.consumed_order_ids:
+                continue
+            for i, r in enumerate(plan.rungs):
+                if i in state.rungs_llenos:
+                    continue
+                if _close(o["price"], r.tp_price):
+                    events.append({"tipo": "RUNG_FILLED", "order_id": oid,
+                                   "rung_index": i, "procedencia": proc})
+                    break
+
+    prev_sl = next((o for o in prev_observed if o.get("kind") == "SL"), None)
+    curr_sl = next((o for o in curr_observed if o.get("kind") == "SL"), None)
+    if prev_sl and curr_sl and not _close(prev_sl["price"], curr_sl["price"]):
+        events.append({"tipo": "SL_MOVED", "nuevo_sl": float(curr_sl["price"]),
+                       "procedencia": proc})
+
+    if curr_qty <= 1e-8:
+        events.append({"tipo": "STOP_HIT", "procedencia": proc})
+
+    return events
+
+
+def advance_live(plan, state: LifecycleState, prev_observed: list[dict],
+                 curr_observed: list[dict], prev_qty: float,
+                 curr_qty: float) -> tuple[LifecycleState, list[dict]]:
+    """Detecta transiciones y avanza la máquina. Devuelve (estado_nuevo, eventos).
+    Puro: compone detect_transitions + step de F1. Spec §6."""
+    events = detect_transitions(plan, state, prev_observed, curr_observed,
+                                prev_qty, curr_qty)
+    for e in events:
+        state = step(state, e, plan)
+        if state.fase == "CLOSED":
+            break
+    return state, events
+
+
+def finalize_conduct(plan, events: list[dict], final_state, *, entry_price: float,
+                     entry_ts: str, exit_ts: str) -> dict:
+    """Conducta al cierre con el libro de fills vivo (la comparación que F2
+    difirió). Campo por campo contra el plan, procedencia 'observado'. NO PnL.
+    Spec §7."""
+    return compute_conduct(plan, events, final_state, entry_price=entry_price,
+                           entry_ts=entry_ts, exit_ts=exit_ts, procedencia="observado")

--- a/tests/test_instrument_tracker.py
+++ b/tests/test_instrument_tracker.py
@@ -89,7 +89,7 @@ def test_advance_live_cierre_lleva_a_closed():
     new, events = advance_live(p, _armed(p), [_sl(p.sl_price, 99)], [],
                                prev_qty=1.0, curr_qty=0.0)
     assert new.fase == "CLOSED"
-    assert new.close_reason in ("SL_HIT", "BE_HIT")
+    assert new.close_reason == "SL_HIT"
 
 
 def test_advance_live_sin_cambios_no_avanza():
@@ -122,3 +122,12 @@ def test_finalize_conduct_al_cierre():
     assert c["rungs_honrados"] == 1
     assert c["procedencia"] == "observado"
     assert "hold_hours" in c
+
+
+def test_dos_tps_en_un_tick_dan_dos_rung_filled():
+    p = _plan()
+    prev = [_tp(105, 11), _tp(110, 12), _sl(p.sl_price, 99)]
+    curr = [_sl(p.sl_price, 99)]   # ambos TP desaparecen, qty baja
+    evs = detect_transitions(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=0.3)
+    rungs = sorted(e["rung_index"] for e in evs if e["tipo"] == "RUNG_FILLED")
+    assert rungs == [0, 1]

--- a/tests/test_instrument_tracker.py
+++ b/tests/test_instrument_tracker.py
@@ -1,4 +1,5 @@
 """Tests del detector/tracker en vivo (instrumento F3a). Puro: sin red, sin DB. Spec §5."""
+import pytest
 from instrument.plan import derive_plan
 from instrument.lifecycle import LifecycleState
 from instrument.tracker import detect_transitions
@@ -133,11 +134,37 @@ def test_dos_tps_en_un_tick_dan_dos_rung_filled():
     assert rungs == [0, 1]
 
 
-import pytest
-
-
 @pytest.mark.network
 def test_track_live_smoke():
     from tools.sync_binance_spot import track_live
     res = track_live(2)
     assert "avanzados" in res and "cerrados" in res
+
+
+def test_track_live_posicion_cerrada_finaliza(monkeypatch, tmp_path):
+    import btc_api, os, sqlite3
+    monkeypatch.setattr(btc_api, "DB_FILE", str(tmp_path / "d.db"))
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        from db.schema import init_db
+        init_db()
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+    from db.transaction import transaction
+    from db.lifecycle_states import db_put_state, db_get_active_state
+    from db.conduct_episodes import db_get_episodes
+    p = _plan()
+    s = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=p.sl_price)
+    with transaction() as con:
+        db_put_state(con, position_id=None, symbol="BTCUSDT", tenant_id=2, estado_vivo="activo",
+                     plan=p, state=s, entry_price=100.0, qty_original=1.0, events=[],
+                     prev_observed=[], prev_qty=1.0, confirmed_at="2026-06-13T00:00:00+00:00",
+                     updated_at="2026-06-13T00:00:00+00:00")
+    # no hay posición open EXTERNAL → pos is None → POSITION_GONE → cerrado + conducta
+    from tools.sync_binance_spot import track_live
+    res = track_live(2)
+    assert res["cerrados"] == 1
+    with __import__("db.transaction", fromlist=["snapshot_connection"]).snapshot_connection() as con:
+        con.row_factory = sqlite3.Row
+        assert db_get_active_state(con, tenant_id=2, symbol="BTCUSDT") is None  # ya no activo
+        assert len(db_get_episodes(con, tenant_id=2)) == 1                       # conducta persistida

--- a/tests/test_instrument_tracker.py
+++ b/tests/test_instrument_tracker.py
@@ -131,3 +131,13 @@ def test_dos_tps_en_un_tick_dan_dos_rung_filled():
     evs = detect_transitions(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=0.3)
     rungs = sorted(e["rung_index"] for e in evs if e["tipo"] == "RUNG_FILLED")
     assert rungs == [0, 1]
+
+
+import pytest
+
+
+@pytest.mark.network
+def test_track_live_smoke():
+    from tools.sync_binance_spot import track_live
+    res = track_live(2)
+    assert "avanzados" in res and "cerrados" in res

--- a/tests/test_instrument_tracker.py
+++ b/tests/test_instrument_tracker.py
@@ -1,0 +1,69 @@
+"""Tests del detector/tracker en vivo (instrumento F3a). Puro: sin red, sin DB. Spec §5."""
+from instrument.plan import derive_plan
+from instrument.lifecycle import LifecycleState
+from instrument.tracker import detect_transitions
+
+
+def _z(tipo, bajo, alto, centro):
+    return {"tipo": tipo, "precio_bajo": bajo, "precio_alto": alto,
+            "centro": centro, "toques": 3, "confluencia_redondo": []}
+
+
+def _plan():
+    zonas = [_z("soporte", 94, 96, 95),
+             _z("resistencia", 104, 106, 105),
+             _z("resistencia", 109, 111, 110)]
+    return derive_plan(zonas, entry_price=100.0)
+
+
+def _armed(p, **kw):
+    return LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=p.sl_price, **kw)
+
+
+def _tp(price, oid, qty=1.0):
+    return {"kind": "TP", "price": price, "qty": qty, "order_id": oid}
+
+
+def _sl(price, oid, qty=1.0):
+    return {"kind": "SL", "price": price, "qty": qty, "order_id": oid}
+
+
+def test_tp_desaparece_con_caida_de_qty_es_rung_filled():
+    p = _plan()
+    prev = [_tp(105, 11), _sl(p.sl_price, 99)]
+    curr = [_sl(p.sl_price, 99)]
+    evs = detect_transitions(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=0.5)
+    rung = [e for e in evs if e["tipo"] == "RUNG_FILLED"]
+    assert len(rung) == 1 and rung[0]["rung_index"] == 0 and rung[0]["order_id"] == "11"
+
+
+def test_tp_desaparece_sin_caida_de_qty_es_cancelacion():
+    p = _plan()
+    prev = [_tp(105, 11), _sl(p.sl_price, 99)]
+    curr = [_sl(p.sl_price, 99)]
+    evs = detect_transitions(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=1.0)
+    assert not any(e["tipo"] == "RUNG_FILLED" for e in evs)
+
+
+def test_rung_idempotente_por_order_id():
+    p = _plan()
+    prev = [_tp(105, 11)]
+    curr = []
+    st = _armed(p, consumed_order_ids=frozenset({"11"}))
+    evs = detect_transitions(p, st, prev, curr, prev_qty=1.0, curr_qty=0.5)
+    assert not any(e["tipo"] == "RUNG_FILLED" for e in evs)
+
+
+def test_sl_cambia_a_entry_es_sl_moved():
+    p = _plan()
+    prev = [_sl(p.sl_price, 99)]
+    curr = [_sl(p.entry_price, 99)]
+    evs = detect_transitions(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=1.0)
+    sl = [e for e in evs if e["tipo"] == "SL_MOVED"]
+    assert len(sl) == 1 and sl[0]["nuevo_sl"] == p.entry_price
+
+
+def test_qty_cero_es_stop_hit():
+    p = _plan()
+    evs = detect_transitions(p, _armed(p), [_sl(p.sl_price, 99)], [], prev_qty=1.0, curr_qty=0.0)
+    assert any(e["tipo"] == "STOP_HIT" for e in evs)

--- a/tests/test_instrument_tracker.py
+++ b/tests/test_instrument_tracker.py
@@ -67,3 +67,34 @@ def test_qty_cero_es_stop_hit():
     p = _plan()
     evs = detect_transitions(p, _armed(p), [_sl(p.sl_price, 99)], [], prev_qty=1.0, curr_qty=0.0)
     assert any(e["tipo"] == "STOP_HIT" for e in evs)
+
+
+# ── Task 2: advance_live ────────────────────────────────────────────────────
+from instrument.tracker import advance_live
+
+
+def test_advance_live_aplica_rung_y_avanza():
+    p = _plan()
+    prev = [_tp(105, 11), _sl(p.sl_price, 99)]
+    curr = [_sl(p.sl_price, 99)]
+    new, events = advance_live(p, _armed(p), prev, curr, prev_qty=1.0, curr_qty=0.5)
+    assert 0 in new.rungs_llenos
+    assert "11" in new.consumed_order_ids
+    assert any(e["tipo"] == "RUNG_FILLED" for e in events)
+    assert new.fase == "RUNNING"
+
+
+def test_advance_live_cierre_lleva_a_closed():
+    p = _plan()
+    new, events = advance_live(p, _armed(p), [_sl(p.sl_price, 99)], [],
+                               prev_qty=1.0, curr_qty=0.0)
+    assert new.fase == "CLOSED"
+    assert new.close_reason in ("SL_HIT", "BE_HIT")
+
+
+def test_advance_live_sin_cambios_no_avanza():
+    p = _plan()
+    obs = [_sl(p.sl_price, 99)]
+    new, events = advance_live(p, _armed(p), obs, obs, prev_qty=1.0, curr_qty=1.0)
+    assert events == []
+    assert new.fase == "CONFIRMED"

--- a/tests/test_instrument_tracker.py
+++ b/tests/test_instrument_tracker.py
@@ -98,3 +98,27 @@ def test_advance_live_sin_cambios_no_avanza():
     new, events = advance_live(p, _armed(p), obs, obs, prev_qty=1.0, curr_qty=1.0)
     assert events == []
     assert new.fase == "CONFIRMED"
+
+
+# ── Task 6: finalize_conduct ────────────────────────────────────────────────
+from instrument.tracker import finalize_conduct
+
+
+def test_finalize_conduct_al_cierre():
+    p = _plan()
+    events = [
+        {"tipo": "RUNG_FILLED", "order_id": "11", "rung_index": 0, "procedencia": "observado"},
+        {"tipo": "SL_MOVED", "nuevo_sl": p.entry_price, "procedencia": "observado"},
+        {"tipo": "STOP_HIT", "procedencia": "observado"},
+    ]
+    from instrument.lifecycle import LifecycleState, step
+    st = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=p.sl_price)
+    for e in events:
+        st = step(st, e, p)
+    c = finalize_conduct(p, events, st, entry_price=100.0,
+                         entry_ts="2026-06-10T00:00:00+00:00",
+                         exit_ts="2026-06-12T00:00:00+00:00")
+    assert c["adherencia_be"] is True
+    assert c["rungs_honrados"] == 1
+    assert c["procedencia"] == "observado"
+    assert "hold_hours" in c

--- a/tests/test_lifecycle_states.py
+++ b/tests/test_lifecycle_states.py
@@ -5,7 +5,7 @@ from instrument.plan import derive_plan
 from instrument.lifecycle import LifecycleState
 from db.lifecycle_states import (
     plan_to_json, plan_from_json, state_to_row, state_from_row,
-    db_put_state, db_get_active_state,
+    db_put_state, db_get_active_state, db_list_active,
 )
 
 
@@ -48,7 +48,8 @@ def _con():
             plan_json TEXT NOT NULL, entry_price REAL NOT NULL, qty_original REAL,
             fase TEXT NOT NULL, rungs_llenos_json TEXT NOT NULL,
             consumed_orders_json TEXT NOT NULL, sl_actual REAL, be_movido INTEGER NOT NULL,
-            size_restante_frac REAL, events_json TEXT NOT NULL DEFAULT '[]',
+            size_restante_frac REAL, close_reason TEXT,
+            events_json TEXT NOT NULL DEFAULT '[]',
             prev_observed_json TEXT, prev_qty REAL,
             confirmed_at TEXT NOT NULL, updated_at TEXT NOT NULL,
             UNIQUE (tenant_id, symbol, confirmed_at))""")
@@ -65,3 +66,37 @@ def test_put_y_get_active():
                  updated_at="2026-06-13T00:00:00+00:00")
     row = db_get_active_state(con, tenant_id=2, symbol="BTCUSDT")
     assert row is not None and row["symbol"] == "BTCUSDT" and row["estado_vivo"] == "activo"
+
+
+def test_reconfirmar_supersede_la_anterior_activa():
+    con = _con()
+    p = _plan()
+    s = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=p.sl_price)
+    for ts in ("2026-06-13T00:00:00+00:00", "2026-06-14T00:00:00+00:00"):
+        db_put_state(con, position_id=None, symbol="BTCUSDT", tenant_id=2, estado_vivo="activo",
+                     plan=p, state=s, entry_price=100.0, qty_original=1.0, events=[],
+                     prev_observed=[], prev_qty=1.0, confirmed_at=ts, updated_at=ts)
+    activos = db_list_active(con, tenant_id=2)
+    assert len(activos) == 1   # la primera fue superseded
+    assert activos[0]["confirmed_at"] == "2026-06-14T00:00:00+00:00"
+
+
+def test_close_reason_persiste_y_roundtrip():
+    con = _con()
+    p = _plan()
+    s = LifecycleState(plan_id=0, fase="CLOSED", sl_actual=p.sl_price, close_reason="SL_HIT")
+    db_put_state(con, position_id=None, symbol="ETHUSDT", tenant_id=3, estado_vivo="cerrado",
+                 plan=p, state=s, entry_price=200.0, qty_original=0.5, events=[],
+                 prev_observed=[], prev_qty=0.5, confirmed_at="2026-06-13T01:00:00+00:00",
+                 updated_at="2026-06-13T01:00:00+00:00")
+    row = con.execute(
+        "SELECT close_reason FROM lifecycle_states WHERE symbol='ETHUSDT' AND tenant_id=3"
+    ).fetchone()
+    assert row is not None and row[0] == "SL_HIT"
+
+
+def test_state_row_roundtrip_preserva_close_reason_none():
+    s = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=99.0)
+    assert s.close_reason is None
+    s2 = state_from_row(state_to_row(s))
+    assert s2.close_reason is None

--- a/tests/test_lifecycle_states.py
+++ b/tests/test_lifecycle_states.py
@@ -1,0 +1,67 @@
+"""Tests del domicilio lifecycle_states (instrumento F3a). Spec §3."""
+import sqlite3
+
+from instrument.plan import derive_plan
+from instrument.lifecycle import LifecycleState
+from db.lifecycle_states import (
+    plan_to_json, plan_from_json, state_to_row, state_from_row,
+    db_put_state, db_get_active_state,
+)
+
+
+def _z(tipo, bajo, alto, centro):
+    return {"tipo": tipo, "precio_bajo": bajo, "precio_alto": alto,
+            "centro": centro, "toques": 3, "confluencia_redondo": []}
+
+
+def _plan():
+    return derive_plan([_z("soporte", 94, 96, 95), _z("resistencia", 104, 106, 105)],
+                       entry_price=100.0)
+
+
+def test_plan_json_roundtrip():
+    p = _plan()
+    p2 = plan_from_json(plan_to_json(p))
+    assert p2.entry_price == p.entry_price
+    assert [r.tp_price for r in p2.rungs] == [r.tp_price for r in p.rungs]
+    assert p2.sl_price == p.sl_price and p2.runner_frac == p.runner_frac
+
+
+def test_state_row_roundtrip_preserva_frozensets():
+    s = LifecycleState(plan_id=0, fase="RUNNING",
+                       rungs_llenos=frozenset({0}), consumed_order_ids=frozenset({"11"}),
+                       sl_actual=99.0, be_movido=True, size_restante_frac=0.5)
+    s2 = state_from_row(state_to_row(s))
+    assert s2.rungs_llenos == frozenset({0})
+    assert s2.consumed_order_ids == frozenset({"11"})
+    assert s2.be_movido is True and s2.fase == "RUNNING"
+
+
+def _con():
+    con = sqlite3.connect(":memory:")
+    con.row_factory = sqlite3.Row
+    con.execute("""
+        CREATE TABLE lifecycle_states (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, position_id INTEGER,
+            symbol TEXT NOT NULL, tenant_id INTEGER NOT NULL,
+            estado_vivo TEXT NOT NULL CHECK (estado_vivo IN ('activo','cerrado','incierto')),
+            plan_json TEXT NOT NULL, entry_price REAL NOT NULL, qty_original REAL,
+            fase TEXT NOT NULL, rungs_llenos_json TEXT NOT NULL,
+            consumed_orders_json TEXT NOT NULL, sl_actual REAL, be_movido INTEGER NOT NULL,
+            size_restante_frac REAL, events_json TEXT NOT NULL DEFAULT '[]',
+            prev_observed_json TEXT, prev_qty REAL,
+            confirmed_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            UNIQUE (tenant_id, symbol, confirmed_at))""")
+    return con
+
+
+def test_put_y_get_active():
+    con = _con()
+    p = _plan()
+    s = LifecycleState(plan_id=0, fase="CONFIRMED", sl_actual=p.sl_price)
+    db_put_state(con, position_id=7, symbol="BTCUSDT", tenant_id=2, estado_vivo="activo",
+                 plan=p, state=s, entry_price=100.0, qty_original=1.0, events=[],
+                 prev_observed=[], prev_qty=1.0, confirmed_at="2026-06-13T00:00:00+00:00",
+                 updated_at="2026-06-13T00:00:00+00:00")
+    row = db_get_active_state(con, tenant_id=2, symbol="BTCUSDT")
+    assert row is not None and row["symbol"] == "BTCUSDT" and row["estado_vivo"] == "activo"

--- a/tests/test_lifecycle_states_migration.py
+++ b/tests/test_lifecycle_states_migration.py
@@ -1,0 +1,96 @@
+"""Tests de la migración lifecycle_states (instrumento F3a).
+
+Verifica que init_db() crea la tabla con las columnas correctas (incluido
+close_reason), que el CHECK de estado_vivo rechaza valores inválidos, y que
+una doble llamada a init_db() es idempotente. Patrón: test_conduct_episodes_migration.py.
+"""
+import os
+import sqlite3
+
+import pytest
+
+
+def _fresh_db(tmp_path) -> sqlite3.Connection:
+    db_path = tmp_path / "lifecycle_states_test.db"
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        import btc_api
+        original = btc_api.DB_FILE
+        btc_api.DB_FILE = str(db_path)
+        try:
+            from db.schema import init_db
+            init_db()
+            con = sqlite3.connect(str(db_path))
+            con.isolation_level = None  # autocommit — los INSERTs de test se ven solos
+            return con
+        finally:
+            btc_api.DB_FILE = original
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+
+
+@pytest.fixture
+def fresh_db_con(tmp_path):
+    con = _fresh_db(tmp_path)
+    yield con
+    con.close()
+
+
+class TestMigracionLifecycleStates:
+    def test_tabla_existe_con_columnas_esperadas(self, fresh_db_con):
+        con = fresh_db_con
+        row = con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='lifecycle_states'"
+        ).fetchone()
+        assert row is not None, "lifecycle_states table must exist after init_db()"
+        cols = {r[1] for r in con.execute("PRAGMA table_info(lifecycle_states)")}
+        expected = {
+            "id", "position_id", "symbol", "tenant_id", "estado_vivo",
+            "plan_json", "entry_price", "qty_original", "fase",
+            "rungs_llenos_json", "consumed_orders_json", "sl_actual",
+            "be_movido", "size_restante_frac", "close_reason",
+            "events_json", "prev_observed_json", "prev_qty",
+            "confirmed_at", "updated_at",
+        }
+        assert expected <= cols
+
+    def test_estado_vivo_check_rechaza_valor_invalido(self, fresh_db_con):
+        con = fresh_db_con
+        with pytest.raises(sqlite3.IntegrityError):
+            con.execute(
+                """INSERT INTO lifecycle_states
+                   (symbol, tenant_id, estado_vivo, plan_json, entry_price,
+                    fase, rungs_llenos_json, consumed_orders_json, be_movido,
+                    confirmed_at, updated_at)
+                   VALUES ('BTCUSDT', 1, 'fantasma', '{}', 100.0,
+                           'CONFIRMED', '[]', '[]', 0,
+                           '2026-06-13T00:00:00+00:00', '2026-06-13T00:00:00+00:00')"""
+            )
+
+    def test_estado_vivo_activo_aceptado(self, fresh_db_con):
+        con = fresh_db_con
+        con.execute(
+            """INSERT INTO lifecycle_states
+               (symbol, tenant_id, estado_vivo, plan_json, entry_price,
+                fase, rungs_llenos_json, consumed_orders_json, be_movido,
+                confirmed_at, updated_at)
+               VALUES ('BTCUSDT', 1, 'activo', '{}', 100.0,
+                       'CONFIRMED', '[]', '[]', 0,
+                       '2026-06-13T00:00:00+00:00', '2026-06-13T00:00:00+00:00')"""
+        )
+        n = con.execute("SELECT COUNT(*) FROM lifecycle_states").fetchone()[0]
+        assert n == 1
+
+    def test_migracion_idempotente(self, tmp_path):
+        from db.schema import init_db
+        import btc_api
+        db_path = tmp_path / "idempotent_lifecycle_test.db"
+        os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+        original = btc_api.DB_FILE
+        try:
+            btc_api.DB_FILE = str(db_path)
+            init_db()
+            init_db()  # segunda ejecución — debe ser idempotente
+        finally:
+            btc_api.DB_FILE = original
+            os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)

--- a/tests/test_plan_api.py
+++ b/tests/test_plan_api.py
@@ -1,0 +1,68 @@
+"""Tests de los endpoints del plan vivo (instrumento F3a). Spec §4/§6."""
+import os
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.plan import router, construir_hechos
+from auth.dependencies import get_current_tenant_id
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_tenant_id] = lambda: 2
+    return TestClient(app)
+
+
+def _zonas():
+    return [{"tipo": "soporte", "precio_bajo": 94, "precio_alto": 96, "centro": 95,
+             "toques": 3, "confluencia_redondo": []},
+            {"tipo": "resistencia", "precio_bajo": 104, "precio_alto": 106, "centro": 105,
+             "toques": 3, "confluencia_redondo": []}]
+
+
+def test_derive_devuelve_plan_sin_persistir():
+    with patch("api.plan._zonas_now", return_value=_zonas()):
+        r = _app().get("/plan/derive/BTCUSDT?entry_price=100")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["entry"] == 100.0
+    assert [rg["tp_price"] for rg in body["rungs"]] == [105.0]
+    assert body["sl_plan"] == 94.0 * (1 - 0.01)
+
+
+def test_confirm_crea_la_fila(monkeypatch, tmp_path):
+    import btc_api
+    monkeypatch.setattr(btc_api, "DB_FILE", str(tmp_path / "d.db"))
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        from db.schema import init_db
+        init_db()
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+    with patch("api.plan._zonas_now", return_value=_zonas()):
+        r = _app().post("/plan/confirm", json={"symbol": "BTCUSDT", "entry_price": 100.0})
+    assert r.status_code == 200 and r.json()["estado_vivo"] == "activo"
+
+
+def test_hechos_no_contienen_imperativos():
+    hechos = construir_hechos(rungs_llenos=[0], be_movido=True, estado_vivo="activo",
+                              sl_actual=100.0, sl_plan=93.06)
+    texto = " ".join(hechos).lower()
+    for imperativo in ("mové", "movete", "cerrá", "vendé", "comprá", "mueve", "cierra"):
+        assert imperativo not in texto
+
+
+def test_hechos_reportan_tp1_y_be():
+    hechos = construir_hechos(rungs_llenos=[0], be_movido=True, estado_vivo="activo",
+                              sl_actual=100.0, sl_plan=93.06)
+    texto = " ".join(hechos).lower()
+    assert "tp1" in texto and "break-even" in texto
+
+
+def test_vista_router_registrado():
+    import btc_api
+    rutas = {getattr(r, "path", None) for r in btc_api.app.routes}
+    assert "/plan/{symbol}" in rutas

--- a/tests/test_plan_api.py
+++ b/tests/test_plan_api.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.plan import router, construir_hechos
+from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
 
 
@@ -13,6 +14,7 @@ def _app():
     app = FastAPI()
     app.include_router(router)
     app.dependency_overrides[get_current_tenant_id] = lambda: 2
+    app.dependency_overrides[verify_api_key] = lambda: None
     return TestClient(app)
 
 
@@ -66,3 +68,21 @@ def test_vista_router_registrado():
     import btc_api
     rutas = {getattr(r, "path", None) for r in btc_api.app.routes}
     assert "/plan/{symbol}" in rutas
+
+
+def test_vista_sin_plan_activo_devuelve_none(monkeypatch, tmp_path):
+    import btc_api
+    monkeypatch.setattr(btc_api, "DB_FILE", str(tmp_path / "d.db"))
+    os.environ["MIGRATE_QTY_ALLOW_BULK_QUARANTINE"] = "1"
+    try:
+        from db.schema import init_db
+        init_db()
+    finally:
+        os.environ.pop("MIGRATE_QTY_ALLOW_BULK_QUARANTINE", None)
+    r = _app().get("/plan/NOPEUSDT")
+    assert r.status_code == 200 and r.json()["estado_vivo"] is None
+
+
+def test_confirm_payload_incompleto_es_422():
+    r = _app().post("/plan/confirm", json={"symbol": "BTCUSDT"})   # falta entry_price
+    assert r.status_code == 422

--- a/tools/sync_binance_spot.py
+++ b/tools/sync_binance_spot.py
@@ -12,6 +12,7 @@ Spec: docs/superpowers/specs/es/2026-06-10-conexion-binance-solo-lectura-spec.md
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sqlite3
 from datetime import datetime, timezone
@@ -27,6 +28,12 @@ from data.providers.binance_account import (
 from db.binance_credentials import (
     db_get_binance_credential_raw, db_get_decrypted_secret, db_set_credential_status,
 )
+from db.lifecycle_states import (
+    db_list_active, db_update_state, plan_from_json, state_from_row,
+)
+from db.conduct_episodes import db_put_episode
+from instrument.tracker import advance_live, finalize_conduct
+from instrument.lifecycle import step
 
 log = logging.getLogger(__name__)
 
@@ -137,7 +144,11 @@ def sync_tenant(tenant_id: int, *, autocreate: bool = False, dry_run: bool = Fal
     except _DryRunAbort:
         pass
     if not dry_run and holder.get("report", {}).get("status") == "ACTIVE":
-        holder["report"]["track_live"] = track_live(tenant_id)
+        try:
+            holder["report"]["track_live"] = track_live(tenant_id)
+        except Exception as e:  # noqa: BLE001
+            log.error("TRACK_LIVE_FAILED tenant=%s causa=%s", tenant_id, e)
+            holder["report"]["track_live"] = {"error": str(e)}
     return holder["report"]
 
 
@@ -145,64 +156,70 @@ def track_live(tenant_id: int) -> dict:
     """Tras el sync: avanza el estado vivo de cada plan activo desde los
     observed_orders frescos + la qty real. Read-only sobre positions; escribe
     lifecycle_states + (al cierre) conduct_episodes. Sin push, sin PositionClosure."""
-    import json
     from db.transaction import snapshot_connection, transaction
-    from db.lifecycle_states import (
-        db_list_active, db_update_state, plan_from_json, state_from_row,
-    )
-    from db.conduct_episodes import db_put_episode
-    from instrument.tracker import advance_live, finalize_conduct
 
     now = datetime.now(timezone.utc).isoformat()
     with snapshot_connection() as con:
         con.row_factory = sqlite3.Row
         activos = list(db_list_active(con, tenant_id=tenant_id))
 
-    avanzados = cerrados = 0
+    avanzados = cerrados = saltados = 0
     for row in activos:
-        symbol = row["symbol"]
-        with snapshot_connection() as con:
-            con.row_factory = sqlite3.Row
-            pos = con.execute(
-                "SELECT qty FROM positions WHERE symbol=? AND tenant_id=? "
-                "AND status='open' AND control_domain='EXTERNAL' LIMIT 1",
-                (symbol, tenant_id)).fetchone()
-            obs_rows = con.execute(
-                "SELECT kind, price, qty, order_id FROM observed_orders "
-                "WHERE tenant_id=? AND symbol=?", (tenant_id, symbol)).fetchall()
-        if pos is None:
+        try:
+            symbol = row["symbol"]
+            with snapshot_connection() as con:
+                con.row_factory = sqlite3.Row
+                # El índice único EXTERNAL (tenant,symbol,market,direction) garantiza
+                # ≤1 fila open por símbolo en el setup mono-market; LIMIT 1 es seguro.
+                pos = con.execute(
+                    "SELECT qty FROM positions WHERE symbol=? AND tenant_id=? "
+                    "AND status='open' AND control_domain='EXTERNAL' LIMIT 1",
+                    (symbol, tenant_id)).fetchone()
+                obs_rows = con.execute(
+                    "SELECT kind, price, qty, order_id FROM observed_orders "
+                    "WHERE tenant_id=? AND symbol=?", (tenant_id, symbol)).fetchall()
+            plan = plan_from_json(row["plan_json"])
+            state = state_from_row(row)
+            prev_observed = json.loads(row["prev_observed_json"] or "[]")
+            prev_events = json.loads(row["events_json"] or "[]")
+            if pos is None:
+                # La posición ya no está abierta (cerrada/reconciliada externamente).
+                # Cierra el lifecycle honestamente (RECONCILED) y finaliza conducta.
+                new_state = step(state, {"tipo": "POSITION_GONE", "procedencia": "observado"}, plan)
+                new_events = [{"tipo": "POSITION_GONE", "procedencia": "observado"}]
+                curr_observed = prev_observed
+                curr_qty = row["prev_qty"] if row["prev_qty"] is not None else 0.0
+            else:
+                curr_qty = float(pos["qty"] or 0.0)
+                curr_observed = [dict(o) for o in obs_rows]
+                prev_qty = row["prev_qty"] if row["prev_qty"] is not None else curr_qty
+                new_state, new_events = advance_live(plan, state, prev_observed, curr_observed,
+                                                     prev_qty, curr_qty)
+            all_events = prev_events + new_events
+            if new_state.fase == "CLOSED":
+                conduct = finalize_conduct(plan, all_events, new_state,
+                                           entry_price=row["entry_price"],
+                                           entry_ts=row["confirmed_at"], exit_ts=now)
+                with transaction() as con:
+                    db_put_episode(con, position_id=row["position_id"], symbol=symbol,
+                                   tenant_id=tenant_id, entry_ts=row["confirmed_at"],
+                                   exit_ts=now, conduct=conduct, plan_json=row["plan_json"],
+                                   reproduced=True, created_ts=now)
+                    db_update_state(con, row_id=row["id"], estado_vivo="cerrado",
+                                    state=new_state, events=all_events,
+                                    prev_observed=curr_observed, prev_qty=curr_qty, updated_at=now)
+                cerrados += 1
+            else:
+                with transaction() as con:
+                    db_update_state(con, row_id=row["id"], estado_vivo=row["estado_vivo"],
+                                    state=new_state, events=all_events,
+                                    prev_observed=curr_observed, prev_qty=curr_qty, updated_at=now)
+                avanzados += 1
+        except Exception as e:  # noqa: BLE001 — un símbolo no debe tumbar el lote
+            log.warning("TRACK_LIVE_SKIP symbol=%s causa=%s", row.get("symbol"), e)
+            saltados += 1
             continue
-        curr_qty = float(pos["qty"] or 0.0)
-        curr_observed = [dict(o) for o in obs_rows]
-        plan = plan_from_json(row["plan_json"])
-        state = state_from_row(row)
-        prev_observed = json.loads(row["prev_observed_json"] or "[]")
-        prev_qty = row["prev_qty"] if row["prev_qty"] is not None else curr_qty
-        prev_events = json.loads(row["events_json"] or "[]")
-
-        new_state, new_events = advance_live(plan, state, prev_observed, curr_observed,
-                                             prev_qty, curr_qty)
-        all_events = prev_events + new_events
-        if new_state.fase == "CLOSED":
-            conduct = finalize_conduct(plan, all_events, new_state,
-                                       entry_price=row["entry_price"],
-                                       entry_ts=row["confirmed_at"], exit_ts=now)
-            with transaction() as con:
-                db_put_episode(con, position_id=row["position_id"], symbol=symbol,
-                               tenant_id=tenant_id, entry_ts=row["confirmed_at"],
-                               exit_ts=now, conduct=conduct, plan_json=row["plan_json"],
-                               reproduced=True, created_ts=now)
-                db_update_state(con, row_id=row["id"], estado_vivo="cerrado",
-                                state=new_state, events=all_events,
-                                prev_observed=curr_observed, prev_qty=curr_qty, updated_at=now)
-            cerrados += 1
-        else:
-            with transaction() as con:
-                db_update_state(con, row_id=row["id"], estado_vivo=row["estado_vivo"],
-                                state=new_state, events=all_events,
-                                prev_observed=curr_observed, prev_qty=curr_qty, updated_at=now)
-            avanzados += 1
-    return {"avanzados": avanzados, "cerrados": cerrados}
+    return {"avanzados": avanzados, "cerrados": cerrados, "saltados": saltados}
 
 
 def main() -> int:

--- a/tools/sync_binance_spot.py
+++ b/tools/sync_binance_spot.py
@@ -136,7 +136,73 @@ def sync_tenant(tenant_id: int, *, autocreate: bool = False, dry_run: bool = Fal
                 raise _DryRunAbort()   # rollback: el dry-run NO persiste
     except _DryRunAbort:
         pass
+    if not dry_run and holder.get("report", {}).get("status") == "ACTIVE":
+        holder["report"]["track_live"] = track_live(tenant_id)
     return holder["report"]
+
+
+def track_live(tenant_id: int) -> dict:
+    """Tras el sync: avanza el estado vivo de cada plan activo desde los
+    observed_orders frescos + la qty real. Read-only sobre positions; escribe
+    lifecycle_states + (al cierre) conduct_episodes. Sin push, sin PositionClosure."""
+    import json
+    from db.transaction import snapshot_connection, transaction
+    from db.lifecycle_states import (
+        db_list_active, db_update_state, plan_from_json, state_from_row,
+    )
+    from db.conduct_episodes import db_put_episode
+    from instrument.tracker import advance_live, finalize_conduct
+
+    now = datetime.now(timezone.utc).isoformat()
+    with snapshot_connection() as con:
+        con.row_factory = sqlite3.Row
+        activos = list(db_list_active(con, tenant_id=tenant_id))
+
+    avanzados = cerrados = 0
+    for row in activos:
+        symbol = row["symbol"]
+        with snapshot_connection() as con:
+            con.row_factory = sqlite3.Row
+            pos = con.execute(
+                "SELECT qty FROM positions WHERE symbol=? AND tenant_id=? "
+                "AND status='open' AND control_domain='EXTERNAL' LIMIT 1",
+                (symbol, tenant_id)).fetchone()
+            obs_rows = con.execute(
+                "SELECT kind, price, qty, order_id FROM observed_orders "
+                "WHERE tenant_id=? AND symbol=?", (tenant_id, symbol)).fetchall()
+        if pos is None:
+            continue
+        curr_qty = float(pos["qty"] or 0.0)
+        curr_observed = [dict(o) for o in obs_rows]
+        plan = plan_from_json(row["plan_json"])
+        state = state_from_row(row)
+        prev_observed = json.loads(row["prev_observed_json"] or "[]")
+        prev_qty = row["prev_qty"] if row["prev_qty"] is not None else curr_qty
+        prev_events = json.loads(row["events_json"] or "[]")
+
+        new_state, new_events = advance_live(plan, state, prev_observed, curr_observed,
+                                             prev_qty, curr_qty)
+        all_events = prev_events + new_events
+        if new_state.fase == "CLOSED":
+            conduct = finalize_conduct(plan, all_events, new_state,
+                                       entry_price=row["entry_price"],
+                                       entry_ts=row["confirmed_at"], exit_ts=now)
+            with transaction() as con:
+                db_put_episode(con, position_id=row["position_id"], symbol=symbol,
+                               tenant_id=tenant_id, entry_ts=row["confirmed_at"],
+                               exit_ts=now, conduct=conduct, plan_json=row["plan_json"],
+                               reproduced=True, created_ts=now)
+                db_update_state(con, row_id=row["id"], estado_vivo="cerrado",
+                                state=new_state, events=all_events,
+                                prev_observed=curr_observed, prev_qty=curr_qty, updated_at=now)
+            cerrados += 1
+        else:
+            with transaction() as con:
+                db_update_state(con, row_id=row["id"], estado_vivo=row["estado_vivo"],
+                                state=new_state, events=all_events,
+                                prev_observed=curr_observed, prev_qty=curr_qty, updated_at=now)
+            avanzados += 1
+    return {"avanzados": avanzados, "cerrados": cerrados}
 
 
 def main() -> int:


### PR DESCRIPTION
## Resumen

Tercera fase del instrumento: el **acompañante en vivo**, pull-only. Sigue una posición REAL del operador contra el plan que confirmó, y al cierre mide su conducta con el libro de fills vivo — la comparación plan-vs-conducta campo-por-campo que F2 difirió honestamente. Es el tercer y último refutador de la falsación progresiva (F1 envelope → F2 simulación → **F3 fills vivos**).

### El invariante que lo gobierna (revelado por Axiom-0)
El deadlock push-vs-pull se disolvió cuando Axiom-0 reveló lo que las tres voces orbitaban:
> **El instrumento solo tiene unidades mientras permanezca FUERA del término que mide.**

De ahí: el instrumento **emite hechos observables, NUNCA instrucciones de conducta** ("TP1 se llenó" es espejo; "mové el SL" sería autoría que mide su propio eco). Y **pull-only** (decisión del operador, honrando el lock CD-3/CD-5 de posiciones EXTERNAL).

### Qué se construyó
- `instrument/tracker.py` — `detect_transitions` (eventos desde snapshots de `observed_orders` + qty, idempotente, honesto sobre fill-vs-cancel) + `advance_live` + `finalize_conduct`.
- `db/lifecycle_states.py` + migración — el domicilio del estado vivo (≤1 activa por símbolo, `close_reason` persistido).
- `api/plan.py` — gate `derive`/`confirm` (tipado, 422/503, `verify_api_key`, BNC-12) + vista pull `GET /plan/{symbol}` con el constructor de **hechos anti-imperativo**.
- `tools/sync_binance_spot.py` — `track_live` corre tras el sync: read-only sobre `positions`, conducta al cierre a `conduct_episodes`. Cierra honestamente las posiciones desaparecidas (`POSITION_GONE`).

### Invariantes (verificados en el review holístico)
- **Fuera del término que mide:** solo hechos, nunca instrucciones (test anti-imperativo).
- **Pull-only:** cero push (honra CD-3/CD-5).
- **Frontera dura:** read-only sobre `positions`, sin `PositionClosure`, sin escribir `closed`. Solo escribe `lifecycle_states` + `conduct_episodes`.
- **Sin PnL:** conducta campo-por-campo (veto F2 vigente). **BNC-12:** AUTO_DERIVED rechazado en el gate.

## El instrumento, completo
- **F1** ✅ la columna · **F2** ✅ el refutador determinista · **F3a** ✅ el acompañante vivo (este PR)
- Pendiente: **F3b** — la tarjeta de selección compuesta A+C+D.1 (su propio spec).

## Test plan
- [x] Tracker puro: detección fill-vs-cancel, idempotencia order_id, SL/BE/STOP, conducta al cierre.
- [x] Domicilio: roundtrip serialización, supersede ≤1 activa, migración real.
- [x] Endpoints: derive/confirm/vista, anti-imperativo, 422/503, BNC-12.
- [x] Hook: cierre de posición desaparecida finaliza conducta (test DB).
- [x] Gate rápido CI (`-m "not network" -n auto`): 3537 passed, 0 nuevas fallas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)