### PR TITLE
feat: El Instrumento Fase 3b — la tarjeta de selección (cierra el instrumento)

### DIFF
--- a/api/valleys.py
+++ b/api/valleys.py
@@ -2,14 +2,21 @@
 universo de mercado es global (spec §0, §5.3).
 
 Lee la foto regenerable que escribe tools.run_valley_screener. NO computa nada
-en el request (el fetch de 200+ símbolos es pesado y vive en el comando)."""
+en el request (el fetch de 200+ símbolos es pesado y vive en el comando).
+
+F3b: GET /valley-eval/{symbol} — A on-demand para UN símbolo arbitrario.
+Red fuera de tx, sin caché, read-only. Spec §2."""
 from __future__ import annotations
 
 import json
 import logging
 import os
 
+import requests
 from fastapi import APIRouter
+
+from api.levels import BinanceUnavailable, _fetch_daily_bars
+from screener.valley_filter import classify_liveness, evaluate_symbol
 
 log = logging.getLogger("api.valleys")
 
@@ -21,6 +28,26 @@ _OUTPUT = os.path.join(os.path.dirname(os.path.dirname(__file__)),
 _EMPTY = {"generated_at": None,
           "coverage": {"universe": 0, "evaluated": 0, "complete": False},
           "candidates": []}
+
+
+@router.get("/valley-eval/{symbol}", summary="Evalúa vida + rango de UNA moneda (A on-demand)")
+def get_valley_eval(symbol: str) -> dict:
+    """A para un símbolo arbitrario: fetch de velas (reusa D.1) + evaluate_symbol
+    (puro). Devuelve los hechos si está VIVA y EN RANGO; si no, reporta POR QUÉ
+    (razones de liveness — hechos, no juicio de atractivo). no_disponible si la
+    red falla. Read-only, red fuera de tx, sin caché. Spec §2."""
+    symbol = symbol.upper()[:20]
+    try:
+        bars = _fetch_daily_bars(symbol)
+    except (requests.RequestException, BinanceUnavailable) as e:
+        log.warning("VALLEY_EVAL_NO_DISPONIBLE symbol=%s causa=%s", symbol, e)
+        return {"symbol": symbol, "estado": "no_disponible"}
+    cand = evaluate_symbol(symbol, bars)
+    if cand is None:
+        vivo, razones = classify_liveness(bars)
+        return {"symbol": symbol, "estado": "ok", "candidata": False,
+                "vivo": vivo, "razones_muerte": razones}
+    return {"symbol": symbol, "estado": "ok", "candidata": True, **cand}
 
 
 @router.get("/valley-candidates", summary="Candidatas del screener de valles (vivas + en rango)")

--- a/docs/superpowers/plans/2026-06-13-instrumento-fase3b-tarjeta.md
+++ b/docs/superpowers/plans/2026-06-13-instrumento-fase3b-tarjeta.md
@@ -1,0 +1,458 @@
+# El Instrumento — Fase 3b (la tarjeta de selección) · Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Componer A (vida+rango on-demand) + D.1 (niveles) + C (dossier) en una tarjeta por moneda, en el frontend, con costuras visibles y cero veredicto compuesto.
+
+**Architecture:** Un endpoint backend mínimo `GET /valley-eval/{symbol}` (reusa el fetch de D.1 + `evaluate_symbol` puro) y una tarjeta React `CoinCard` que llama los tres endpoints en paralelo, cada bloque independiente (dossier lazy), sin score ni badge agregado. Reutiliza `LevelsPanel` y `ProjectDossier`.
+
+**Tech Stack:** FastAPI + pytest (backend); React + TypeScript + Vitest (frontend).
+
+**Spec:** `docs/superpowers/specs/es/2026-06-13-instrumento-fase3b-tarjeta-design.md`.
+
+**Branch:** `feat/instrumento-fase3b-tarjeta` (ya creada).
+
+**Restricción central:** la tarjeta EXHIBE, no firma — cero veredicto compuesto (test anti-veredicto). Read-only, red fuera de tx, sin caché.
+
+---
+
+## File Structure
+
+| Archivo | Responsabilidad |
+|---|---|
+| `api/valleys.py` (modificar) | Añadir `GET /valley-eval/{symbol}` (A on-demand). Router ya registrado. |
+| `frontend/src/types.ts` (modificar) | Tipo `ValleyEval`. |
+| `frontend/src/api.ts` (modificar) | Cliente `getValleyEval`. |
+| `frontend/src/components/CoinCard.tsx` (crear) + `.module.css` | La tarjeta compuesta (3 bloques, dossier lazy, anti-veredicto). |
+| `frontend/src/components/ValleysView.tsx` (modificar) | Input de símbolo → abre la `CoinCard`. |
+| `tests/test_valley_eval_api.py`, `CoinCard.test.tsx` (crear) | Tests. |
+
+---
+
+### Task 1: `GET /valley-eval/{symbol}` — A on-demand
+
+**Files:**
+- Modify: `api/valleys.py`
+- Test: `tests/test_valley_eval_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_valley_eval_api.py
+"""Tests del endpoint A on-demand GET /valley-eval/{symbol} (instrumento F3b). Spec §2."""
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.valleys import router
+from api.levels import BinanceUnavailable
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_candidata_true_devuelve_hechos():
+    cand = {"symbol": "ADAUSDT", "price": 0.42, "pct_rango": 0.18,
+            "semanas_consolidando": 9, "vol_percentil": 0.22,
+            "volumen_usd_dia": 3_000_000, "distancia_ath_pct": 0.86, "razones_vida": []}
+    with patch("api.valleys._fetch_daily_bars", return_value=[{}] * 130), \
+         patch("api.valleys.evaluate_symbol", return_value=cand):
+        r = _app().get("/valley-eval/ADAUSDT")
+    body = r.json()
+    assert body["estado"] == "ok" and body["candidata"] is True
+    assert body["pct_rango"] == 0.18
+
+
+def test_no_candidata_reporta_razones():
+    with patch("api.valleys._fetch_daily_bars", return_value=[{}] * 130), \
+         patch("api.valleys.evaluate_symbol", return_value=None), \
+         patch("api.valleys.classify_liveness", return_value=(False, ["volumen_bajo_piso"])):
+        r = _app().get("/valley-eval/XYZUSDT")
+    body = r.json()
+    assert body["candidata"] is False
+    assert body["vivo"] is False
+    assert body["razones_muerte"] == ["volumen_bajo_piso"]
+
+
+def test_red_caida_es_no_disponible_sin_500():
+    with patch("api.valleys._fetch_daily_bars", side_effect=BinanceUnavailable("klines HTTP 503")):
+        r = _app().get("/valley-eval/ADAUSDT")
+    assert r.status_code == 200 and r.json()["estado"] == "no_disponible"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_valley_eval_api.py -v`
+Expected: FAIL (la ruta `/valley-eval/{symbol}` no existe → 404)
+
+- [ ] **Step 3: Write minimal implementation**
+
+En `api/valleys.py`, añadir los imports al tope (tras los existentes):
+
+```python
+import requests
+
+from api.levels import _fetch_daily_bars, BinanceUnavailable
+from screener.valley_filter import evaluate_symbol, classify_liveness
+```
+
+Y el endpoint (tras `get_valley_candidates`):
+
+```python
+@router.get("/valley-eval/{symbol}", summary="Evalúa vida + rango de UNA moneda (A on-demand)")
+def get_valley_eval(symbol: str) -> dict:
+    """A para un símbolo arbitrario: fetch de velas (reusa D.1) + evaluate_symbol
+    (puro). Devuelve los hechos si está VIVA y EN RANGO; si no, reporta POR QUÉ
+    (razones de liveness — hechos, no juicio de atractivo). no_disponible si la
+    red falla. Read-only, red fuera de tx, sin caché. Spec §2."""
+    symbol = symbol.upper()[:20]
+    try:
+        bars = _fetch_daily_bars(symbol)
+    except (requests.RequestException, BinanceUnavailable) as e:
+        log.warning("VALLEY_EVAL_NO_DISPONIBLE symbol=%s causa=%s", symbol, e)
+        return {"symbol": symbol, "estado": "no_disponible"}
+    cand = evaluate_symbol(symbol, bars)
+    if cand is None:
+        vivo, razones = classify_liveness(bars)
+        return {"symbol": symbol, "estado": "ok", "candidata": False,
+                "vivo": vivo, "razones_muerte": razones}
+    return {"symbol": symbol, "estado": "ok", "candidata": True, **cand}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_valley_eval_api.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/valleys.py tests/test_valley_eval_api.py
+git commit -m "feat(api): GET /valley-eval/{symbol} — A on-demand (hechos de vida/rango, no_disponible sin 500)"
+```
+
+---
+
+### Task 2: frontend — tipo `ValleyEval` + cliente `getValleyEval`
+
+**Files:**
+- Modify: `frontend/src/types.ts`, `frontend/src/api.ts`
+- Test: `frontend/src/api.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// frontend/src/api.test.ts — añadir
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getValleyEval } from './api';
+
+describe('getValleyEval', () => {
+  afterEach(() => vi.restoreAllMocks());
+  it('pide GET /valley-eval/:symbol', async () => {
+    const payload = { symbol: 'ADAUSDT', estado: 'ok', candidata: true, pct_rango: 0.18 };
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
+    const res = await getValleyEval('ADAUSDT');
+    expect(res.candidata).toBe(true);
+    expect(spy.mock.calls[0][0]).toContain('/valley-eval/ADAUSDT');
+  });
+});
+```
+
+> Si `api.test.ts` ya usa otro patrón de mock, seguilo; lo esencial es verificar la URL `/valley-eval/{symbol}`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/api.test.ts`
+Expected: FAIL (`getValleyEval` no exportado)
+
+- [ ] **Step 3: Write minimal implementation**
+
+En `frontend/src/types.ts`, al final:
+
+```typescript
+// ---- F3b: A on-demand (vida + rango de una moneda). Spec §2 ----
+export interface ValleyEval {
+  symbol:                string;
+  estado:                'ok' | 'no_disponible';
+  candidata?:            boolean;
+  vivo?:                 boolean;
+  razones_muerte?:       string[];
+  // presentes solo si candidata=true (los hechos de A):
+  price?:                number;
+  pct_rango?:            number;
+  semanas_consolidando?: number;
+  vol_percentil?:        number;
+  volumen_usd_dia?:      number;
+  distancia_ath_pct?:    number;
+  razones_vida?:         string[];
+}
+```
+
+En `frontend/src/api.ts`, al final:
+
+```typescript
+// ---- F3b A on-demand — GET /valley-eval/:symbol ----
+export function getValleyEval(symbol: string) {
+  return request<import('./types').ValleyEval>(`/valley-eval/${symbol}`);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/api.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/types.ts frontend/src/api.ts frontend/src/api.test.ts
+git commit -m "feat(fe): tipo ValleyEval + cliente getValleyEval"
+```
+
+---
+
+### Task 3: `CoinCard` — la tarjeta compuesta (costuras visibles)
+
+**Files:**
+- Create: `frontend/src/components/CoinCard.tsx`, `frontend/src/components/CoinCard.module.css`
+- Test: `frontend/src/components/CoinCard.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// frontend/src/components/CoinCard.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { CoinCard } from './CoinCard';
+import * as api from '../api';
+
+afterEach(() => vi.restoreAllMocks());
+
+const _levels = { symbol: 'SOLUSDT', estado: 'ok', generated_at: '2026-06-13T00:00:00+00:00',
+  price_live: 142, zonas: [], ubicacion: { dentro_de: null, techo: null, piso: null } };
+const _dossier = { symbol: 'SOLUSDT', estado_general: 'rastreable', equipo_identificado: true,
+  equipo: [], presencia: {}, actividad: {}, financiacion: [], hitos: [], no_encontrado_en: [],
+  generated_at: '2026-06-13T00:00:00+00:00' };
+const _vidaOk = { symbol: 'SOLUSDT', estado: 'ok', candidata: true, pct_rango: 0.18,
+  semanas_consolidando: 9, volumen_usd_dia: 3_000_000 };
+
+function _mockAll(vida: unknown) {
+  vi.spyOn(api, 'getValleyEval').mockResolvedValue(vida as never);
+  vi.spyOn(api, 'getLevels').mockResolvedValue(_levels as never);
+  vi.spyOn(api, 'getDossier').mockResolvedValue(_dossier as never);
+}
+
+describe('CoinCard', () => {
+  it('pinta los tres bloques (Vida, Niveles, Fundamentales)', async () => {
+    _mockAll(_vidaOk);
+    render(<CoinCard symbol="SOLUSDT" />);
+    expect(await screen.findByText(/Vida/)).toBeInTheDocument();
+    expect(screen.getByText(/Niveles/)).toBeInTheDocument();
+    expect(screen.getByText(/Fundamentales/)).toBeInTheDocument();
+  });
+
+  it('un bloque no_disponible degrada solo (los otros siguen)', async () => {
+    _mockAll({ symbol: 'SOLUSDT', estado: 'no_disponible' });
+    render(<CoinCard symbol="SOLUSDT" />);
+    expect(await screen.findByText(/Niveles/)).toBeInTheDocument();   // los otros bloques siguen
+    expect(screen.getByText(/Sin datos/)).toBeInTheDocument();        // el bloque vida caído
+  });
+
+  it('no emite veredicto compuesto (anti-veredicto)', async () => {
+    _mockAll(_vidaOk);
+    const { container } = render(<CoinCard symbol="SOLUSDT" />);
+    await screen.findByText(/Vida/);
+    expect(/comprá|comprar|buena|score|recomend|veredicto|potencial/i
+      .test(container.textContent ?? '')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/CoinCard.test.tsx`
+Expected: FAIL (`CoinCard` no existe)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+// frontend/src/components/CoinCard.tsx
+// ============================================================
+// CoinCard — la tarjeta de selección compuesta (F3b).
+// Tres bloques YUXTAPUESTOS (A vida · D.1 niveles · C dossier),
+// cada uno con su propio estado/frescura. La tarjeta EXHIBE, no
+// firma: cero veredicto compuesto, cero score. Spec §3.
+// ============================================================
+import React, { useEffect, useState } from 'react';
+import type { ValleyEval, SrLevels, Dossier } from '../types';
+import { getValleyEval, getLevels, getDossier } from '../api';
+import { LevelsPanel } from './LevelsPanel';
+import { ProjectDossier } from './ProjectDossier';
+import styles from './CoinCard.module.css';
+
+const VidaBlock: React.FC<{ ev: ValleyEval | null; loading: boolean }> = ({ ev, loading }) => {
+  if (loading) return <div className={styles.empty}>Evaluando…</div>;
+  if (!ev || ev.estado === 'no_disponible') return <div className={styles.empty}>Sin datos</div>;
+  if (ev.candidata) {
+    return (
+      <div className={styles.row}>
+        viva · en rango {((ev.pct_rango ?? 0) * 100).toFixed(0)}% ·{' '}
+        {ev.semanas_consolidando} semanas ·{' '}
+        ${Math.round(ev.volumen_usd_dia ?? 0).toLocaleString('en-US')}/día
+      </div>
+    );
+  }
+  return (
+    <div className={styles.row}>
+      {ev.vivo ? 'viva, fuera de rango' : 'no candidata'}
+      {ev.razones_muerte && ev.razones_muerte.length > 0
+        ? ` — ${ev.razones_muerte.join(', ')}` : ''}
+    </div>
+  );
+};
+
+export const CoinCard: React.FC<{ symbol: string }> = ({ symbol }) => {
+  const [vida, setVida] = useState<ValleyEval | null>(null);
+  const [vidaLoading, setVidaLoading] = useState(true);
+  const [levels, setLevels] = useState<SrLevels | null>(null);
+  const [levelsLoading, setLevelsLoading] = useState(true);
+  const [dossier, setDossier] = useState<Dossier | null>(null);
+  const [dossierLoading, setDossierLoading] = useState(true);
+
+  useEffect(() => {
+    setVida(null); setVidaLoading(true);
+    setLevels(null); setLevelsLoading(true);
+    setDossier(null); setDossierLoading(true);
+    // Tres llamadas INDEPENDIENTES en paralelo; cada bloque pinta cuando llega.
+    getValleyEval(symbol).then(setVida).finally(() => setVidaLoading(false));
+    getLevels(symbol).then(setLevels).finally(() => setLevelsLoading(false));
+    getDossier(symbol).then(setDossier).finally(() => setDossierLoading(false));  // lazy: Exa lento
+  }, [symbol]);
+
+  return (
+    <div className={styles.card}>
+      <header className={styles.head}>{symbol.replace('USDT', '')}</header>
+
+      <section className={styles.sec}>
+        <h4>Vida</h4>
+        <VidaBlock ev={vida} loading={vidaLoading} />
+      </section>
+
+      <section className={styles.sec}>
+        <h4>Niveles</h4>
+        {(levels || levelsLoading)
+          ? <LevelsPanel levels={levels!} loading={levelsLoading} />
+          : <div className={styles.empty}>Sin datos</div>}
+      </section>
+
+      <section className={styles.sec}>
+        <h4>Fundamentales</h4>
+        {(dossier || dossierLoading)
+          ? <ProjectDossier dossier={dossier!} loading={dossierLoading} />
+          : <div className={styles.empty}>Sin datos</div>}
+      </section>
+    </div>
+  );
+};
+```
+
+```css
+/* frontend/src/components/CoinCard.module.css */
+.card { border: 1px solid var(--border, #2a2a2a); border-radius: 8px; padding: 12px; margin-top: 12px; }
+.head { font-weight: 600; font-size: 1.1em; margin-bottom: 8px; }
+/* secciones VISUALMENTE DISTINTAS — las costuras son la honestidad (sin fusión) */
+.sec { border-top: 1px solid var(--border, #2a2a2a); padding: 8px 0; }
+.sec h4 { margin: 0 0 4px; font-size: 0.85em; opacity: 0.7; text-transform: uppercase; letter-spacing: 0.04em; }
+.row { font-variant-numeric: tabular-nums; }
+.empty { opacity: 0.7; }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/CoinCard.test.tsx`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/CoinCard.tsx frontend/src/components/CoinCard.module.css frontend/src/components/CoinCard.test.tsx
+git commit -m "feat(fe): CoinCard — tarjeta compuesta A+C+D.1 (costuras visibles, anti-veredicto)"
+```
+
+---
+
+### Task 4: input de símbolo en `ValleysView` → abre la tarjeta
+
+**Files:**
+- Modify: `frontend/src/components/ValleysView.tsx`, `frontend/src/components/ValleysView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// frontend/src/components/ValleysView.test.tsx — añadir dentro del describe
+it('ofrece un input de símbolo para abrir la tarjeta', () => {
+  render(<ValleysView snapshot={snap} loading={false} />);
+  expect(screen.getByPlaceholderText(/símbolo/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /ver tarjeta/i })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/ValleysView.test.tsx`
+Expected: FAIL (no hay input de símbolo)
+
+- [ ] **Step 3: Write minimal implementation**
+
+En `frontend/src/components/ValleysView.tsx`:
+- Añadir el import: `import { CoinCard } from './CoinCard';`
+- Añadir estado tras los `useState` existentes:
+```typescript
+  const [cardInput, setCardInput] = useState('');
+  const [cardSymbol, setCardSymbol] = useState('');
+```
+- Dentro del `<div className={styles.wrap}>`, ANTES de la tabla, añadir el buscador + la tarjeta:
+```tsx
+      <form
+        className={styles.buscador}
+        onSubmit={(e) => { e.preventDefault(); setCardSymbol(cardInput.trim().toUpperCase()); }}
+      >
+        <input
+          value={cardInput}
+          onChange={(e) => setCardInput(e.target.value)}
+          placeholder="Símbolo (ej. SOLUSDT)"
+        />
+        <button type="submit">Ver tarjeta</button>
+      </form>
+      {cardSymbol && <CoinCard symbol={cardSymbol} />}
+```
+
+(`cardSymbol` arranca vacío → la `CoinCard` NO se monta hasta que el operador busca, así que no dispara fetches en el render inicial de los tests existentes.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/ValleysView.test.tsx`
+Expected: PASS (los existentes + el nuevo; el test "no badge de compra ni señal" sigue pasando — "Ver tarjeta"/"Símbolo" no matchean su regex)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/ValleysView.tsx frontend/src/components/ValleysView.test.tsx
+git commit -m "feat(fe): input de símbolo en la Vista Valles → abre la CoinCard"
+```
+
+---
+
+## Verificación final
+
+- [ ] **Backend:** `python -m pytest tests/test_valley_eval_api.py -v` → 3 verde.
+- [ ] **Gate rápido (CI):** `python -m pytest tests/ -m "not network" -n auto -q` → sin regresiones.
+- [ ] **Frontend:** `cd frontend && npm test` → todo verde (incl. `CoinCard`, `getValleyEval`, el input de `ValleysView`).
+- [ ] **Anti-veredicto:** confirmar que `CoinCard.test.tsx` pasa — la tarjeta no contiene texto de compra/score/recomendación.
+- [ ] **Humo manual (opcional, red):** con el API corriendo, teclear un símbolo en la Vista Valles → ver los tres bloques (Vida/Niveles/Fundamentales) pintar, el dossier llegando después.

--- a/docs/superpowers/specs/es/2026-06-13-instrumento-fase3b-tarjeta-design.md
+++ b/docs/superpowers/specs/es/2026-06-13-instrumento-fase3b-tarjeta-design.md
@@ -1,0 +1,119 @@
+# El Instrumento — Fase 3b (la tarjeta de selección) · Diseño
+
+**Fecha:** 2026-06-13
+**Rama:** `feat/instrumento-fase3b-tarjeta`
+**Parte de:** el instrumento completo. La última pieza — los **órganos de entrada** (A vivo + C dossier + D.1 niveles) cosidos en una vista por moneda.
+
+## §0 — Qué es F3b, y la restricción que lo gobierna
+
+F3b compone los tres sensores pre-entrada en **una tarjeta por moneda**: A (¿está viva y en rango?), C (dossier de fundamentales citados), D.1 (zonas S/R + precio vivo). Cada uno ya existe y ya afirma SOLO hechos, sin veredicto.
+
+**La restricción central (revelada por el roster, Voronov):** la tarjeta es **donde se gasta la neutralidad de cada sensor**. Tres hechos neutrales yuxtapuestos generan un cuarto objeto que ninguno autorizó: **la correlación percibida** ("vivo + fundamentales limpios + precio en soporte" se lee como "comprá" — un veredicto que no se escribe en ningún campo, se escribe en el ojo). Es el riesgo del dossier ("añade convicción sin poder") consumado.
+
+Por eso la decisión de arquitectura (roster **unánime: composición en frontend**, no un compositor backend):
+> Un compositor backend produce UN objeto con UN status — reifica la correlación en el contrato (la firma). El frontend, con tres relojes, tres estados, tres latencias, mantiene **las costuras visibles**. Las costuras son la honestidad. El compositor firma el veredicto; el frontend solo exhibe.
+
+**El instrumento que mide conducta no puede emitir la conducta que mide.** La tarjeta exhibe; no firma.
+
+## §1 — Arquitectura
+
+Una pieza backend mínima (A on-demand) + la tarjeta frontend que compone.
+
+| Pieza | Archivo | Responsabilidad |
+|---|---|---|
+| A on-demand | `api/valleys.py` → `GET /valley-eval/{symbol}` | Reusa `_fetch_daily_bars` (de `api/levels.py`) + `evaluate_symbol` (puro, de `screener/valley_filter.py`). Devuelve los hechos de vida/rango de UNA moneda, o `no_disponible` si la red falla. |
+| La tarjeta | `frontend/src/components/CoinCard.tsx` + `.module.css` | Toma un símbolo (tecleado o clic en la tabla de valles), llama A + D.1 + C en paralelo; cada bloque pinta cuando llega, con su propio estado/frescura. Dossier lazy. |
+| Cliente | `frontend/src/api.ts` → `getValleyEval(symbol)` | Cliente del nuevo endpoint A. |
+| Tipos | `frontend/src/types.ts` → `ValleyEval` | Tipo de la respuesta de A on-demand. |
+| Cableado | `frontend/src/components/ValleysView.tsx` | Botón/entrada que abre la `CoinCard` para un símbolo. |
+
+`GET /levels/{symbol}` (D.1) y `GET /dossier/{symbol}` (C) ya existen y se reutilizan tal cual.
+
+## §2 — A on-demand: `GET /valley-eval/{symbol}`
+
+Por qué A necesita un path por-símbolo: hoy A solo se expone como la FOTO del screener (`GET /valley-candidates`, sobre el universo). Pero `evaluate_symbol(symbol, bars)` es **puro** — solo le falta el fetch de velas. Halberg confirmó que el contrato de barras de `_fetch_daily_bars` (D.1, 365 días) satisface a A (necesita ≥120, lee hasta 365).
+
+```python
+@router.get("/valley-eval/{symbol}", summary="Evalúa vida + rango de UNA moneda (A on-demand)")
+def get_valley_eval(symbol: str) -> dict:
+    """A para un símbolo arbitrario: fetch de velas + evaluate_symbol (puro).
+    Devuelve los hechos si está VIVA y EN RANGO, o un veredicto honesto de por
+    qué no (no es un juicio de atractivo — son hechos de liveness). no_disponible
+    si la red falla. Read-only, red fuera de tx, sin caché."""
+    symbol = symbol.upper()[:20]
+    try:
+        bars = _fetch_daily_bars(symbol)   # reusa el fetch de D.1
+    except (requests.RequestException, BinanceUnavailable) as e:
+        log.warning("VALLEY_EVAL_NO_DISPONIBLE symbol=%s causa=%s", symbol, e)
+        return {"symbol": symbol, "estado": "no_disponible"}
+    cand = evaluate_symbol(symbol, bars)          # bars ya es el contrato puro
+    if cand is None:
+        # NO es candidata: viva-pero-no-en-rango, o no-viva. Reportar el hecho.
+        vivo, razones = classify_liveness(bars)   # hechos de por qué
+        return {"symbol": symbol, "estado": "ok", "candidata": False,
+                "vivo": vivo, "razones_muerte": razones}
+    return {"symbol": symbol, "estado": "ok", "candidata": True, **cand}
+```
+
+**Nota de contrato de barras:** `_fetch_daily_bars` (de `api/levels.py`) ya devuelve el dict del contrato puro (`open_time/open/high/low/close/volume/quote_volume`), que es exactamente lo que `evaluate_symbol`/`classify_liveness` consumen. No hace falta remapear. `BinanceUnavailable` también se importa de `api/levels.py`.
+
+**Honestidad (no veredicto):** la respuesta reporta `candidata: true/false` y, si false, los `razones_muerte` (hechos: `volumen_bajo_piso`, `volumen_agonizante`, etc.) — describe POR QUÉ no es candidata, no si es "mala". Mismo estándar de A.
+
+`no_disponible` (red caída) ≠ `candidata: false` (evaluó, no califica) — la misma distinción honesta de A/C/D.1.
+
+## §3 — La tarjeta `CoinCard.tsx` (composición, costuras visibles)
+
+Toma un `symbol` y dispara **tres llamadas independientes en paralelo**:
+- A → `getValleyEval(symbol)` (rápido)
+- D.1 → `getLevels(symbol)` (rápido)
+- C → `getDossier(symbol)` (lento, Exa — **lazy**: se dispara al abrir, pinta cuando llega)
+
+Cada bloque tiene su **propio estado** (cargando / ok / no_disponible) y pinta **independientemente** cuando su llamada resuelve. Un bloque caído muestra "sin datos" sin tocar los otros.
+
+Layout — tres secciones **visualmente distintas**, apiladas, cada una con su propia etiqueta de frescura:
+
+```
+┌─ SOLUSDT ──────────────────────────────┐
+│ VIDA (A)            · hace unos segundos │   ← bloque A
+│   viva · en rango 18% · 9 semanas · …    │
+│   (o: "no es candidata — volumen bajo")  │
+├──────────────────────────────────────────┤
+│ NIVELES (D.1)       · precio vivo         │   ← bloque D.1
+│   precio 142.3 · techo 150 (+5.4%)        │
+│   piso 138 (−3%) · zonas…                 │
+├──────────────────────────────────────────┤
+│ FUNDAMENTALES (C)   · cargando…/fecha     │   ← bloque C (lazy)
+│   equipo: 9 · github activo · …           │
+│   (o "sin datos")                         │
+└──────────────────────────────────────────┘
+```
+
+**Anti-veredicto (la restricción de Voronov, hecha código):**
+- **Cero score agregado, cero badge "comprá/buena", cero color que implique juicio.** No hay una cuarta línea que resuma los tres.
+- Los tres bloques quedan separados, con sus propios timestamps — el operador ve tres hechos apilados, nunca una frase fusionada.
+- Reutiliza los componentes existentes donde aplique: el bloque D.1 puede reusar `LevelsPanel`, el bloque C puede reusar `ProjectDossier`. El bloque A es nuevo (mínimo).
+
+## §4 — Cableado en `ValleysView`
+
+La tabla del screener ya lista candidatas con botones Dossier + Niveles. F3b añade:
+- Un **input de símbolo** (teclear cualquier ticker) que abre la `CoinCard` — el valor real de la tarjeta (Cassian: "poder pegar un ticker y ver A+C+D.1 al instante").
+- Opcional: clic en una fila de la tabla también abre su `CoinCard`.
+
+Los botones Dossier/Niveles separados pueden quedarse o reemplazarse por la tarjeta unificada — decisión menor de UX en implementación; lo esencial es que la tarjeta exista y sea consultable por símbolo arbitrario.
+
+## §5 — Pruebas
+
+**Backend** (`tests/test_valley_eval_api.py`): `get_valley_eval` con fetch mockeado → `candidata: true` (hechos), `candidata: false` (con razones), `no_disponible` (red caída sin 500). Read-only, sin caché, sin escritura.
+
+**Frontend** (`CoinCard.test.tsx`): los tres bloques mockeados pintan; un bloque `no_disponible` degrada solo (los otros siguen); **test anti-veredicto** — el `textContent` de la tarjeta NO contiene `comprá|buena|score|recomend|veredicto|potencial`; no hay una línea-resumen de los tres.
+
+## §6 — Invariantes preservados
+- **La tarjeta exhibe, no firma** (Voronov): cero veredicto compuesto; costuras visibles (tres estados, tres frescuras).
+- **Composición en frontend** (roster unánime): no un compositor backend que reifique la correlación.
+- **A on-demand es hechos, no juicio:** `candidata: false` reporta razones (hechos), no "malo".
+- **Read-only, red fuera de tx, sin caché** en `valley-eval`; degradación honesta `no_disponible` (sin 500).
+
+## §7 — Fuera de alcance (defer / delete)
+- **Compositor backend `GET /valley/{symbol}`** — DEFER hasta un segundo consumidor (Cassian).
+- **Cualquier score/ranking/badge de atractivo** — DELETE (la celda B del programa; viola la neutralidad).
+- **Caché de `valley-eval`** — DELETE (A es barato; el screener-snapshot ya cubre el caso de universo).

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   getSymbols, getStatus,
   getCapital, putCapital, getPreferences, putPreferences,
-  getLevels,
+  getLevels, getValleyEval,
 } from './api';
 
 const originalFetch = globalThis.fetch;
@@ -203,6 +203,23 @@ describe('api client', () => {
       expect(resp.price_live).toBe(67230);
       expect(resp.zonas).toHaveLength(2);
       expect(resp.ubicacion.techo?.centro).toBe(69100);
+    });
+  });
+
+  // ============================================================
+  // F3b getValleyEval
+  // ============================================================
+
+  describe('getValleyEval', () => {
+    afterEach(() => vi.restoreAllMocks());
+    it('pide GET /valley-eval/:symbol', async () => {
+      const payload = { symbol: 'ADAUSDT', estado: 'ok', candidata: true, pct_rango: 0.18 };
+      const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      );
+      const res = await getValleyEval('ADAUSDT');
+      expect(res.candidata).toBe(true);
+      expect(spy.mock.calls[0][0]).toContain('/valley-eval/ADAUSDT');
     });
   });
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -427,3 +427,8 @@ export function getDossier(symbol: string, refresh = false) {
 export function getLevels(symbol: string) {
   return request<import('./types').SrLevels>(`/levels/${symbol}`);
 }
+
+// ---- F3b A on-demand — GET /valley-eval/:symbol ----
+export function getValleyEval(symbol: string) {
+  return request<import('./types').ValleyEval>(`/valley-eval/${symbol}`);
+}

--- a/frontend/src/components/CoinCard.module.css
+++ b/frontend/src/components/CoinCard.module.css
@@ -1,0 +1,6 @@
+.card { border: 1px solid var(--border, #2a2a2a); border-radius: 8px; padding: 12px; margin-top: 12px; }
+.head { font-weight: 600; font-size: 1.1em; margin-bottom: 8px; }
+.sec { border-top: 1px solid var(--border, #2a2a2a); padding: 8px 0; }
+.sec h4 { margin: 0 0 4px; font-size: 0.85em; opacity: 0.7; text-transform: uppercase; letter-spacing: 0.04em; }
+.row { font-variant-numeric: tabular-nums; }
+.empty { opacity: 0.7; }

--- a/frontend/src/components/CoinCard.test.tsx
+++ b/frontend/src/components/CoinCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { CoinCard } from './CoinCard';
+import * as api from '../api';
+
+afterEach(() => vi.restoreAllMocks());
+
+const _levels = { symbol: 'SOLUSDT', estado: 'ok', generated_at: '2026-06-13T00:00:00+00:00',
+  price_live: 142, zonas: [], ubicacion: { dentro_de: null, techo: null, piso: null } };
+const _dossier = { symbol: 'SOLUSDT', estado_general: 'rastreable', equipo_identificado: true,
+  equipo: [], presencia: {}, actividad: {}, financiacion: [], hitos: [], no_encontrado_en: [],
+  generated_at: '2026-06-13T00:00:00+00:00' };
+const _vidaOk = { symbol: 'SOLUSDT', estado: 'ok', candidata: true, pct_rango: 0.18,
+  semanas_consolidando: 9, volumen_usd_dia: 3_000_000 };
+
+function _mockAll(vida: unknown) {
+  vi.spyOn(api, 'getValleyEval').mockResolvedValue(vida as never);
+  vi.spyOn(api, 'getLevels').mockResolvedValue(_levels as never);
+  vi.spyOn(api, 'getDossier').mockResolvedValue(_dossier as never);
+}
+
+describe('CoinCard', () => {
+  it('pinta los tres bloques (Vida, Niveles, Fundamentales)', async () => {
+    _mockAll(_vidaOk);
+    render(<CoinCard symbol="SOLUSDT" />);
+    expect(await screen.findByText(/Vida/)).toBeInTheDocument();
+    expect(screen.getByText(/Niveles/)).toBeInTheDocument();
+    expect(screen.getByText(/Fundamentales/)).toBeInTheDocument();
+  });
+
+  it('un bloque no_disponible degrada solo (los otros siguen)', async () => {
+    _mockAll({ symbol: 'SOLUSDT', estado: 'no_disponible' });
+    render(<CoinCard symbol="SOLUSDT" />);
+    expect(await screen.findByText(/Niveles/)).toBeInTheDocument();
+    expect(screen.getByText(/Sin datos/)).toBeInTheDocument();
+  });
+
+  it('no emite veredicto compuesto (anti-veredicto)', async () => {
+    _mockAll(_vidaOk);
+    const { container } = render(<CoinCard symbol="SOLUSDT" />);
+    await screen.findByText(/Vida/);
+    expect(/comprá|comprar|buena|score|recomend|veredicto|potencial/i
+      .test(container.textContent ?? '')).toBe(false);
+  });
+});

--- a/frontend/src/components/CoinCard.tsx
+++ b/frontend/src/components/CoinCard.tsx
@@ -1,0 +1,76 @@
+// ============================================================
+// CoinCard — la tarjeta de selección compuesta (F3b).
+// Tres bloques YUXTAPUESTOS (A vida · D.1 niveles · C dossier),
+// cada uno con su propio estado/frescura. La tarjeta EXHIBE, no
+// firma: cero veredicto compuesto, cero score. Spec §3.
+// ============================================================
+import React, { useEffect, useState } from 'react';
+import type { ValleyEval, SrLevels, Dossier } from '../types';
+import { getValleyEval, getLevels, getDossier } from '../api';
+import { LevelsPanel } from './LevelsPanel';
+import { ProjectDossier } from './ProjectDossier';
+import styles from './CoinCard.module.css';
+
+const VidaBlock: React.FC<{ ev: ValleyEval | null; loading: boolean }> = ({ ev, loading }) => {
+  if (loading) return <div className={styles.empty}>Evaluando…</div>;
+  if (!ev || ev.estado === 'no_disponible') return <div className={styles.empty}>Sin datos</div>;
+  if (ev.candidata) {
+    return (
+      <div className={styles.row}>
+        viva · en rango {((ev.pct_rango ?? 0) * 100).toFixed(0)}% ·{' '}
+        {ev.semanas_consolidando} semanas ·{' '}
+        ${Math.round(ev.volumen_usd_dia ?? 0).toLocaleString('en-US')}/día
+      </div>
+    );
+  }
+  return (
+    <div className={styles.row}>
+      {ev.vivo ? 'viva, fuera de rango' : 'no candidata'}
+      {ev.razones_muerte && ev.razones_muerte.length > 0
+        ? ` — ${ev.razones_muerte.join(', ')}` : ''}
+    </div>
+  );
+};
+
+export const CoinCard: React.FC<{ symbol: string }> = ({ symbol }) => {
+  const [vida, setVida] = useState<ValleyEval | null>(null);
+  const [vidaLoading, setVidaLoading] = useState(true);
+  const [levels, setLevels] = useState<SrLevels | null>(null);
+  const [levelsLoading, setLevelsLoading] = useState(true);
+  const [dossier, setDossier] = useState<Dossier | null>(null);
+  const [dossierLoading, setDossierLoading] = useState(true);
+
+  useEffect(() => {
+    setVida(null); setVidaLoading(true);
+    setLevels(null); setLevelsLoading(true);
+    setDossier(null); setDossierLoading(true);
+    getValleyEval(symbol).then(setVida).finally(() => setVidaLoading(false));
+    getLevels(symbol).then(setLevels).finally(() => setLevelsLoading(false));
+    getDossier(symbol).then(setDossier).finally(() => setDossierLoading(false));
+  }, [symbol]);
+
+  return (
+    <div className={styles.card}>
+      <header className={styles.head}>{symbol.replace('USDT', '')}</header>
+
+      <section className={styles.sec}>
+        <h4>Vida</h4>
+        <VidaBlock ev={vida} loading={vidaLoading} />
+      </section>
+
+      <section className={styles.sec}>
+        <h4>Niveles</h4>
+        {(levels || levelsLoading)
+          ? <LevelsPanel levels={levels!} loading={levelsLoading} />
+          : <div className={styles.empty}>Sin datos</div>}
+      </section>
+
+      <section className={styles.sec}>
+        <h4>Fundamentales</h4>
+        {(dossier || dossierLoading)
+          ? <ProjectDossier dossier={dossier!} loading={dossierLoading} />
+          : <div className={styles.empty}>Sin datos</div>}
+      </section>
+    </div>
+  );
+};

--- a/frontend/src/components/ValleysView.test.tsx
+++ b/frontend/src/components/ValleysView.test.tsx
@@ -45,4 +45,10 @@ describe('ValleysView', () => {
     render(<ValleysView snapshot={snap} loading={false} />);
     expect(screen.getAllByRole('button', { name: /niveles/i })).toHaveLength(2);
   });
+
+  it('ofrece un input de símbolo para abrir la tarjeta', () => {
+    render(<ValleysView snapshot={snap} loading={false} />);
+    expect(screen.getByPlaceholderText(/símbolo/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ver tarjeta/i })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ValleysView.tsx
+++ b/frontend/src/components/ValleysView.tsx
@@ -10,6 +10,7 @@ import { getDossier, getLevels } from '../api';
 import { formatPrice } from '../utils';
 import { ProjectDossier } from './ProjectDossier';
 import { LevelsPanel } from './LevelsPanel';
+import { CoinCard } from './CoinCard';
 import styles from './ValleysView.module.css';
 
 export const ValleysView: React.FC<{ snapshot: ValleySnapshot; loading: boolean }> = ({
@@ -19,6 +20,8 @@ export const ValleysView: React.FC<{ snapshot: ValleySnapshot; loading: boolean 
   const [dossierLoading, setDossierLoading] = useState(false);
   const [levels, setLevels] = useState<SrLevels | null>(null);
   const [levelsLoading, setLevelsLoading] = useState(false);
+  const [cardInput, setCardInput] = useState('');
+  const [cardSymbol, setCardSymbol] = useState('');
 
   if (loading) return <div className={styles.empty}>Cargando…</div>;
   const { generated_at, coverage, candidates } = snapshot;
@@ -31,6 +34,17 @@ export const ValleysView: React.FC<{ snapshot: ValleySnapshot; loading: boolean 
   }
   return (
     <div className={styles.wrap}>
+      <form
+        onSubmit={(e) => { e.preventDefault(); setCardSymbol(cardInput.trim().toUpperCase()); }}
+      >
+        <input
+          value={cardInput}
+          onChange={(e) => setCardInput(e.target.value)}
+          placeholder="Símbolo (ej. SOLUSDT)"
+        />
+        <button type="submit">Ver tarjeta</button>
+      </form>
+      {cardSymbol && <CoinCard symbol={cardSymbol} />}
       <div className={`${styles.meta} prose`}>
         Foto del {new Date(generated_at).toLocaleString('es-ES')} · cobertura{' '}
         {coverage.evaluated} / {coverage.universe}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -545,6 +545,22 @@ export interface SrLevels {
   ubicacion:    SrUbicacion;
 }
 
+// ---- F3b: A on-demand (vida + rango de una moneda). Spec §2 ----
+export interface ValleyEval {
+  symbol:                string;
+  estado:                'ok' | 'no_disponible';
+  candidata?:            boolean;
+  vivo?:                 boolean;
+  razones_muerte?:       string[];
+  price?:                number;
+  pct_rango?:            number;
+  semanas_consolidando?: number;
+  vol_percentil?:        number;
+  volumen_usd_dia?:      number;
+  distancia_ath_pct?:    number;
+  razones_vida?:         string[];
+}
+
 // Dossier C — hechos citados de un proyecto (sin veredicto). Spec §2.
 export interface DossierMiembro { nombre: string; rol: string | null; enlaces: string[]; fuente: string; }
 export interface DossierCanal { url: string | null; activo: 'si' | 'no' | 'desconocido'; fuente: string | null; }

--- a/tests/test_valley_eval_api.py
+++ b/tests/test_valley_eval_api.py
@@ -1,0 +1,43 @@
+"""Tests del endpoint A on-demand GET /valley-eval/{symbol} (instrumento F3b). Spec §2."""
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.valleys import router
+from api.levels import BinanceUnavailable
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_candidata_true_devuelve_hechos():
+    cand = {"symbol": "ADAUSDT", "price": 0.42, "pct_rango": 0.18,
+            "semanas_consolidando": 9, "vol_percentil": 0.22,
+            "volumen_usd_dia": 3_000_000, "distancia_ath_pct": 0.86, "razones_vida": []}
+    with patch("api.valleys._fetch_daily_bars", return_value=[{}] * 130), \
+         patch("api.valleys.evaluate_symbol", return_value=cand):
+        r = _app().get("/valley-eval/ADAUSDT")
+    body = r.json()
+    assert body["estado"] == "ok" and body["candidata"] is True
+    assert body["pct_rango"] == 0.18
+
+
+def test_no_candidata_reporta_razones():
+    with patch("api.valleys._fetch_daily_bars", return_value=[{}] * 130), \
+         patch("api.valleys.evaluate_symbol", return_value=None), \
+         patch("api.valleys.classify_liveness", return_value=(False, ["volumen_bajo_piso"])):
+        r = _app().get("/valley-eval/XYZUSDT")
+    body = r.json()
+    assert body["candidata"] is False
+    assert body["vivo"] is False
+    assert body["razones_muerte"] == ["volumen_bajo_piso"]
+
+
+def test_red_caida_es_no_disponible_sin_500():
+    with patch("api.valleys._fetch_daily_bars", side_effect=BinanceUnavailable("klines HTTP 503")):
+        r = _app().get("/valley-eval/ADAUSDT")
+    assert r.status_code == 200 and r.json()["estado"] == "no_disponible"


### PR DESCRIPTION
## Resumen

La última pieza del instrumento: la **tarjeta de selección compuesta**. Pegás un ticker y ves los tres órganos de entrada en una vista por moneda — Vida (A) · Niveles (D.1) · Fundamentales (C) — yuxtapuestos, con las costuras visibles.

### La decisión central (roster unánime + restricción de Voronov)
La composición vive en el **frontend**, NO en un compositor backend. La razón es ontológica, no técnica:
> Tres hechos neutrales yuxtapuestos generan un cuarto objeto que ninguno autorizó: la **correlación percibida** ("vivo + fundamentales limpios + precio en soporte" se lee como "comprá"). Un compositor backend produce UN objeto con UN status — **reifica la correlación en el contrato (firma el veredicto)**. El frontend, con tres relojes/estados/latencias, mantiene **las costuras visibles**. El instrumento que mide conducta no puede emitir la conducta que mide. **La tarjeta exhibe; no firma.**

### Qué se construyó
- `api/valleys.py` — `GET /valley-eval/{symbol}`: A on-demand (reusa el fetch de D.1 + `evaluate_symbol` puro). Devuelve hechos de vida/rango, o `candidata: false` con razones, o `no_disponible`. Read-only, sin caché.
- `frontend` — tipo `ValleyEval` + cliente, `CoinCard` (tres bloques independientes en paralelo, dossier lazy, degradación por-bloque, **cero veredicto compuesto**), input de símbolo en la Vista Valles.

### Invariantes (verificados en el review holístico)
- **La tarjeta exhibe, no firma:** cero score agregado, cero badge, sin cuarta línea-resumen. Test anti-veredicto sobre el DOM compuesto.
- **Composición en frontend** (no compositor backend — defer hasta un segundo consumidor).
- **Bloques independientes:** un bloque `no_disponible` degrada solo. **A on-demand es hechos, no juicio.**

## El instrumento, completo
- **F1** ✅ la columna · **F2** ✅ el refutador determinista · **F3a** ✅ el acompañante vivo · **F3b** ✅ la tarjeta de selección (este PR)
- Los órganos de entrada (A/C/D.1) cosidos + el cuerpo temporal (la columna que mide conducta) = el instrumento entero.

## Test plan
- [x] A on-demand: candidata true (hechos) / false (razones) / no_disponible sin 500.
- [x] `CoinCard`: tres bloques pintan, degradación por-bloque aislada, anti-veredicto.
- [x] `getValleyEval` + input de símbolo en la Vista Valles.
- [x] Gate rápido CI (`-m "not network"`): 3540 passed, 0 nuevas fallas. Frontend: 161 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)