### PR TITLE
Valles: pulido de microcopy (solace-wren)

### DIFF
--- a/frontend/src/components/valles/Copilot.tsx
+++ b/frontend/src/components/valles/Copilot.tsx
@@ -10,18 +10,18 @@ const VERDICT  = /(compr|conviene|mejor|vend|buena|mala)/i;
 
 export function canned(qRaw: string): CannedReply {
   const q = (qRaw || '').toLowerCase();
-  if (SIZING.test(q)) return { refusal: true, tag: 'no te dice cuánto', html: <>El tamaño lo decides tú, a propósito. Valles no te dice cuánto poner — solo te muestra los hechos para que decidas con tu criterio.</> };
+  if (SIZING.test(q)) return { refusal: true, tag: 'no te dice cuánto', html: <>El tamaño lo decides tú, a propósito. Valles no te dice cuánto poner. Solo te muestra los hechos para que decidas con tu criterio.</> };
   if (DECISION.test(q) || VERDICT.test(q)) return { refusal: true, tag: 'no decide', html: <>No te digo si comprar ni cuál es "la mejor". No existe un puntaje de calidad: la herramienta muestra hechos y el veredicto es tuyo.</> };
   if (q.includes('valle') || q.includes('quiet') || q.includes('viva')) return { tag: 'fact', html: <>"En valle" quiere decir que la moneda <b>se mueve poco</b>, dentro de una franja angosta, durante varias semanas. Es una descripción del gráfico, no un consejo.</> };
   if (q.includes('viej') || q.includes('fresc') || q.includes('ranci') || q.includes('actual')) return { tag: 'fact', html: <>Cada lectura te dice su edad. Si algo es de hace varios días te aviso que pudo cambiar.</> };
   return { tag: 'fact', html: <>Te leo hechos: si está viva, dónde está el precio respecto a sus paredes, y quién está detrás con su fuente. Pregúntame por cualquiera.</> };
 }
 
-const SUGG = ['¿Qué quiere decir "en valle"?', '¿Está vieja la info?', '¿Cuál conviene comprar?', '¿Cuánto pongo?'];
+const SUGG = ['¿Qué quiere decir "en valle"?', '¿Está vieja la información?', '¿Cuál conviene comprar?', '¿Cuánto pongo?'];
 type Msg = { role: 'user' | 'assistant'; html: React.ReactNode; tag?: string; refusal?: boolean };
 
 export const Copilot: React.FC<{ onClose: () => void }> = ({ onClose }) => {
-  const [msgs, setMsgs] = useState<Msg[]>([{ role: 'assistant', tag: 'fact', html: <>Te leo los hechos de las tres lentes. No predigo, no rankeo, y no te digo cuánto poner.</> }]);
+  const [msgs, setMsgs] = useState<Msg[]>([{ role: 'assistant', tag: 'fact', html: <>Te leo los hechos de las tres lentes. No predigo, no digo cuál es mejor, y no te digo cuánto poner.</> }]);
   const [input, setInput] = useState('');
   const scroll = useRef<HTMLDivElement>(null);
   useEffect(() => { if (scroll.current) scroll.current.scrollTop = scroll.current.scrollHeight; }, [msgs]);

--- a/frontend/src/components/valles/FundScreen.tsx
+++ b/frontend/src/components/valles/FundScreen.tsx
@@ -22,14 +22,14 @@ export const FundScreen: React.FC<{ symbol: string; state: AsyncState<Dossier>; 
     answer = <Loading label="Buscando quién está detrás…" />;
   } else if (error || !data || data.estado_general === 'no_disponible') {
     answer = (
-      <Callout tone="mute" icon="×" title="No se pudo averiguar ahora" sub="Falló la búsqueda — es un problema de la herramienta, no del proyecto.">
+      <Callout tone="mute" icon="×" title="No se pudo averiguar ahora" sub="Falló la búsqueda. Es un problema de la herramienta, no del proyecto.">
         <Retry onClick={onRefresh} />
       </Callout>
     );
   } else if (data.estado_general === 'opaco') {
     answer = (
       <Callout tone="ochre" icon="◍" title="No se encontró quién está detrás"
-        sub={<>Se buscó equipo, presencia y actividad pública, y <b>no apareció nada</b>. Eso es un dato sobre el proyecto — no es una falla de la herramienta.{data.no_encontrado_en.length > 0 && <> No se halló en: {data.no_encontrado_en.join(', ')}.</>}</>} />
+        sub={<>Se buscó equipo, presencia y actividad pública, y <b>no apareció nada</b>. Eso es un dato sobre el proyecto, no una falla de la herramienta.{data.no_encontrado_en.length > 0 && <> No se halló en: {data.no_encontrado_en.join(', ')}.</>}</>} />
     );
   } else {
     answer = (

--- a/frontend/src/components/valles/NivelesScreen.tsx
+++ b/frontend/src/components/valles/NivelesScreen.tsx
@@ -27,10 +27,10 @@ export const NivelesScreen: React.FC<{ symbol: string; state: AsyncState<SrLevel
     let lead: string, say: React.ReactNode, ratio: number;
     if (inside && inside.tipo === 'soporte') {
       lead = 'El precio está sobre un piso'; ratio = 0.7;
-      say = <>Es un piso donde el precio <b>ya giró ahí {inside.toques} veces</b> antes — un hecho del gráfico.</>;
+      say = <>Es un piso donde el precio <b>ya giró ahí {inside.toques} veces</b> antes.</>;
     } else if (inside && inside.tipo === 'resistencia') {
       lead = 'El precio está contra un techo'; ratio = 0.3;
-      say = <>Es un techo donde el precio <b>ya giró ahí {inside.toques} veces</b> antes — un hecho del gráfico.</>;
+      say = <>Es un techo donde el precio <b>ya giró ahí {inside.toques} veces</b> antes.</>;
     } else {
       lead = 'Está en el medio';
       const t = u.techo ? u.techo.dist_pct : 1, p = u.piso ? Math.abs(u.piso.dist_pct) : 1;

--- a/frontend/src/components/valles/PickScreen.tsx
+++ b/frontend/src/components/valles/PickScreen.tsx
@@ -24,7 +24,7 @@ export const PickScreen: React.FC<{ snapshot: ValleySnapshot; onPick: (sym: stri
 
       {candidates.length > 0 && (
         <p className={styles.vwPickLead}>
-          Son las que ahora mismo se mueven poco y siguen vivas — el filtro que hace Valles,
+          Son las que ahora mismo se mueven poco y siguen vivas: el filtro que hace Valles,
           mecánico, no un consejo. Elige una para mirarla de cerca con las tres lentes.
         </p>
       )}

--- a/frontend/src/components/valles/VidaScreen.tsx
+++ b/frontend/src/components/valles/VidaScreen.tsx
@@ -8,7 +8,7 @@ import styles from './valles.module.css';
 const RAZONES_MUERTE: Record<string, string> = {
   volumen_bajo_piso: 'El volumen está por debajo del piso que se pide.',
   volumen_agonizante: 'El volumen viene cayendo hasta casi apagarse.',
-  velas_planas: 'Las velas están casi planas — apenas se mueve.',
+  velas_planas: 'Las velas están casi planas: apenas se mueve.',
   historia_insuficiente: 'No hay suficiente historia para evaluarla.',
 };
 


### PR DESCRIPTION
Pasada de microcopy sobre el recorrido cálido de Valles (post-#595), por la skill `solace-wren`.

## Cambios (solo copy, doctrina intacta)
- **Guion-largo (—) de ~7 a 1**: en español es la señal #1 de slop. Pasan a punto, dos puntos o coma (PickScreen, VidaScreen, FundScreen, Copilot).
- **Jerga → lenguaje del lector diana (~70 años)**: "no rankeo" → "no digo cuál es mejor" (anglicismo + nombra el veredicto que la herramienta niega); "info" → "información".
- **Redundancia**: se quita "— un hecho del gráfico" de los dos lead-ins de Niveles; el ancla ya vive una vez en la nota neutral.

## Lo que NO se tocó
Las negaciones doctrinales ("no un consejo", "no una falla", "no te dice qué hacer") cargan la ley del producto, no son relleno. Los `…` de carga son funcionales.

## Verificación
- `valles` suite 34/34, `tsc` limpio. Gate de doctrina (anti-veredicto) intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)