### PR TITLE
fix(valles): un agente por sección + un solo loader al pensar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -810,7 +810,10 @@ const App: React.FC = () => {
         agentEnabled={AGENT_ENABLED}
       />
 
-      {AGENT_ENABLED && (
+      {/* El copiloto global de la app NO se monta en el tab Valles: esa
+          sección tiene su propio copiloto (surface 'valles') y los dos FABs
+          se solapaban. Una sección, un agente. */}
+      {AGENT_ENABLED && mainTab !== 'valles' && (
         <AgentDock
           open={dockOpen}
           onOpen={() => openDock()}

--- a/frontend/src/components/valles/Copilot.test.tsx
+++ b/frontend/src/components/valles/Copilot.test.tsx
@@ -2,8 +2,44 @@
 // La función canned() fue eliminada cuando se conectó el agente real
 // (useAgentStream / surface='valles'). La doctrina anti-veredicto es
 // ahora una responsabilidad del backend (system prompt + denylist +
-// LLM judge). Las preguntas trampa llegan al agente real y se rechazan
-// con un evento SSE `refusal`. Ver doctrine.test.tsx para la prueba
-// de integración del bubble vwBubbleRefusal.
-import { it } from 'vitest';
-it.todo('canned() eliminado — doctrina cubierta en doctrine.test.tsx');
+// LLM judge). Ver doctrine.test.tsx para la prueba del bubble refusal.
+//
+// Este archivo cubre el estado "pensando": Valles buffea la respuesta
+// (no streamea), así que el placeholder assistant queda vacío hasta el
+// final. NO debe pintarse como burbuja vacía + un loader aparte (doble
+// burbuja); debe ser UNA sola burbuja con el loader de tres puntos.
+import { render, act } from '@testing-library/react';
+import { it, expect, vi } from 'vitest';
+import { Copilot } from './Copilot';
+import type { ChatMsg } from '../../agent/useAgentStream';
+
+// Hook mockeado: turno en vuelo → user + placeholder assistant vacío, loading.
+vi.mock('../../agent/useAgentStream', () => {
+  const msgs: ChatMsg[] = [
+    { role: 'user', text: '¿cuál conviene comprar?' },
+    { role: 'assistant', text: '', tool_chips: [] },
+  ];
+  return {
+    useAgentStream: () => ({
+      msgs,
+      loading: true,
+      sendTurn: vi.fn().mockResolvedValue(undefined),
+      resetConversation: vi.fn(),
+      confirmProposal: vi.fn(),
+      loadConversation: vi.fn(),
+      streamGreeting: vi.fn(),
+      hydrating: false,
+    }),
+  };
+});
+
+it('mientras piensa muestra UN solo loader, no una burbuja vacía + puntos', async () => {
+  await act(async () => {
+    render(<Copilot onClose={() => {}} />);
+  });
+  // Exactamente un indicador de "pensando" (role=status).
+  expect(document.querySelectorAll('[role="status"]').length).toBe(1);
+  // Dos burbujas en total: la del usuario + la del loader. El placeholder
+  // assistant vacío NO se pinta (si se pintara, serían tres).
+  expect(document.querySelectorAll('[class*="vwBubble"]').length).toBe(2);
+});

--- a/frontend/src/components/valles/Copilot.tsx
+++ b/frontend/src/components/valles/Copilot.tsx
@@ -37,6 +37,12 @@ export const Copilot: React.FC<{ onClose: () => void; symbol?: string }> = ({ on
   // Greeting inicial estático — el agente real responde cuando el usuario pregunta.
   const showGreeting = msgs.length === 0;
 
+  // "Pensando": Valles buffea la respuesta (no streamea token a token), así que
+  // el placeholder assistant queda vacío hasta el final. No lo pintamos como
+  // burbuja vacía; en su lugar mostramos UN loader de tres puntos.
+  const last = msgs[msgs.length - 1];
+  const thinking = loading && (!last || last.role !== 'assistant' || last.text === '');
+
   return (
     <>
       <div className={styles.vwScrim} onClick={onClose} />
@@ -53,21 +59,31 @@ export const Copilot: React.FC<{ onClose: () => void; symbol?: string }> = ({ on
               <div className={styles.vwBubble}>Te leo hechos: si está viva, dónde está el precio respecto a sus paredes, y quién está detrás con su fuente. Pregúntame por cualquiera.</div>
             </div>
           )}
-          {msgs.map((m: ChatMsg, i: number) => (
-            <div className={`${styles.vwMsg} ${m.role === 'user' ? styles.vwMsgUser : ''}`} key={i}>
-              {m.role === 'assistant' && (
-                <span className={`${styles.vwTag} ${m.refusal ? '' : styles.vwTagFact}`}>
-                  {m.refusal ? 'no decide' : 'fact'}
-                </span>
-              )}
-              <div className={`${styles.vwBubble} ${m.refusal ? styles.vwBubbleRefusal : ''}`}>
-                {m.text}
+          {msgs.map((m: ChatMsg, i: number) => {
+            // Placeholder vacío mientras piensa → no se pinta (el loader lo cubre).
+            if (m.role === 'assistant' && !m.text) return null;
+            return (
+              <div className={`${styles.vwMsg} ${m.role === 'user' ? styles.vwMsgUser : ''}`} key={i}>
+                {m.role === 'assistant' && (
+                  <span className={`${styles.vwTag} ${m.refusal ? '' : styles.vwTagFact}`}>
+                    {m.refusal ? 'no decide' : 'fact'}
+                  </span>
+                )}
+                <div className={`${styles.vwBubble} ${m.refusal ? styles.vwBubbleRefusal : ''}`}>
+                  {m.text}
+                </div>
               </div>
-            </div>
-          ))}
-          {loading && (
+            );
+          })}
+          {thinking && (
             <div className={styles.vwMsg}>
-              <div className={styles.vwBubble}>…</div>
+              <div className={styles.vwBubble}>
+                <span className={styles.vwTyping} role="status" aria-label="Pensando">
+                  <span className={styles.vwTypingDot} />
+                  <span className={styles.vwTypingDot} />
+                  <span className={styles.vwTypingDot} />
+                </span>
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/components/valles/valles.module.css
+++ b/frontend/src/components/valles/valles.module.css
@@ -469,6 +469,23 @@
   color: var(--ochre); margin-left: 4px;
 }
 .vwTagFact { color: var(--sage); }
+
+/* "Pensando": tres puntos en una sola burbuja, sin tag. */
+.vwTyping { display: inline-flex; align-items: center; gap: 5px; padding: 2px 0; }
+.vwTypingDot {
+  width: 7px; height: 7px; border-radius: 50%; background: var(--ink-3);
+  animation: vwTypingBlink 1.4s ease-in-out infinite both;
+}
+.vwTypingDot:nth-child(2) { animation-delay: 0.2s; }
+.vwTypingDot:nth-child(3) { animation-delay: 0.4s; }
+@keyframes vwTypingBlink {
+  0%, 80%, 100% { opacity: 0.25; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-2px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .vwTypingDot { animation: none; opacity: 0.5; }
+}
+
 .vwDockSugg { display: flex; flex-wrap: wrap; gap: 7px; padding: 0 20px 12px; }
 .vwSugg {
   font-family: var(--sans); font-size: 12.5px; color: var(--ink-2);


### PR DESCRIPTION
## Resumen

Dos bugs visuales del copiloto de Valles, reportados con captura:

1. **Dos agentes colisionando.** El `AgentDock` global (FAB ◈) se montaba en todos los tabs y se solapaba con el copiloto propio de Valles. Ahora **no se monta cuando `mainTab === 'valles'`** — una sección, un agente.
2. **Doble burbuja al "pensar".** Valles buffea la respuesta (no streamea, por doctrina), así que el placeholder assistant vacío se pintaba como burbuja vacía **más** un loader aparte. Ahora el placeholder vacío no se pinta y se muestra **una sola burbuja con un loader de tres puntos animado** (respeta `prefers-reduced-motion`).

## Test Plan

- [x] `tsc --noEmit` limpio.
- [x] `vitest run src/components/valles` → 29 passed (incluye un test nuevo que ancla "1 loader, 2 burbujas, sin placeholder vacío" para que el doble-burbuja no regrese).
- [ ] Verificación visual en el tab Valles (sin ◈ global; un solo bubble con puntos al preguntar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)