### PR TITLE
feat(deploy): PR1 — código para desacoplar el scanner (backward-compatible)

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -104,13 +104,30 @@ def post_health_reactivate(symbol: str, body: ReactivateRequest):
     return {"ok": True, "symbol": symbol.upper(), "state": get_symbol_state(symbol.upper())}
 
 
-@router.get("/health", summary="Health check for monitoring and Docker")
+@router.get("/health/live", summary="Readiness: proceso + schema listos (sin scanner)")
+def health_live():
+    """Readiness probe: 200 si uvicorn responde y el schema está presente.
+
+    Usa SELECT 1 FROM users LIMIT 1 (tabla canónica) — no bare SELECT 1 —
+    para detectar schema incompleto. No toca el scanner.
+    Es la ruta que el deploy poll-ea para confirmar que la instancia está lista.
+    """
+    try:
+        with snapshot_connection() as con:
+            con.execute("SELECT 1 FROM users LIMIT 1")
+        return {"ready": True}
+    except Exception as e:
+        return JSONResponse(content={"ready": False, "detail": str(e)}, status_code=503)
+
+
+@router.get("/health", summary="Health check (liveness del scanner vía DB)")
 def health_check():
-    """Returns system health status. HTTP 200 = healthy, 503 = degraded."""
-    # Lazy import to avoid circular dep: btc_api imports api.health at module
-    # load time, so we cannot import btc_api at the top of this module.
-    import btc_api as _btc_api  # noqa: PLC0415
-    _scanner_state = _btc_api._scanner_state
+    """Returns system health status. HTTP 200 = healthy, 503 = degraded.
+
+    Deriva la liveness del scanner de la DB via api.scanner_liveness —
+    funciona en instancias web-only donde no hay scanner thread en proceso.
+    """
+    from api.scanner_liveness import scanner_liveness  # noqa: PLC0415
 
     checks = {}
 
@@ -122,32 +139,15 @@ def health_check():
     except Exception as e:
         checks["database"] = f"error: {e}"
 
-    # Scanner thread status
-    checks["scanner"] = "ok" if _scanner_state.get("running") else "stopped"
+    snap = scanner_liveness()
+    fr = snap["frescura"]["estado"]
+    checks["scanner"] = fr
+    checks["scan_freshness"] = fr
+    checks["scans_total"] = snap.get("scans_total", 0)
+    checks["signals_total"] = snap.get("signals_total", 0)
 
-    # Last scan freshness
-    last_ts = _scanner_state.get("last_scan_ts")
-    if last_ts:
-        try:
-            last_dt = datetime.fromisoformat(last_ts)
-            age_sec = (datetime.now(timezone.utc) - last_dt).total_seconds()
-            cfg = load_config()
-            interval = cfg.get("scan_interval_sec", 300)
-            checks["scan_freshness"] = "ok" if age_sec < interval * 3 else f"stale ({int(age_sec)}s ago)"
-        except Exception:
-            checks["scan_freshness"] = "unknown"
-    else:
-        checks["scan_freshness"] = "no_scans_yet"
-
-    # Stats
-    checks["scans_total"] = _scanner_state.get("scans_total", 0)
-    checks["signals_total"] = _scanner_state.get("signals_total", 0)
-    checks["errors"] = _scanner_state.get("errors", 0)
-
-    healthy = checks["database"] == "ok" and checks["scanner"] == "ok"
-    status_code = 200 if healthy else 503
-
+    healthy = checks["database"] == "ok" and fr == "fresco"
     return JSONResponse(
         content={"healthy": healthy, "checks": checks},
-        status_code=status_code
+        status_code=200 if healthy else 503
     )

--- a/api/scanner_liveness.py
+++ b/api/scanner_liveness.py
@@ -12,8 +12,12 @@ Schema verificado en db/schema.py líneas 126-142 y db/signals.py líneas 39-44:
 """
 from __future__ import annotations
 
+import sqlite3
+
 from db.transaction import snapshot_connection as _snapshot_connection
 from freshness import LiveSnapshot
+
+_EMPTY_FACTS = {"last_scan_ts": None, "scans_total": 0, "signals_total": 0}
 
 
 def _query_scanner_facts() -> dict:
@@ -22,13 +26,20 @@ def _query_scanner_facts() -> dict:
     Usa snapshot_connection (WAL-concurrent, sin writer lock) porque
     esta lectura es terminal — se serializa a la respuesta HTTP, no
     alimenta ninguna mutación posterior.
+
+    Tolerante a la tabla ausente: una API web-only podría consultar antes
+    de que el scanner-service haya creado el schema → degradar a 'muerto'
+    (LiveSnapshot con generated_at=None), nunca un 500.
     """
-    with _snapshot_connection() as con:
-        last_scan_ts = con.execute("SELECT MAX(ts) FROM scans").fetchone()[0]
-        scans_total = con.execute("SELECT COUNT(*) FROM scans").fetchone()[0]
-        signals_total = con.execute(
-            'SELECT COUNT(*) FROM scans WHERE "señal" = 1'
-        ).fetchone()[0]
+    try:
+        with _snapshot_connection() as con:
+            last_scan_ts = con.execute("SELECT MAX(ts) FROM scans").fetchone()[0]
+            scans_total = con.execute("SELECT COUNT(*) FROM scans").fetchone()[0]
+            signals_total = con.execute(
+                'SELECT COUNT(*) FROM scans WHERE "señal" = 1'
+            ).fetchone()[0]
+    except sqlite3.OperationalError:
+        return dict(_EMPTY_FACTS)
     return {
         "last_scan_ts": last_scan_ts,
         "scans_total": scans_total,

--- a/api/scanner_liveness.py
+++ b/api/scanner_liveness.py
@@ -1,0 +1,61 @@
+"""Liveness del scanner derivada de la DB (no de memoria de proceso).
+
+Para que una API web-only reporte la verdad del trading-scanner.service
+incluso cuando no hay scanner thread corriendo en el mismo proceso.
+
+Cumple el non-negotiable #8: el estado vivo cruza un límite de proceso,
+así que su frescura debe vivir en el contrato (LiveSnapshot), NO en memoria.
+
+Schema verificado en db/schema.py líneas 126-142 y db/signals.py líneas 39-44:
+- Columna de tiempo: ts (TEXT NOT NULL)
+- Columna de señal:  señal (INTEGER NOT NULL DEFAULT 0, vale 1 cuando activa)
+"""
+from __future__ import annotations
+
+from db.transaction import snapshot_connection as _snapshot_connection
+from freshness import LiveSnapshot
+
+
+def _query_scanner_facts() -> dict:
+    """Lee la DB y devuelve conteos + timestamp del último scan.
+
+    Usa snapshot_connection (WAL-concurrent, sin writer lock) porque
+    esta lectura es terminal — se serializa a la respuesta HTTP, no
+    alimenta ninguna mutación posterior.
+    """
+    with _snapshot_connection() as con:
+        last_scan_ts = con.execute("SELECT MAX(ts) FROM scans").fetchone()[0]
+        scans_total = con.execute("SELECT COUNT(*) FROM scans").fetchone()[0]
+        signals_total = con.execute(
+            'SELECT COUNT(*) FROM scans WHERE "señal" = 1'
+        ).fetchone()[0]
+    return {
+        "last_scan_ts": last_scan_ts,
+        "scans_total": scans_total,
+        "signals_total": signals_total,
+    }
+
+
+def scanner_liveness(*, umbral_seg: float = 900.0) -> dict:
+    """Devuelve el estado de liveness del scanner envuelto en LiveSnapshot.
+
+    Args:
+        umbral_seg: segundos antes de considerar el scanner 'rancio'.
+                    Default 900 s (15 min) — el intervalo de scan nominal.
+
+    Returns:
+        dict con keys: scans_total, signals_total, last_scan_ts, frescura
+        donde frescura = {estado, edad_seg, generated_at, umbral_seg}.
+        estado es 'fresco' | 'rancio' | 'muerto'.
+    """
+    facts = _query_scanner_facts()
+    payload = {
+        "scans_total": facts["scans_total"],
+        "signals_total": facts["signals_total"],
+        "last_scan_ts": facts["last_scan_ts"],
+    }
+    return LiveSnapshot(
+        payload=payload,
+        generated_at=facts["last_scan_ts"],
+        umbral_seg=umbral_seg,
+    ).to_response()

--- a/btc_api.py
+++ b/btc_api.py
@@ -244,18 +244,23 @@ async def lifespan(app: FastAPI):
     # rather than on the first /auth/login request.
     _jwt_secret()
 
-    log.info("Initializing DB schema…")
-    init_db()
-    with transaction() as con:
-        init_auth_db(con)
-        init_system_state(con)
+    if os.getenv("SKIP_DB_INIT") != "1":
+        log.info("Initializing DB schema…")
+        init_db()
+        with transaction() as con:
+            init_auth_db(con)
+            init_system_state(con)
+        # First-time setup gate. Picks one of three paths (env / cli / web)
+        # or no-ops if a user already exists.
+        _bootstrap_first_user()
+    else:
+        log.info("SKIP_DB_INIT=1 — schema y bootstrap los hace trading-scanner.service")
 
-    # First-time setup gate. Picks one of three paths (env / cli / web)
-    # or no-ops if a user already exists.
-    _bootstrap_first_user()
-
-    log.info("Starting scanner thread…")
-    start_scanner_thread()
+    if os.getenv("RUN_SCANNER", "1") == "1":
+        log.info("Starting scanner thread…")
+        start_scanner_thread()
+    else:
+        log.info("RUN_SCANNER=0 — instancia web-only, scanner desacoplado")
     yield
     # #495 root-cause fix: deterministic teardown of the three managed
     # background threads (scanner, health monitor, kill-switch calibrator).

--- a/btc_api.py
+++ b/btc_api.py
@@ -23,7 +23,7 @@ except ImportError:
     pass
 
 import requests as req_lib  # tests patch btc_api.req_lib.post (test_api.py); also used directly at line 187
-from fastapi import Depends, FastAPI, Query
+from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -57,6 +57,7 @@ from api.config import CONFIG_FILE, DEFAULTS_FILE, SECRETS_FILE, get_config, sav
 from api.config import router as config_router
 from api.deps import verify_api_key
 from api.health import router as health_router
+from api.scanner_liveness import scanner_liveness
 from api.capital import router as capital_router
 from api.kill_switch import router as kill_switch_router
 from api.notifications import router as notifications_router
@@ -325,10 +326,10 @@ def root():
     return {
         "service":     "Crypto Scanner API — Ultimate Macro V6.0",
         "version":     "2.0.0",
-        "symbols":     _scanner_state.get("symbols_active", []),
+        "symbols":     get_active_symbols(),
         "num_symbols": cfg.get("num_symbols", 20),
         "docs":        f"http://localhost:{API_PORT}/docs",
-        "scanner":     _scanner_state,
+        "scanner":     scanner_liveness(),
         "webhook_configurado": bool(cfg.get("webhook_url")),
     }
 
@@ -358,7 +359,7 @@ def get_ticker():
                 "changes": cached_payload.get("changes", {}),
                 "cached":  True}
 
-    symbols = _scanner_state.get("symbols_active") or get_active_symbols()
+    symbols = get_active_symbols()
     try:
         # Binance rejects whitespace inside the symbols array. Compact JSON
         # (no spaces) is required: `["BTC","ETH"]` not `["BTC", "ETH"]`.
@@ -443,7 +444,7 @@ def get_macro():
 def list_symbols():
     """Retorna el último escaneo de cada símbolo, ordenado por señal y score."""
     import json as _json  # noqa: PLC0415 — local import keeps the module-level surface unchanged
-    symbols = _scanner_state.get("symbols_active") or get_active_symbols()
+    symbols = get_active_symbols()
     # READ via snapshot_connection (WAL-concurrent, no writer lock) — #494
     with snapshot_connection() as con:
         rows    = get_signals_summary(con)
@@ -481,7 +482,7 @@ def status():
     with snapshot_connection() as con:
         latest = get_latest_scan(con)
     return {
-        "scanner_state": _scanner_state,
+        "scanner_state": scanner_liveness(),
         "ultimo_escaneo": {
             "ts":      latest["ts"]      if latest else None,
             "symbol":  latest["symbol"]  if latest else None,
@@ -505,6 +506,8 @@ def force_scan(
     symbol: Optional[str] = Query(None, description="Par a escanear (ej: ETHUSDT). Sin valor escanea todos.")
 ):
     """Ejecuta el scanner ahora. Sin symbol escanea todos los pares activos."""
+    if os.getenv("RUN_SCANNER", "1") != "1":
+        raise HTTPException(status_code=409, detail="scan corre en trading-scanner.service")
     cfg     = load_config()
     symbols = [symbol.upper()] if symbol else get_active_symbols(cfg.get("num_symbols", 20))
     results = [execute_scan_for_symbol(sym, cfg) for sym in symbols]

--- a/db/connection.py
+++ b/db/connection.py
@@ -110,16 +110,23 @@ def backup_db() -> None:
     os.makedirs(_BACKUP_DIR, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     backup_path = os.path.join(_BACKUP_DIR, f"signals_{timestamp}.db")
+    tmp_path = backup_path + ".tmp"
     try:
         with closing(sqlite3.connect(db_file)) as src:
-            with closing(sqlite3.connect(backup_path)) as dst:
+            with closing(sqlite3.connect(tmp_path)) as dst:
                 src.backup(dst)
+        os.replace(tmp_path, backup_path)
         log.info(f"DB backup: {backup_path}")
-        # Cleanup old backups
+        # Cleanup old backups — pattern excludes *.tmp intentionally
         backups = sorted(glob.glob(os.path.join(_BACKUP_DIR, "signals_*.db")))
         for old in backups[:-_BACKUP_MAX_FILES]:
             os.remove(old)
             log.info(f"DB backup removed: {old}")
     except Exception as e:
+        try:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except OSError:
+            pass
         log.warning(f"DB backup failed: {e}")
 

--- a/docs/superpowers/plans/2026-06-15-deploy-zero-downtime-pr1-codigo.md
+++ b/docs/superpowers/plans/2026-06-15-deploy-zero-downtime-pr1-codigo.md
@@ -1,0 +1,477 @@
+# Deploy zero-downtime — PR1 (código) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]` checkboxes.
+
+**Goal:** Preparar el código para desacoplar el scanner del proceso de la API, **100% backward-compatible** (mergeable sin cambiar nada en prod: el unit viejo no setea env → defaults = como hoy). El cutover de infra es PR2 + manual.
+
+**Arquitectura:** Gates de entorno (`RUN_SCANNER`, `SKIP_DB_INIT`) en el lifespan; un entrypoint de scanner-service (`scanner_main.py`); endpoints que derivan la liveness del scanner de la **DB** (no de `_scanner_state` en memoria); `/health/live` de readiness; `backup_db` atómico.
+
+**Tech stack:** Python / FastAPI / SQLite (WAL) / pytest.
+
+**Spec:** [[docs/superpowers/specs/es/2026-06-15-deploy-zero-downtime-decouple-scanner-spec.md]] (v2, tras críticos).
+
+**Invariantes (no romper):** todo cambio default-preserva el comportamiento actual. `python btc_api.py` y los tests (sin env) arrancan el scanner + corren el DDL como hoy. Gate: `python -m pytest tests/ -m "not network" -n auto -q`.
+
+---
+
+## Task 1: `backup_db` atómico (tmpfile + rename)
+
+**Files:** Modify `db/connection.py:100-124`. Test: `tests/test_deploy_decouple.py` (NUEVO).
+
+Hoy `backup_db` escribe directo a `signals_<ts>.db`; un kill a media-`.backup()` deja un backup truncado que la rotación trata como válido (Halberg #6). Fix: escribir a `.tmp` y `os.rename` al completar (atómico).
+
+- [ ] **Step 1: Failing test**
+```python
+# tests/test_deploy_decouple.py
+import os, glob, sqlite3, importlib
+
+
+def test_backup_db_atomic_no_partial_on_failure(tmp_path, monkeypatch):
+    import db.connection as conn
+    # DB fuente mínima
+    src = tmp_path / "signals.db"
+    sqlite3.connect(str(src)).executescript("CREATE TABLE t(x); INSERT INTO t VALUES(1);")
+    bdir = tmp_path / "backups"
+    monkeypatch.setattr(conn, "_resolve_db_file", lambda: str(src))
+    monkeypatch.setattr(conn, "_BACKUP_DIR", str(bdir))
+    # Forzar fallo a mitad del backup: el .backup real lanza
+    real_connect = sqlite3.connect
+    def boom_connect(path, *a, **k):
+        c = real_connect(path, *a, **k)
+        if str(path).endswith(".tmp"):
+            orig = c.backup
+            def boom(*aa, **kk): raise RuntimeError("kill a media backup")
+            c.backup = boom
+        return c
+    monkeypatch.setattr(conn.sqlite3, "connect", boom_connect)
+    conn.backup_db()  # no debe lanzar (captura) y NO debe dejar un signals_*.db válido
+    finals = glob.glob(os.path.join(str(bdir), "signals_*.db"))
+    assert finals == [], "un backup fallido no debe dejar un .db final (solo .tmp basura, si acaso)"
+```
+
+- [ ] **Step 2: Run → FAIL** `python -m pytest tests/test_deploy_decouple.py::test_backup_db_atomic_no_partial_on_failure -v`
+
+- [ ] **Step 3: Implement** — en `db/connection.py::backup_db`, escribir a `backup_path + ".tmp"` y renombrar:
+```python
+    backup_path = os.path.join(_BACKUP_DIR, f"signals_{timestamp}.db")
+    tmp_path = backup_path + ".tmp"
+    try:
+        with closing(sqlite3.connect(db_file)) as src:
+            with closing(sqlite3.connect(tmp_path)) as dst:
+                src.backup(dst)
+        os.replace(tmp_path, backup_path)   # rename atómico; solo aparece el .db completo
+        log.info(f"DB backup: {backup_path}")
+        backups = sorted(glob.glob(os.path.join(_BACKUP_DIR, "signals_*.db")))
+        for old in backups[:-_BACKUP_MAX_FILES]:
+            os.remove(old)
+            log.info(f"DB backup removed: {old}")
+    except Exception as e:
+        try:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except OSError:
+            pass
+        log.warning(f"DB backup failed: {e}")
+```
+
+- [ ] **Step 4: Run → PASS**
+- [ ] **Step 5: Commit** `git commit -m "fix(deploy): backup_db escribe a tmpfile + rename atómico"`
+
+---
+
+## Task 2: Helper de frescura del scanner desde la DB
+
+**Files:** Create `api/scanner_liveness.py`. Test: `tests/test_deploy_decouple.py`.
+
+Deriva la liveness del scanner de la **DB** (no de `_scanner_state` en memoria), para que una API web-only reporte la verdad del `trading-scanner.service`. Lee el último scan ts de la tabla `scans` + counts, y lo envuelve en `LiveSnapshot`.
+
+> Antes de implementar: leer `db/signals.py` para la firma exacta — la tabla `scans`, cómo obtener el último ts (hoy `get_latest_scan` ordena por `id DESC`; la columna de tiempo es `ts`), y un COUNT de scans/signals. Usar `snapshot_connection` (lector WAL, sin writer-lock).
+
+- [ ] **Step 1: Failing test**
+```python
+def test_scanner_liveness_from_db(monkeypatch):
+    from api import scanner_liveness
+    from datetime import datetime, timezone, timedelta
+    reciente = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+    monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
+                        lambda: {"last_scan_ts": reciente, "scans_total": 10, "signals_total": 2})
+    snap = scanner_liveness.scanner_liveness(umbral_seg=900)
+    assert snap["frescura"]["estado"] == "fresco"
+    assert snap["scans_total"] == 10
+
+
+def test_scanner_liveness_muerto_sin_scans(monkeypatch):
+    from api import scanner_liveness
+    monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
+                        lambda: {"last_scan_ts": None, "scans_total": 0, "signals_total": 0})
+    snap = scanner_liveness.scanner_liveness(umbral_seg=900)
+    assert snap["frescura"]["estado"] == "muerto"
+```
+
+- [ ] **Step 2: Run → FAIL** (ImportError).
+
+- [ ] **Step 3: Implement** `api/scanner_liveness.py`:
+```python
+"""Liveness del scanner derivada de la DB (no de memoria de proceso).
+
+Para que una API web-only (sin el thread scanner) reporte la verdad del
+trading-scanner.service: el último scan ts vive en la tabla `scans`, no en
+`btc_api._scanner_state`. Cumple el non-negotiable #8 (frescura en el
+contrato, cross-proceso)."""
+from __future__ import annotations
+
+from db.transaction import snapshot_connection
+from freshness import LiveSnapshot
+
+
+def _query_scanner_facts() -> dict:
+    """Último scan ts + totales, leídos de la DB (snapshot, WAL-concurrente)."""
+    with snapshot_connection() as con:
+        row = con.execute("SELECT MAX(ts) FROM scans").fetchone()
+        last_scan_ts = row[0] if row else None
+        scans_total = con.execute("SELECT COUNT(*) FROM scans").fetchone()[0]
+        signals_total = con.execute(
+            "SELECT COUNT(*) FROM scans WHERE \"señal\" = 1").fetchone()[0]
+    return {"last_scan_ts": last_scan_ts,
+            "scans_total": scans_total, "signals_total": signals_total}
+
+
+def scanner_liveness(*, umbral_seg: float = 900.0) -> dict:
+    """Payload de liveness del scanner con su frescura (fresco/rancio/muerto).
+    `umbral_seg` por defecto = scan_interval_sec*3 (300*3)."""
+    facts = _query_scanner_facts()
+    payload = {"scans_total": facts["scans_total"],
+               "signals_total": facts["signals_total"],
+               "last_scan_ts": facts["last_scan_ts"]}
+    return LiveSnapshot(payload=payload, generated_at=facts["last_scan_ts"],
+                        umbral_seg=umbral_seg).to_response()
+```
+> NOTA: verificar el nombre real de la columna de señal en `scans` (`señal`/`signal`) leyendo `db/signals.py`/`db/schema.py` y ajustar la query. Si `ts` no es ISO-8601, adaptar la derivación.
+
+- [ ] **Step 4: Run → PASS**
+- [ ] **Step 5: Commit** `git commit -m "feat(deploy): helper de liveness del scanner desde la DB (#8)"`
+
+---
+
+## Task 3: `GET /health/live` (readiness desacoplado)
+
+**Files:** Modify `api/health.py`. Test: `tests/test_deploy_decouple.py`.
+
+Readiness que NO toca el scanner: 200 si uvicorn responde + schema presente. Valida una tabla canónica (`users`), no `SELECT 1` pelado (Halberg #7), para detectar schema incompleto.
+
+- [ ] **Step 1: Failing test**
+```python
+def test_health_live_ok_without_scanner(monkeypatch):
+    from fastapi.testclient import TestClient
+    import btc_api
+    monkeypatch.setenv("RUN_SCANNER", "0")
+    monkeypatch.setenv("SKIP_DB_INIT", "1")
+    monkeypatch.setenv("RUN_AS_SERVICE", "0")  # evita el guard anti-pytest
+    with TestClient(btc_api.app) as c:
+        r = c.get("/health/live")
+    assert r.status_code == 200
+    assert r.json()["ready"] is True
+```
+> (Este test ejercita el lifespan con los gates; depende de Task 7. Si se ejecuta antes, marcar xfail temporal o reordenar: Task 7 antes que 3. Recomendado: implementar Task 7 primero y este test al final.)
+
+- [ ] **Step 2: Run → FAIL** (404).
+
+- [ ] **Step 3: Implement** — en `api/health.py`, añadir:
+```python
+@router.get("/health/live", summary="Readiness: proceso + schema listos (sin scanner)")
+def health_live():
+    """200 si uvicorn responde y el schema está presente. NO toca el scanner —
+    es el endpoint que pollea el blue-green deploy. Ver spec §3(A)."""
+    try:
+        with snapshot_connection() as con:
+            con.execute("SELECT 1 FROM users LIMIT 1")
+        return {"ready": True}
+    except Exception as e:
+        return JSONResponse(content={"ready": False, "detail": str(e)}, status_code=503)
+```
+
+- [ ] **Step 4: Run → PASS**
+- [ ] **Step 5: Commit** `git commit -m "feat(deploy): GET /health/live readiness desacoplado del scanner"`
+
+---
+
+## Task 4: `/health` deriva liveness del scanner de la DB + gate 200/503 sobre frescura
+
+**Files:** Modify `api/health.py:107-153`. Test: `tests/test_deploy_decouple.py`.
+
+`/health` deja de leer `_scanner_state` (memoria) y de gatear sobre `running`; pasa a frescura DB (`fresco`→200, `rancio`/`muerto`→503). Quita `errors` (solo-memoria, sin fuente DB).
+
+- [ ] **Step 1: Failing test**
+```python
+def test_health_503_when_scanner_stale(monkeypatch):
+    from fastapi.testclient import TestClient
+    import btc_api
+    from api import scanner_liveness
+    monkeypatch.setenv("RUN_SCANNER", "0"); monkeypatch.setenv("SKIP_DB_INIT", "1"); monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    # frescura muerta → 503
+    monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
+                        lambda: {"last_scan_ts": None, "scans_total": 0, "signals_total": 0})
+    with TestClient(btc_api.app) as c:
+        r = c.get("/health")
+    assert r.status_code == 503
+    assert "errors" not in r.json()["checks"]
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement** — reescribir `health_check()` para usar `scanner_liveness` en vez de `_btc_api._scanner_state`:
+```python
+@router.get("/health", summary="Health check (liveness del scanner vía DB)")
+def health_check():
+    from api.scanner_liveness import scanner_liveness
+    checks = {}
+    try:
+        with snapshot_connection() as con:
+            con.execute("SELECT 1")
+        checks["database"] = "ok"
+    except Exception as e:
+        checks["database"] = f"error: {e}"
+    snap = scanner_liveness()              # DB-backed (#8)
+    fr = snap["frescura"]["estado"]        # fresco | rancio | muerto
+    checks["scanner"] = fr
+    checks["scan_freshness"] = fr
+    checks["scans_total"] = snap.get("scans_total", 0)
+    checks["signals_total"] = snap.get("signals_total", 0)
+    healthy = checks["database"] == "ok" and fr == "fresco"
+    return JSONResponse(content={"healthy": healthy, "checks": checks},
+                        status_code=200 if healthy else 503)
+```
+(Eliminar el `import btc_api as _btc_api` y el bloque de `_scanner_state`.)
+
+- [ ] **Step 4: Run → PASS** + correr `tests/test_api.py` (si hay tests de /health, actualizarlos al nuevo contrato).
+- [ ] **Step 5: Commit** `git commit -m "feat(deploy): /health gatea sobre frescura del scanner desde la DB (#8)"`
+
+---
+
+## Task 5: `/` y `/status` derivan la liveness del scanner de la DB
+
+**Files:** Modify `btc_api.py:317-326` (`/`) y `:473-479` (`/status`). Test: `tests/test_deploy_decouple.py`.
+
+> Leer los handlers exactos. `/` usa `_scanner_state.get("symbols_active", [])` (:323) y `_scanner_state` entero (:326); `/status` usa `_scanner_state` (:479). Reemplazar la fuente del estado del scanner por `scanner_liveness()` (DB) y el `symbols` por `get_active_symbols()`. Preservar el resto de la forma de respuesta.
+
+- [ ] **Step 1: Failing test** — montar la app web-only (RUN_SCANNER=0), mock `scanner_liveness` con ts viejo, GET `/status` → el `scanner_state.frescura.estado` refleja la DB (`muerto`), no `Iniciando...` de memoria.
+- [ ] **Step 2: Run → FAIL**
+- [ ] **Step 3: Implement** — en `/`: `"symbols": get_active_symbols()`, `"scanner": scanner_liveness()`. En `/status`: `"scanner_state": scanner_liveness()`. (Import lazy de `scanner_liveness` y `get_active_symbols` si hace falta evitar ciclos.)
+- [ ] **Step 4: Run → PASS**
+- [ ] **Step 5: Commit** `git commit -m "feat(deploy): / y /status leen liveness del scanner de la DB"`
+
+---
+
+## Task 6: `/ticker` y `/symbols` usan `get_active_symbols()` directo
+
+**Files:** Modify `btc_api.py:356` y `:441`. Test: cubierto por no-regresión.
+
+Hoy: `symbols = _scanner_state.get("symbols_active") or get_active_symbols()`. La web-only nunca puebla `symbols_active` → cae al fallback igual, pero el read de memoria es ruido y divergiría si una instancia tuviera estado parcial. Quitar el read.
+
+- [ ] **Step 1:** cambiar ambas líneas a `symbols = get_active_symbols()`.
+- [ ] **Step 2: Run** `python -m pytest tests/test_api.py -m "not network" -q` → verde (la fuente de verdad es la config).
+- [ ] **Step 3: Commit** `git commit -m "feat(deploy): /ticker y /symbols leen el watchlist de la config, no de _scanner_state"`
+
+---
+
+## Task 7: Gates `SKIP_DB_INIT` (incl. `_bootstrap_first_user`) + `RUN_SCANNER` en el lifespan
+
+**Files:** Modify `btc_api.py:247-258`. Test: `tests/test_deploy_decouple.py`.
+
+- [ ] **Step 1: Failing tests**
+```python
+def test_run_scanner_0_no_threads(monkeypatch):
+    import scanner.runtime as rt
+    from fastapi.testclient import TestClient
+    import btc_api
+    monkeypatch.setenv("RUN_SCANNER", "0"); monkeypatch.setenv("SKIP_DB_INIT", "1"); monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    rt._managed_threads.clear()
+    with TestClient(btc_api.app):
+        pass
+    assert rt._managed_threads == [], "RUN_SCANNER=0 NO debe arrancar threads"
+
+
+def test_skip_db_init_no_ddl_no_bootstrap(monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+    calls = {"init_db": 0, "bootstrap": 0}
+    monkeypatch.setattr(btc_api, "init_db", lambda *a, **k: calls.__setitem__("init_db", calls["init_db"]+1))
+    monkeypatch.setattr(btc_api, "_bootstrap_first_user", lambda *a, **k: calls.__setitem__("bootstrap", calls["bootstrap"]+1))
+    monkeypatch.setenv("RUN_SCANNER", "0"); monkeypatch.setenv("SKIP_DB_INIT", "1"); monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    with TestClient(btc_api.app):
+        pass
+    assert calls["init_db"] == 0 and calls["bootstrap"] == 0
+```
+
+- [ ] **Step 2: Run → FAIL**
+
+- [ ] **Step 3: Implement** — reescribir el bloque del lifespan (`btc_api.py:247-258`) según spec §4.1:
+```python
+    if os.getenv("SKIP_DB_INIT") != "1":
+        log.info("Initializing DB schema…")
+        init_db()
+        with transaction() as con:
+            init_auth_db(con)
+            init_system_state(con)
+        _bootstrap_first_user()
+    else:
+        log.info("SKIP_DB_INIT=1 — schema y bootstrap los hace trading-scanner.service")
+    if os.getenv("RUN_SCANNER", "1") == "1":
+        log.info("Starting scanner thread…")
+        start_scanner_thread()
+    else:
+        log.info("RUN_SCANNER=0 — instancia web-only, scanner desacoplado")
+```
+(`_jwt_secret()` en :245 queda FUERA del gate.)
+
+- [ ] **Step 4: Run → PASS** + el suite completo (los tests existentes corren sin env → defaults → scanner+DDL como hoy).
+- [ ] **Step 5: Commit** `git commit -m "feat(deploy): gates RUN_SCANNER y SKIP_DB_INIT en el lifespan (backward-compatible)"`
+
+---
+
+## Task 8: `/scan` → 409 cuando `RUN_SCANNER != 1`
+
+**Files:** Modify `btc_api.py:493+` (el handler POST `/scan`). Test: `tests/test_deploy_decouple.py`.
+
+- [ ] **Step 1: Failing test**
+```python
+def test_scan_409_on_web_only(monkeypatch):
+    from fastapi.testclient import TestClient
+    import btc_api
+    monkeypatch.setenv("RUN_SCANNER", "0"); monkeypatch.setenv("SKIP_DB_INIT", "1"); monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    with TestClient(btc_api.app) as c:
+        r = c.post("/scan")   # ajustar a la firma real (params/auth si aplica)
+    assert r.status_code == 409
+```
+> Leer el handler `/scan` para su firma/auth real y ajustar el test (puede requerir api-key/role).
+
+- [ ] **Step 2: Run → FAIL**
+- [ ] **Step 3: Implement** — al inicio del handler `/scan`:
+```python
+    if os.getenv("RUN_SCANNER", "1") != "1":
+        raise HTTPException(status_code=409, detail="scan corre en trading-scanner.service")
+```
+- [ ] **Step 4: Run → PASS**
+- [ ] **Step 5: Commit** `git commit -m "feat(deploy): /scan devuelve 409 en instancia web-only (RUN_SCANNER=0)"`
+
+---
+
+## Task 9: `scanner_main.py` — entrypoint del scanner-service
+
+**Files:** Create `scanner_main.py` (raíz). Test: `tests/test_deploy_decouple.py`.
+
+Corre el DDL (dueño del schema), envía `sd_notify(READY=1)`, arranca los threads, instala el handler de SIGTERM/SIGINT, y bloquea. NO arranca uvicorn.
+
+- [ ] **Step 1: Failing test** (importable + el handler para el stop event)
+```python
+def test_scanner_main_importable_and_sd_notify_noop_without_socket(monkeypatch):
+    monkeypatch.delenv("NOTIFY_SOCKET", raising=False)
+    import importlib, scanner_main
+    importlib.reload(scanner_main)
+    scanner_main._sd_notify("READY=1")  # sin NOTIFY_SOCKET → no-op, no lanza
+```
+
+- [ ] **Step 2: Run → FAIL** (ModuleNotFoundError).
+
+- [ ] **Step 3: Implement** `scanner_main.py`:
+```python
+"""Entrypoint del trading-scanner.service: corre el scanner desacoplado de la
+API. Dueño del schema (DDL + bootstrap), notifica readiness a systemd
+(Type=notify) tras migrar, arranca los 5 threads, y para limpio en SIGTERM.
+NO arranca uvicorn. Ver spec §4.2."""
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import sys
+
+os.environ.setdefault("RUN_AS_SERVICE", "1")
+os.environ.setdefault("RUN_SCANNER", "1")
+
+import logging
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("scanner_main")
+
+
+def _sd_notify(state: str) -> None:
+    """sd_notify sin dependencia: escribe `state` al $NOTIFY_SOCKET (si existe).
+    No-op cuando no corre bajo systemd Type=notify."""
+    addr = os.environ.get("NOTIFY_SOCKET")
+    if not addr:
+        return
+    if addr.startswith("@"):              # abstract namespace
+        addr = "\0" + addr[1:]
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as s:
+            s.connect(addr)
+            s.sendall(state.encode("utf-8"))
+    except OSError as e:
+        log.warning("sd_notify falló: %s", e)
+
+
+def main() -> int:
+    from db.connection import init_db
+    from db.transaction import transaction
+    from db.schema import init_system_state
+    from auth.db import init_auth_db
+    from btc_api import _bootstrap_first_user
+    from scanner.runtime import start_scanner_thread, stop_managed_threads, _thread_stop_event
+
+    log.info("scanner-service: migrando schema…")
+    init_db()
+    with transaction() as con:
+        init_auth_db(con)
+        init_system_state(con)
+    _bootstrap_first_user()
+    _sd_notify("READY=1")                 # ← systemd marca el service "ready" SOLO acá (post-DDL)
+
+    def _handler(signum, _frame):
+        log.info("señal %s — parando threads…", signum)
+        _thread_stop_event.set()
+        stop_managed_threads()
+    signal.signal(signal.SIGTERM, _handler)
+    signal.signal(signal.SIGINT, _handler)
+
+    log.info("scanner-service: arrancando threads…")
+    start_scanner_thread()
+    _thread_stop_event.wait()             # bloquea hasta SIGTERM
+    log.info("scanner-service: salida limpia.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+> Verificar los imports reales: `init_system_state` (en `db/schema.py`?), `init_auth_db` (en `auth/db.py`? o donde lo importa btc_api), `_bootstrap_first_user` (en btc_api). Ajustar las rutas de import a las reales (leer los imports de `btc_api.py`).
+
+- [ ] **Step 4: Run → PASS**
+- [ ] **Step 5: Commit** `git commit -m "feat(deploy): scanner_main.py entrypoint del scanner-service (sd_notify + SIGTERM)"`
+
+---
+
+## Task 10: Cierre — suite completa + auto-review
+
+**Files:** —
+
+- [ ] **Step 1:** `python -m pytest tests/ -m "not network" -n auto -q` → todo verde (incluidos los tests existentes con defaults = comportamiento de hoy).
+- [ ] **Step 2:** Verificar manualmente: `RUN_SCANNER=0 SKIP_DB_INIT=1 RUN_AS_SERVICE=0 python -c "import btc_api"` importa; y `python scanner_main.py` (sin systemd) arranca el scanner como standalone (Ctrl+C para limpio).
+- [ ] **Step 3: Commit** cualquier ajuste.
+
+---
+
+## Self-Review
+
+| Spec | Task |
+|---|---|
+| backup_db atómico (§8) | 1 |
+| frescura desde DB (§3C, #8) | 2, 4, 5 |
+| /health/live (§3A) | 3 |
+| /health 200/503 + sin `errors` (§3C) | 4 |
+| /ticker,/symbols sin _scanner_state (§3C) | 6 |
+| gates lifespan + _bootstrap gateado (§4.1) | 7 |
+| /scan 409 (§4.1) | 8 |
+| scanner_main.py: sd_notify+SIGTERM (§4.2) | 9 |
+| backward-compatible (defaults=hoy) | 7, 10 |
+
+**Nota:** los units systemd, nginx, deploy.yml y el cutover son **PR2 + manual** (no en este plan). Este PR no cambia el runtime de prod hasta que PR2 + el cutover activen los gates.

--- a/docs/superpowers/specs/es/2026-06-15-deploy-zero-downtime-decouple-scanner-spec.md
+++ b/docs/superpowers/specs/es/2026-06-15-deploy-zero-downtime-decouple-scanner-spec.md
@@ -1,0 +1,195 @@
+# Deploy zero-downtime — desacoplar el scanner del proceso de la API
+
+**Fecha:** 2026-06-15
+**Estado:** Diseño v2 (tras panel w6jzy5vev + pase de críticos Serrano + Halberg)
+**Relacionados:** [[2026-04-29-trading-sdar-dev-deploy-design]] · [[docs/atomic-deploy-migration.md]] (PR #377 abandonado) · CLAUDE.md non-negotiable #8 (frescura), #1 (PositionClosure)
+
+> **Changelog v2 (pase de críticos).** Serrano (clínico) + Halberg (runtime) revisaron v1 contra el código real. El *orden* del cutover y el modelo WAL se confirmaron correctos, pero se cerraron bloqueadores que solo aparecen bajo fallas reales:
+> - **Reboot:** `After=` ≠ readiness → la API arrancaba con `SKIP_DB_INIT=1` contra schema no-migrado → crash-loop. **Fix:** `trading-scanner.service` es `Type=notify` y envía `sd_notify(READY=1)` tras el DDL; las APIs lo `After=`+`Wants=` (§4.3).
+> - **Deploys concurrentes:** `cancel-in-progress: true` cancelaba a media-mutación → include a un color muerto → 502 persistente. **Fix:** `cancel-in-progress: false` + self-heal del include (§4.5).
+> - **"Un solo escritor por construcción" era falso:** `_bootstrap_first_user` (boot) y `/scan` (POST) escriben desde la API web-only. **Fix:** gatear ambos; reformular a "un solo escritor **periódico** por construcción; writes bajo demanda serializados por WAL como hoy" (§2, §4.1).
+> - **SIGTERM:** no hay handler de señal en el repo. `scanner_main.py` lo trae (§4.2).
+> - **Corrección (C):** faltaban `/ticker` y `/symbols` (también leen `_scanner_state`); contadores de observabilidad se perdían; contrato 200/503 de `/health` indefinido. **Fix:** §3 + §5 ampliados.
+> - **Otros:** `backup_db` a tmpfile+rename (no deja backups truncados al kill); escritura atómica del include; `--timeout-graceful-shutdown 30` en las APIs; `/health/live` valida tabla canónica; sudoers acotado; reconciliación de unit drift en el deploy.
+
+## 1. Problema y causa raíz
+
+Cada deploy a `main` hace `systemctl restart trading-spacial`, que tumba el **único proceso uvicorn** ~10-15s mientras (a) re-importa la app y (b) corre el **DDL de boot** + arranca el **scanner in-process** (5 threads) sobre la DB. Durante esa ventana nginx no tiene upstream → **ráfaga de 503** al frontend (que hace polling de muchos endpoints). Verificado en prod: 117 respuestas 503 hoy, todas en las ventanas de restart de los deploys #598/#599.
+
+**Causa raíz:** el scanner (pesado, dueño de frescura) vive en el *path de arranque del request-server*. Cualquier reinicio del request-server arrastra el costo de arrancar el scanner. Para zero-downtime hay que **sacar el scanner del proceso de la API**.
+
+## 2. Decisión: decouple-scanner
+
+Mover el scanner a su **propio servicio systemd** (`trading-scanner.service`). La API queda **web-only** y arranca en ~2s (sin scanner, sin DDL) → se vuelve **blue-green** detrás de nginx con **~0 downtime de cliente** vía `nginx -s reload` (no failover frágil con `proxy_next_upstream` reintentando POSTs no idempotentes).
+
+Por qué gana (criterio en orden):
+1. **Zero-downtime real:** ataca la causa raíz; la API arranca en ~2s.
+2. **Un solo escritor PERIÓDICO por construcción:** solo `trading-scanner.service` corre `start_scanner_thread()` (los 5 threads escritores de alta frecuencia: scanner, health-monitor, kill-switch-calibrator, screener, sync). Las APIs (`RUN_SCANNER=0`) nunca arrancan ese escritor periódico — garantizado por systemd, no por un lock en runtime. **Honestidad (críticos):** la API web-only sigue siendo escritora BAJO DEMANDA en tres rutas, que se neutralizan o se aceptan explícitamente: (a) `_bootstrap_first_user` en boot → **se gatea** bajo `SKIP_DB_INIT` (§4.1); (b) `/scan` (POST, corre `execute_scan_for_symbol`) → **devuelve 409** cuando `RUN_SCANNER=0` (§4.1); (c) las acciones de operador (PositionClosure → `BEGIN IMMEDIATE`, persistencia de turnos del agente) ya coexisten hoy con el scanner serializadas por WAL + `busy_timeout=15000` (`db/connection.py:96`) — NO son escritores nuevos. Tras (a) y (b), la API web-only solo escribe lo que ya escribía hoy un proceso único, serializado por WAL.
+3. **Migración sin downtime y reversible** (§6).
+4. **No resucita ninguno de los 3 bloqueos del PR #377:** layout plano intacto, cero symlinks, mismo `.venv`/`.env`/DB; la DB se resuelve vía `__file__` (`db/connection.py`), no vía cwd-symlink.
+
+**Descartados** (cada uno con killer confirmado en código): blue-green con scanner gateado *dentro* del proceso (la instancia web-only daría 503 perpetuo en `/health` y violaría #8); gunicorn `--workers 1` + HUP (no es readiness-gated → la ventana de 10-15s regresa; flock Linux-only rompe el suite de Windows); socket-activation como solución final (solo convierte 503→cuelgue de 10-15s); resucitar el atomic-deploy de symlinks (#377). Ver el panel para el detalle.
+
+## 3. Las tres correcciones obligatorias (el panel las exigió)
+
+El killer compartido de los approaches de failover: **`api/health.py:107-153` (`/health`) deriva la liveness de `btc_api._scanner_state` (memoria de proceso)** y exige `scanner=='ok'` para HTTP 200. Una instancia web-only nunca pone `running=True` → 503 perpetuo. Y eso es, además, una violación del #8 (estado vivo en memoria, no en el contrato). Correcciones:
+
+- **(A) `GET /health/live` — readiness desacoplado.** Devuelve 200 si uvicorn responde + el schema está presente (`snapshot_connection` + `SELECT 1 FROM users LIMIT 1` — tabla canónica, **no** un `SELECT 1` pelado, para detectar schema incompleto; Halberg #7), **sin tocar `_scanner_state`**. Es el endpoint que pollean el deploy y el health-gate del blue-green. (Como uvicorn no liga el socket hasta que el lifespan startup termina, un 200 en `/health/live` ⇒ lifespan completo ⇒ middlewares montados ⇒ listo para tráfico — confirmado por Halberg.)
+- **(B) `SKIP_DB_INIT=1` en las APIs web-only.** El lifespan (`btc_api.py:247-255`) corre `init_db()`/`init_auth_db`/`init_system_state` **y `_bootstrap_first_user()`** (este último abre `BEGIN IMMEDIATE` y puede `INSERT INTO users` en primer boot — Serrano #1). **TODO ese bloque** se envuelve en `if os.getenv("SKIP_DB_INIT") != "1": ...`. El `trading-scanner.service` es el **dueño único del schema y del bootstrap del primer usuario** (no setea el flag → migra + bootstrapea). Las APIs lo setean → cero writes en boot. La existencia del schema cuando la API arranca la garantiza el `Type=notify` del scanner (§4.3), no el `After=` solo.
+- **(C) Frescura + estado del scanner desde la DB, no desde memoria (#8).** Siete rutas leen `_scanner_state` de memoria; en una API web-only reportarían falso. Migración por ruta:
+  - **`/health`, `/status`, `/`** (liveness del scanner): derivar de la **DB** — `scans_total`/`signals_total` de `COUNT` sobre las tablas (no del contador en memoria); `last_scan_ts` del **`MAX(ts)` de la tabla `scans`** (nombrar la columna explícito; hoy `get_latest_scan` ordena por `id DESC`, hay que derivar el ts real — Serrano #14), envuelto en `freshness.LiveSnapshot` (`fresco`/`rancio`/`muerto` contra `scan_interval_sec*3`). El contador `errors` (solo-memoria, sin fuente DB) **se elimina del contrato** de `/health` (declararlo; Serrano #7).
+  - **`/ticker`, `/symbols`** (Serrano #2): hoy leen `_scanner_state["symbols_active"]` con fallback a `get_active_symbols()`. Cambiar a leer `get_active_symbols()` directo (la config es la fuente de verdad), eliminando el read de memoria → mismo watchlist en toda instancia.
+- **Contrato 200/503 de `/health`** (Serrano #8): `/health` deja de gatear sobre `_scanner_state["running"]` y pasa a gatear sobre la **frescura DB**: `200` si la frescura del scanner es `fresco`; `503` si `rancio`/`muerto` o DB caída. Así un monitor externo (Docker/uptime) alerta cuando el `trading-scanner.service` muere — que es justo lo que `/health` debe vigilar ahora.
+
+## 4. Arquitectura
+
+### 4.1 Gates de entorno (en `btc_api.py` lifespan)
+
+| Env var | Default | API web-only | scanner-service | Unit viejo (compat) |
+|---|---|---|---|---|
+| `RUN_SCANNER` | `'1'` | `'0'` | `'1'` | (ausente → `'1'`, scanner in-process como hoy) |
+| `SKIP_DB_INIT` | ausente (`!= '1'`) | `'1'` | ausente (migra) | (ausente → corre DDL como hoy) |
+| `RUN_AS_SERVICE` | (existente) `'1'` | `'1'` | `'1'` | `'1'` |
+
+Backward-compatible: el unit viejo `trading-spacial` no setea ninguna → defaults preservan el comportamiento actual (scanner + DDL in-process). `python btc_api.py` y los tests (sin `RUN_SCANNER`) también arrancan el scanner como hoy.
+
+Cambios en el lifespan (el `_bootstrap_first_user` entra DENTRO del gate — Serrano #1):
+```python
+if os.getenv("SKIP_DB_INIT") != "1":
+    log.info("Initializing DB schema…")
+    init_db()
+    with transaction() as con:
+        init_auth_db(con)
+        init_system_state(con)
+    _bootstrap_first_user()   # abre BEGIN IMMEDIATE / puede INSERT — solo el dueño del schema
+else:
+    log.info("SKIP_DB_INIT=1 — schema y bootstrap los hace trading-scanner.service")
+if os.getenv("RUN_SCANNER", "1") == "1":
+    log.info("Starting scanner thread…")
+    start_scanner_thread()
+else:
+    log.info("RUN_SCANNER=0 — instancia web-only, scanner desacoplado")
+```
+`_jwt_secret()` (`:245`, fail-fast, read) se mantiene FUERA del gate. `stop_managed_threads()` (teardown, `:267`) ya es idempotente → sin cambio (en la web-only no hay threads que juntar).
+
+**`/scan` (POST) gateado** (Serrano #4): `execute_scan_for_symbol` es un escritor; en la API web-only no debe correr. Al inicio del handler: `if os.getenv("RUN_SCANNER", "1") != "1": raise HTTPException(409, "scan corre en trading-scanner.service")`.
+
+### 4.2 `scanner_main.py` (NUEVO, raíz) — entrypoint del scanner-service
+
+- Setea `RUN_AS_SERVICE=1`, `RUN_SCANNER=1`.
+- Corre el DDL (dueño del schema): `init_db()` + `init_auth_db` + `init_system_state` + `_bootstrap_first_user()`.
+- **`sd_notify("READY=1")` JUSTO DESPUÉS de que el DDL termina** (antes de `start_scanner_thread`). Implementación sin dependencia: escribir `READY=1` al socket de `$NOTIFY_SOCKET` (raw `AF_UNIX/SOCK_DGRAM`, ~10 líneas; no requiere la lib `systemd`). Esto es lo que hace que `Type=notify` + el `After=` de las APIs **espere a que el schema exista** (cierra el crash-loop de reboot, Halberg #1).
+- `start_scanner_thread()` (los 5 threads: scanner, health-monitor, kill-switch-calibrator, screener, sync).
+- **Handler de `SIGTERM` (NO existe en el repo hoy — Halberg #3):** `signal.signal(signal.SIGTERM, handler)` (y SIGINT) donde `handler` (a) llama `stop_managed_threads()` y (b) setea el evento que desbloquea el `wait()` del main. Requiere exportar `_thread_stop_event` desde `scanner/runtime.py`.
+- Bloquea en `_thread_stop_event.wait()`. **NO arranca uvicorn.**
+- Emite su frescura vía `freshness.LiveSnapshot` (ya escribe `data/symbols_status.json` por ciclo + los scans a la DB con timestamp — la fuente de #8).
+- **NOTA de teardown (Halberg #3):** el calibrator no chequea `stop_event` entre sliders del grid (`run_optimization_v2`), así que una iteración en vuelo puede tardar decenas de segundos. Los threads son `daemon=True`: si exceden el join, el proceso sale y el intérprete los mata. SQLite WAL + `BEGIN IMMEDIATE` cortado **no corrompe** (rollback implícito). Pero `backup_db` cortado deja un backup truncado → ver §8 (fix: tmpfile+rename). `TimeoutStopSec=60` (no 20) para dar margen al grid del calibrator.
+
+### 4.3 systemd (3 units)
+
+- **`trading-scanner.service`** (NUEVO): **`Type=notify`** (envía `READY=1` tras el DDL — §4.2), `ExecStart=.../python /var/www/trading/scanner_main.py`, `Environment=RUN_SCANNER=1 RUN_AS_SERVICE=1`, `EnvironmentFile=/var/www/trading/.env`, `WorkingDirectory=/var/www/trading`, `ProtectSystem=strict`, `ReadWritePaths=/var/www/trading`, `Restart=on-failure`, `TimeoutStopSec=60` (margen para `stop_managed_threads` + un slider del calibrator en vuelo, sin SIGKILL a media transacción).
+- **`trading-api@.service`** (NUEVO, template): `ExecStart=.../uvicorn btc_api:app --host 127.0.0.1 --port %i --timeout-graceful-shutdown 30` (drena requests/SSE en vuelo en el stop — Halberg #5), `Environment=RUN_SCANNER=0 SKIP_DB_INIT=1 RUN_AS_SERVICE=1`, `EnvironmentFile=/var/www/trading/.env`, **`Wants=trading-scanner.service` + `After=trading-scanner.service`** — con el scanner en `Type=notify`, el `After=` **espera el `READY=1`** (post-DDL) antes de arrancar la API → el schema existe cuando la API web-only (`SKIP_DB_INIT=1`) arranca, incluso en reboot frío (cierra Halberg #1). `After=` NO crea dependencia de runtime: si el scanner cae después, la API sigue. Mismas restricciones. Instancias `@8100` y `@8101` (blue/green).
+- El unit viejo **`trading-spacial`** se conserva (disabled) en disco para rollback inmediato.
+
+### 4.4 nginx (include + upstream)
+
+- Extraer el upstream a `/etc/nginx/conf.d/trading-upstream.conf`: `upstream trading_api { server 127.0.0.1:8100; }` (un solo color activo a la vez; el deploy reescribe SOLO este include 8100↔8101).
+- En `trading.sdar.dev.conf`: cambiar `proxy_pass http://127.0.0.1:8100/` (en `location /api/` Y `location = /api/auth/login`) a `http://trading_api/...` preservando el path-rewrite.
+- **Location aislado `/api/agent/`** para SSE: `proxy_buffering off; proxy_read_timeout 3600s;` (los streams del copiloto son long-lived). Sin `proxy_next_upstream` (un stream a medias no se reintenta).
+- **Escritura ATÓMICA del include** (Halberg #4): el deploy escribe el include a un tmpfile y hace `mv` (rename atómico en el mismo filesystem), nunca un redirect `>` in-place — para que `nginx -t`/un reload concurrente nunca lea un include parcial/vacío. Luego `nginx -t && nginx -s reload` (el reload **no corta** conexiones establecidas; arranca workers nuevos antes de retirar los viejos).
+
+### 4.5 `deploy.yml` blue-green
+
+**`concurrency` (Halberg #7 — BLOQUEANTE):** cambiar `cancel-in-progress: true` → **`false`** para `deploy-production`. Un deploy que muta estado de infra en pasos no-atómicos NO debe ser cancelable a media-secuencia (cancelar deja el include apuntando a un color muerto → 502 persistente de minutos). Los deploys se **serializan/encolan** — aceptable.
+
+Reemplazar el step `pip install + restart service` por:
+0. **Self-heal (paso 0):** leer el color al que apunta el include; si ese color **no** tiene proceso vivo (`systemctl is-active trading-api@<color>` != active), reparar antes de empezar (reapuntar al color sano o arrancar el que falte). Cubre un deploy previo que quedó a medias.
+1. `pip install --upgrade -r requirements.txt` (venv compartido, una vez).
+2. **Verificar estado de puertos** (Serrano #12): `systemctl is-active` de ambos `trading-api@8100/8101` + `ss -ltnp` para confirmar quién escucha dónde, antes de decidir colores.
+3. Detectar el color **activo** (el del include) y el **inactivo**.
+4. Arrancar el color **inactivo** (`systemctl start trading-api@<inactivo>`).
+5. Poll `curl -fsS http://localhost:<inactivo>/health/live` hasta 200 (~2s).
+6. **Reescribir el include ATÓMICAMENTE** (tmpfile + `mv`) → `server 127.0.0.1:<inactivo>;` + `nginx -t && nginx -s reload`.
+7. `systemctl stop trading-api@<activo-viejo>` (drena vía `--timeout-graceful-shutdown 30`; el cliente ya va al nuevo).
+8. Scanner: `systemctl restart trading-scanner` (reinicia ~15s pero **cero impacto de cliente** — ningún endpoint depende del proceso scanner; solo retrasa un ciclo de 300s).
+9. Health-poll final apunta a **`/health/live`**, no a `/health`.
+10. **Reconciliación de unit drift** (Serrano #9): un step que `diff` los `deploy/*.service` versionados contra los instalados en `/etc/systemd/system/` y falle (o reinstale + `daemon-reload`) si divergen — el invariante "API nunca migra" no debe depender de un archivo editado a mano una vez.
+
+## 5. Contrato de frescura (#8)
+
+- El **freshness owner** de `scanner_loop`/`screener_loop`/`sync_loop`/health-monitor/calibrator pasa de "lifespan de la API" a **`trading-scanner.service`**. Actualizar [[docs/superpowers/inventario-estado-vivo.md]] + el spec de liveness, y `mex log`. **Sin esto es violación del gate #8.**
+- La liveness que la API reporta (`/health`, `/status`, `/`) se deriva de la DB (último scan ts) vía `LiveSnapshot`, no de `_scanner_state`. Un dato `rancio`/`muerto` se reporta honesto (el scanner-service caído → frescura `muerto`, no un mute falso).
+
+## 6. Cutover de prod — zero-downtime y reversible
+
+**El orden importa.** En todo el proceso el cliente nunca queda sin upstream.
+
+1. **Mergear PRIMERO el PR de solo-código** (gates + `/health/live` + `scanner_main.py` + frescura-desde-DB + tests) por el deploy ACTUAL. En runtime nada cambia (el unit viejo no setea env → defaults = como hoy). Este es el **último deploy con el restart de siempre**. Verificar `/health` verde.
+2. (Manual, server, sin downtime) Crear los 3 units + el include nginx (apuntando a `:8100`, el proceso viejo), **sin activarlos**. `daemon-reload`. Ampliar sudoers. Respaldar el `.conf` de nginx.
+3. (Manual) Editar nginx → `upstream trading_api { server 127.0.0.1:8100; }`, cambiar los `proxy_pass`, añadir el location SSE. `nginx -t && nginx -s reload`. Cero impacto (aún apunta al proceso viejo en `:8100`).
+4. **CUTOVER sin hueco** (el orden lo confirmó Halberg: cero hueco de cliente; el viejo `:8100` sirve hasta 4d). **Minimizar la ventana 4a→4d** — durante ella corren 2 scanners (transitorio):
+   - (4a) `systemctl start trading-scanner` (dueño del schema). Verificar en journalctl que envía `READY=1`, los 5 threads arrancan y escribe scans.
+   - (4b) `systemctl start trading-api@8101` (web-only, puerto libre — verificar `:8101` libre antes). Poll `:8101/health/live` hasta 200 (~2s).
+   - (4c) Reescribir el include ATÓMICAMENTE → `:8101` + `nginx -t && nginx -s reload`. El cliente ahora va a `:8101` (sin scanner).
+   - (4d) `systemctl stop trading-spacial` **inmediatamente tras 4c** (mata el segundo scanner in-process y libera `:8100`). **Desde aquí: un solo scanner.**
+   - (4e) `systemctl start trading-api@8100`; poll `/health/live`; queda como color standby.
+   - (4f) `systemctl disable trading-spacial`; verificar `is-active` == inactive (cierra el riesgo de doble-scanner por reboot). Unit en disco para rollback.
+   - **Transitorio 2 scanners (4a→4d, segundos):** seguro contra corrupción (WAL + `BEGIN IMMEDIATE` serializan). Efectos lógicos aceptados en esa ventana: **notificación Telegram duplicada** (el dedupe es por-proceso en memoria + bypass `critical` — Serrano #3, Halberg) y posible doble-evaluación de stops. El cierre va por **`PositionClosure` (non-negotiable #1), idempotente/TOCTOU-guarded** → no hay doble-cierre; el riesgo es a lo sumo una notificación repetida. La ventana de segundos lo acota.
+5. **Mergear el PR de `deploy.yml` blue-green.** Deploy de prueba (commit no-op) con `while true; do curl -s -o /dev/null -w '%{http_code}\n' https://trading.sdar.dev/api/health/live; sleep 0.5; done` corriendo → confirmar **CERO 502/503** en la ventana del swap. Confirmar en journalctl que **solo** el scanner-service loguea el arranque del scanner (un solo escritor).
+6. Actualizar inventario/spec de liveness + `mex log`.
+
+**Rollback** (en cualquier punto): reapuntar el include nginx → puerto del color sano + reload; o re-habilitar `trading-spacial` (en disco) + parar los 3 units nuevos + include → `:8100`. El código es backward-compatible (defaults = como hoy).
+
+## 7. Tests (CI)
+
+- Con `RUN_SCANNER=0` el lifespan **NO** registra threads en `_managed_threads` (debe fallar el merge si arranca el scanner).
+- Con `SKIP_DB_INIT=1` el lifespan **NO** ejecuta `init_db` **NI `_bootstrap_first_user`** (spy/mock) → **ningún `BEGIN IMMEDIATE` en boot** de la API web-only (Serrano #13).
+- `/scan` (POST) devuelve **409** cuando `RUN_SCANNER=0`.
+- `/health/live` devuelve 200 con el scanner detenido (DB+schema ok); y **503/no-200** si falta una tabla canónica (schema incompleto).
+- La liveness del scanner reportada por `/health`,`/status`,`/` se deriva de la DB (mock de scan ts viejo → `/health` 503 `rancio`/`muerto`; reciente → 200 `fresco`). `/ticker`,`/symbols` no leen `_scanner_state`.
+- Gate: `python -m pytest tests/ -m "not network" -n auto -q`.
+
+## 8. Riesgos residuales
+
+- **Doble-escritor accidental por disciplina (no por lock):** si `trading-spacial` viejo revive (reboot que lo reactiva, alguien lo `enable`) junto al scanner-service, hay 2 scanners → scans/notificaciones Telegram duplicadas + 2 calibradores (degradación lógica, NO corrupción — `BEGIN IMMEDIATE` serializa). Mitigación bloqueante: `systemctl disable --now trading-spacial` + verificar `is-active`=inactive. **Mitigación dura recomendada (no bloqueante v1):** un *writer-lease* — heartbeat PID con TTL en una fila de DB que haga que un segundo scanner se rehúse a arrancar. Fuera de alcance de v1; anotado como follow-up.
+- **SSE del copiloto se corta al PARAR el color viejo:** `nginx -s reload` NO los corta (drena), pero el `systemctl stop` del color sí, tras el graceful-shutdown window. El cliente SSE del frontend usa `fetch()+ReadableStream` (no `EventSource`) → NO auto-reconecta con Last-Event-ID; un stream cortado muestra error y el operador reintenta. **Degradación aceptada** (deploys infrecuentes; rara vez mid-turn). Mitigación: `--timeout-graceful-shutdown` alto (60-120s) en uvicorn.
+- **Auto-cierre de stops (TP/SL/time-limit):** vive dentro de `execute_scan_for_symbol` → se mueve **entero** al scanner-service. Durante los ~10-15s del restart del scanner-service nadie vigila stops. NO es regresión (hoy ya se chequean 1×/ciclo de 300s, no continuo), pero un boot fallido del scanner deja stops sin cobertura hasta que `Restart=on-failure` lo levante. Vigilar con alerta de frescura.
+- **`backup_db` truncado al kill** (Halberg #6): `db/connection.py:100-124` abre el backup sin `busy_timeout` y `src.backup(dst)` itera páginas; un SIGKILL a media-backup deja un `.db` truncado que la rotación trata como válido (bomba para rollback). **Fix:** escribir el backup a un tmpfile y `os.rename` al destino al completar (atómico) — un kill deja el tmpfile basura, nunca un backup "válido" parcial.
+- **Sudoers acotado** (Serrano #10): conceder al runner de CI SOLO los comandos exactos con args fijos — `systemctl start/stop trading-api@8100`, `trading-api@8101`, `systemctl restart trading-scanner`, `systemctl is-active ...`, `systemctl daemon-reload`, `nginx -t`, `nginx -s reload`, y el `mv` del include a `/etc/nginx/conf.d/trading-upstream.conf`. NO un `systemctl *` abierto ni escritura libre a `/etc/nginx/`.
+- **Alerta de frescura del scanner** (Serrano #11): el auto-cierre de stops vive en el scanner-service; un crash-loop lo deja sin vigilante. `/health` (que ahora gatea sobre frescura DB) es el hook: un monitor externo sobre `/health` 503 = scanner `muerto`/`rancio` → alerta. Definir el destinatario/umbral antes del cutover (no aspiracional).
+- **Complejidad operativa permanente:** 3 units + include nginx editado por CI + sudoers acotado. El include apuntando a un color parado = 502; mitigado por el self-heal (paso 0) + health-gate estricto a `/health/live`. Drift repo↔server mitigado por la reconciliación del paso 10.
+- **Techo arquitectónico sin tocar:** sigue siendo SQLite de un solo escritor en un solo nodo. Esto resuelve el dolor actual de forma proporcional; no escala a multi-nodo (eso sería Postgres, epic separado).
+
+## 9. Fuera de alcance
+
+- Writer-lease duro (heartbeat con TTL) — follow-up recomendado, no v1.
+- Postgres / multi-nodo.
+- Atomic-deploy de symlinks (PR #377, abandonado).
+- Zero-downtime para SSE (best-effort con reconexión del cliente).
+
+## 10. Mapa de archivos
+
+**Código (PR 1 — solo-código, backward-compatible):**
+- `btc_api.py` — gates `RUN_SCANNER`/`SKIP_DB_INIT` (con `_bootstrap_first_user` DENTRO del gate) en el lifespan (`:245-258`); `/scan` → 409 si `RUN_SCANNER!=1`; `/ticker`,`/symbols`,`/status`,`/` dejan de leer `_scanner_state` (liveness/symbols desde DB/config).
+- `api/health.py` — `GET /health/live` (readiness, `SELECT 1 FROM users`); `/health` deriva frescura del scanner de la DB y gatea 200/503 sobre ella; quita el contador `errors` del contrato.
+- `scanner_main.py` (NUEVO) — entrypoint del scanner-service: DDL + bootstrap + `sd_notify(READY=1)` + `start_scanner_thread` + handler SIGTERM/SIGINT + `wait()`.
+- `scanner/runtime.py` — exportar `_thread_stop_event` (para el handler de `scanner_main`).
+- `db/connection.py` — `backup_db` a tmpfile + `os.rename` (no deja backups truncados).
+- (helper) un módulo chico para derivar la frescura del scanner de la DB (`MAX(ts)` de `scans`, counts) envuelta en `LiveSnapshot`.
+- `tests/test_deploy_decouple.py` (NUEVO) — los tests de §7.
+
+**Infra (PR 2 — deploy.yml; + setup manual one-time en server):**
+- `.github/workflows/deploy.yml` — `cancel-in-progress: false`; rutina blue-green con self-heal (paso 0), verificación de puertos, escritura atómica del include, reconciliación de unit drift (§4.5).
+- `deploy/trading-scanner.service` (`Type=notify`, `TimeoutStopSec=60`), `deploy/trading-api@.service` (`Type=notify`-aware vía `After/Wants`, `--timeout-graceful-shutdown 30`), `deploy/trading-upstream.conf` (NUEVOS, versionados como fuente de verdad).
+- `deploy/sudoers-trading` (NUEVO) — el allow-list acotado de comandos para CI.
+- `docs/superpowers/inventario-estado-vivo.md` — owner → `trading-scanner.service`.
+
+## 11. Orden de ejecución
+
+```
+PR 1 (solo-código): gates + /health/live + frescura-DB + scanner_main.py + tests  → merge (último deploy "viejo")
+  → setup manual server (3 units + nginx include, sin activar)
+  → cutover zero-downtime (scanner-service → api@8101 → swap nginx → stop viejo → api@8100 standby → disable viejo)
+  → PR 2 (deploy.yml blue-green) → merge → deploy de prueba con monitor de 503 == 0
+  → actualizar inventario #8 + mex log
+```

--- a/scanner_main.py
+++ b/scanner_main.py
@@ -9,8 +9,10 @@ import signal
 import socket
 import sys
 
-os.environ.setdefault("RUN_AS_SERVICE", "1")
-os.environ.setdefault("RUN_SCANNER", "1")
+# OJO: NO mutar os.environ a nivel de módulo. Importar este módulo (p.ej. en
+# tests) no debe setear RUN_AS_SERVICE/RUN_SCANNER en el proceso — eso filtra
+# a tests posteriores bajo ejecución serial (CI), disparando el guard
+# anti-pytest del lifespan. Los defaults se setean dentro de main().
 
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -34,6 +36,9 @@ def _sd_notify(state: str) -> None:
 
 
 def main() -> int:
+    # Defaults del servicio — aquí, NO a nivel de módulo (ver nota arriba).
+    os.environ.setdefault("RUN_AS_SERVICE", "1")
+    os.environ.setdefault("RUN_SCANNER", "1")
     # Imports diferidos: el módulo debe importar sin tocar la DB.
     from db.schema import init_db          # btc_api.py:99 — NO db.connection
     from db.transaction import transaction

--- a/scanner_main.py
+++ b/scanner_main.py
@@ -35,7 +35,7 @@ def _sd_notify(state: str) -> None:
 
 def main() -> int:
     # Imports diferidos: el módulo debe importar sin tocar la DB.
-    from db.connection import init_db
+    from db.schema import init_db          # btc_api.py:99 — NO db.connection
     from db.transaction import transaction
     # Rutas verificadas en btc_api.py líneas 39-43:
     #   from db.auth_schema import (has_any_user, init_auth_db, init_system_state, ...)

--- a/scanner_main.py
+++ b/scanner_main.py
@@ -1,0 +1,71 @@
+"""Entrypoint del trading-scanner.service: el scanner desacoplado de la API.
+Dueño del schema (DDL + bootstrap), notifica readiness a systemd (Type=notify)
+tras migrar, arranca los threads, para limpio en SIGTERM. NO arranca uvicorn.
+Ver spec §4.2."""
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import sys
+
+os.environ.setdefault("RUN_AS_SERVICE", "1")
+os.environ.setdefault("RUN_SCANNER", "1")
+
+import logging
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("scanner_main")
+
+
+def _sd_notify(state: str) -> None:
+    """sd_notify sin dependencia: escribe `state` al $NOTIFY_SOCKET si existe.
+    No-op fuera de systemd Type=notify."""
+    addr = os.environ.get("NOTIFY_SOCKET")
+    if not addr:
+        return
+    if addr.startswith("@"):
+        addr = "\0" + addr[1:]
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as s:
+            s.connect(addr)
+            s.sendall(state.encode("utf-8"))
+    except OSError as e:
+        log.warning("sd_notify falló: %s", e)
+
+
+def main() -> int:
+    # Imports diferidos: el módulo debe importar sin tocar la DB.
+    from db.connection import init_db
+    from db.transaction import transaction
+    # Rutas verificadas en btc_api.py líneas 39-43:
+    #   from db.auth_schema import (has_any_user, init_auth_db, init_system_state, ...)
+    from db.auth_schema import init_auth_db, init_system_state
+    from btc_api import _bootstrap_first_user
+    from scanner.runtime import (
+        start_scanner_thread, stop_managed_threads, _thread_stop_event,
+    )
+
+    log.info("scanner-service: migrando schema…")
+    init_db()
+    with transaction() as con:
+        init_auth_db(con)
+        init_system_state(con)
+    _bootstrap_first_user()
+    _sd_notify("READY=1")
+
+    def _handler(signum, _frame):
+        log.info("señal %s — parando threads…", signum)
+        _thread_stop_event.set()
+        stop_managed_threads()
+    signal.signal(signal.SIGTERM, _handler)
+    signal.signal(signal.SIGINT, _handler)
+
+    log.info("scanner-service: arrancando threads…")
+    start_scanner_thread()
+    _thread_stop_event.wait()
+    log.info("scanner-service: salida limpia.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_api_health_parity.py
+++ b/tests/test_api_health_parity.py
@@ -39,13 +39,16 @@ def client(monkeypatch, tmp_path):
 
 
 def test_health_liveness_no_scanner(client):
-    """GET /health returns 503 when scanner is not running."""
+    """GET /health returns 503 when no scans exist in DB (scanner never ran)."""
     r = client.get("/health")
     assert r.status_code == 503
     body = r.json()
     assert body["healthy"] is False
     assert body["checks"]["database"] == "ok"
-    assert body["checks"]["scanner"] == "stopped"
+    # Nuevo contrato: scanner liveness viene de la DB; sin scans → "muerto".
+    # "stopped" era el contrato viejo basado en memoria de proceso (PR6→PR8).
+    assert body["checks"]["scanner"] == "muerto"
+    assert "errors" not in body["checks"]
 
 
 def test_health_symbols_auth_empty(client):

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -151,3 +151,43 @@ def test_defaults_preserve_today(monkeypatch):
     with TestClient(btc_api.app):
         pass
     assert calls["init_db"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TASK 3: /health/live — readiness probe (proceso + schema, sin scanner)
+# TASK 4: /health — gatea sobre frescura DB del scanner
+# ---------------------------------------------------------------------------
+
+def test_health_live_ok_without_scanner(monkeypatch):
+    from fastapi.testclient import TestClient
+    import btc_api
+    monkeypatch.setenv("RUN_SCANNER", "0"); monkeypatch.setenv("SKIP_DB_INIT", "1"); monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    with TestClient(btc_api.app) as c:
+        r = c.get("/health/live")
+    assert r.status_code == 200 and r.json()["ready"] is True
+
+
+def test_health_503_when_scanner_stale(monkeypatch):
+    from fastapi.testclient import TestClient
+    import btc_api
+    from api import scanner_liveness
+    monkeypatch.setenv("RUN_SCANNER", "0"); monkeypatch.setenv("SKIP_DB_INIT", "1"); monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
+                        lambda: {"last_scan_ts": None, "scans_total": 0, "signals_total": 0})
+    with TestClient(btc_api.app) as c:
+        r = c.get("/health")
+    assert r.status_code == 503
+    assert "errors" not in r.json()["checks"]
+
+
+def test_health_200_when_scanner_fresh(monkeypatch):
+    from fastapi.testclient import TestClient
+    import btc_api
+    from api import scanner_liveness
+    from datetime import datetime, timezone
+    monkeypatch.setenv("RUN_SCANNER", "0"); monkeypatch.setenv("SKIP_DB_INIT", "1"); monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
+                        lambda: {"last_scan_ts": datetime.now(timezone.utc).isoformat(), "scans_total": 5, "signals_total": 1})
+    with TestClient(btc_api.app) as c:
+        r = c.get("/health")
+    assert r.status_code == 200 and r.json()["checks"]["scanner"] == "fresco"

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -191,3 +191,61 @@ def test_health_200_when_scanner_fresh(monkeypatch):
     with TestClient(btc_api.app) as c:
         r = c.get("/health")
     assert r.status_code == 200 and r.json()["checks"]["scanner"] == "fresco"
+
+
+# ---------------------------------------------------------------------------
+# DEPLOY DECOUPLE: /scan 409 + /status scanner_state de la DB
+# ---------------------------------------------------------------------------
+
+def test_scan_409_on_web_only(monkeypatch):
+    """RUN_SCANNER=0 → POST /scan devuelve 409 antes de ejecutar nada."""
+    from fastapi.testclient import TestClient
+    import btc_api
+    from api.deps import verify_api_key
+    from auth.dependencies import get_current_user
+    from auth.models import User
+
+    monkeypatch.setenv("RUN_SCANNER", "0")
+    monkeypatch.setenv("SKIP_DB_INIT", "1")
+    monkeypatch.setenv("RUN_AS_SERVICE", "0")
+
+    fake_admin = User(
+        id=1, email="admin@test.com", role="admin",
+        is_active=True, created_at="2026-01-01T00:00:00",
+        password_changed_at="2026-01-01T00:00:00",
+    )
+    btc_api.app.dependency_overrides[verify_api_key] = lambda: None
+    btc_api.app.dependency_overrides[get_current_user] = lambda: fake_admin
+    try:
+        with TestClient(btc_api.app) as c:
+            r = c.post("/scan")
+    finally:
+        btc_api.app.dependency_overrides.pop(verify_api_key, None)
+        btc_api.app.dependency_overrides.pop(get_current_user, None)
+
+    assert r.status_code == 409
+
+
+def test_status_scanner_from_db(monkeypatch):
+    """RUN_SCANNER=0 → GET /status devuelve scanner_state con frescura (de la DB, no de memoria)."""
+    from fastapi.testclient import TestClient
+    import btc_api
+    from api import scanner_liveness
+    from api.deps import verify_api_key
+
+    monkeypatch.setenv("RUN_SCANNER", "0")
+    monkeypatch.setenv("SKIP_DB_INIT", "1")
+    monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
+                        lambda: {"last_scan_ts": None, "scans_total": 0, "signals_total": 0})
+
+    btc_api.app.dependency_overrides[verify_api_key] = lambda: None
+    try:
+        with TestClient(btc_api.app) as c:
+            r = c.get("/status")
+    finally:
+        btc_api.app.dependency_overrides.pop(verify_api_key, None)
+
+    assert r.status_code == 200
+    # el estado del scanner ahora trae 'frescura' (DB), no el dict de memoria con 'running'
+    assert "frescura" in r.json()["scanner_state"]

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -264,6 +264,33 @@ def test_scanner_main_importable_and_sd_notify_noop(monkeypatch):
     scanner_main._sd_notify("READY=1")
 
 
+def test_scanner_main_import_does_not_leak_run_as_service(monkeypatch):
+    # Importar scanner_main NO debe setear RUN_AS_SERVICE en el proceso. Si lo
+    # hiciera (setdefault a nivel de módulo), bajo CI serial filtraría a
+    # test_setup.py → el guard anti-pytest del lifespan revienta. Regresión real.
+    import os, importlib
+    monkeypatch.delenv("RUN_AS_SERVICE", raising=False)
+    import scanner_main
+    importlib.reload(scanner_main)
+    assert os.environ.get("RUN_AS_SERVICE") is None, "import scanner_main filtró RUN_AS_SERVICE"
+
+
+def test_scanner_liveness_missing_table_is_muerto(monkeypatch):
+    # Una API web-only que consulta antes de que el scanner cree el schema
+    # debe degradar a 'muerto', no lanzar 500.
+    import sqlite3
+    from api import scanner_liveness
+
+    class _Con:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def execute(self, *a): raise sqlite3.OperationalError("no such table: scans")
+
+    monkeypatch.setattr(scanner_liveness, "_snapshot_connection", lambda: _Con())
+    snap = scanner_liveness.scanner_liveness()
+    assert snap["frescura"]["estado"] == "muerto"
+
+
 def test_scanner_main_deferred_imports_resolve():
     # main() difiere sus imports; el test del módulo no los ejercita, así que
     # un import roto (p.ej. init_db de db.connection en vez de db.schema)

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -1,6 +1,80 @@
 import os, glob, sqlite3
 
 
+def test_scanner_liveness_from_db(monkeypatch):
+    from api import scanner_liveness
+    from datetime import datetime, timezone, timedelta
+    reciente = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+    monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
+                        lambda: {"last_scan_ts": reciente, "scans_total": 10, "signals_total": 2})
+    snap = scanner_liveness.scanner_liveness(umbral_seg=900)
+    assert snap["frescura"]["estado"] == "fresco"
+    assert snap["scans_total"] == 10
+
+
+def test_scanner_liveness_muerto_sin_scans(monkeypatch):
+    from api import scanner_liveness
+    monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
+                        lambda: {"last_scan_ts": None, "scans_total": 0, "signals_total": 0})
+    snap = scanner_liveness.scanner_liveness(umbral_seg=900)
+    assert snap["frescura"]["estado"] == "muerto"
+
+
+def test_scanner_liveness_query_sql_valida(tmp_path, monkeypatch):
+    """Valida que _query_scanner_facts usa los nombres de columna reales del schema:
+    ts (columna de tiempo) y señal (columna de señal). Crea un in-memory DB con el
+    schema real de scans y verifica que la query no falla.
+    Columnas verificadas en db/schema.py línea 126-142 y db/signals.py línea 39-44."""
+    import sqlite3 as _sqlite3
+    import db.connection as conn_mod
+    import db.transaction as tx_mod
+    from contextlib import contextmanager
+
+    # Crear una DB in-memory con el schema real de scans
+    mem_con = _sqlite3.connect(":memory:")
+    mem_con.row_factory = _sqlite3.Row
+    mem_con.execute("""
+        CREATE TABLE scans (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts          TEXT    NOT NULL,
+            symbol      TEXT    NOT NULL DEFAULT 'BTCUSDT',
+            estado      TEXT    NOT NULL,
+            señal       INTEGER NOT NULL DEFAULT 0,
+            setup       INTEGER NOT NULL DEFAULT 0,
+            price       REAL,
+            lrc_pct     REAL,
+            rsi_1h      REAL,
+            score       INTEGER,
+            score_label TEXT,
+            macro_ok    INTEGER,
+            gatillo     INTEGER,
+            payload     TEXT
+        )
+    """)
+    # Insertar una fila de señal activa
+    from datetime import datetime, timezone, timedelta
+    ts_reciente = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
+    mem_con.execute(
+        "INSERT INTO scans (ts, symbol, estado, señal) VALUES (?, 'BTCUSDT', 'ok', 1)",
+        (ts_reciente,)
+    )
+    mem_con.commit()
+
+    # Monkeypatch snapshot_connection para devolver la DB en memoria
+    from api import scanner_liveness
+
+    @contextmanager
+    def fake_snapshot():
+        yield mem_con
+
+    monkeypatch.setattr(scanner_liveness, "_snapshot_connection", fake_snapshot)
+
+    facts = scanner_liveness._query_scanner_facts()
+    assert facts["scans_total"] == 1
+    assert facts["signals_total"] == 1
+    assert facts["last_scan_ts"] is not None
+
+
 def test_backup_db_atomic_no_partial_on_failure(tmp_path, monkeypatch):
     import db.connection as conn
     src = tmp_path / "signals.db"

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -264,6 +264,20 @@ def test_scanner_main_importable_and_sd_notify_noop(monkeypatch):
     scanner_main._sd_notify("READY=1")
 
 
+def test_scanner_main_deferred_imports_resolve():
+    # main() difiere sus imports; el test del módulo no los ejercita, así que
+    # un import roto (p.ej. init_db de db.connection en vez de db.schema)
+    # pasaba desapercibido y crasheaba el scanner-service en prod. Este test
+    # importa exactamente los nombres que main() necesita.
+    from db.schema import init_db          # noqa: F401
+    from db.transaction import transaction  # noqa: F401
+    from db.auth_schema import init_auth_db, init_system_state  # noqa: F401
+    from btc_api import _bootstrap_first_user  # noqa: F401
+    from scanner.runtime import (  # noqa: F401
+        start_scanner_thread, stop_managed_threads, _thread_stop_event,
+    )
+
+
 def test_scanner_main_sd_notify_writes_to_socket(tmp_path, monkeypatch):
     import sys
     import importlib

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -249,3 +249,42 @@ def test_status_scanner_from_db(monkeypatch):
     assert r.status_code == 200
     # el estado del scanner ahora trae 'frescura' (DB), no el dict de memoria con 'running'
     assert "frescura" in r.json()["scanner_state"]
+
+
+# ---------------------------------------------------------------------------
+# TASK 9: scanner_main.py — entrypoint del scanner-service (sd_notify)
+# ---------------------------------------------------------------------------
+
+def test_scanner_main_importable_and_sd_notify_noop(monkeypatch):
+    monkeypatch.delenv("NOTIFY_SOCKET", raising=False)
+    import importlib
+    import scanner_main
+    importlib.reload(scanner_main)
+    # sin NOTIFY_SOCKET, _sd_notify es no-op y no lanza
+    scanner_main._sd_notify("READY=1")
+
+
+def test_scanner_main_sd_notify_writes_to_socket(tmp_path, monkeypatch):
+    import sys
+    import importlib
+    import pytest
+
+    # AF_UNIX SOCK_DGRAM puede no estar disponible en algunos runners de Windows.
+    socket = pytest.importorskip("socket")
+    if not hasattr(socket, "AF_UNIX"):
+        pytest.skip("AF_UNIX no disponible en este runner")
+
+    import scanner_main
+    importlib.reload(scanner_main)
+
+    sock_path = str(tmp_path / "notify.sock")
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    try:
+        srv.bind(sock_path)
+        srv.settimeout(2)
+        monkeypatch.setenv("NOTIFY_SOCKET", sock_path)
+        scanner_main._sd_notify("READY=1")
+        data, _ = srv.recvfrom(64)
+        assert data == b"READY=1"
+    finally:
+        srv.close()

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -233,8 +233,12 @@ def test_status_scanner_from_db(monkeypatch):
     from api import scanner_liveness
     from api.deps import verify_api_key
 
+    # RUN_SCANNER=0 (web-only) pero SIN SKIP_DB_INIT: el DDL crea el schema, así
+    # /status puede leer `scans` (get_latest_scan) sin depender de que OTRO test
+    # haya creado la tabla en la DB compartida — fragilidad order-dependent que
+    # solo se veía en CI serial (no en -n auto). El punto del test (scanner_state
+    # con frescura desde la DB) se valida con RUN_SCANNER=0 + el monkeypatch.
     monkeypatch.setenv("RUN_SCANNER", "0")
-    monkeypatch.setenv("SKIP_DB_INIT", "1")
     monkeypatch.setenv("RUN_AS_SERVICE", "0")
     monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
                         lambda: {"last_scan_ts": None, "scans_total": 0, "signals_total": 0})

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -105,3 +105,49 @@ def test_backup_db_success_creates_final(tmp_path, monkeypatch):
     conn.backup_db()
     finals = glob.glob(os.path.join(str(bdir), "signals_*.db"))
     assert len(finals) == 1 and not finals[0].endswith(".tmp")
+
+
+# ---------------------------------------------------------------------------
+# TASK 7: Gates RUN_SCANNER y SKIP_DB_INIT
+# ---------------------------------------------------------------------------
+
+def test_run_scanner_0_no_threads(monkeypatch):
+    import scanner.runtime as rt
+    from fastapi.testclient import TestClient
+    import btc_api
+    monkeypatch.setenv("RUN_SCANNER", "0")
+    monkeypatch.setenv("SKIP_DB_INIT", "1")
+    monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    rt._managed_threads.clear()
+    with TestClient(btc_api.app):
+        pass
+    assert rt._managed_threads == [], "RUN_SCANNER=0 NO debe arrancar threads"
+
+
+def test_skip_db_init_no_ddl_no_bootstrap(monkeypatch):
+    import btc_api
+    from fastapi.testclient import TestClient
+    calls = {"init_db": 0, "bootstrap": 0}
+    monkeypatch.setattr(btc_api, "init_db", lambda *a, **k: calls.__setitem__("init_db", calls["init_db"] + 1))
+    monkeypatch.setattr(btc_api, "_bootstrap_first_user", lambda *a, **k: calls.__setitem__("bootstrap", calls["bootstrap"] + 1))
+    monkeypatch.setenv("RUN_SCANNER", "0")
+    monkeypatch.setenv("SKIP_DB_INIT", "1")
+    monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    with TestClient(btc_api.app):
+        pass
+    assert calls["init_db"] == 0 and calls["bootstrap"] == 0
+
+
+def test_defaults_preserve_today(monkeypatch):
+    # Sin env → DDL corre + scanner arranca (comportamiento de hoy).
+    import btc_api
+    from fastapi.testclient import TestClient
+    calls = {"init_db": 0}
+    monkeypatch.setattr(btc_api, "init_db", lambda *a, **k: calls.__setitem__("init_db", calls["init_db"] + 1))
+    monkeypatch.setattr(btc_api, "start_scanner_thread", lambda *a, **k: None)
+    monkeypatch.delenv("RUN_SCANNER", raising=False)
+    monkeypatch.delenv("SKIP_DB_INIT", raising=False)
+    monkeypatch.setenv("RUN_AS_SERVICE", "0")
+    with TestClient(btc_api.app):
+        pass
+    assert calls["init_db"] == 1

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -1,0 +1,33 @@
+import os, glob, sqlite3
+
+
+def test_backup_db_atomic_no_partial_on_failure(tmp_path, monkeypatch):
+    import db.connection as conn
+    src = tmp_path / "signals.db"
+    sqlite3.connect(str(src)).executescript("CREATE TABLE t(x); INSERT INTO t VALUES(1);")
+    bdir = tmp_path / "backups"
+    monkeypatch.setattr(conn, "_resolve_db_file", lambda: str(src))
+    monkeypatch.setattr(conn, "_BACKUP_DIR", str(bdir))
+    real_connect = sqlite3.connect
+    def boom_connect(path, *a, **k):
+        c = real_connect(path, *a, **k)
+        if str(path).endswith(".tmp"):
+            def boom(*aa, **kk): raise RuntimeError("kill a media backup")
+            c.backup = boom
+        return c
+    monkeypatch.setattr(conn.sqlite3, "connect", boom_connect)
+    conn.backup_db()  # captura el error, NO debe dejar un signals_*.db final válido
+    finals = glob.glob(os.path.join(str(bdir), "signals_*.db"))
+    assert finals == [], f"un backup fallido no debe dejar un .db final, encontré: {finals}"
+
+
+def test_backup_db_success_creates_final(tmp_path, monkeypatch):
+    import db.connection as conn
+    src = tmp_path / "signals.db"
+    sqlite3.connect(str(src)).executescript("CREATE TABLE t(x); INSERT INTO t VALUES(1);")
+    bdir = tmp_path / "backups"
+    monkeypatch.setattr(conn, "_resolve_db_file", lambda: str(src))
+    monkeypatch.setattr(conn, "_BACKUP_DIR", str(bdir))
+    conn.backup_db()
+    finals = glob.glob(os.path.join(str(bdir), "signals_*.db"))
+    assert len(finals) == 1 and not finals[0].endswith(".tmp")


### PR DESCRIPTION
## Resumen

Primer PR (solo-código) del epic deploy zero-downtime. Prepara el desacople del scanner a su propio servicio systemd, **100% backward-compatible**: el unit viejo no setea ninguna env → defaults = comportamiento de hoy (scanner in-process + DDL). **Cero cambio de runtime en prod** hasta que PR2 + el cutover manual activen los gates.

- **Gates del lifespan** (`btc_api.py`): `RUN_SCANNER` (default `1`) y `SKIP_DB_INIT` (con `_bootstrap_first_user` dentro del gate). Defaults preservan hoy.
- **`scanner_main.py`** (NUEVO): entrypoint del futuro `trading-scanner.service` — dueño del schema, `sd_notify(READY=1)` post-DDL (cierra el crash-loop de reboot), handler SIGTERM/SIGINT.
- **Liveness del scanner desde la DB** (`api/scanner_liveness.py` + `/health`, `/status`, `/`): cumple #8 (frescura en el contrato, cross-proceso) en vez de leer `_scanner_state` de memoria — para que una API web-only reporte la verdad del scanner-service. `/ticker`,`/symbols` leen el watchlist de la config.
- **`/health/live`** (NUEVO): readiness desacoplado del scanner (lo pollea el blue-green deploy).
- **`/scan` → 409** cuando `RUN_SCANNER!=1` (la API web-only no es el escritor).
- **`backup_db` atómico** (tmpfile + rename): no deja backups truncados al kill.

Diseño v2 tras panel multi-agente + críticos Serrano/Halberg: `docs/superpowers/specs/es/2026-06-15-deploy-zero-downtime-decouple-scanner-spec.md`. Plan: `docs/superpowers/plans/2026-06-15-deploy-zero-downtime-pr1-codigo.md`.

## Test Plan

- [x] `pytest -m "not network" -n auto` → 3615 passed, 2 skipped, 0 regresiones.
- [x] Backward-compat verificado: sin env → DDL + scanner como hoy (`test_setup.py` 13/13, `test_defaults_preserve_today`).
- [x] Web-only: `RUN_SCANNER=0 SKIP_DB_INIT=1` → sin threads, sin DDL/bootstrap, `/scan` 409, `/health/live` 200.
- [x] `scanner_main.py` importa + imports diferidos de `main()` resueltos (test que caza el import roto).

PR2 (deploy.yml blue-green + units systemd + nginx) y el cutover manual van aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)