### PR TITLE
fix(deploy): /health barato (sin full-scan) + /health/live público

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -139,12 +139,11 @@ def health_check():
     except Exception as e:
         checks["database"] = f"error: {e}"
 
-    snap = scanner_liveness()
+    snap = scanner_liveness()              # barato: último scan ts (id-indexed)
     fr = snap["frescura"]["estado"]
     checks["scanner"] = fr
     checks["scan_freshness"] = fr
-    checks["scans_total"] = snap.get("scans_total", 0)
-    checks["signals_total"] = snap.get("signals_total", 0)
+    checks["last_scan_ts"] = snap.get("last_scan_ts")
 
     healthy = checks["database"] == "ok" and fr == "fresco"
     return JSONResponse(

--- a/api/scanner_liveness.py
+++ b/api/scanner_liveness.py
@@ -17,54 +17,47 @@ import sqlite3
 from db.transaction import snapshot_connection as _snapshot_connection
 from freshness import LiveSnapshot
 
-_EMPTY_FACTS = {"last_scan_ts": None, "scans_total": 0, "signals_total": 0}
+_EMPTY_FACTS = {"last_scan_ts": None}
 
 
 def _query_scanner_facts() -> dict:
-    """Lee la DB y devuelve conteos + timestamp del último scan.
+    """Devuelve el timestamp del último scan — BARATO.
 
-    Usa snapshot_connection (WAL-concurrent, sin writer lock) porque
-    esta lectura es terminal — se serializa a la respuesta HTTP, no
-    alimenta ninguna mutación posterior.
+    Usa `ORDER BY id DESC LIMIT 1` (la PK `id` está indexada → ~0.1 ms),
+    NO `MAX(ts)`/`COUNT(*)` que son full-scans (~8 s c/u) sobre la tabla
+    `scans` grande de prod y tumbaban el health probe (regresión PR1: el
+    `/health` con tres full-scans tardaba >20 s → timeout del deploy).
+    La frescura (#8) solo necesita el último ts; los conteos eran stats
+    informativas y NO valían un full-scan en un endpoint caliente.
 
-    Tolerante a la tabla ausente: una API web-only podría consultar antes
-    de que el scanner-service haya creado el schema → degradar a 'muerto'
-    (LiveSnapshot con generated_at=None), nunca un 500.
+    snapshot_connection (WAL-concurrent, sin writer lock). Tolerante a la
+    tabla ausente: una API web-only que consulta antes de que el
+    scanner-service cree el schema degrada a 'muerto', nunca 500.
     """
     try:
         with _snapshot_connection() as con:
-            last_scan_ts = con.execute("SELECT MAX(ts) FROM scans").fetchone()[0]
-            scans_total = con.execute("SELECT COUNT(*) FROM scans").fetchone()[0]
-            signals_total = con.execute(
-                'SELECT COUNT(*) FROM scans WHERE "señal" = 1'
-            ).fetchone()[0]
+            row = con.execute(
+                "SELECT ts FROM scans ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            last_scan_ts = row[0] if row else None
     except sqlite3.OperationalError:
         return dict(_EMPTY_FACTS)
-    return {
-        "last_scan_ts": last_scan_ts,
-        "scans_total": scans_total,
-        "signals_total": signals_total,
-    }
+    return {"last_scan_ts": last_scan_ts}
 
 
 def scanner_liveness(*, umbral_seg: float = 900.0) -> dict:
-    """Devuelve el estado de liveness del scanner envuelto en LiveSnapshot.
+    """Liveness del scanner (último scan ts + frescura) envuelto en LiveSnapshot.
 
     Args:
         umbral_seg: segundos antes de considerar el scanner 'rancio'.
-                    Default 900 s (15 min) — el intervalo de scan nominal.
+                    Default 900 s (3× el intervalo nominal de 300 s).
 
     Returns:
-        dict con keys: scans_total, signals_total, last_scan_ts, frescura
-        donde frescura = {estado, edad_seg, generated_at, umbral_seg}.
-        estado es 'fresco' | 'rancio' | 'muerto'.
+        dict con keys: last_scan_ts, frescura{estado, edad_seg, generated_at,
+        umbral_seg}. estado es 'fresco' | 'rancio' | 'muerto'.
     """
     facts = _query_scanner_facts()
-    payload = {
-        "scans_total": facts["scans_total"],
-        "signals_total": facts["signals_total"],
-        "last_scan_ts": facts["last_scan_ts"],
-    }
+    payload = {"last_scan_ts": facts["last_scan_ts"]}
     return LiveSnapshot(
         payload=payload,
         generated_at=facts["last_scan_ts"],

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -79,6 +79,7 @@ def _bypass_role_or_none() -> str | None:
 # /auth/login and /auth/refresh are entry points: no session yet.
 _PUBLIC_PATHS_EXACT: frozenset = frozenset({
     "/health",       # <-- exact match ONLY; see comment above
+    "/health/live",  # readiness probe (deploy blue-green + monitoring) — público
     "/auth/login",
     "/auth/refresh",
     "/openapi.json",

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -6,10 +6,10 @@ def test_scanner_liveness_from_db(monkeypatch):
     from datetime import datetime, timezone, timedelta
     reciente = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
     monkeypatch.setattr(scanner_liveness, "_query_scanner_facts",
-                        lambda: {"last_scan_ts": reciente, "scans_total": 10, "signals_total": 2})
+                        lambda: {"last_scan_ts": reciente})
     snap = scanner_liveness.scanner_liveness(umbral_seg=900)
     assert snap["frescura"]["estado"] == "fresco"
-    assert snap["scans_total"] == 10
+    assert snap["last_scan_ts"] == reciente
 
 
 def test_scanner_liveness_muerto_sin_scans(monkeypatch):
@@ -18,6 +18,28 @@ def test_scanner_liveness_muerto_sin_scans(monkeypatch):
                         lambda: {"last_scan_ts": None, "scans_total": 0, "signals_total": 0})
     snap = scanner_liveness.scanner_liveness(umbral_seg=900)
     assert snap["frescura"]["estado"] == "muerto"
+
+
+def test_scanner_liveness_query_is_cheap_no_full_scan():
+    # Regresión PR1: /health corría COUNT(*)+MAX(ts) (~8s c/u) sobre la tabla
+    # scans grande de prod → timeout del health probe. El query DEBE ser barato
+    # (ORDER BY id DESC LIMIT 1, id-indexed). Guard contra que vuelva el full-scan.
+    import inspect
+    from api import scanner_liveness
+    # Aislar el CUERPO (sin docstring, que menciona COUNT/MAX en prosa).
+    src = inspect.getsource(scanner_liveness._query_scanner_facts)
+    body = src.split('"""', 2)[-1].upper()   # todo tras el docstring
+    assert "ORDER BY ID DESC LIMIT 1" in body
+    assert "COUNT(" not in body, "COUNT(*) es full-scan en la tabla scans grande"
+    assert "MAX(" not in body, "MAX(ts) es full-scan"
+
+
+def test_health_live_is_public():
+    # El readiness probe lo pollea el deploy blue-green (PR2) sin auth y un
+    # monitor externo — DEBE estar exento del AuthMiddleware o da 401 (lo dio
+    # en prod tras PR1).
+    from auth.middleware import _PUBLIC_PATHS_EXACT
+    assert "/health/live" in _PUBLIC_PATHS_EXACT
 
 
 def test_scanner_liveness_query_sql_valida(tmp_path, monkeypatch):
@@ -70,9 +92,9 @@ def test_scanner_liveness_query_sql_valida(tmp_path, monkeypatch):
     monkeypatch.setattr(scanner_liveness, "_snapshot_connection", fake_snapshot)
 
     facts = scanner_liveness._query_scanner_facts()
-    assert facts["scans_total"] == 1
-    assert facts["signals_total"] == 1
+    # Query barato (ORDER BY id DESC LIMIT 1): solo el último ts, sin COUNT/MAX.
     assert facts["last_scan_ts"] is not None
+    assert "scans_total" not in facts   # full-scans eliminados (regresión PR1)
 
 
 def test_backup_db_atomic_no_partial_on_failure(tmp_path, monkeypatch):


### PR DESCRIPTION
## Hotfix — regresión de PR1 detectada en el deploy a prod

El deploy de PR1 (#600) **falló en el health-check** (el servicio quedó arriba y sano, pero `/health` timeouteaba). Causa: el rewrite de `/health` derivaba la liveness con `COUNT(*)` + `MAX(ts)` + `COUNT WHERE señal=1` sobre la tabla `scans` (135k filas en prod) — **tres full-scans, ~8s cada uno** → `/health` tardaba >20s → timeout del health-check del deploy (y de cualquier monitor externo). En la DB de test (chica) era instantáneo, por eso pasó CI.

**Fixes:**
- `api/scanner_liveness.py`: el último scan ts se obtiene con `SELECT ts FROM scans ORDER BY id DESC LIMIT 1` (la PK `id` está indexada → **0.1ms** vs 8.8s). Se eliminan los conteos `scans_total`/`signals_total` (eran stats informativas; no valen un full-scan en un endpoint caliente; la frescura #8 solo necesita el último ts).
- `api/health.py`: `/health` ya no reporta los conteos; mantiene frescura + database.
- `auth/middleware.py`: `/health/live` añadido a `_PUBLIC_PATHS_EXACT` — sin esto da **401** (lo dio en prod; lo pollea el blue-green de PR2 + monitoring).
- Tests: guard de regresión (el query no usa COUNT/MAX, sí el id-indexed) + `/health/live` es público.

## Test Plan
- [x] Timing verificado en prod: `COUNT(*)` 7.6s, `MAX(ts)` 8.8s, `ORDER BY id DESC LIMIT 1` 0.1ms.
- [x] Gate **serial** completo (igual que CI): 3620 passed, 2 skipped, 0 fallas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)