### PR TITLE
fix(deploy): ts ' UTC' del scanner → frescura correcta + deploy pollea /health/live

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,8 +112,11 @@ jobs:
           # /health after restart on the large prod DB. The prior single-shot
           # "sleep 15 + one curl" failed 5 of 6 recent deploys even when the
           # rsync + restart had already succeeded — a false-red. Retry instead.
+          # /health/live = readiness (proceso + schema), el gate correcto para
+          # un deploy. /health es frescura del scanner (503 en la ventana de
+          # ~minutos tras restart hasta el primer ciclo) → NO sirve de readiness.
           for i in $(seq 1 12); do
-            if ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "curl -fsS http://localhost:8100/health" >/dev/null 2>&1; then
+            if ssh -i ~/.ssh/deploy_key ubuntu@${HOST} "curl -fsS http://localhost:8100/health/live" >/dev/null 2>&1; then
               echo "Health check passed (attempt ${i}/12)."
               exit 0
             fi

--- a/api/scanner_liveness.py
+++ b/api/scanner_liveness.py
@@ -42,7 +42,18 @@ def _query_scanner_facts() -> dict:
             last_scan_ts = row[0] if row else None
     except sqlite3.OperationalError:
         return dict(_EMPTY_FACTS)
-    return {"last_scan_ts": last_scan_ts}
+    return {"last_scan_ts": _normalize_scan_ts(last_scan_ts)}
+
+
+def _normalize_scan_ts(ts: str | None) -> str | None:
+    """El `ts` de la tabla `scans` se guarda como 'YYYY-MM-DD HH:MM:SS UTC'
+    (NO ISO-8601 — viene del campo `timestamp` del reporte del scanner). El
+    sufijo ' UTC' rompe `datetime.fromisoformat` en `LiveSnapshot._edad_seg`
+    → edad=None → 'muerto' permanente. Lo normalizamos a un offset parseable.
+    Idempotente para ts ya en ISO (sin ' UTC' que reemplazar)."""
+    if not ts:
+        return None
+    return ts.replace(" UTC", "+00:00")
 
 
 def scanner_liveness(*, umbral_seg: float = 900.0) -> dict:

--- a/tests/test_deploy_decouple.py
+++ b/tests/test_deploy_decouple.py
@@ -20,6 +20,41 @@ def test_scanner_liveness_muerto_sin_scans(monkeypatch):
     assert snap["frescura"]["estado"] == "muerto"
 
 
+def test_normalize_scan_ts_handles_utc_suffix():
+    from api.scanner_liveness import _normalize_scan_ts
+    from datetime import datetime
+    # formato real de prod: 'YYYY-MM-DD HH:MM:SS UTC'
+    norm = _normalize_scan_ts("2026-06-15 15:06:38 UTC")
+    assert datetime.fromisoformat(norm)  # ahora parsea
+    assert _normalize_scan_ts(None) is None
+    # idempotente para ISO
+    assert _normalize_scan_ts("2026-06-15T15:06:38+00:00") == "2026-06-15T15:06:38+00:00"
+
+
+def test_scanner_liveness_prod_ts_format_is_fresco(monkeypatch):
+    # El bug que tumbó el deploy: el ts de scans viene como ' UTC' (no ISO),
+    # LiveSnapshot no lo parseaba → 'muerto' permanente aunque el scan fuera
+    # reciente. Reproduce el formato exacto de prod.
+    import sqlite3
+    from contextlib import contextmanager
+    from datetime import datetime, timezone, timedelta
+    from api import scanner_liveness
+
+    mem = sqlite3.connect(":memory:")
+    mem.execute("CREATE TABLE scans (id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT NOT NULL)")
+    reciente = (datetime.now(timezone.utc) - timedelta(seconds=120)).strftime("%Y-%m-%d %H:%M:%S UTC")
+    mem.execute("INSERT INTO scans (ts) VALUES (?)", (reciente,))
+    mem.commit()
+
+    @contextmanager
+    def fake_snapshot():
+        yield mem
+
+    monkeypatch.setattr(scanner_liveness, "_snapshot_connection", fake_snapshot)
+    snap = scanner_liveness.scanner_liveness(umbral_seg=900)
+    assert snap["frescura"]["estado"] == "fresco", snap["frescura"]
+
+
 def test_scanner_liveness_query_is_cheap_no_full_scan():
     # Regresión PR1: /health corría COUNT(*)+MAX(ts) (~8s c/u) sobre la tabla
     # scans grande de prod → timeout del health probe. El query DEBE ser barato


### PR DESCRIPTION
## Hotfix 2 — el deploy seguía rojo (health-check)

Tras el hotfix #601, `/health` quedó rápido (7ms) y `/health/live` público (200), pero el deploy SEGUÍA rojo porque `/health` devolvía **503 `scanner: muerto`** aunque el último scan era de hace ~8 min (<15 min umbral).

**Causa:** el `ts` de la tabla `scans` se guarda como **`'2026-06-15 15:06:38 UTC'`** (no ISO-8601 — viene del campo `timestamp` del reporte del scanner). `LiveSnapshot._edad_seg` hace `datetime.fromisoformat(...)`, que falla con el sufijo `' UTC'` → `edad=None` → `'muerto'` permanente. Mis tests pasaban porque usaban `.isoformat()`; prod usa otro formato (mismatch test-vs-prod, verificado por SSH).

**Fixes:**
- `api/scanner_liveness.py`: `_normalize_scan_ts` convierte `' UTC'` → `'+00:00'` (parseable; idempotente para ISO).
- `.github/workflows/deploy.yml`: el health-check pollea **`/health/live`** (readiness: proceso + schema) en vez de `/health` (frescura del scanner, que da 503 en la ventana de minutos tras restart hasta el primer ciclo). Readiness es el gate correcto para un deploy.
- Tests que reproducen el formato exacto de prod (`'... UTC'` → `fresco`).

## Test Plan
- [x] Verificado por SSH: el ts de prod es `'YYYY-MM-DD HH:MM:SS UTC'`, /health daba 503 muerto; /health/live 200.
- [x] Gate **serial** completo: 3622 passed, 0 fallas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)