### PR TITLE
feat(deploy): PR2a — artefactos blue-green (units, nginx, sudoers, runbook)

### DIFF
--- a/deploy/CUTOVER.md
+++ b/deploy/CUTOVER.md
@@ -1,0 +1,110 @@
+# Cutover a blue-green — runbook (one-time, manual, zero-downtime)
+
+Migra el server (`ubuntu@trading` / alias `atrium-aws`, `/var/www/trading`) del
+modelo single-process (`trading-spacial`, scanner in-process) al blue-green
+(`trading-scanner` + `trading-api@8100/8101`). **El cliente nunca queda sin
+upstream.** Rollback en cada punto. Requiere PR1 ya en prod (gates + scanner_main
++ /health/live) — ✅ ya está.
+
+> Verificá antes: `curl -fsS http://localhost:8100/health/live` da `{"ready":true}`
+> y `ls /var/www/trading/scanner_main.py` existe (lo trae el rsync de PR1).
+
+## 0. Pre-flight (sin downtime)
+```bash
+ssh atrium-aws
+cd /var/www/trading
+sudo cp /etc/nginx/conf.d/trading.sdar.dev.conf ~/trading.sdar.dev.conf.bak.$(date +%s)   # backup nginx
+ls deploy/   # confirmá que los artefactos llegaron por rsync
+```
+
+## 1. Instalar los 3 units + sudoers (sin activar)
+```bash
+sudo cp deploy/trading-scanner.service /etc/systemd/system/trading-scanner.service
+sudo cp deploy/trading-api@.service     /etc/systemd/system/trading-api@.service
+sudo install -m 0440 deploy/sudoers-trading /etc/sudoers.d/trading-deploy
+sudo visudo -c                          # valida sudoers; si falla, rm el archivo
+sudo systemctl daemon-reload
+```
+
+## 2. Instalar el include de nginx + chown (para que el deploy lo reescriba sin sudo)
+```bash
+sudo cp deploy/trading-upstream.conf /etc/nginx/conf.d/trading-upstream.conf
+sudo chown ubuntu:ubuntu /etc/nginx/conf.d/trading-upstream.conf
+# El include arranca apuntando a :8100 (el proceso viejo) → cero impacto.
+```
+
+## 3. Apuntar el server block al upstream (UNA vez)
+Editar `/etc/nginx/conf.d/trading.sdar.dev.conf`: en `location /api/` y en
+`location = /api/auth/login`, cambiar `proxy_pass http://127.0.0.1:8100/...`
+por `proxy_pass http://trading_api/...` (mismo path-rewrite). Aislar el SSE:
+```nginx
+location /api/agent/ {
+    proxy_pass http://trading_api/agent/;
+    proxy_buffering off;
+    proxy_read_timeout 3600s;
+    proxy_set_header Host $host;
+    # (replicar los proxy_set_header del location /api/ existente)
+}
+```
+```bash
+sudo nginx -t && sudo nginx -s reload    # aún apunta a :8100 (proceso viejo) → cero impacto
+```
+
+## 4. CUTOVER sin hueco (minimizar 4a→4d)
+```bash
+# 4a — arrancar el scanner-service (dueño del schema). Esperá READY + scans.
+sudo systemctl start trading-scanner
+sudo systemctl status trading-scanner --no-pager -n 5   # active, "READY"
+sudo journalctl -u trading-scanner -n 20 --no-pager     # 5 threads arrancan, escribe scans
+
+# 4b — arrancar la API web-only en el puerto LIBRE (verificá que :8101 esté libre)
+ss -ltnp | grep 8101 || echo "8101 libre"
+sudo systemctl start trading-api@8101
+for i in $(seq 1 15); do curl -fsS http://localhost:8101/health/live && break; sleep 1; done   # 200 ~2s
+
+# 4c — swap atómico del include → :8101 + reload (cliente pasa a la API sin scanner)
+printf 'upstream trading_api {\n    server 127.0.0.1:8101;\n}\n' > /tmp/tu.conf
+mv -f /tmp/tu.conf /etc/nginx/conf.d/trading-upstream.conf
+sudo nginx -t && sudo nginx -s reload
+
+# 4d — INMEDIATO: parar el viejo (mata el 2º scanner in-process, libera :8100)
+sudo systemctl stop trading-spacial     # desde aquí: UN solo scanner
+
+# 4e — arrancar el standby en :8100
+sudo systemctl start trading-api@8100
+for i in $(seq 1 15); do curl -fsS http://localhost:8100/health/live && break; sleep 1; done
+
+# 4f — deshabilitar el viejo (cierra el riesgo de doble-scanner por reboot)
+sudo systemctl disable trading-spacial
+systemctl is-active trading-spacial     # debe decir "inactive"
+sudo systemctl enable trading-scanner trading-api@8100 trading-api@8101   # arrancan en boot
+```
+
+## 5. Verificación
+```bash
+curl -fsS http://localhost:8101/health/live   # {"ready":true}
+curl -s   http://localhost:8101/health        # {"healthy":true,...,"scanner":"fresco"}
+sudo journalctl -u trading-scanner -n 5 --no-pager   # SOLO acá debe loguear scans (un escritor)
+curl -k -s -o /dev/null -w "%{http_code}\n" --resolve trading.sdar.dev:443:127.0.0.1 https://trading.sdar.dev/api/auth/me   # 401 (sano)
+```
+
+## 6. Mergear el PR2 (deploy.yml blue-green)
+Solo DESPUÉS de que el cutover quedó verde. El primer deploy nuevo corre la
+rutina blue-green contra el server ya migrado. Deploy de prueba (commit no-op)
+con un monitor en paralelo:
+```bash
+while true; do curl -k -s -o /dev/null -w '%{http_code}\n' --resolve trading.sdar.dev:443:127.0.0.1 https://trading.sdar.dev/api/health/live; sleep 0.5; done
+# Confirmá CERO 502/503 en la ventana del swap.
+```
+
+## Rollback (en cualquier punto)
+```bash
+# Reapuntar nginx al color sano + reload:
+printf 'upstream trading_api {\n    server 127.0.0.1:<color-sano>;\n}\n' > /tmp/tu.conf
+mv -f /tmp/tu.conf /etc/nginx/conf.d/trading-upstream.conf && sudo nginx -s reload
+# O volver al modelo viejo entero:
+sudo systemctl stop trading-api@8100 trading-api@8101 trading-scanner
+sudo systemctl enable --now trading-spacial          # el unit viejo sigue en disco
+# restaurar el server block: sudo cp ~/trading.sdar.dev.conf.bak.<ts> /etc/nginx/conf.d/trading.sdar.dev.conf && sudo nginx -s reload
+```
+El código es backward-compatible (RUN_SCANNER default '1', SKIP_DB_INIT ausente → el viejo migra + escanea como hoy).

--- a/deploy/sudoers-trading
+++ b/deploy/sudoers-trading
@@ -1,0 +1,25 @@
+# /etc/sudoers.d/trading-deploy  (instalar: sudo install -m 0440 deploy/sudoers-trading /etc/sudoers.d/trading-deploy && sudo visudo -c)
+#
+# Allow-list ACOTADO de comandos que el deploy de CI (usuario ubuntu) corre sin
+# password. Solo estos binarios con estos args — NO un `systemctl *` abierto ni
+# escritura libre a /etc/nginx. El include de nginx lo reescribe el deploy vía
+# un mv de un tmpfile a /etc/nginx/conf.d/trading-upstream.conf, que es chown
+# ubuntu:ubuntu (ver CUTOVER.md), así NO necesita sudo para el mv.
+#
+# Rutas de binarios en Ubuntu 24: systemctl=/usr/bin/systemctl, nginx=/usr/sbin/nginx.
+Cmnd_Alias TRADING_DEPLOY = \
+    /usr/bin/systemctl start trading-api@8100, \
+    /usr/bin/systemctl start trading-api@8101, \
+    /usr/bin/systemctl stop trading-api@8100, \
+    /usr/bin/systemctl stop trading-api@8101, \
+    /usr/bin/systemctl restart trading-api@8100, \
+    /usr/bin/systemctl restart trading-api@8101, \
+    /usr/bin/systemctl restart trading-scanner, \
+    /usr/bin/systemctl is-active trading-api@8100, \
+    /usr/bin/systemctl is-active trading-api@8101, \
+    /usr/bin/systemctl is-active trading-scanner, \
+    /usr/bin/systemctl daemon-reload, \
+    /usr/sbin/nginx -t, \
+    /usr/sbin/nginx -s reload
+
+ubuntu ALL=(root) NOPASSWD: TRADING_DEPLOY

--- a/deploy/trading-api@.service
+++ b/deploy/trading-api@.service
@@ -1,0 +1,30 @@
+# /etc/systemd/system/trading-api@.service
+# API web-only (template; instancia por puerto: trading-api@8100 / @8101).
+# RUN_SCANNER=0 (no arranca el scanner) + SKIP_DB_INIT=1 (el scanner-service es
+# el dueño del schema). Blue-green detrás de nginx. Fuente de verdad en deploy/.
+[Unit]
+Description=Trading Spacial — API web-only (puerto %i)
+# After= con el scanner en Type=notify ESPERA su READY=1 (post-DDL) → en reboot
+# el schema existe cuando esta API (SKIP_DB_INIT=1) arranca. Wants= (no Requires)
+# = dependencia suave: si el scanner cae luego, la API sigue sirviendo.
+After=network.target trading-scanner.service
+Wants=trading-scanner.service
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/var/www/trading
+EnvironmentFile=/var/www/trading/.env
+Environment=RUN_SCANNER=0 SKIP_DB_INIT=1 RUN_AS_SERVICE=1
+# --timeout-graceful-shutdown 30: drena requests/SSE en vuelo al hacer stop.
+ExecStart=/var/www/trading/.venv/bin/uvicorn btc_api:app --host 127.0.0.1 --port %i --timeout-graceful-shutdown 30
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/www/trading
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/trading-scanner.service
+++ b/deploy/trading-scanner.service
@@ -1,0 +1,30 @@
+# /etc/systemd/system/trading-scanner.service
+# Scanner desacoplado de la API (epic deploy zero-downtime). Dueño del schema +
+# los 5 threads escritores. Type=notify: envía READY=1 tras el DDL (scanner_main
+# ._sd_notify), así las APIs ordenadas After= esperan a que el schema exista —
+# cierra el crash-loop de reboot. Fuente de verdad versionada en deploy/.
+[Unit]
+Description=Trading Spacial — scanner desacoplado (schema owner + 5 threads)
+After=network.target
+
+[Service]
+Type=notify
+NotifyAccess=main
+User=ubuntu
+WorkingDirectory=/var/www/trading
+EnvironmentFile=/var/www/trading/.env
+Environment=RUN_SCANNER=1 RUN_AS_SERVICE=1
+ExecStart=/var/www/trading/.venv/bin/python /var/www/trading/scanner_main.py
+Restart=on-failure
+RestartSec=5
+# Margen para que stop_managed_threads junte los 5 threads (un slider del
+# calibrator en vuelo puede tardar) sin SIGKILL a media transacción.
+TimeoutStopSec=60
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/www/trading
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/trading-upstream.conf
+++ b/deploy/trading-upstream.conf
@@ -1,0 +1,11 @@
+# /etc/nginx/conf.d/trading-upstream.conf
+# Upstream del API de trading. UN solo color activo a la vez (blue-green). El
+# deploy reescribe SOLO la línea `server` (8100 <-> 8101) ATÓMICAMENTE (tmpfile
+# + mv) y hace `nginx -s reload`. El reload no corta conexiones establecidas.
+#
+# El server block trading.sdar.dev.conf debe apuntar sus `proxy_pass` a
+# http://trading_api/ (en vez de http://127.0.0.1:8100/) — ese cambio se hace
+# UNA vez en el cutover (ver deploy/CUTOVER.md), no por el deploy.
+upstream trading_api {
+    server 127.0.0.1:8100;
+}

--- a/docs/superpowers/inventario-estado-vivo.md
+++ b/docs/superpowers/inventario-estado-vivo.md
@@ -16,14 +16,15 @@ Spec: `docs/superpowers/specs/es/2026-06-13-liveness-frescura-huerfanos-design.m
 
 | Reader | Writer | Owner de frescura en prod | Frescura en contrato | Estado |
 |---|---|---|---|---|
-| `GET /valley-candidates` | `tools.run_valley_screener.regenerate` | `screener_loop` (lifespan, 6h) | `LiveSnapshot` | **migrado** |
+| `GET /valley-candidates` | `tools.run_valley_screener.regenerate` | `screener_loop` (**trading-scanner.service**, 6h) | `LiveSnapshot` | **migrado** |
 | `GET /dossier/{symbol}` | `research.dossier.build_dossier_live` | on-request (auto-cura tras TTL) | `LiveSnapshot` | **migrado** |
 | `GET /levels/{symbol}` | Binance on-request (vivo cada request, sin caché) | n/a (no cruza snapshot) | `LiveSnapshot` | **migrado** · plan `2026-06-15-valles-copiloto-agente-real` PASO 0 |
 | `GET /valley-eval/{symbol}` | Binance on-request (vivo cada request, sin caché) | n/a (no cruza snapshot) | `LiveSnapshot` | **migrado** · plan `2026-06-15-valles-copiloto-agente-real` PASO 0 |
-| `observed_orders` + F3a `track_live` | `tools.sync_binance_spot.sync_tenant` | `sync_loop` (lifespan, 5min) | estado en DB (`updated_at`) | **migrado (latido)** · deuda: sin `LiveSnapshot` en el reader |
-| `symbols_status.json` | `update_symbols_json` | `scanner_loop` (lifespan) | trae `updated_at` | **respira-vía-scanner** · deuda: sin `LiveSnapshot` |
+| `observed_orders` + F3a `track_live` | `tools.sync_binance_spot.sync_tenant` | `sync_loop` (**trading-scanner.service**, 5min) | estado en DB (`updated_at`) | **migrado (latido)** · deuda: sin `LiveSnapshot` en el reader |
+| `symbols_status.json` | `update_symbols_json` | `scanner_loop` (**trading-scanner.service**) | trae `updated_at` | **respira-vía-scanner** · deuda: sin `LiveSnapshot` |
 | `equity` | computado on-read (`compute_real_equity`) | n/a (vivo por consulta) | n/a | **respira** (no cruza frontera-snapshot) |
-| `kill_switch state` | `health_monitor_loop` | lifespan | observability | **respira-vía-scanner** · deuda: sin `LiveSnapshot` |
+| `kill_switch state` | `health_monitor_loop` | **trading-scanner.service** | observability | **respira-vía-scanner** · deuda: sin `LiveSnapshot` |
+| `GET /health` (liveness del scanner) | `api.scanner_liveness` (último scan ts DB) | **trading-scanner.service** | `LiveSnapshot` | **migrado** · epic deploy zero-downtime |
 
 ## Cómo se paga la deuda
 Los readers "respira-vía-scanner" están vivos (un thread del lifespan los regenera),


### PR DESCRIPTION
## PR2a — fuente de verdad para el cutover (sin cambio de runtime)

Artefactos versionados para migrar el server a blue-green. **No cambia el `deploy.yml`** (sigue single-process restart) → seguro de mergear; el rsync lleva `deploy/` al server para el cutover.

- `deploy/trading-scanner.service` — scanner desacoplado, `Type=notify` (envía READY=1 tras el DDL → las APIs esperan el schema en reboot), `TimeoutStopSec=60`.
- `deploy/trading-api@.service` — template web-only por puerto, `RUN_SCANNER=0 SKIP_DB_INIT=1`, `--timeout-graceful-shutdown 30`, `After/Wants=trading-scanner`.
- `deploy/trading-upstream.conf` — upstream de nginx (un color activo; el deploy reescribe la línea `server` atómicamente).
- `deploy/sudoers-trading` — allow-list acotado (solo los systemctl/nginx que el CI necesita).
- `deploy/CUTOVER.md` — runbook zero-downtime paso a paso, con rollback en cada punto.
- `inventario-estado-vivo.md` — owner del scanner (`scanner_loop`/`screener_loop`/`sync_loop`/health-monitor) → `trading-scanner.service` (#8).

## Orden
1. Merge PR2a → deploy (single-process) lleva `deploy/` al server.
2. **Cutover manual** (`deploy/CUTOVER.md`) — instalar units + nginx, secuencia zero-downtime.
3. **PR2b** (`deploy.yml` blue-green) — merge DESPUÉS del cutover.

Diseño: `docs/superpowers/specs/es/2026-06-15-deploy-zero-downtime-decouple-scanner-spec.md` (v2, tras críticos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)