### PR TITLE
style(frontend): polish cálido — main sin padding + paneles sin gradiente oscuro

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -32,7 +32,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  padding: 18px 24px 24px;
+  padding: 0;
 }
 .appMobile .main {
   padding: 0 12px;

--- a/frontend/src/components/AgentDock.module.css
+++ b/frontend/src/components/AgentDock.module.css
@@ -67,7 +67,6 @@
   width: 420px;
   height: 560px;
   max-height: calc(100% - 48px);
-  background: linear-gradient(180deg, rgba(14, 19, 18, 0.97), rgba(10, 14, 14, 0.97));
   backdrop-filter: blur(16px) saturate(140%);
   -webkit-backdrop-filter: blur(16px) saturate(140%);
   border: 1px solid var(--bull);
@@ -446,8 +445,8 @@
 /* H.4 history sidebar trigger — lives in the dock header. */
 .historyOpen {
   background: none;
-  border: 1px solid rgba(106, 215, 255, 0.25);
-  color: rgba(232, 237, 243, 0.85);
+  border: 1px solid var(--bull, #6ad7ff);
+  color: var(--bull, #6ad7ff);
   cursor: pointer;
   font-size: 11px;
   letter-spacing: 0.04em;
@@ -455,6 +454,6 @@
   font-family: inherit;
 }
 .historyOpen:hover {
-  border-color: var(--bull, #6ad7ff);
-  color: var(--bull, #6ad7ff);
+  border-color: rgba(106, 215, 255, 0.25);
+  color: rgba(232, 237, 243, 0.85);
 }

--- a/frontend/src/components/AutoTuneView.module.css
+++ b/frontend/src/components/AutoTuneView.module.css
@@ -147,9 +147,7 @@
   gap: 14px;
   padding: 16px 20px;
   border: 1px solid var(--nbc-border-dim);
-  background:
-    linear-gradient(180deg, rgba(106, 215, 255, 0.04), rgba(14, 18, 19, 0.65)),
-    var(--nbc-surface-solid);
+  background: var(--nbc-surface-solid);
   position: relative;
 }
 .brief::before {

--- a/frontend/src/components/ConfigPanel.module.css
+++ b/frontend/src/components/ConfigPanel.module.css
@@ -21,7 +21,7 @@
   width: 460px;
   max-width: 90vw;
   z-index: 100;
-  background: linear-gradient(180deg, rgba(14, 19, 16, 0.98), rgba(10, 14, 12, 0.98));
+  background: var(--warn-dim);
   backdrop-filter: blur(16px) saturate(140%);
   -webkit-backdrop-filter: blur(16px) saturate(140%);
   border-left: 1px solid var(--bull);

--- a/frontend/src/components/HistorialView.module.css
+++ b/frontend/src/components/HistorialView.module.css
@@ -210,9 +210,7 @@
   gap: 14px;
   padding: 16px 20px;
   border: 1px solid var(--nbc-border-dim);
-  background:
-    linear-gradient(180deg, rgba(106, 215, 255, 0.04), rgba(14, 18, 19, 0.65)),
-    var(--nbc-surface-solid);
+  background: var(--nbc-surface-solid);
   position: relative;
 }
 .brief::before {


### PR DESCRIPTION
## Qué es

Ajustes de estilo en vivo sobre el Mercado cálido (Fase 1 ya en `main`), revisados con Samuel pantalla a pantalla.

- **`App.module.css`** — `.main` a `padding: 0` para que el Mercado quede a sangre completa (la columna `.mw-wrap` ya controla su espaciado). Afecta a todas las tabs por compartir `.main`.
- **`AgentDock`** — quitado el gradiente negro de `.dock` (queda vidrio translúcido sobre el papel); invertidos los estados normal/hover de `.historyOpen` (visible por defecto, se atenúa al hover).
- **`AutoTuneView` + `HistorialView`** — `.brief` background → `var(--nbc-surface-solid)` (sin el gradiente oscuro).
- **`ConfigPanel`** — `.slideout` background → `var(--warn-dim)`.

Solo CSS. `vite build` + `tsc` verdes localmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
