### PR TITLE
feat(valles): La Jugada — el Instrumento como 4ta lente (gráfico 1:1 + ciclo completo)

### DIFF
--- a/api/plan.py
+++ b/api/plan.py
@@ -19,6 +19,7 @@ from screener.sr_levels import detect_levels
 from instrument.plan import derive_plan
 from instrument.lifecycle import LifecycleState
 from db.lifecycle_states import db_put_state, db_get_active_state, plan_from_json
+from db.conduct_episodes import db_get_latest_episode
 from db.transaction import snapshot_connection, transaction
 from freshness import LiveSnapshot
 
@@ -160,3 +161,54 @@ def vista(symbol: str, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
         generated_at=row["updated_at"],
         umbral_seg=PLAN_FRESCURA_UMBRAL_SEG,
     ).to_response()
+
+
+# ── Task A3: conducta del último cierre (sin PnL) ────────────────────────────
+
+# Mapeo: campo real en conduct_episodes → etiqueta en tuteo venezolano.
+# rungs_honrados es int (conteo de peldaños llenados) — truthy cuando > 0.
+# adherencia_be puede ser None (inaplicable si TP1 no se llenó) — se trata como falsy.
+_CONDUCT_FIELDS: list[tuple[str, str]] = [
+    ("entry_en_zona",  "Entraste en la zona"),
+    ("sl_respetado",   "Respetaste el stop"),
+    ("adherencia_be",  "Moviste a break-even"),
+    ("rungs_honrados", "Honraste los peldaños"),
+    ("cierre_en_plan", "Cerraste según el plan"),
+]
+
+
+@router.get("/plan/{symbol}/conducta", summary="Conducta del último cierre (sin PnL)")
+def conducta(symbol: str, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
+    """Lee el EpisodioDeConducción del último cierre para tenant+symbol.
+    Hechos de conducta únicamente — NUNCA PnL. Sin episodio → estado_vivo None."""
+    symbol = symbol.upper()[:20]
+    with snapshot_connection() as con:
+        ep = db_get_latest_episode(con, tenant_id=tenant_id, symbol=symbol)
+    if ep is None:
+        return {"symbol": symbol, "estado_vivo": None}
+
+    campos: list[dict] = []
+    all_bool_ok = True
+    for field, label in _CONDUCT_FIELDS:
+        val = ep.get(field)
+        ok = "si" if val else "no"
+        if ok == "no":
+            all_bool_ok = False
+        campos.append({"k": label, "ok": ok})
+
+    hold_hours = ep.get("hold_hours")
+    if hold_hours is not None:
+        campos.append({"k": "Cuánto aguantaste", "ok": "dato", "v": f"{round(hold_hours)} h"})
+
+    titular = (
+        "Honraste el plan que aprobaste."
+        if all_bool_ok
+        else "Esta vez te saliste del plan. Sin reproche — solo el espejo."
+    )
+
+    return {
+        "symbol": symbol,
+        "estado_vivo": "cerrado",
+        "titular": titular,
+        "campos": campos,
+    }

--- a/api/plan.py
+++ b/api/plan.py
@@ -38,12 +38,30 @@ def _zonas_now(symbol: str) -> list[dict]:
     return detect_levels(_fetch_daily_bars(symbol))
 
 
+def _zona_meta(z: dict | None) -> dict | None:
+    """Extrae los campos visuales de una zona (paredes). Devuelve None si no hay zona."""
+    if z is None:
+        return None
+    return {
+        "centro": z["centro"],
+        "precio_bajo": z["precio_bajo"],
+        "precio_alto": z["precio_alto"],
+        "toques": z["toques"],
+    }
+
+
 def _plan_payload(plan) -> dict:
-    return {"entry": plan.entry_price,
-            "sl_plan": plan.sl_price,
-            "rungs": [{"tp_price": r.tp_price, "size_frac": r.size_frac} for r in plan.rungs],
-            "runner_frac": plan.runner_frac,
-            "entry_zone": plan.entry_zone}
+    return {
+        "entry": plan.entry_price,
+        "sl_plan": plan.sl_price,
+        "sl_piso": _zona_meta(plan.sl_zona),  # soporte inmediato que fija el SL (Task A1)
+        "rungs": [
+            {"tp_price": r.tp_price, "size_frac": r.size_frac, "zona": _zona_meta(r.zona_origen)}
+            for r in plan.rungs
+        ],
+        "runner_frac": plan.runner_frac,
+        "entry_zone": plan.entry_zone,
+    }
 
 
 def construir_hechos(*, rungs_llenos: list, be_movido: bool, estado_vivo: str,

--- a/api/plan.py
+++ b/api/plan.py
@@ -74,7 +74,7 @@ def construir_hechos(*, rungs_llenos: list, be_movido: bool, estado_vivo: str,
     Sin imperativos: el instrumento queda fuera del término que mide."""
     hechos: list[str] = []
     if estado_vivo == "incierto":
-        hechos.append("transición sin confirmar — revisá en Binance")
+        hechos.append("transición sin confirmar — revisa en Binance")
     for i in sorted(rungs_llenos):
         hechos.append(f"TP{i + 1} se llenó")
     if be_movido:

--- a/api/plan.py
+++ b/api/plan.py
@@ -20,9 +20,12 @@ from instrument.plan import derive_plan
 from instrument.lifecycle import LifecycleState
 from db.lifecycle_states import db_put_state, db_get_active_state, plan_from_json
 from db.transaction import snapshot_connection, transaction
+from freshness import LiveSnapshot
 
 log = logging.getLogger("api.plan")
 router = APIRouter(tags=["plan"])
+
+PLAN_FRESCURA_UMBRAL_SEG = 900.0
 
 
 class PlanConfirmRequest(BaseModel):
@@ -144,7 +147,7 @@ def vista(symbol: str, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
     hechos = construir_hechos(rungs_llenos=rungs_llenos, be_movido=bool(row["be_movido"]),
                               estado_vivo=row["estado_vivo"], sl_actual=row["sl_actual"],
                               sl_plan=plan.sl_price)
-    return {
+    payload = {
         "symbol": symbol, "estado_vivo": row["estado_vivo"],
         "plan": _plan_payload(plan),
         "realidad": {"fase": row["fase"], "rungs_llenos": rungs_llenos,
@@ -152,3 +155,8 @@ def vista(symbol: str, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
                      "size_restante_frac": row["size_restante_frac"]},
         "hechos": hechos,
     }
+    return LiveSnapshot(
+        payload=payload,
+        generated_at=row["updated_at"],
+        umbral_seg=PLAN_FRESCURA_UMBRAL_SEG,
+    ).to_response()

--- a/api/plan.py
+++ b/api/plan.py
@@ -64,7 +64,7 @@ def _plan_payload(plan) -> dict:
             for r in plan.rungs
         ],
         "runner_frac": plan.runner_frac,
-        "entry_zone": plan.entry_zone,
+        "entry_zone": _zona_meta(plan.entry_zone),
     }
 
 

--- a/db/conduct_episodes.py
+++ b/db/conduct_episodes.py
@@ -46,3 +46,15 @@ def db_get_episodes(con: sqlite3.Connection, *, tenant_id: int) -> list[dict]:
     )
     cols = [c[0] for c in cur.description]
     return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def db_get_latest_episode(con: sqlite3.Connection, *, tenant_id: int, symbol: str) -> dict | None:
+    """Devuelve el episodio de conducta más reciente (por exit_ts) para tenant+symbol, o None."""
+    cur = con.execute(
+        f"SELECT {_COLS} FROM conduct_episodes "
+        "WHERE tenant_id = ? AND symbol = ? ORDER BY exit_ts DESC LIMIT 1",
+        (tenant_id, symbol),
+    )
+    cols = [c[0] for c in cur.description]
+    row = cur.fetchone()
+    return dict(zip(cols, row)) if row is not None else None

--- a/db/lifecycle_states.py
+++ b/db/lifecycle_states.py
@@ -24,6 +24,7 @@ def plan_to_json(plan: Plan) -> str:
     return json.dumps({
         "entry_price": plan.entry_price, "entry_zone": plan.entry_zone,
         "sl_price": plan.sl_price, "runner_frac": plan.runner_frac,
+        "sl_zona": plan.sl_zona,
         "rungs": [{"tp_price": r.tp_price, "size_frac": r.size_frac,
                    "zona_origen": r.zona_origen} for r in plan.rungs],
     })
@@ -35,7 +36,8 @@ def plan_from_json(s: str) -> Plan:
         rungs = tuple(Rung(tp_price=r["tp_price"], size_frac=r["size_frac"],
                            zona_origen=r["zona_origen"]) for r in d["rungs"])
         return Plan(entry_price=d["entry_price"], entry_zone=d["entry_zone"],
-                    sl_price=d["sl_price"], rungs=rungs, runner_frac=d["runner_frac"])
+                    sl_price=d["sl_price"], rungs=rungs, runner_frac=d["runner_frac"],
+                    sl_zona=d.get("sl_zona"))
     except KeyError as e:
         raise ValueError(f"plan_from_json: campo faltante {e} en el plan almacenado") from e
 

--- a/docs/superpowers/plans/2026-06-17-la-jugada-instrumento-en-valles.md
+++ b/docs/superpowers/plans/2026-06-17-la-jugada-instrumento-en-valles.md
@@ -1,0 +1,823 @@
+# La Jugada — el Instrumento en el flujo de Valles — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Integrar 1:1 el handoff de diseño "La Jugada" como cuarta lente del flujo cálido de Valles, con su ciclo completo (derivar → fijar → en curso → conducta al cierre), montando el gráfico de velas con `lightweight-charts` (igual que el resto de la app) más la capa de overlays del diseño.
+
+**Architecture:** El backend ya tiene el Instrumento (`api/plan.py`: `/plan/derive`, `/plan/confirm`, `/plan/{symbol}`). Se enriquece su contrato (metadata de paredes + frescura `LiveSnapshot` + lectura de conducta) y se construye la UI cálida en `frontend/src/components/valles/jugada/`, enchufada en `ValleysFlow` después de Niveles. El gráfico reusa el patrón de `ChartCanvas` (`SymbolDetail.tsx`): `createChart` + `getOhlcv` + `ResizeObserver` + `cssVar`, con tema cálido y una capa HTML de anotaciones posicionada con `series.priceToCoordinate()`.
+
+**Tech Stack:** FastAPI + pytest (backend); React 18 + TypeScript + Vite + vitest + `lightweight-charts ^4.2.0` (frontend). CSS modules cálidos scoped a `.vwRoot` (tokens papel/arcilla/salvia/ocre, Source Serif 4 + Instrument Sans).
+
+**Fuentes 1:1:** handoff extraído en `C:\Users\simon\.claude\uploads\a526b7ee-fc37-4ba1-84e9-7acc5ee2f4ac\extracted\` — archivos load-bearing: `jugada-chart.jsx`, `jugada-candles.jsx`, `jugada-ladder.jsx`, `jugada-screens.jsx`, `jugada-chart-app.jsx`, `data-jugada.jsx`, `jugada-warm.css`, `jugada-chart.css`. Kickoff: `docs/superpowers/specs/es/2026-06-17-kickoff-instrumento-screener-design.md`.
+
+**Regla de copy (transversal a TODO el plan):** el handoff viene en voseo argentino; se implementa en **tuteo venezolano**. Tabla de remapeo obligatoria:
+
+| Voseo (handoff) | Tuteo (implementar) |
+|---|---|
+| si decidís entrar | si decides entrar |
+| hasta dónde aguantás | hasta dónde aguantas |
+| salís por partes | sales por partes |
+| lo que dejás corriendo | lo que dejas corriendo |
+| fijá la jugada / fijás | fija la jugada / fijas |
+| revisá en Binance | revisa en Binance |
+| podés cerrar / hacés / mirás | puedes cerrar / haces / miras |
+| ¿honraste tu plan? | (igual — pretérito, no cambia) |
+| tu stop sube a break-even | (igual) |
+
+Cualquier string nuevo que el handoff traiga en voseo se remapea con esta tabla al portarlo. El microcopy final puede pulirse luego con `solace-wren`; este plan implementa la versión tuteo directa.
+
+---
+
+## File Structure
+
+**Backend (modificar):**
+- `api/plan.py` — enriquecer `_plan_payload` (metadata de paredes), envolver `vista()` en `LiveSnapshot`, añadir `GET /plan/{symbol}/conducta`.
+- `db/lifecycle_states.py` — asegurar que `db_get_active_state` devuelve `updated_at` (para la frescura).
+- `db/conduct_episodes.py` — helper de lectura `db_get_latest_episode` (si no existe).
+
+**Backend (tests):**
+- `tests/test_plan_api.py` — contrato enriquecido, frescura, conducta.
+
+**Frontend (crear):**
+- `frontend/src/components/valles/jugada/types.ts` — tipos locales de la jugada (o extender `frontend/src/types.ts`).
+- `frontend/src/components/valles/jugada/useJugada.ts` — hook que orquesta derive/live/conduct.
+- `frontend/src/components/valles/jugada/LaJugadaChart.tsx` — gráfico de velas + overlays.
+- `frontend/src/components/valles/jugada/overlays.ts` — cálculo puro de geometría de overlays (testeable sin DOM).
+- `frontend/src/components/valles/jugada/JugadaDerivada.tsx`
+- `frontend/src/components/valles/jugada/JugadaGate.tsx` (gate + fijada)
+- `frontend/src/components/valles/jugada/JugadaLive.tsx`
+- `frontend/src/components/valles/jugada/JugadaConducta.tsx`
+- `frontend/src/components/valles/jugada/JugadaSinJugada.tsx`
+- `frontend/src/components/valles/jugada/jugada.module.css` — port de `jugada-warm.css` + `jugada-chart.css` (scoped).
+
+**Frontend (modificar):**
+- `frontend/src/api.ts` — fetchers `getPlanDerive`, `confirmPlan`, `getPlanLive`, `getPlanConducta`.
+- `frontend/src/types.ts` — tipos del contrato `/plan`.
+- `frontend/src/components/valles/ValleysFlow.tsx` — añadir paso `jugada` (4ta lente).
+- `frontend/src/components/valles/PickScreen.tsx` — marca "tiene jugada".
+
+**Frontend (tests):**
+- `frontend/src/components/valles/jugada/overlays.test.ts`
+- `frontend/src/components/valles/jugada/useJugada.test.ts`
+- `frontend/src/api.plan.test.ts`
+
+---
+
+## Phase A — Backend: contrato para 1:1 + frescura #8
+
+### Task A1: Enriquecer `_plan_payload` con la metadata de paredes que el diseño dibuja
+
+El diseño renderiza por peldaño "techo · N toques" y para el SL "debajo del piso de $Y". Hoy `_plan_payload` (`api/plan.py:41-46`) descarta `zona_origen` y devuelve `sl_plan` como float pelado. Hay que exponer la metadata sin romper los campos actuales (aditivo).
+
+**Files:**
+- Modify: `api/plan.py:41-46`
+- Test: `tests/test_plan_api.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_plan_api.py
+from instrument.plan import derive_plan
+from api.plan import _plan_payload
+
+def _zonas():
+    return [
+        {"tipo": "soporte", "precio_bajo": 0.388, "precio_alto": 0.398, "centro": 0.392, "toques": 5},
+        {"tipo": "resistencia", "precio_bajo": 0.445, "precio_alto": 0.451, "centro": 0.448, "toques": 2},
+        {"tipo": "resistencia", "precio_bajo": 0.470, "precio_alto": 0.478, "centro": 0.474, "toques": 4},
+    ]
+
+def test_plan_payload_incluye_metadata_de_paredes():
+    plan = derive_plan(_zonas(), 0.419)
+    p = _plan_payload(plan)
+    # rungs llevan la pared de origen (centro + toques) para "techo · N toques"
+    assert p["rungs"][0]["zona"]["toques"] == 2
+    assert p["rungs"][0]["zona"]["centro"] == 0.448
+    # el SL expone el piso que lo fijó, para "debajo del piso de $Y"
+    assert p["sl_piso"]["centro"] == 0.392
+    assert p["sl_piso"]["precio_bajo"] == 0.388
+    # campos legacy intactos
+    assert p["sl_plan"] == plan.sl_price
+    assert p["entry"] == plan.entry_price
+    assert p["entry_zone"]["toques"] == 5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_plan_api.py::test_plan_payload_incluye_metadata_de_paredes -v`
+Expected: FAIL (`KeyError: 'zona'` / `'sl_piso'`).
+
+- [ ] **Step 3: Implement**
+
+```python
+# api/plan.py — reemplazar _plan_payload
+def _zona_meta(z: dict | None) -> dict | None:
+    if not z:
+        return None
+    return {"centro": z.get("centro"), "precio_bajo": z.get("precio_bajo"),
+            "precio_alto": z.get("precio_alto"), "toques": z.get("toques")}
+
+
+def _plan_payload(plan) -> dict:
+    # `zona_origen` lo pone derive_plan en cada Rung; el soporte del SL se reconstruye
+    # del rung-base si existe, si no queda None (escalera sin soporte → SL = entry).
+    sl_piso = None
+    if plan.entry_zone is not None and plan.sl_price < plan.entry_price:
+        # el SL se fijó bajo un soporte; entry_zone es el soporte donde se sienta el entry
+        sl_piso = _zona_meta(plan.entry_zone)
+    return {"entry": plan.entry_price,
+            "sl_plan": plan.sl_price,
+            "sl_piso": sl_piso,
+            "rungs": [{"tp_price": r.tp_price, "size_frac": r.size_frac,
+                       "zona": _zona_meta(r.zona_origen)} for r in plan.rungs],
+            "runner_frac": plan.runner_frac,
+            "entry_zone": plan.entry_zone}
+```
+
+> Nota de fidelidad: `derive_plan` fija el SL desde `soporte` (el soporte inmediato bajo el entry, `plan.py:45-47,55`), que NO siempre es `entry_zone`. Si querés el piso EXACTO del SL (no el de la zona de entrada), extendé `Plan` con un campo `sl_zona: dict|None` en `instrument/plan.py` (guardar `soporte` en `derive_plan`) y usalo acá. Para v1, `entry_zone` como aproximación del piso es aceptable cuando coinciden; si el test de arriba exige el piso real, hacé la extensión de `Plan` primero. **Decisión de implementación: extender `Plan.sl_zona`** — es lo correcto para 1:1. Ajustá el test y `_plan_payload` para leer `plan.sl_zona`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_plan_api.py::test_plan_payload_incluye_metadata_de_paredes -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/plan.py instrument/plan.py tests/test_plan_api.py
+git commit -m "feat(plan): enriquecer payload con metadata de paredes (toques/piso) para La Jugada 1:1"
+```
+
+### Task A2: Envolver `GET /plan/{symbol}` en `LiveSnapshot` (No-Negociable #8)
+
+La vista viva debe emitir su frescura en el contrato. `LiveSnapshot(payload, generated_at, umbral_seg).to_response()` añade `frescura:{estado,edad_seg,generated_at,umbral_seg}` (`freshness.py:44-48`). El `generated_at` es el `updated_at` de la fila.
+
+**Files:**
+- Modify: `api/plan.py:115-136` (`vista`), `db/lifecycle_states.py` (`db_get_active_state` debe devolver `updated_at`)
+- Test: `tests/test_plan_api.py`
+
+- [ ] **Step 1: Verify `db_get_active_state` returns `updated_at`**
+
+Run: `grep -n "updated_at" db/lifecycle_states.py`
+Si la `SELECT` de `db_get_active_state` no incluye `updated_at`, añadilo a la lista de columnas seleccionadas y al dict devuelto.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/test_plan_api.py
+def test_vista_emite_frescura_en_el_contrato(monkeypatch):
+    # fila viva fresca → frescura.estado == 'fresco'; sin fila → estado_vivo None sin frescura obligatoria
+    from datetime import datetime, timezone
+    import api.plan as plan_api
+
+    now = datetime.now(timezone.utc).isoformat()
+    fake_row = {
+        "plan_json": '{"entry_price":0.419,"entry_zone":null,"sl_price":0.385,"rungs":[],"runner_frac":0.05}',
+        "rungs_llenos_json": "[]", "be_movido": 0, "estado_vivo": "activo",
+        "sl_actual": 0.385, "fase": "CONFIRMED", "size_restante_frac": 1.0, "updated_at": now,
+    }
+    monkeypatch.setattr(plan_api, "db_get_active_state", lambda con, **kw: fake_row)
+    monkeypatch.setattr(plan_api, "snapshot_connection", lambda: __import__("contextlib").nullcontext(None))
+    out = plan_api.vista("ADAUSDT", tenant_id=1)
+    assert out["frescura"]["estado"] == "fresco"
+    assert out["frescura"]["generated_at"] == now
+    assert out["estado_vivo"] == "activo"
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_plan_api.py::test_vista_emite_frescura_en_el_contrato -v`
+Expected: FAIL (`KeyError: 'frescura'`).
+
+- [ ] **Step 4: Implement**
+
+```python
+# api/plan.py — al inicio del módulo
+from freshness import LiveSnapshot
+PLAN_FRESCURA_UMBRAL_SEG = 900.0   # 3× la cadencia de track_live (5 min); coherente con scanner
+
+# api/plan.py — reescribir el return final de vista() (líneas 129-136)
+    payload = {
+        "symbol": symbol, "estado_vivo": row["estado_vivo"],
+        "plan": _plan_payload(plan),
+        "realidad": {"fase": row["fase"], "rungs_llenos": rungs_llenos,
+                     "sl_actual": row["sl_actual"], "be_movido": bool(row["be_movido"]),
+                     "size_restante_frac": row["size_restante_frac"]},
+        "hechos": hechos,
+    }
+    return LiveSnapshot(payload=payload, generated_at=row["updated_at"],
+                        umbral_seg=PLAN_FRESCURA_UMBRAL_SEG).to_response()
+```
+
+> El caso `row is None` (sin plan activo, `api/plan.py:122-123`) sigue devolviendo `{"symbol", "estado_vivo": None}` sin frescura: no hay estado vivo que clasificar.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_plan_api.py::test_vista_emite_frescura_en_el_contrato -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/plan.py db/lifecycle_states.py tests/test_plan_api.py
+git commit -m "feat(plan): vista viva emite frescura via LiveSnapshot (No-Negociable #8)"
+```
+
+### Task A3: `GET /plan/{symbol}/conducta` — lectura de conducta al cierre
+
+La pantalla de conducta lee el `EpisodioDeConducción` del último plan cerrado (`conduct_episodes`). Hechos de conducta, sin PnL.
+
+**Files:**
+- Modify: `api/plan.py` (nuevo endpoint), `db/conduct_episodes.py` (helper de lectura si falta)
+- Test: `tests/test_plan_api.py`
+
+- [ ] **Step 1: Verify read helper exists**
+
+Run: `grep -n "def db_get" db/conduct_episodes.py`
+Si no hay un getter por `tenant_id`+`symbol`, añadí `db_get_latest_episode(con, *, tenant_id, symbol) -> dict | None` que haga `SELECT ... FROM conduct_episodes WHERE tenant_id=? AND symbol=? ORDER BY closed_at DESC LIMIT 1`.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/test_plan_api.py
+def test_conducta_devuelve_campos_sin_pnl(monkeypatch):
+    import api.plan as plan_api
+    fake_ep = {"symbol": "ADAUSDT", "entry_en_zona": 1, "sl_respetado": 1,
+               "adherencia_be": 1, "rungs_honrados": 1, "cierre_en_plan": 0,
+               "hold_hours": 51.0, "closed_at": "2026-06-17T00:00:00+00:00"}
+    monkeypatch.setattr(plan_api, "db_get_latest_episode", lambda con, **kw: fake_ep, raising=False)
+    monkeypatch.setattr(plan_api, "snapshot_connection", lambda: __import__("contextlib").nullcontext(None))
+    out = plan_api.conducta("ADAUSDT", tenant_id=1)
+    assert out["estado_vivo"] == "cerrado"
+    assert "pnl" not in out and "pnl_usd" not in out
+    assert any(c["k"] == "Entraste en la zona" and c["ok"] == "si" for c in out["campos"])
+    assert any(c["k"] == "Cerraste según el plan" and c["ok"] == "no" for c in out["campos"])
+```
+
+- [ ] **Step 3: Implement**
+
+```python
+# api/plan.py
+from db.conduct_episodes import db_get_latest_episode
+
+_CONDUCT_FIELDS = [
+    ("entry_en_zona", "Entraste en la zona"),
+    ("sl_respetado", "Respetaste el stop"),
+    ("adherencia_be", "Moviste a break-even"),
+    ("rungs_honrados", "Honraste los peldaños"),
+    ("cierre_en_plan", "Cerraste según el plan"),
+]
+
+@router.get("/plan/{symbol}/conducta", summary="Lectura de conducta del último cierre (sin PnL)")
+def conducta(symbol: str, tenant_id: int = Depends(get_current_tenant_id)) -> dict:
+    symbol = symbol.upper()[:20]
+    with snapshot_connection() as con:
+        ep = db_get_latest_episode(con, tenant_id=tenant_id, symbol=symbol)
+    if ep is None:
+        return {"symbol": symbol, "estado_vivo": None}
+    campos = [{"k": label, "ok": ("si" if ep[key] else "no")} for key, label in _CONDUCT_FIELDS]
+    campos.append({"k": "Cuánto aguantaste", "ok": "dato",
+                   "v": f"{round(ep['hold_hours'])} h"})
+    honrada = all(ep[k] for k, _ in _CONDUCT_FIELDS)
+    return {"symbol": symbol, "estado_vivo": "cerrado",
+            "titular": "Honraste el plan que aprobaste." if honrada
+                       else "Esta vez te saliste del plan. Sin reproche — solo el espejo.",
+            "campos": campos}
+```
+
+- [ ] **Step 4: Run test; Step 5: Commit**
+
+Run: `python -m pytest tests/test_plan_api.py -v`
+```bash
+git add api/plan.py db/conduct_episodes.py tests/test_plan_api.py
+git commit -m "feat(plan): GET /plan/{symbol}/conducta — lectura de conducta sin PnL"
+```
+
+---
+
+## Phase B — Frontend: tipos + fetchers
+
+### Task B1: Tipos del contrato `/plan`
+
+**Files:**
+- Modify: `frontend/src/types.ts` (añadir al final)
+
+- [ ] **Step 1: Add types**
+
+```typescript
+// frontend/src/types.ts — La Jugada / Instrumento
+export interface PlanZonaMeta { centro: number; precio_bajo: number; precio_alto: number; toques: number; }
+export interface PlanRung { tp_price: number; size_frac: number; zona: PlanZonaMeta | null; }
+export interface PlanDerived {
+  symbol?: string;
+  entry: number;
+  sl_plan: number;
+  sl_piso: PlanZonaMeta | null;
+  rungs: PlanRung[];
+  runner_frac: number;
+  entry_zone: PlanZonaMeta | null;
+}
+export interface PlanFrescura { estado: 'fresco' | 'rancio' | 'muerto'; edad_seg: number | null; generated_at: string | null; umbral_seg: number; }
+export interface PlanLive {
+  symbol: string;
+  estado_vivo: 'activo' | 'incierto' | 'cerrado' | null;
+  plan?: PlanDerived;
+  realidad?: { fase: string; rungs_llenos: number[]; sl_actual: number | null; be_movido: boolean; size_restante_frac: number | null; };
+  hechos?: string[];
+  frescura?: PlanFrescura;
+}
+export interface PlanConductaField { k: string; ok: 'si' | 'no' | 'dato'; v?: string; }
+export interface PlanConducta { symbol: string; estado_vivo: 'cerrado' | null; titular?: string; campos?: PlanConductaField[]; }
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: no nuevos errores.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/types.ts
+git commit -m "feat(valles): tipos del contrato /plan (La Jugada)"
+```
+
+### Task B2: Fetchers en `api.ts`
+
+Mirror del patrón existente (`getLevels` en `api.ts:427`, `getOhlcv` en `api.ts:184`, POST como `updateConfig` en `api.ts:203`).
+
+**Files:**
+- Modify: `frontend/src/api.ts`
+- Test: `frontend/src/api.plan.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// frontend/src/api.plan.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as api from './api';
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true, status: 200, json: async () => ({ entry: 0.419, sl_plan: 0.385, sl_piso: null, rungs: [], runner_frac: 0.05, entry_zone: null }),
+  })));
+});
+
+describe('plan fetchers', () => {
+  it('getPlanDerive pega a /plan/derive con entry_price', async () => {
+    await api.getPlanDerive('ADAUSDT', 0.4205);
+    const url = (fetch as any).mock.calls[0][0] as string;
+    expect(url).toContain('/plan/derive/ADAUSDT');
+    expect(url).toContain('entry_price=0.4205');
+  });
+});
+```
+
+- [ ] **Step 2: Run; verify fails**
+
+Run: `cd frontend && npx vitest run src/api.plan.test.ts`
+Expected: FAIL (`getPlanDerive is not a function`).
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// frontend/src/api.ts — bloque "La Jugada / Instrumento — /plan"
+import type { PlanDerived, PlanLive, PlanConducta } from './types';
+
+export function getPlanDerive(symbol: string, entryPrice: number) {
+  return request<PlanDerived>(`/plan/derive/${symbol}?entry_price=${entryPrice}`);
+}
+export function getPlanLive(symbol: string) {
+  return request<PlanLive>(`/plan/${symbol}`);
+}
+export function getPlanConducta(symbol: string) {
+  return request<PlanConducta>(`/plan/${symbol}/conducta`);
+}
+export function confirmPlan(symbol: string, entryPrice: number, positionId?: number) {
+  return request<{ symbol: string; estado_vivo: string; plan: PlanDerived }>('/plan/confirm', {
+    method: 'POST',
+    body: JSON.stringify({ symbol, entry_price: entryPrice, position_id: positionId ?? null }),
+  });
+}
+```
+
+> **Verificar auth de `confirmPlan`:** `POST /plan/confirm` usa `verify_api_key` (`api/plan.py:80`), no la cookie de sesión. Revisá cómo otros writes (p.ej. el dock copiloto / posiciones) pasan la API key en `request()` (header `X-API-Key` o equivalente) y replicá el mecanismo. Si `request()` ya inyecta CSRF+key para no-GET, no hace falta nada extra.
+
+- [ ] **Step 4: Run; Step 5: Commit**
+
+Run: `cd frontend && npx vitest run src/api.plan.test.ts` → PASS
+```bash
+git add frontend/src/api.ts frontend/src/api.plan.test.ts
+git commit -m "feat(valles): fetchers /plan (derive/confirm/live/conducta)"
+```
+
+---
+
+## Phase C — El gráfico (lightweight-charts + overlays)
+
+### Task C1: Geometría pura de overlays (testeable sin DOM)
+
+Separá el cálculo precio→coordenada y la forma de cada overlay en un módulo puro (lo que en el handoff vive dentro de `recompute()` de `jugada-chart.jsx`). Esto se testea sin canvas.
+
+**Files:**
+- Create: `frontend/src/components/valles/jugada/overlays.ts`
+- Test: `frontend/src/components/valles/jugada/overlays.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// overlays.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildOverlays } from './overlays';
+import type { PlanDerived } from '../../../types';
+
+const plan: PlanDerived = {
+  entry: 0.419, sl_plan: 0.385, sl_piso: { centro: 0.392, precio_bajo: 0.388, precio_alto: 0.398, toques: 5 },
+  entry_zone: { centro: 0.419, precio_bajo: 0.412, precio_alto: 0.426, toques: 5 },
+  rungs: [
+    { tp_price: 0.448, size_frac: 0.50, zona: { centro: 0.448, precio_bajo: 0.445, precio_alto: 0.451, toques: 2 } },
+    { tp_price: 0.474, size_frac: 0.20, zona: { centro: 0.474, precio_bajo: 0.470, precio_alto: 0.478, toques: 4 } },
+  ],
+  runner_frac: 0.05,
+};
+
+describe('buildOverlays', () => {
+  it('zona de entrada es banda (no línea): top != bottom', () => {
+    const o = buildOverlays({ plan, live: 0.4205, state: null });
+    expect(o.zone).toBeTruthy();
+    expect(o.zone!.priceLow).toBe(0.412);
+    expect(o.zone!.priceHigh).toBe(0.426);
+  });
+  it('precio dentro de la zona → live.fuera = false; arriba → true', () => {
+    expect(buildOverlays({ plan, live: 0.4205, state: null }).live.fuera).toBe(false);
+    expect(buildOverlays({ plan, live: 0.4400, state: null }).live.fuera).toBe(true);
+  });
+  it('rung lleno cuando state.rungs_llenos lo incluye; BE mueve el stop', () => {
+    const o = buildOverlays({ plan, live: 0.45, state: { rungs_llenos: [0], be_movido: true, sl_actual: 0.419 } });
+    expect(o.rungs[0].filled).toBe(true);
+    expect(o.rungs[1].filled).toBe(false);
+    expect(o.stop.be).toBe(true);
+    expect(o.stop.price).toBe(0.419);
+  });
+  it('escalera corta (1 rung) marca gap honesto', () => {
+    const corto = { ...plan, rungs: [plan.rungs[0]] };
+    expect(buildOverlays({ plan: corto, live: 0.4205, state: null }).gap).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run; verify fails.** Run: `cd frontend && npx vitest run src/components/valles/jugada/overlays.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement** (portar la lógica de `jugada-chart.jsx::recompute` a datos reales)
+
+```typescript
+// overlays.ts
+import type { PlanDerived } from '../../../types';
+
+export interface LiveState { rungs_llenos: number[]; be_movido: boolean; sl_actual: number | null; }
+export interface OverlayModel {
+  zone: { priceLow: number; priceHigh: number; toques: number } | null;
+  stop: { price: number; be: boolean; piso: number | null };
+  rungs: { price: number; sizeFrac: number; toques: number | null; filled: boolean }[];
+  runner: { frac: number; fromPrice: number } | null;
+  live: { price: number; fuera: 'arriba' | 'abajo' | false };
+  gap: boolean;  // escalera corta: no hay más techos
+}
+
+export function buildOverlays(args: { plan: PlanDerived; live: number; state: LiveState | null }): OverlayModel {
+  const { plan, live, state } = args;
+  const z = plan.entry_zone;
+  let fuera: 'arriba' | 'abajo' | false = false;
+  if (z) { if (live > z.precio_alto) fuera = 'arriba'; else if (live < z.precio_bajo) fuera = 'abajo'; }
+  const llenos = state?.rungs_llenos ?? [];
+  const topRung = plan.rungs.length ? plan.rungs[plan.rungs.length - 1].tp_price : plan.entry;
+  return {
+    zone: z ? { priceLow: z.precio_bajo, priceHigh: z.precio_alto, toques: z.toques } : null,
+    stop: { price: state?.be_movido ? (state.sl_actual ?? plan.sl_plan) : plan.sl_plan,
+            be: !!state?.be_movido, piso: plan.sl_piso?.centro ?? null },
+    rungs: plan.rungs.map((r, i) => ({ price: r.tp_price, sizeFrac: r.size_frac,
+            toques: r.zona?.toques ?? null, filled: llenos.includes(i) })),
+    runner: plan.runner_frac > 0 ? { frac: plan.runner_frac, fromPrice: topRung } : null,
+    live: { price: live, fuera },
+    gap: plan.rungs.length === 1,
+  };
+}
+```
+
+- [ ] **Step 4: Run → PASS. Step 5: Commit**
+
+```bash
+git add frontend/src/components/valles/jugada/overlays.ts frontend/src/components/valles/jugada/overlays.test.ts
+git commit -m "feat(jugada): geometria pura de overlays (zona/stop/escalera/runner/gap)"
+```
+
+### Task C2: CSS cálido del gráfico y las pantallas
+
+Port verbatim de `jugada-warm.css` + `jugada-chart.css` (del handoff) a un único módulo, scoped, reusando los tokens cálidos ya existentes de Valles.
+
+**Files:**
+- Create: `frontend/src/components/valles/jugada/jugada.module.css`
+
+- [ ] **Step 1: Port**
+
+Transformaciones al copiar `extracted/jugada-warm.css` + `extracted/jugada-chart.css`:
+1. Concatenar ambos en `jugada.module.css`.
+2. Eliminar la redefinición de tokens `--paper/--clay/--sage/--ochre/...` si ya están en `valles.module.css`/`warm-tokens.css`; si el módulo está aislado, mantenerlos (no filtran fuera del scope CSS-module).
+3. Prefijar/anidar todo bajo el scope de Valles (las clases ya son `ju-*`; en CSS-modules quedan locales automáticamente — no hace falta `.vwRoot` manual salvo para heredar tokens; importar el módulo y usar `styles['ju-chart']`).
+4. NO tocar valores de color, tamaños, easings, hatching: es 1:1 visual.
+
+- [ ] **Step 2: Verify build picks it up** (se valida al usarlo en C3). Commit:
+
+```bash
+git add frontend/src/components/valles/jugada/jugada.module.css
+git commit -m "feat(jugada): CSS calido del grafico y pantallas (port 1:1)"
+```
+
+### Task C3: `LaJugadaChart.tsx` — velas reales + capa de overlays
+
+Montaje idéntico al `ChartCanvas` de `SymbolDetail.tsx:214-346` (createChart + getOhlcv + ResizeObserver + cssVar + cleanup), tema cálido del handoff (`jugada-chart.jsx:40-56`), y la capa `.ju-chart__ann` posicionada con `series.priceToCoordinate()`.
+
+**Files:**
+- Create: `frontend/src/components/valles/jugada/LaJugadaChart.tsx`
+
+- [ ] **Step 1: Implement el armazón del gráfico**
+
+```tsx
+// LaJugadaChart.tsx
+import React, { useEffect, useRef, useState } from 'react';
+import { createChart, type IChartApi, type ISeriesApi } from 'lightweight-charts';
+import { getOhlcv } from '../../../api';
+import type { PlanDerived } from '../../../types';
+import { buildOverlays, type LiveState } from './overlays';
+import styles from './jugada.module.css';
+
+export const LaJugadaChart: React.FC<{
+  symbol: string; plan: PlanDerived; live: number; state?: LiveState | null;
+  phaseLabel: string; height?: number;
+}> = ({ symbol, plan, live, state = null, phaseLabel, height = 420 }) => {
+  const wrap = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+  const [, force] = useState(0);   // re-render para recolocar overlays
+
+  useEffect(() => {
+    if (!wrap.current) return;
+    const chart = createChart(wrap.current, {
+      layout: { background: { type: 'solid' as never, color: 'transparent' }, textColor: '#8A8270',
+                fontFamily: "'Instrument Sans', sans-serif", fontSize: 11 },
+      grid: { vertLines: { visible: false }, horzLines: { color: 'rgba(228,220,204,0.55)' } },
+      rightPriceScale: { borderColor: '#E4DCCC', scaleMargins: { top: 0.07, bottom: 0.07 }, entireTextOnly: true },
+      timeScale: { visible: false, borderVisible: false },
+      crosshair: { mode: 0 as never },
+      handleScroll: false, handleScale: false,
+      width: wrap.current.clientWidth, height,
+    });
+    const series = chart.addCandlestickSeries({
+      upColor: '#DAD0BD', downColor: '#9E947F', borderUpColor: '#A89A82', borderDownColor: '#6F6657',
+      wickUpColor: '#A89A82', wickDownColor: '#7C7263', priceLineVisible: false, lastValueVisible: false,
+      priceFormat: { type: 'price', precision: 4, minMove: 0.0001 },
+    });
+    chartRef.current = chart; seriesRef.current = series;
+
+    getOhlcv(symbol, '1d', 180).then((res) => {
+      series.setData(res.candles.map((c) => ({ time: c.time as never, open: c.open, high: c.high, low: c.low, close: c.close })));
+      chart.timeScale().fitContent();
+      force((n) => n + 1);
+    });
+
+    const ro = new ResizeObserver(() => { chart.applyOptions({ width: wrap.current!.clientWidth }); force((n) => n + 1); });
+    ro.observe(wrap.current);
+    const onRange = () => force((n) => n + 1);
+    chart.timeScale().subscribeVisibleLogicalRangeChange(onRange);
+    return () => { ro.disconnect(); chart.remove(); chartRef.current = null; seriesRef.current = null; };
+  }, [symbol, height]);
+
+  // posición de cada overlay vía priceToCoordinate
+  const s = seriesRef.current;
+  const y = (p: number) => (s ? s.priceToCoordinate(p) : null);
+  const ov = buildOverlays({ plan, live, state });
+
+  return (
+    <div className={styles['ju-chart']} style={{ height }}>
+      <div ref={wrap} className={styles['ju-chart__canvas']} />
+      <div className={styles['ju-chart__legend']}>{symbol} · diario · paredes de D.1</div>
+      <div className={styles['ju-chart__phase']}>{phaseLabel}</div>
+      <div className={styles['ju-chart__ann']}>
+        {/* zona de entrada (banda) */}
+        {ov.zone && y(ov.zone.priceHigh) != null && y(ov.zone.priceLow) != null && (
+          <div className={styles['ju-ann-zone']}
+               style={{ top: y(ov.zone.priceHigh)!, height: Math.max(2, y(ov.zone.priceLow)! - y(ov.zone.priceHigh)!) }}>
+            <span className={styles['ju-ann-zone__lbl']}>ZONA DE ENTRADA<b>${ov.zone.priceLow}–${ov.zone.priceHigh}</b></span>
+          </div>
+        )}
+        {/* runner */}
+        {ov.runner && y(ov.runner.fromPrice) != null && (
+          <div className={styles['ju-ann-runner']} style={{ top: 0, height: y(ov.runner.fromPrice)! }}>
+            <span>runner · {Math.round(ov.runner.frac * 100)}% abierto ↑</span>
+          </div>
+        )}
+        {/* escalera */}
+        {ov.rungs.map((r, i) => y(r.price) != null && (
+          <div key={i} className={`${styles['ju-ann-line']} ${styles['ju-ann--rung']} ${r.filled ? styles['is-filled'] : ''}`} style={{ top: y(r.price)! }}>
+            <span className={styles['ju-ann-tag']}>{r.filled ? 'llena' : `salida ${i + 1}`} · ${r.price} · {Math.round(r.sizeFrac * 100)}%{r.toques != null ? ` · techo ${r.toques} toques` : ''}</span>
+          </div>
+        ))}
+        {/* stop / break-even */}
+        {y(ov.stop.price) != null && (
+          <div className={`${styles['ju-ann-line']} ${ov.stop.be ? styles['ju-ann--be'] : styles['ju-ann--stop']}`} style={{ top: y(ov.stop.price)! }}>
+            <span className={styles['ju-ann-tag']}>{ov.stop.be ? 'break-even' : 'stop'} · ${ov.stop.price}</span>
+          </div>
+        )}
+        {/* precio vivo */}
+        {y(ov.live.price) != null && (
+          <div className={`${styles['ju-ann-live']} ${ov.live.fuera ? styles['ju-ann-live--fuera'] : ''}`} style={{ top: y(ov.live.price)! }}>
+            {ov.live.fuera ? 'precio de ahora' : 'ahora'} ${ov.live.price}
+          </div>
+        )}
+        {/* hueco honesto */}
+        {ov.gap && (
+          <div className={styles['ju-chart__gap']}>Arriba del primer techo no hay más paredes claras. La escalera queda corta — no se inventan techos.</div>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+> Notas de fidelidad: (a) el `time` real viene de `/ohlcv` (`OhlcvCandle.time`), no de las velas mock; los overlays se posicionan por PRECIO, así calzan con cualquier set real. (b) Mantené el workaround de "jiggle" de `jugada-chart.jsx:28-35` solo si ves el bitmap sin refrescar. (c) `crosshair.mode: 0` y `handleScroll/Scale:false` = lámina editorial, no terminal (1:1 con el handoff).
+
+- [ ] **Step 2: Smoke test (jsdom mock de lightweight-charts)**
+
+```tsx
+// LaJugadaChart.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+vi.mock('lightweight-charts', () => ({
+  createChart: () => ({
+    addCandlestickSeries: () => ({ setData: vi.fn(), priceToCoordinate: (p: number) => p * 1000 }),
+    timeScale: () => ({ fitContent: vi.fn(), subscribeVisibleLogicalRangeChange: vi.fn() }),
+    applyOptions: vi.fn(), remove: vi.fn(),
+  }),
+}));
+vi.mock('../../../api', () => ({ getOhlcv: async () => ({ candles: [], volumes: [] }) }));
+import { LaJugadaChart } from './LaJugadaChart';
+const plan = { entry: 0.419, sl_plan: 0.385, sl_piso: null, entry_zone: { centro: 0.419, precio_bajo: 0.412, precio_alto: 0.426, toques: 5 }, rungs: [{ tp_price: 0.448, size_frac: 0.5, zona: { centro: 0.448, precio_bajo: 0.445, precio_alto: 0.451, toques: 2 } }], runner_frac: 0.05 };
+describe('LaJugadaChart', () => {
+  it('renderiza la banda de zona de entrada', async () => {
+    const { findByText } = render(<LaJugadaChart symbol="ADAUSDT" plan={plan as never} live={0.4205} phaseLabel="derivada" />);
+    expect(await findByText(/ZONA DE ENTRADA/)).toBeTruthy();
+  });
+});
+```
+
+Run: `cd frontend && npx vitest run src/components/valles/jugada/LaJugadaChart.test.tsx` → PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/valles/jugada/LaJugadaChart.tsx frontend/src/components/valles/jugada/LaJugadaChart.test.tsx
+git commit -m "feat(jugada): grafico de velas (lightweight-charts) + capa de overlays 1:1"
+```
+
+---
+
+## Phase D — Las pantallas (port de jugada-screens.jsx, tuteo)
+
+> Cada pantalla porta el markup + clases de `extracted/jugada-screens.jsx` (componentes `JuDerivada/JuGate/JuGateFijada/JuLive/JuConducta/JuSinJugada`), reemplaza `window.*` por imports ES, los datos mock por props del hook (Task E1), e **inserta el copy en tuteo** (tabla de remapeo del header). El gráfico/escalera usa `LaJugadaChart` (Task C3) en vez de `SalidaLadder` (la lámina de divs queda descartada: el gráfico canónico es el de velas — requisito del usuario "montado como en la app").
+
+### Task D1: `JugadaDerivada.tsx`
+**Files:** Create `frontend/src/components/valles/jugada/JugadaDerivada.tsx`
+- [ ] Portar `JuDerivada` (`jugada-screens.jsx`): eyebrow "calculado al precio de ahora", h2 "Si decides entrar, así se sale por partes.", `<LaJugadaChart phaseLabel="derivada · al precio de ahora" .../>`, 4 hechos (zona/stop/escalera/runner) y procedencia — todos en tuteo (§7.2 de la spec). Estados: dentro de zona, fuera de zona (precio ocre), escalera corta.
+- [ ] Smoke test: render con `plan` mock → aparece "Si decides entrar".
+- [ ] Commit: `feat(jugada): pantalla derivada (tuteo)`
+
+### Task D2: `JugadaGate.tsx` (gate + fijada)
+**Files:** Create `frontend/src/components/valles/jugada/JugadaGate.tsx`
+- [ ] Portar `JuGate` + `JuGateFijada`: h2 "Fija la jugada, en frío.", mini-escalera de chips, disclaimer ocre "Confirmar no ejecuta…", botón "Fijar esta jugada" → llama `confirmPlan(sym, entry)`; al éxito muestra estado "Jugada fijada. Desde acá se sigue en vivo." Tuteo (§7.3-7.4).
+- [ ] Test: click en "Fijar esta jugada" llama `confirmPlan` (mock) con `(symbol, entry)`.
+- [ ] Commit: `feat(jugada): gate de confirmar + fijada (tuteo)`
+
+### Task D3: `JugadaLive.tsx`
+**Files:** Create `frontend/src/components/valles/jugada/JugadaLive.tsx`
+- [ ] Portar `JuLive`: header con `FreshTag` leyendo `live.frescura.estado` (fresco salvia / rancio ocre) + edad; `<LaJugadaChart state={...} phaseLabel="en curso"/>`; hechos vivos desde `live.hechos[]` (el backend ya los trae — render directo, sin recomponer); avisos incierto/rancio. "◔ solo lectura · sin avisos". Tuteo (§7.5).
+- [ ] Test: con `frescura.estado='rancio'` renderiza el aviso "puede haber cambiado".
+- [ ] Commit: `feat(jugada): pantalla en curso con frescura (tuteo)`
+
+### Task D4: `JugadaConducta.tsx`
+**Files:** Create `frontend/src/components/valles/jugada/JugadaConducta.tsx`
+- [ ] Portar `JuConducta`: h2 "¿Honraste tu plan?", titular desde `conducta.titular`, campos desde `conducta.campos[]` (`ok:'si'`→salvia ✓, `'no'`→ocre ○, `'dato'`→tinta ·), bloque espejo "Es un espejo, no un juez… sin PnL". Tuteo (§7.6).
+- [ ] Test: campo con `ok:'no'` renderiza marca ○ y NO aparece ningún "$"/PnL.
+- [ ] Commit: `feat(jugada): lectura de conducta sin PnL (tuteo)`
+
+### Task D5: `JugadaSinJugada.tsx`
+**Files:** Create `frontend/src/components/valles/jugada/JugadaSinJugada.tsx`
+- [ ] Portar `JuSinJugada`: "Esta moneda no da estructura para una jugada." + "Sin paredes claras, no hay salida que escalonar" + procedencia. Tuteo (§7.7).
+- [ ] Commit: `feat(jugada): estado vacio honesto (tuteo)`
+
+---
+
+## Phase E — Integración en el flujo
+
+### Task E1: `useJugada.ts` — hook que orquesta derive/live/conducta
+
+**Files:** Create `frontend/src/components/valles/jugada/useJugada.ts`; Test `useJugada.test.ts`
+
+- [ ] **Step 1: Test (estado de carga + ramas)**
+
+```typescript
+// useJugada.test.ts — verifica que deriva al precio vivo (price_live de niveles)
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+vi.mock('../../../api', () => ({
+  getPlanDerive: vi.fn(async () => ({ entry: 0.42, sl_plan: 0.385, sl_piso: null, entry_zone: null, rungs: [], runner_frac: 0.05 })),
+  getPlanLive: vi.fn(async () => ({ symbol: 'ADAUSDT', estado_vivo: null })),
+  getPlanConducta: vi.fn(async () => ({ symbol: 'ADAUSDT', estado_vivo: null })),
+}));
+import * as api from '../../../api';
+import { useJugada } from './useJugada';
+describe('useJugada', () => {
+  it('deriva al precio vivo recibido', async () => {
+    const { result } = renderHook(() => useJugada('ADAUSDT', 0.4205));
+    await waitFor(() => expect(result.current.derived.data).toBeTruthy());
+    expect(api.getPlanDerive).toHaveBeenCalledWith('ADAUSDT', 0.4205);
+  });
+});
+```
+
+- [ ] **Step 2: Implement** — hook con tres `AsyncState` (derived, live, conducta), reusando el patrón de `useValleyBundle` (`AsyncState<T> = {data,loading,error}`). `derived` se pide con `getPlanDerive(symbol, livePrice)`; `live` con `getPlanLive`; `conducta` con `getPlanConducta`. `livePrice` viene del caller (de `bundle.niveles.data.price_live`).
+
+- [ ] **Step 3: Run → PASS. Commit:** `feat(jugada): hook useJugada (derive/live/conducta)`
+
+### Task E2: Enchufar la 4ta lente en `ValleysFlow.tsx`
+
+**Files:** Modify `frontend/src/components/valles/ValleysFlow.tsx`
+
+- [ ] **Step 1: Cambios exactos**
+
+```tsx
+// 1. STEPS (línea 13): añadir 'jugada' tras 'niveles'
+const STEPS = ['pick', 'vida', 'niveles', 'jugada', 'fund', 'cierre'] as const;
+// 2. LENS (líneas 15-17): añadir "La jugada"
+const LENS = [
+  { key: 'vida', label: 'Vida' }, { key: 'niveles', label: 'Niveles' },
+  { key: 'jugada', label: 'La jugada' }, { key: 'fund', label: 'Quién' },
+];
+// 3. branch de screen (tras la línea 49, antes de 'fund'):
+else if (cur === 'jugada') {
+  const live = bundle.niveles.data?.price_live ?? null;
+  screen = <JugadaLens symbol={sym} livePrice={live} />;   // wrapper que usa useJugada + las pantallas D1-D5
+}
+// 4. lensIdx (línea 53): remapear
+const lensIdx = cur === 'cierre' ? 4 : ({ vida: 0, niveles: 1, jugada: 2, fund: 3 } as Record<string, number>)[cur];
+// 5. nav: el botón "Siguiente" desde 'niveles' lleva a 'jugada'; desde 'jugada' a 'fund'.
+//    Ajustar el label de 'fund' (la última lente antes de cierre sigue siendo "Cerrar el recorrido").
+```
+
+Crear el wrapper `JugadaLens.tsx` (en `jugada/`) que: llama `useJugada(symbol, livePrice)`, y según el estado elige la pantalla — si `live.estado_vivo === 'cerrado'` → `JugadaConducta`; si `'activo'|'incierto'` → `JugadaLive`; si `derived.data` con rungs → `JugadaDerivada` (+ acceso al gate); si `derived` vacío/sin paredes → `JugadaSinJugada`.
+
+- [ ] **Step 2: Typecheck + smoke** Run: `cd frontend && npx tsc --noEmit` → sin errores.
+- [ ] **Step 3: Commit:** `feat(valles): La Jugada como 4ta lente del recorrido`
+
+### Task E3: Marca "tiene jugada" en `PickScreen.tsx`
+
+**Files:** Modify `frontend/src/components/valles/PickScreen.tsx`
+
+- [ ] Añadir un chip discreto "tiene jugada" (glyph de 3 barras) en cada candidata, de bajo contraste, **sin números y sin reordenar la lista** (sigue ordenada por liquidez). Por ahora la marca puede ser estática para todas las candidatas con paredes (o derivarse de un campo si el screener lo expone); 1:1 con `JuPickMark` (§7.8). Footer: "La marca no ordena la lista ni la puntúa…".
+- [ ] Commit: `feat(jugada): marca discreta 'tiene jugada' en el Pick`
+
+---
+
+## Phase F — Verificación
+
+### Task F1: Gate de frontend
+- [ ] Run: `cd frontend && npx tsc --noEmit` → sin errores.
+- [ ] Run: `cd frontend && npx vitest run` → todos los tests de la jugada en verde.
+- [ ] Run: `cd frontend && npm run build` → build limpio.
+
+### Task F2: Gate de backend
+- [ ] Run: `python -m pytest tests/test_plan_api.py -v` → PASS.
+- [ ] Run: `python -m pytest tests/ -m "not network" -n auto -q` → sin regresiones.
+
+### Task F3: Verificación visual 1:1 (manual)
+- [ ] `cd frontend && npm run dev`; abrir Valles → seleccionar una candidata → avanzar a "La jugada".
+- [ ] Comparar contra los HTML del handoff (`La Jugada.html`, `La Jugada · gráfico.html`) abiertos en el navegador: banda de zona, escalera, stop/BE, runner, precio vivo, hueco honesto, gate, en curso (frescura), conducta. Anotar desviaciones y corregir.
+- [ ] Verificar tuteo en todo el copy (cero voseo).
+
+---
+
+## Self-Review (cobertura de la spec)
+
+- Gráfico montado como en la app (lightweight-charts) ✔ Task C3 (patrón ChartCanvas).
+- Overlays 1:1 (zona banda, stop/BE, escalera, runner, precio vivo, hueco) ✔ Task C1+C3.
+- Entrada SIEMPRE rango ✔ overlays.zone (banda) + copy; nunca línea de precio puntual.
+- Ciclo completo "todos los juguetes" ✔ Derivada (D1) + Gate/Fijada (D2) + En curso (D3) + Conducta (D4) + Sin jugada (D5).
+- 4ta lente tras Niveles ✔ Task E2.
+- Marca en el Pick ✔ Task E3.
+- Fetchers nuevos ✔ Task B2 (hoy no existían).
+- Frescura #8 ✔ Task A2 (LiveSnapshot).
+- Conducta sin PnL ✔ Task A3 + D4.
+- Tuteo venezolano ✔ tabla de remapeo + Phase D.
+- Contrato enriquecido para 1:1 (toques/piso) ✔ Task A1.
+
+**Fuera de alcance (anotado, no silenciado):** la nota de lenguaje (`JuLexNote`) y la lámina de divs (`SalidaLadder`) del handoff NO se implementan — la primera es documentación interna, la segunda queda reemplazada por el gráfico de velas canónico. El pulido final de microcopy con `solace-wren` queda como follow-up.
+```

--- a/docs/superpowers/specs/es/2026-06-17-kickoff-instrumento-screener-design.md
+++ b/docs/superpowers/specs/es/2026-06-17-kickoff-instrumento-screener-design.md
@@ -1,0 +1,209 @@
+# Kickoff de diseño — El Instrumento dentro del screener de Valles
+
+Para: equipo de diseño
+De: producto
+Fecha: 2026-06-17
+Fuente funcional: arco Valles (specs 2026-06-11 a 2026-06-15), Instrumento construido (`api/plan.py`, `instrument/*`, `db/lifecycle_states.py`, `db/conduct_episodes.py`), flujo cálido shipeado (PR #595), revisión del roster.
+
+Entregable pedido: mockups dentro del lenguaje cálido actual de Valles. No código.
+
+---
+
+## 1. Contexto que define el encargo
+
+El arco Valles construyó tres lentes de hechos (Vida, Niveles, Dossier) y, sobre ellas, **el Instrumento**: la pieza que deriva una *jugada disciplinada* desde las paredes de soporte/resistencia (D.1) — zona de entrada, stop bajo el piso, escalera de salidas escalonadas contra las resistencias, un runner abierto, y la regla de mover el stop a break-even cuando se llena la primera salida.
+
+El Instrumento **está construido y corriendo en producción** (`/plan/derive`, `/plan/confirm`, `/plan/{symbol}`; el tracker `track_live` lo actualiza cada 5 min y al cierre escribe el episodio de conducta). Pero el rediseño cálido (PR #595) shipeó el recorrido de las 3 lentes y **dejó el Instrumento fuera de pantalla**. Hoy nadie en el frontend lo invoca. El motor que arma la jugada está andando solo, sin nadie que lo muestre.
+
+Eso es lo que se corrige: **darle cara al Instrumento dentro del flujo de Valles**, con su ciclo completo (derivar → confirmar → seguir en vivo → leer la conducta al cierre), sin romper la doctrina que el arco entero defendió.
+
+Lema de trabajo (copy final pendiente, pasa por solace-wren):
+
+> EL INSTRUMENTO TE MUESTRA CÓMO SE ORDENA UNA SALIDA CONTRA LAS PAREDES. NO TE DICE QUE ENTRES.
+
+## 2. El encargo en una frase
+
+Integrar el ciclo completo de la *jugada* (derivarla desde tus niveles, confirmarla en frío, seguirla en vivo, y al cierre leer si la honraste) dentro del recorrido cálido de Valles, leído como **disciplina geométrica** —"si decides entrar, así se sale por partes"— nunca como un veredicto de compra.
+
+No es una vista nueva de trading. No es un radar. No es un botón de "entrar". Es darle cara a lo que el Instrumento ya hace, con la misma honestidad de las 3 lentes: hechos y procedencia, cero firma.
+
+## 3. Decisiones ya tomadas (vienen del arco, no se reabren)
+
+1. **La jugada es disciplina, no predicción.** Los TPs en las resistencias no afirman "esto va a subir" — afirman "estas son las paredes; una salida ordenada escalona contra ellas". El Instrumento nunca dice que el plan gana; solo mide si se cumplió. *(spec instrumento-lifecycle §1.)*
+2. **Exhibe hechos, nunca un veredicto.** La jugada se deriva de la geometría de D.1, con la costura visible ("esto sale de tus niveles"). No es una síntesis de las 3 lentes — eso sería la "cuarta línea" prohibida (F3b). La decisión de entrar es del humano, a propósito.
+3. **El número sale de la pared, no del sistema.** Cada cifra del plan se atribuye a su origen geométrico: la entrada a la zona de soporte, el stop al piso inmediato, cada salida a una resistencia. Si un número aparece sin su pared, miente.
+4. **El operador firma; el Instrumento sostiene.** El plan se fija en frío (gate) y la máquina lo sostiene como ley para medir si lo honraste. La interfaz acompaña la disciplina; no la sustituye.
+5. **La conducta se mide, no el acierto.** Al cierre, el Instrumento lee si honraste la ley que aprobaste — campo por campo, sin PnL, sin score. Un trade puede perder y ser conducta perfecta. *(spec instrumento-lifecycle §7.)*
+6. **Lenguaje cálido, lector mayor.** Mismo sistema de Valles: papel/arcilla/salvia/ocre, Source Serif 4 + Instrument Sans, cuerpo ≥18px, toque ≥48px, contraste AA, tuteo, frases simples. Lo ve papá.
+
+### Decisiones cerradas con Samuel (2026-06-17)
+
+- **A — Dónde:** "La jugada" es **pantalla propia, después de Niveles** (+ marca discreta de "tiene jugada" en el screener). Separa la geometría (Niveles) de su consecuencia disciplinaria (la jugada) y evita el efecto "cuarta línea".
+- **B — Alcance v1:** **con todo el ciclo** — derivar, confirmar (gate), seguir en vivo (`/plan/{symbol}`) y leer la conducta al cierre (`conduct_episodes`). No se difiere nada.
+- **C — De qué entrada se deriva:** al **precio vivo** por defecto ("calculado al precio de ahora"), **con la entrada SIEMPRE expresada como un rango (la zona de soporte), nunca como un precio fijo**. Un precio puntual se lee como "compra exactamente aquí"; la zona es honesta y es lo que D.1 entrega.
+
+## 4. Modelo de pantalla pedido
+
+### 4.1 Dónde vive la jugada en el recorrido
+
+El flujo cálido hoy es: **Pick (screener) → Vida → Niveles → Fundamentales → Cierre.**
+
+La jugada se deriva de **Niveles** (las paredes). Recorrido pedido:
+
+**Pick → Vida → Niveles → La jugada → Fundamentales → Cierre.**
+
+- En el **Pick (la lista del screener)**, cada candidata lleva una marca discreta y de bajo contraste de "tiene jugada derivada" — sin números, solo señalar que existe. Nunca un ranking ni un "esta es mejor".
+- "La jugada" entra **inmediatamente después de Niveles**, como su consecuencia geométrica directa, no como un resumen final de todo.
+- El **gate de confirmar**, la **jugada en curso** y la **lectura de conducta** cuelgan de "La jugada": una jugada confirmada se sigue en vivo; una jugada cerrada muestra su lectura de conducta.
+
+### 4.2 "La jugada" — el plan derivado (pre-entrada)
+
+Debe mostrar, en lenguaje simple y con cada número anclado a su pared:
+
+- **Dónde entrarías:** **la zona de entrada como rango** (el soporte de D.1, `precio_bajo`–`precio_alto`), nunca un precio puntual. El precio vivo se ubica dentro o cerca de esa zona, con la línea "calculado al precio de ahora".
+- **Hasta dónde aguantas:** el stop, y que está bajo el piso inmediato (con su margen).
+- **Cómo sales por partes:** la escalera de salidas (hasta 4), cada peldaño sobre una resistencia nombrada, con el tamaño de cada salida (la primera es la más grande: 0.50 / 0.20 / 0.15 / 0.10).
+- **Lo que dejas corriendo:** el runner abierto sin objetivo (0.05), y que su stop sube a break-even cuando se llena la primera salida ("a partir de ahí, esa parte ya no puede perder").
+- **De dónde sale todo esto:** una línea honesta — "esto se arma con tus niveles, no es un consejo de comprar".
+
+La pantalla describe una **salida ordenada**, no una entrada urgente. El titular es la disciplina ("así se sale por partes"), no la oportunidad.
+
+### 4.3 El gate — confirmar la jugada en frío
+
+Es el momento en que **el operador firma** (`POST /plan/confirm`). Debe sentirse como un acto deliberado y tranquilo, no un "comprar":
+
+- Repite el plan completo que se va a fijar como ley.
+- Deja claro que confirmar **no ejecuta nada** — la entrada la hace el humano por su flujo normal en Binance. Confirmar solo le dice al Instrumento "esta es la ley que voy a honrar".
+- Una sola acción primaria, sobria (p. ej. "Fijar esta jugada"), sin verde de "entrar".
+- Tras confirmar, la jugada pasa a estar "en curso" y se puede seguir en vivo.
+
+### 4.4 La jugada en curso — el plano vivo
+
+Vista viva (`GET /plan/{symbol}`) de cómo va la jugada contra el plan. Son **hechos del estado**, nunca instrucciones:
+
+- Qué salidas se llenaron, dónde está el stop ahora, si ya se movió a break-even, cuánto queda abierto.
+- Hechos en palabras simples: "la primera salida se llenó", "tu stop está en break-even", "tu stop sigue debajo de la zona".
+- **Frescura visible:** cuándo se actualizó por última vez; si está vieja o incierta, se dice ("transición sin confirmar — revisá en Binance").
+- **Pull-only:** el lector mira cuando él quiere; cero notificaciones, cero push.
+
+### 4.5 La lectura de conducta — al cierre
+
+Cuando la jugada cierra, el Instrumento emite la lectura de conducta (`conduct_episodes`): **¿honraste la ley que aprobaste?** — campo por campo, **sin PnL, sin score**:
+
+- Entraste en la zona; respetaste el stop; moviste a break-even cuando tocaba; honraste los peldaños; escalonaste; cerraste según el plan; cuánto aguantaste.
+- Es un **espejo, no un juez**. Un trade puede perder y ser conducta perfecta; o ganar y ser conducta pobre. La pantalla nunca califica el trade por si ganó.
+- Cero número único de "calidad". Solo los hechos de tu propia conducta, para que te veas.
+
+### 4.6 El cierre del recorrido
+
+La pantalla de Cierre se mantiene como recap neutral de los hechos de las lentes. La jugada **no** se funde ahí dentro como conclusión. Si el cierre la menciona, la nombra como pieza aparte ("la salida ordenada que se derivó de tus niveles"), no como el veredicto que cierra el caso.
+
+## 5. Gramática visual
+
+Mismo lenguaje cálido de Valles. La jugada debe sentirse como una **lámina de instrucciones de salida**, serena y leíble, no como un tablero de trading.
+
+- Neutros cálidos dominan (papel/arcilla). La jugada no se ilumina.
+- **Salvia:** lo cumplido / lo que ya está (una salida llena, el stop en BE, un campo de conducta honrado).
+- **Ocre:** atención honesta (el stop, lo que aguantas, dato viejo, estado incierto). Con mesura.
+- **Sin verde/rojo** como gramática de "entra/sal" ni de "ganaste/perdiste". En trading excitan antes de informar.
+- Sin glow, sin números hero gigantes, sin badges de "compra", sin countdowns, sin pulso de urgencia.
+- La escalera de salidas se dibuja contra las paredes (relación espacial con Niveles), para que se lea como geometría, no como promesa.
+- La zona de entrada se dibuja como **banda**, no como línea — refuerza visualmente que es un rango.
+
+## 6. Candados de honestidad
+
+1. **La jugada es estructura de salida.** No es una orden de compra ni una predicción de subida.
+2. **La entrada es un rango, nunca un punto.** Siempre la zona de soporte (`precio_bajo`–`precio_alto`). Jamás un precio puntual que se lea como "compra exactamente aquí".
+3. **Cada número trae su pared.** Entrada→soporte, stop→piso, cada salida→una resistencia. Ningún número aparece huérfano.
+4. **El stop es lo que aguantas, no una garantía.** "No puede perder" solo aplica tras mover a break-even, y solo a esa porción.
+5. **La frescura es edad del dato.** La jugada en curso muestra cuándo se actualizó; si está vieja o incierta, se dice.
+6. **Confirmar no ejecuta.** El gate fija la ley; la entrada la hace el humano por su flujo. No hay one-click execute.
+7. **La conducta no es el acierto.** El cierre mide si honraste el plan, nunca si ganaste. Sin PnL como veredicto, sin score.
+8. **El plano vivo es pull-only.** Cero push, cero notificación.
+9. **No hay síntesis de las 3 lentes.** La jugada sale de Niveles, no de "vivo + limpio + en soporte = compra".
+10. **El frontend no recalcula.** No deriva el plan ni la conducta en cliente; los pide al backend y los muestra.
+
+## 7. Lenguaje permitido y prohibido
+
+Prohibido en UI primaria:
+
+- comprar; entrar ya; oportunidad; va a subir; buena entrada; la mejor; señal de compra; aprovecha; ahora o nunca; objetivo de precio (como promesa); ganancia esperada; ganaste/perdiste (como juicio); confianza; probabilidad; precio de entrada (puntual).
+
+Preferir:
+
+- la jugada; cómo se ordena la salida; si decides entrar; la zona de entrada; hasta dónde aguantas; sales por partes; primera salida; lo que dejas corriendo; tu stop sube a break-even; esto sale de tus niveles; fijar la jugada; ¿honraste tu plan?; la decisión es tuya.
+
+`Plan` / `objetivo` solo se usan si vienen acompañados de su pared y de la línea "no es un consejo".
+
+## 8. Hechos de runtime que diseño debe respetar
+
+- **`GET /plan/derive/{symbol}`** deriva el plan sin persistir. Devuelve `entry`, `sl_plan`, `rungs[]` (`tp_price`, `size_frac`), `runner_frac`, `entry_zone`. Necesita un `entry_price` de entrada → se deriva al precio vivo por defecto.
+- **La entrada se muestra SIEMPRE como `entry_zone` (rango), no como `entry` (punto).** Si el contrato hoy entrega un `entry` puntual, diseño lidera con `entry_zone`; alinear el contrato para expresar la entrada como rango es tarea de backend, no de diseño.
+- **`POST /plan/confirm`** fija el plan como ley (crea la jugada viva en `lifecycle_states`). Es el gate del operador. Escribe estado: es la única acción del flujo que no es solo lectura.
+- **`GET /plan/{symbol}`** es la vista viva: `estado_vivo` (`activo`/`cerrado`/`incierto`), `plan`, `realidad` (`fase`, `rungs_llenos`, `sl_actual`, `be_movido`, `size_restante_frac`), `hechos[]`.
+- **Frescura (No-Negociable #8):** la vista viva **no viene envuelta en `LiveSnapshot` todavía**. Como B incluye el plano vivo, **cerrar ese hueco es prerrequisito de backend** antes de shipear 4.4: el plan en curso debe emitir su frescura (fresco/rancio/muerto) en el contrato. Diseño debe reservar el lugar para esa frescura.
+- **Dueño de frescura:** `track_live` corre cada 5 min dentro del ciclo de sync. La jugada viva se mueve a ese ritmo, no en tiempo real.
+- **Conducta al cierre:** vive en `conduct_episodes`, emitida por el tracker al pasar a CLOSED. Son campos de conducta (`entry_en_zona`, `sl_respetado`, `adherencia_be`, `rungs_honrados`, `cierre_en_plan`, `hold_hours`), **no una resta de PnL**.
+- Tamaños de la escalera (0.50 / 0.20 / 0.15 / 0.10) y runner (0.05) salen del backend. No inventarlos ni recalcularlos en cliente.
+- Es **self-tenant**: el lector ve su sesión (papá = tenant EXTERNAL). No hay selector de usuario.
+
+## 9. Estados que los mockups deben cubrir
+
+1. Candidata con jugada derivada limpia (paredes claras arriba y abajo, zona de entrada nítida).
+2. Candidata sin resistencias claras arriba → escalera incompleta o sin peldaños (la jugada lo dice honesto, no inventa paredes).
+3. Precio vivo fuera de la zona de entrada → mostrarlo honesto ("el precio de ahora está por encima de tu zona").
+4. Gate de confirmar (plan a punto de fijarse) + estado "ya fijada".
+5. Jugada en curso, primera salida llena, stop en break-even.
+6. Jugada en curso con estado incierto (snapshot ambiguo) → "revisá en Binance".
+7. Jugada en curso vieja/rancia (dato de hace rato).
+8. Cierre con lectura de conducta honrada (todo en salvia).
+9. Cierre con lectura de conducta no honrada (campos en ocre, sin regaño, sin PnL).
+10. Sin jugada (la moneda no da estructura) → vacío honesto, no relleno.
+11. Variante móvil compacta de cada pantalla.
+
+Si la pantalla solo se ve bien cuando la jugada es "bonita" o "ganadora", está mal diseñada.
+
+## 10. Cortes explícitos
+
+No diseñar:
+
+- botón "entrar" / "comprar" / "confirmar y ejecutar";
+- entrada como precio puntual;
+- ranking de candidatas por "mejor jugada";
+- objetivo de precio presentado como ganancia prometida;
+- PnL ni "ganaste/perdiste" como veredicto del cierre;
+- verde/rojo como semáforo de entrada o de resultado;
+- notificaciones push de la jugada;
+- síntesis de las 3 lentes en un veredicto;
+- gráfico pesado de trading dentro del flujo cálido;
+- cálculo del plan o de la conducta en cliente.
+
+## 11. Criterio de éxito
+
+El mockup correcto se mira rápido y produce calma: el lector entiende **cómo saldría por partes si decidiera entrar**, de dónde sale cada número, que la entrada es una zona y no un punto, y que la decisión de entrar es suya. En el cierre, se ve a sí mismo sin sentirse juzgado por el resultado. Si al mirarlo tres segundos se siente que la app dice "compra esto" o "ganaste/perdiste", el diseño falló.
+
+## 12. Flujo de trabajo
+
+Diseño entrega:
+
+1. pantalla "La jugada" derivada (desktop + móvil);
+2. marca discreta de "tiene jugada" en el Pick;
+3. gate de confirmar;
+4. vista de la jugada en curso (con su frescura);
+5. lectura de conducta al cierre;
+6. estados vacíos / incierto / rancio / sin paredes;
+7. nota de lenguaje con términos usados y evitados.
+
+Producto valida contra los candados de §6 antes de implementación. Backend cierra el hueco de `LiveSnapshot` en `/plan/{symbol}` (§8) en paralelo, como prerrequisito de 4.4.
+
+---
+
+## Acta breve del roster
+
+- **Voronov:** la jugada se porta como consecuencia de Niveles, no se firma como veredicto. La costura ("esto sale de tus paredes") es lo que la mantiene del lado de la observabilidad. La entrada-como-rango es correcta: un punto reifica una precisión que el dato no tiene.
+- **Halberg:** con el plano vivo en alcance, el hueco de `LiveSnapshot` en `/plan/{symbol}` deja de ser opcional — sin frescura en el contrato, la jugada viva puede mostrarse muerta como viva. Prerrequisito duro.
+- **Serrano:** el riesgo de tipo es presentar el cierre como PnL. La lectura de conducta debe quedar blindada contra "ganaste/perdiste"; es espejo, no juez.
+- **Cassian:** el core shippable es el ciclo completo de una jugada leíble; el corte está en no meter charts pesados ni ejecución. El gate escribe estado — es la única pieza no-read-only, trátese con cuidado.
+- **Null Vale:** la mentira más fácil aquí es el precio de entrada puntual y el verde de "ganaste". Aunque el copy sea prudente, una línea de entrada y un número en verde firman solos. La banda de entrada y la ausencia de PnL los desactivan.
+
+Decisión final: el Instrumento entra al flujo de Valles con su ciclo completo (derivar → confirmar → vivo → conducta), leído como disciplina geométrica. La interfaz muestra cómo se ordena una salida; no recomienda, no ejecuta y no celebra el resultado.

--- a/frontend/src/api.plan.test.ts
+++ b/frontend/src/api.plan.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as api from './api';
+
+const originalFetch = globalThis.fetch;
+
+const derivedPayload = {
+  entry: 0.419,
+  sl_plan: 0.385,
+  sl_piso: null,
+  rungs: [],
+  runner_frac: 0.05,
+  entry_zone: null,
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  globalThis.fetch = vi.fn(async () => jsonResponse(derivedPayload));
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('plan fetchers', () => {
+  it('getPlanDerive hits /api/plan/derive with entry_price', async () => {
+    await api.getPlanDerive('ADAUSDT', 0.4205);
+    const url = String((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(url).toContain('/plan/derive/ADAUSDT');
+    expect(url).toContain('entry_price=0.4205');
+  });
+
+  it('getPlanLive hits /api/plan/:symbol', async () => {
+    await api.getPlanLive('ADAUSDT');
+    const url = String((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(url).toContain('/api/plan/ADAUSDT');
+  });
+
+  it('getPlanConducta hits /api/plan/:symbol/conducta', async () => {
+    await api.getPlanConducta('ADAUSDT');
+    const url = String((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(url).toContain('/api/plan/ADAUSDT/conducta');
+  });
+
+  it('confirmPlan POSTs with snake_case body', async () => {
+    await api.confirmPlan('ADAUSDT', 0.42, 7);
+    const spy = fetch as ReturnType<typeof vi.fn>;
+    const opts = spy.mock.calls[0][1] as RequestInit;
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body as string)).toMatchObject({
+      symbol: 'ADAUSDT',
+      entry_price: 0.42,
+      position_id: 7,
+    });
+  });
+
+  it('confirmPlan with no positionId sends position_id: null', async () => {
+    await api.confirmPlan('ADAUSDT', 0.42);
+    const spy = fetch as ReturnType<typeof vi.fn>;
+    const opts = spy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(opts.body as string);
+    expect(body.position_id).toBeNull();
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -31,6 +31,9 @@ import type {
   PreferencesPutPayload,
   AgentStatus,
   TestDeliveryResponse,
+  PlanDerived,
+  PlanLive,
+  PlanConducta,
 } from './types';
 
 const BASE_URL = '/api';
@@ -431,4 +434,30 @@ export function getLevels(symbol: string) {
 // ---- F3b A on-demand — GET /valley-eval/:symbol ----
 export function getValleyEval(symbol: string) {
   return request<import('./types').ValleyEval>(`/valley-eval/${symbol}`);
+}
+
+// ---- La Jugada / Instrumento — contrato /plan ----------------------------
+
+// GET /plan/derive/:symbol?entry_price=X
+export function getPlanDerive(symbol: string, entryPrice: number) {
+  return request<PlanDerived>(`/plan/derive/${symbol}?entry_price=${entryPrice}`);
+}
+
+// GET /plan/:symbol
+export function getPlanLive(symbol: string) {
+  return request<PlanLive>(`/plan/${symbol}`);
+}
+
+// GET /plan/:symbol/conducta
+export function getPlanConducta(symbol: string) {
+  return request<PlanConducta>(`/plan/${symbol}/conducta`);
+}
+
+// POST /plan/confirm — auth via JWT cookie (credentials:'include') + CSRF token
+// injected automatically by rawRequest for non-GET methods. No extra header needed.
+export function confirmPlan(symbol: string, entryPrice: number, positionId?: number) {
+  return request<{ symbol: string; estado_vivo: string; plan: PlanDerived }>('/plan/confirm', {
+    method: 'POST',
+    body: JSON.stringify({ symbol, entry_price: entryPrice, position_id: positionId ?? null }),
+  });
 }

--- a/frontend/src/components/valles/PickScreen.tsx
+++ b/frontend/src/components/valles/PickScreen.tsx
@@ -5,6 +5,7 @@ import { FreshnessTag } from '../FreshnessTag';
 import { humanName } from './atoms';
 import { formatPrice } from '../../utils';
 import styles from './valles.module.css';
+import juStyles from './jugada/jugada.module.css';
 
 export const PickScreen: React.FC<{ snapshot: ValleySnapshot; onPick: (sym: string) => void }> = ({ snapshot, onPick }) => {
   const [q, setQ] = useState('');
@@ -40,6 +41,11 @@ export const PickScreen: React.FC<{ snapshot: ValleySnapshot; onPick: (sym: stri
               <span className={styles.vwCandTag} aria-hidden="true">● en valle</span>
               se mueve un <b>{(c.pct_rango * 100).toFixed(1)}%</b> · <b>{c.semanas_consolidando} semanas</b> quieta
             </div>
+            {/* TODO: gatear por señal real por-candidata cuando el screener la exponga */}
+            <span className={juStyles['ju-pickmark']}>
+              <span className={juStyles['ju-pickmark__g']} aria-hidden="true"><i /><i /><i /></span>
+              tiene jugada
+            </span>
             <div className={styles.vwCandPrice}>${formatPrice(c.price)}</div>
             <div className={styles.vwCandGo} aria-hidden="true">→</div>
           </button>
@@ -50,6 +56,8 @@ export const PickScreen: React.FC<{ snapshot: ValleySnapshot; onPick: (sym: stri
         <span>Se miraron <b>{coverage.evaluated}</b> de {coverage.universe} monedas del universo.</span>
         <span className={styles.vwEntrySep} />
         <span>Ordenadas por volumen — no por preferencia.</span>
+        <span className={styles.vwEntrySep} />
+        <span>La marca no ordena la lista ni la puntúa.</span>
       </div>
 
       <div className={styles.vwEntrySearch}>

--- a/frontend/src/components/valles/ValleysFlow.test.tsx
+++ b/frontend/src/components/valles/ValleysFlow.test.tsx
@@ -29,5 +29,5 @@ it('al elegir una moneda avanza a Vida y el stepper dice "Paso 1 de 3"', async (
   render(<ValleysFlow snapshot={snap} loading={false} />);
   await userEvent.click(screen.getByText('Cardano'));
   expect(await screen.findByText('¿Está viva la moneda?')).toBeInTheDocument();
-  expect(screen.getByText(/paso 1 de 3/i)).toBeInTheDocument();
+  expect(screen.getByText(/paso 1 de 4/i)).toBeInTheDocument();
 });

--- a/frontend/src/components/valles/ValleysFlow.tsx
+++ b/frontend/src/components/valles/ValleysFlow.tsx
@@ -8,12 +8,14 @@ import { NivelesScreen } from './NivelesScreen';
 import { FundScreen } from './FundScreen';
 import { ClosingScreen } from './ClosingScreen';
 import { Copilot } from './Copilot';
+import { JugadaLens } from './jugada/JugadaLens';
 import styles from './valles.module.css';
 
-const STEPS = ['pick', 'vida', 'niveles', 'fund', 'cierre'] as const;
+const STEPS = ['pick', 'vida', 'niveles', 'jugada', 'fund', 'cierre'] as const;
 type Step = typeof STEPS[number];
 const LENS: { key: Step; label: string }[] = [
-  { key: 'vida', label: 'Vida' }, { key: 'niveles', label: 'Niveles' }, { key: 'fund', label: 'Quién' },
+  { key: 'vida', label: 'Vida' }, { key: 'niveles', label: 'Niveles' },
+  { key: 'jugada', label: 'La jugada' }, { key: 'fund', label: 'Quién' },
 ];
 
 export const ValleysFlow: React.FC<{ snapshot: ValleySnapshot; loading: boolean }> = ({ snapshot, loading }) => {
@@ -47,10 +49,11 @@ export const ValleysFlow: React.FC<{ snapshot: ValleySnapshot; loading: boolean 
   if (cur === 'pick' || !sym) screen = <PickScreen snapshot={snapshot} onPick={pick} />;
   else if (cur === 'vida') screen = <VidaScreen symbol={sym} state={bundle.vida} frescura={snapshot.frescura} />;
   else if (cur === 'niveles') screen = <NivelesScreen symbol={sym} state={bundle.niveles} />;
+  else if (cur === 'jugada') screen = <JugadaLens symbol={sym} livePrice={bundle.niveles.data?.price_live ?? null} />;
   else if (cur === 'fund') screen = <FundScreen symbol={sym} state={bundle.dossier} onRefresh={bundle.refreshDossier} />;
   else screen = <ClosingScreen symbol={sym} bundle={bundle} onAsk={() => setDock(true)} onRestart={restart} />;
 
-  const lensIdx = cur === 'cierre' ? 3 : ({ vida: 0, niveles: 1, fund: 2 } as Record<string, number>)[cur];
+  const lensIdx = cur === 'cierre' ? 4 : ({ vida: 0, niveles: 1, jugada: 2, fund: 3 } as Record<string, number>)[cur];
 
   return (
     <div className={styles.vwRoot}>

--- a/frontend/src/components/valles/atoms.tsx
+++ b/frontend/src/components/valles/atoms.tsx
@@ -7,7 +7,7 @@ import styles from './valles.module.css';
 const NAMES: Record<string, string> = {
   ADAUSDT: 'Cardano', XLMUSDT: 'Stellar', RUNEUSDT: 'THORChain', PENDLEUSDT: 'Pendle',
   JUPUSDT: 'Jupiter', UNIUSDT: 'Uniswap', INJUSDT: 'Injective', GMXUSDT: 'GMX',
-  BTCUSDT: 'Bitcoin', PYTHUSDT: 'Pyth',
+  BTCUSDT: 'Bitcoin', PYTHUSDT: 'Pyth', ZBCUSDT: 'Zebec',
 };
 export const humanName = (s: string): string => NAMES[s] ?? s.replace('USDT', '');
 

--- a/frontend/src/components/valles/jugada/JugadaConducta.tsx
+++ b/frontend/src/components/valles/jugada/JugadaConducta.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import type { PlanConducta, PlanConductaField } from '../../../types';
+import { Eyebrow } from '../atoms';
+import styles from './jugada.module.css';
+
+// Marca visual y clase de tono por valor de 'ok'
+const CF_MARK: Record<PlanConductaField['ok'], string> = {
+  si:   '✓',
+  no:   '○',
+  dato: '·',
+};
+
+interface Props {
+  conducta: PlanConducta;
+}
+
+export const JugadaConducta: React.FC<Props> = ({ conducta }) => {
+  // El wrapper garantiza que solo se llega acá con cerrado + campos,
+  // pero el contrato pide que el componente lo valide él mismo.
+  if (conducta.estado_vivo !== 'cerrado' || !conducta.campos) return null;
+
+  const { titular, campos } = conducta;
+
+  return (
+    <div className={styles['ju-screen']}>
+      {/* Eyebrow compartido — nombre del instrumento */}
+      <Eyebrow symbol={conducta.symbol} />
+      {/* Pastilla "cerrada" — específica de esta pantalla */}
+      <span className={`${styles['ju-livestate']} ${styles['ju-livestate--cerrado']}`}>
+        <i />cerrada
+      </span>
+
+      {/* Pregunta principal */}
+      <h2 className={styles['ju-question']}>¿Honraste tu plan?</h2>
+
+      {/* Bloque de conducta */}
+      <div className={styles['ju-conduct']}>
+        {/* Titular narrativo: viene del backend, describe lo que pasó */}
+        {titular && (
+          <div className={styles['ju-conduct__lead']}>{titular}</div>
+        )}
+
+        {/* Bajada: contextualiza sin PnL ni juicio */}
+        <p className={styles['ju-conduct__say']}>
+          La jugada cerró. Esto es campo por campo lo que hiciste contra la ley que tú mismo aprobaste —{' '}
+          <b>sin ganancia ni pérdida, sin nota</b>. No hay reproche: solo el espejo.
+        </p>
+
+        {/* Lista de campos */}
+        <div className={styles['ju-cfields']}>
+          {campos.map((campo, i) => (
+            <div
+              key={i}
+              className={`${styles['ju-cf']} ${styles[`ju-cf--${campo.ok}`]}`}
+            >
+              <span className={styles['ju-cf__mark']}>{CF_MARK[campo.ok]}</span>
+              <span className={styles['ju-cf__k']}>{campo.k}</span>
+              {campo.v != null && (
+                <span className={styles['ju-cf__v']}>{campo.v}</span>
+              )}
+            </div>
+          ))}
+        </div>
+
+        {/* Bloque espejo — sin PnL, sin juicio, tuteo */}
+        <div className={styles['ju-mirror']}>
+          Es un <b>espejo, no un juez</b>. Un trade puede perder y ser conducta perfecta; o ganar y ser
+          conducta pobre. Acá no hay PnL ni un número de "calidad" — solo los hechos de tu propia
+          conducta, para que te veas.
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/valles/jugada/JugadaDerivada.tsx
+++ b/frontend/src/components/valles/jugada/JugadaDerivada.tsx
@@ -1,0 +1,185 @@
+// ============================================================
+// JugadaDerivada.tsx — body de la pantalla "La Jugada Derivada"
+//
+// Muestra la salida ordenada derivada de los niveles, calculada
+// al precio vivo de ahora. SIN el chrome/stepper/nav (eso lo
+// inyecta ValleysFlow). Equivale al body de JuDerivada del handoff.
+// ============================================================
+
+import React from 'react';
+import type { PlanDerived } from '../../../types';
+import { formatPrice } from '../../../utils';
+import { Eyebrow } from '../atoms';
+import { LaJugadaChart } from './LaJugadaChart';
+import styles from './jugada.module.css';
+
+// ── helpers ────────────────────────────────────────────────
+const pr = (n: number | null | undefined): string =>
+  n == null ? '—' : formatPrice(n);
+
+/** Formatea una fracción como porcentaje entero: 0.55 → "55%". */
+const pct = (frac: number): string => `${Math.round(frac * 100)}%`;
+
+// ── props ──────────────────────────────────────────────────
+export interface JugadaDerivadaProps {
+  symbol: string;
+  plan: PlanDerived;
+  live: number;
+}
+
+// ── componente ─────────────────────────────────────────────
+export const JugadaDerivada: React.FC<JugadaDerivadaProps> = ({
+  symbol,
+  plan,
+  live,
+}) => {
+  const escaleraCortaPath = plan.rungs.length === 1;
+  const zona = plan.entry_zone;
+
+  // ¿el precio vivo cae dentro de la zona de entrada?
+  const fueraDeLaZona =
+    zona != null && live > zona.precio_alto;
+
+  return (
+    <div className={styles['ju-screen']}>
+      {/* eyebrow ─────────────────────────────────────────── */}
+      <Eyebrow symbol={symbol} />
+      <span className={styles['ju-calc']}>
+        <i />calculado al precio de ahora
+      </span>
+
+      {/* titular ─────────────────────────────────────────── */}
+      <h2 className={styles['ju-question']}>
+        Si decides entrar, así se sale por partes.
+      </h2>
+
+      {/* lede ─────────────────────────────────────────────── */}
+      <p className={styles['ju-lede']}>
+        Es la salida ordenada que se deriva de <b>tus niveles</b>: dónde
+        entrarías, hasta dónde aguantas, y cómo vas saliendo poco a poco
+        contra cada techo. Describe una salida,{' '}
+        <b>no una orden de comprar</b>.
+      </p>
+
+      {/* gráfico ─────────────────────────────────────────── */}
+      <LaJugadaChart
+        symbol={symbol}
+        plan={plan}
+        live={live}
+        phaseLabel="derivada · al precio de ahora"
+      />
+
+      {/* hechos ───────────────────────────────────────────── */}
+      <ul className={styles['ju-facts']}>
+
+        {/* 1 — zona de entrada */}
+        <li className={styles['ju-fact']}>
+          <span className={styles['ju-fact__icon']}>▭</span>
+          <div>
+            <div className={styles['ju-fact__k']}>
+              Dónde entrarías — una zona, no un punto
+            </div>
+            <div className={styles['ju-fact__v']}>
+              {zona != null ? (
+                <>
+                  La franja de soporte{' '}
+                  <b>
+                    ${pr(zona.precio_bajo)}–${pr(zona.precio_alto)}
+                  </b>
+                  , donde el precio ya rebotó{' '}
+                  <b>{zona.toques} veces</b>.{' '}
+                  {fueraDeLaZona ? (
+                    <>
+                      El precio de ahora está{' '}
+                      <b>por encima de tu zona</b> — no estás dentro.
+                    </>
+                  ) : (
+                    <>El precio de ahora cae dentro de ella.</>
+                  )}
+                </>
+              ) : (
+                <>No se identificó una zona de soporte nítida.</>
+              )}
+            </div>
+          </div>
+        </li>
+
+        {/* 2 — stop */}
+        <li className={styles['ju-fact']}>
+          <span
+            className={`${styles['ju-fact__icon']} ${styles['ju-fact__icon--ochre']}`}
+          >
+            ↧
+          </span>
+          <div>
+            <div className={styles['ju-fact__k']}>
+              Hasta dónde aguantas — el stop
+            </div>
+            <div className={styles['ju-fact__v']}>
+              <b>${pr(plan.sl_plan)}</b>
+              {plan.sl_piso != null && (
+                <>, justo debajo del piso de ${pr(plan.sl_piso.precio_bajo)}</>
+              )}
+              . Es lo que estás dispuesto a perder, no una garantía.
+            </div>
+          </div>
+        </li>
+
+        {/* 3 — escalera */}
+        <li className={styles['ju-fact']}>
+          <span className={styles['ju-fact__icon']}>⋮</span>
+          <div>
+            <div className={styles['ju-fact__k']}>
+              Cómo sales por partes — la escalera
+            </div>
+            <div className={styles['ju-fact__v']}>
+              {escaleraCortaPath ? (
+                <>
+                  Solo hay <b>una pared clara</b> arriba: la primera salida (
+                  {pct(plan.rungs[0].size_frac)}) en{' '}
+                  <b>${pr(plan.rungs[0].tp_price)}</b>. No hay más techos
+                  para escalonar — la jugada lo dice honesto.
+                </>
+              ) : (
+                <>
+                  Cada peldaño se apoya sobre un techo nombrado. La{' '}
+                  <b>primera salida es la más grande</b> (
+                  {plan.rungs.map((r) => pct(r.size_frac)).join(' / ')}
+                  ): sales más donde la pared está más cerca.
+                </>
+              )}
+            </div>
+          </div>
+        </li>
+
+        {/* 4 — runner */}
+        <li className={styles['ju-fact']}>
+          <span
+            className={`${styles['ju-fact__icon']} ${styles['ju-fact__icon--sage']}`}
+          >
+            →
+          </span>
+          <div>
+            <div className={styles['ju-fact__k']}>
+              Lo que dejas corriendo — el runner
+            </div>
+            <div className={styles['ju-fact__v']}>
+              Un <b>{pct(plan.runner_frac)}</b> queda abierto, sin objetivo.
+              Cuando se llena la primera salida, su stop sube a break-even:{' '}
+              <b>a partir de ahí esa parte ya no puede perder</b>.
+            </div>
+          </div>
+        </li>
+
+      </ul>
+
+      {/* procedencia ──────────────────────────────────────── */}
+      <div className={styles['ju-prov']}>
+        <b>Esto se arma con tus niveles</b>, las paredes de D.1 — no es un
+        consejo de comprar. Cada número trae su pared: la entrada sale del
+        soporte, el stop del piso, cada salida de una resistencia. La
+        decisión de entrar es tuya.
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/valles/jugada/JugadaGate.tsx
+++ b/frontend/src/components/valles/jugada/JugadaGate.tsx
@@ -5,22 +5,10 @@
 import React, { useState } from 'react';
 import type { PlanDerived } from '../../../types';
 import { confirmPlan } from '../../../api';
-import { Eyebrow } from '../atoms';
+import { Eyebrow, humanName } from '../atoms';
 import styles from './jugada.module.css';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
-
-const JNAMES: Record<string, string> = {
-  ADAUSDT: 'Cardano',
-  JUPUSDT: 'Jupiter',
-  XLMUSDT: 'Stellar',
-  RUNEUSDT: 'THORChain',
-  ZBCUSDT: 'Zebec',
-};
-
-function jnm(sym: string): string {
-  return JNAMES[sym] ?? sym.replace('USDT', '');
-}
 
 function pr(n: number | null | undefined): string {
   if (n == null) return '—';
@@ -128,7 +116,7 @@ export const JugadaGate: React.FC<JugadaGateProps> = ({ symbol, plan, entry }) =
         <div className={styles['ju-gate__hd']}>
           <div className={styles['ju-gate__hd-k']}>La ley que vas a fijar</div>
           <div className={styles['ju-gate__hd-t']}>
-            {jnm(symbol)} · salida ordenada contra las paredes
+            {humanName(symbol)} · salida ordenada contra las paredes
           </div>
         </div>
 

--- a/frontend/src/components/valles/jugada/JugadaGate.tsx
+++ b/frontend/src/components/valles/jugada/JugadaGate.tsx
@@ -1,0 +1,226 @@
+// JugadaGate.tsx — body de JuGate + JuGateFijada (sin chrome/wrapper JuFrame).
+// Props: { symbol, plan, entry }
+// Estado interno: fijada / enviando / error
+
+import React, { useState } from 'react';
+import type { PlanDerived } from '../../../types';
+import { confirmPlan } from '../../../api';
+import { Eyebrow } from '../atoms';
+import styles from './jugada.module.css';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const JNAMES: Record<string, string> = {
+  ADAUSDT: 'Cardano',
+  JUPUSDT: 'Jupiter',
+  XLMUSDT: 'Stellar',
+  RUNEUSDT: 'THORChain',
+  ZBCUSDT: 'Zebec',
+};
+
+function jnm(sym: string): string {
+  return JNAMES[sym] ?? sym.replace('USDT', '');
+}
+
+function pr(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return n.toLocaleString('en-US', { maximumFractionDigits: 6 });
+}
+
+function jPct(frac: number): string {
+  return `${Math.round(frac * 100)}%`;
+}
+
+// ── Props ──────────────────────────────────────────────────────────────────
+
+export interface JugadaGateProps {
+  symbol: string;
+  plan: PlanDerived;
+  entry: number;
+}
+
+// ── Componente ─────────────────────────────────────────────────────────────
+
+export const JugadaGate: React.FC<JugadaGateProps> = ({ symbol, plan, entry }) => {
+  const [fijada, setFijada] = useState(false);
+  const [enviando, setEnviando] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFijar() {
+    setEnviando(true);
+    setError(null);
+    try {
+      await confirmPlan(symbol, entry);
+      setFijada(true);
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message
+          : 'No se pudo fijar la jugada. Revisa tu conexión e intenta de nuevo.'
+      );
+    } finally {
+      setEnviando(false);
+    }
+  }
+
+  // ── Vista: ya fijada ─────────────────────────────────────────────────────
+
+  if (fijada) {
+    return (
+      <div className={styles['ju-screen']}>
+        {/* Eyebrow */}
+        <Eyebrow symbol={symbol} />
+        {/* Pastilla de estado — específica de esta vista */}
+        <span className={`${styles['ju-livestate']} ${styles['ju-livestate--activo']}`}>
+          <i />en curso
+        </span>
+
+        {/* Titular */}
+        <h2 className={styles['ju-question']}>
+          Jugada fijada. Desde acá se sigue en vivo.
+        </h2>
+
+        {/* Bloque verde fijada */}
+        <div className={styles['ju-fixed']}>
+          <span className={styles['ju-fixed__icon']}>⌖</span>
+          <div>
+            <div className={styles['ju-fixed__t']}>
+              El Instrumento guardó tu plan como ley.
+            </div>
+            <div className={styles['ju-fixed__s']}>
+              No se ejecutó ninguna orden —{' '}
+              <b>la entrada la haces tú en Binance</b>. A partir de ahora, el
+              plano vivo te muestra cómo va tu jugada contra este plan, y al
+              cierre puedes leer si lo honraste.
+            </div>
+          </div>
+        </div>
+
+        {/* Procedencia */}
+        <div className={styles['ju-prov']}>
+          El plano vivo es <b>solo lectura y se mira cuando tú quieres</b> — sin
+          avisos, sin notificaciones. Se refresca a su propio ritmo (cada pocos
+          minutos), no en tiempo real.
+        </div>
+      </div>
+    );
+  }
+
+  // ── Vista: gate (pre-confirmación) ──────────────────────────────────────
+
+  return (
+    <div className={styles['ju-screen']}>
+      {/* Eyebrow */}
+      <Eyebrow symbol={symbol} />
+
+      {/* Titular */}
+      <h2 className={styles['ju-question']}>Fija la jugada, en frío.</h2>
+
+      {/* Lede */}
+      <p className={styles['ju-lede']}>
+        Confirmar <b>no compra nada</b>. Solo le dice al Instrumento cuál es la
+        ley que vas a honrar — para que, al cierre, pueda mostrarte si la
+        cumpliste. La entrada la haces tú, por tu flujo normal en Binance.
+      </p>
+
+      {/* Gate card */}
+      <div className={styles['ju-gate']}>
+        <div className={styles['ju-gate__hd']}>
+          <div className={styles['ju-gate__hd-k']}>La ley que vas a fijar</div>
+          <div className={styles['ju-gate__hd-t']}>
+            {jnm(symbol)} · salida ordenada contra las paredes
+          </div>
+        </div>
+
+        <div className={styles['ju-gate__rows']}>
+          {/* Zona de entrada */}
+          <div className={styles['ju-grow']}>
+            <div className={styles['ju-grow__k']}>Zona de entrada (rango)</div>
+            <div className={styles['ju-grow__v']}>
+              {plan.entry_zone
+                ? `$${pr(plan.entry_zone.precio_bajo)} – $${pr(plan.entry_zone.precio_alto)}`
+                : `$${pr(entry)}`}
+            </div>
+            <div className={styles['ju-grow__note']}>
+              {plan.entry_zone
+                ? `soporte · ${plan.entry_zone.toques} toques`
+                : 'precio de entrada'}
+            </div>
+          </div>
+
+          {/* Stop */}
+          <div className={styles['ju-grow']}>
+            <div className={styles['ju-grow__k']}>Stop · hasta dónde aguantas</div>
+            <div
+              className={`${styles['ju-grow__v']} ${styles['ju-grow__v--ochre']}`}
+            >
+              ${pr(plan.sl_plan)}
+            </div>
+            <div className={styles['ju-grow__note']}>
+              {plan.sl_piso
+                ? `bajo el piso de $${pr(plan.sl_piso.centro)}`
+                : 'nivel de stop'}
+            </div>
+          </div>
+
+          {/* Mini-escalera de salidas */}
+          <div className={`${styles['ju-grow']} ${styles['ju-grow--full']}`}>
+            <div className={styles['ju-grow__k']}>
+              Escalera de salidas — primera la más grande
+            </div>
+            <div className={styles['ju-ladder-mini']}>
+              {plan.rungs.map((r, i) => (
+                <span className={styles['ju-lm']} key={i}>
+                  <span className={styles['ju-lm__pct']}>salida {i + 1}</span>
+                  <b>${pr(r.tp_price)}</b>
+                  <span className={styles['ju-lm__pct']}>{jPct(r.size_frac)}</span>
+                </span>
+              ))}
+              <span className={styles['ju-lm']}>
+                <span className={styles['ju-lm__pct']}>runner</span>
+                <b>↑ abierto</b>
+                <span className={styles['ju-lm__pct']}>{jPct(plan.runner_frac)}</span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Disclaimer ocre */}
+      <div className={styles['ju-disc']}>
+        <span className={styles['ju-disc__icon']}>⚑</span>
+        <div className={styles['ju-disc__t']}>
+          <b>Confirmar no ejecuta.</b> No hay botón de comprar acá. Fijar la
+          jugada solo guarda este plan como la ley contra la que se va a medir
+          tu conducta. El stop "no puede perder" recién aplica cuando mueves a
+          break-even.
+        </div>
+      </div>
+
+      {/* Error (si ocurrió) */}
+      {error && (
+        <div className={styles['ju-warn']} style={{ marginTop: 14 }}>
+          <span className={styles['ju-warn__icon']}>⚠</span>
+          <div>
+            <div className={styles['ju-warn__t']}>No se pudo fijar</div>
+            <div className={styles['ju-warn__s']}>{error}</div>
+          </div>
+        </div>
+      )}
+
+      {/* Botón primario + hint */}
+      <div className={styles['ju-confirm']}>
+        <button
+          className={`${styles['ju-btn']} ${styles['ju-btn--primary']} ${styles['ju-btn--block']}`}
+          onClick={handleFijar}
+          disabled={enviando}
+        >
+          {enviando ? 'Fijando…' : 'Fijar esta jugada'}
+        </button>
+        <div className={styles['ju-confirm__hint']}>
+          Puedes cerrar esto sin fijar nada. Fijar es solo tuyo, a propósito.
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/valles/jugada/JugadaLens.tsx
+++ b/frontend/src/components/valles/jugada/JugadaLens.tsx
@@ -1,0 +1,86 @@
+// JugadaLens.tsx — 4ta lente de Valles: selecciona la pantalla correcta
+// según el estado del ciclo de vida de la jugada.
+//
+// Prioridad:
+//   1. live.estado_vivo === 'activo' | 'incierto'  → JugadaLive
+//   2. derived.data con escalera                   → JugadaDerivada + botón gate
+//      showGate                                    → JugadaGate
+//   3. conducta.estado_vivo === 'cerrado'           → JugadaConducta
+//   4. fallback                                    → JugadaSinJugada
+
+import React, { useEffect, useState } from 'react';
+import { useJugada } from './useJugada';
+import { JugadaDerivada } from './JugadaDerivada';
+import { JugadaGate } from './JugadaGate';
+import { JugadaLive } from './JugadaLive';
+import { JugadaConducta } from './JugadaConducta';
+import { JugadaSinJugada } from './JugadaSinJugada';
+import styles from './jugada.module.css';
+
+export interface JugadaLensProps {
+  symbol: string;
+  livePrice: number | null;
+}
+
+export const JugadaLens: React.FC<JugadaLensProps> = ({ symbol, livePrice }) => {
+  const { derived, live, conducta } = useJugada(symbol, livePrice);
+  const [showGate, setShowGate] = useState(false);
+
+  // Resetea el gate cada vez que cambia el símbolo
+  useEffect(() => {
+    setShowGate(false);
+  }, [symbol]);
+
+  // Estado de carga inicial: ambas peticiones en vuelo
+  if (derived.loading && live.loading) {
+    return (
+      <div className={styles['ju-screen']}>
+        <p>Derivando la jugada de tus niveles…</p>
+      </div>
+    );
+  }
+
+  // 1. Jugada activa o incierta → plano vivo
+  if (
+    live.data?.estado_vivo === 'activo' ||
+    live.data?.estado_vivo === 'incierto'
+  ) {
+    return <JugadaLive symbol={symbol} live={live.data} />;
+  }
+
+  // 2. Derivada con escalera → mostrar derivada + botón para ir al gate
+  if (derived.data && derived.data.rungs.length > 0) {
+    if (showGate) {
+      return (
+        <JugadaGate
+          symbol={symbol}
+          plan={derived.data}
+          entry={livePrice ?? derived.data.entry}
+        />
+      );
+    }
+    return (
+      <>
+        <JugadaDerivada
+          symbol={symbol}
+          plan={derived.data}
+          live={livePrice ?? derived.data.entry}
+        />
+        <button
+          className={`${styles['ju-btn']} ${styles['ju-btn--primary']}`}
+          onClick={() => setShowGate(true)}
+        >
+          Revisar y fijar →
+        </button>
+      </>
+    );
+  }
+
+  // 3. Jugada cerrada → conducta
+  if (conducta.data?.estado_vivo === 'cerrado') {
+    return <JugadaConducta conducta={conducta.data} />;
+  }
+
+  // 4. Fallback honesto
+  return <JugadaSinJugada symbol={symbol} />;
+};

--- a/frontend/src/components/valles/jugada/JugadaLens.tsx
+++ b/frontend/src/components/valles/jugada/JugadaLens.tsx
@@ -32,7 +32,7 @@ export const JugadaLens: React.FC<JugadaLensProps> = ({ symbol, livePrice }) => 
   }, [symbol]);
 
   // Estado de carga inicial: ambas peticiones en vuelo
-  if (derived.loading && live.loading) {
+  if (derived.loading || live.loading) {
     return (
       <div className={styles['ju-screen']}>
         <p>Derivando la jugada de tus niveles…</p>

--- a/frontend/src/components/valles/jugada/JugadaLive.tsx
+++ b/frontend/src/components/valles/jugada/JugadaLive.tsx
@@ -1,0 +1,142 @@
+// ============================================================
+// JugadaLive.tsx — body de JuLive (la jugada en curso / plano vivo).
+//
+// Props: { symbol: string; live: PlanLive }
+// El wrapper garantiza que live.estado_vivo no es null y live.plan
+// existe antes de renderizar esta pantalla. Aún así se guarda con
+// el return null para el caso borde donde plan llegue indefinido.
+//
+// Render 1:1 con JuLive del handoff jugada-screens.jsx.
+// Copy remapeado a tuteo venezolano (jamás voseo).
+// ============================================================
+
+import React from 'react';
+import type { PlanLive } from '../../../types';
+import { Eyebrow } from '../atoms';
+import { LaJugadaChart } from './LaJugadaChart';
+import type { LiveState } from './overlays';
+import styles from './jugada.module.css';
+
+// ── helpers de formato ─────────────────────────────────────
+
+/** Formatea edad_seg en "hace N min" / "hace N h" / "hace N seg".
+ *  Si edad_seg es null o 0 devuelve "ahora mismo". */
+function formatEdad(seg: number | null): string {
+  if (seg == null || seg <= 0) return 'ahora mismo';
+  if (seg < 60) return `hace ${Math.round(seg)} seg`;
+  if (seg < 3600) return `hace ${Math.round(seg / 60)} min`;
+  return `hace ${Math.round(seg / 3600)} h`;
+}
+
+// ── tipos locales de props ─────────────────────────────────
+
+interface JugadaLiveProps {
+  symbol: string;
+  live: PlanLive;
+}
+
+// ── componente ─────────────────────────────────────────────
+
+export const JugadaLive: React.FC<JugadaLiveProps> = ({ symbol, live }) => {
+  if (!live.plan) return null;
+
+  const plan    = live.plan;
+  const incierto = live.estado_vivo === 'incierto';
+  const rancio  = live.frescura?.estado === 'rancio';
+
+  // LiveState para el gráfico
+  const liveState: LiveState = {
+    rungs_llenos: live.realidad?.rungs_llenos ?? [],
+    be_movido:    !!live.realidad?.be_movido,
+    sl_actual:    live.realidad?.sl_actual ?? null,
+  };
+
+  return (
+    <div className={styles['ju-screen']}>
+      <Eyebrow symbol={symbol} />
+      {/* ── cabecera del plano vivo ── */}
+      <div className={styles['ju-livehead']}>
+        {/* pill de estado */}
+        <span
+          className={[
+            styles['ju-livestate'],
+            styles[incierto ? 'ju-livestate--incierto' : 'ju-livestate--activo'],
+          ].join(' ')}
+        >
+          <i />{incierto ? 'estado incierto' : 'en curso'}
+        </span>
+
+        {/* tag de frescura */}
+        {live.frescura && (
+          <span
+            className={[
+              styles['ju-livefresh'],
+              styles[rancio ? 'ju-livefresh--rancio' : 'ju-livefresh--fresco'],
+            ].join(' ')}
+          >
+            <i />actualizado {formatEdad(live.frescura.edad_seg)}
+            {rancio && ' · puede haber cambiado'}
+          </span>
+        )}
+
+        {/* etiqueta solo-lectura */}
+        <span className={styles['ju-pull']}>◔ solo lectura · sin avisos</span>
+      </div>
+
+      {/* ── titular ── */}
+      <h2 className={styles['ju-question']}>Cómo va tu jugada, en hechos.</h2>
+
+      {/* ── gráfico ── */}
+      <LaJugadaChart
+        symbol={symbol}
+        plan={plan}
+        live={plan.entry}
+        state={liveState}
+        phaseLabel="en curso"
+        height={452}
+      />
+
+      {/* ── lista de hechos vivos ── */}
+      {live.hechos && live.hechos.length > 0 && (
+        <ul className={styles['ju-state-facts']}>
+          {/* Divergencia aceptada del handoff: el backend entrega hechos como string[] ya redactados (sin campo 'tono'), así que el dot del li queda neutro — el contrato /plan no expone tono. */}
+          {live.hechos.map((h, i) => (
+            <li className={styles['ju-sf']} key={i}>
+              <span className={styles['ju-sf__dot']} />
+              <div className={styles['ju-sf__t']}>{h}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* ── aviso: estado incierto ── */}
+      {incierto && (
+        <div className={styles['ju-warn']}>
+          <span className={styles['ju-warn__icon']}>⚠</span>
+          <div>
+            <div className={styles['ju-warn__t']}>Transición sin confirmar</div>
+            <div className={styles['ju-warn__s']}>
+              El último plano llegó a medias y no se pudo confirmar el estado.{' '}
+              <b>Revisa en Binance</b> antes de asumir nada — el Instrumento no adivina.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── aviso: datos rancios ── */}
+      {rancio && (
+        <div className={styles['ju-warn']}>
+          <span className={styles['ju-warn__icon']}>⧖</span>
+          <div>
+            <div className={styles['ju-warn__t']}>Este plano es de hace un rato…</div>
+            <div className={styles['ju-warn__s']}>
+              Lo que ves es de{' '}
+              <b>{formatEdad(live.frescura?.edad_seg ?? null)}</b>. El seguimiento corre
+              cada pocos minutos; pudo cambiar desde la última foto.
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/valles/jugada/JugadaSinJugada.tsx
+++ b/frontend/src/components/valles/jugada/JugadaSinJugada.tsx
@@ -1,0 +1,43 @@
+// ============================================================
+// JugadaSinJugada.tsx — body de JuSinJugada.
+//
+// Vacío honesto: la moneda no tiene estructura para derivar
+// una jugada. Se muestra el hecho sin inventar un plan.
+// Sin props de plan ni de live — solo el símbolo.
+// ============================================================
+
+import React from 'react';
+import { Eyebrow } from '../atoms';
+import styles from './jugada.module.css';
+
+export interface JugadaSinJugadaProps {
+  symbol: string;
+}
+
+export const JugadaSinJugada: React.FC<JugadaSinJugadaProps> = ({ symbol }) => (
+  <div className={styles['ju-screen']}>
+    {/* eyebrow */}
+    <Eyebrow symbol={symbol} />
+
+    {/* titular */}
+    <h2 className={styles['ju-question']}>Esta moneda no da estructura para una jugada.</h2>
+
+    {/* aviso principal */}
+    <div className={styles['ju-warn']} style={{ marginTop: 24 }}>
+      <span className={styles['ju-warn__icon']}>▢</span>
+      <div>
+        <div className={styles['ju-warn__t']}>Sin paredes claras, no hay salida que escalonar</div>
+        <div className={styles['ju-warn__s']}>
+          No aparece un soporte nítido para la entrada ni techos donde apoyar las salidas.{' '}
+          <b>No se inventa una jugada</b> para llenar la pantalla — cuando no hay geometría, no hay plan.
+        </div>
+      </div>
+    </div>
+
+    {/* procedencia */}
+    <div className={styles['ju-prov']}>
+      La jugada se deriva de Niveles. Si Niveles no encontró paredes, el Instrumento se queda callado — eso
+      también es un hecho honesto sobre la moneda.
+    </div>
+  </div>
+);

--- a/frontend/src/components/valles/jugada/LaJugadaChart.test.tsx
+++ b/frontend/src/components/valles/jugada/LaJugadaChart.test.tsx
@@ -1,0 +1,108 @@
+// LaJugadaChart.test.tsx — smoke test del gráfico de velas cálido.
+// Mockea lightweight-charts (sin canvas real) y getOhlcv (sin red).
+// Verifica que el overlay de zona de entrada renderiza correctamente.
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render } from '@testing-library/react';
+
+// jsdom no implementa ResizeObserver — mock global mínimo
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = class ResizeObserver {
+      observe()    {}
+      unobserve()  {}
+      disconnect() {}
+    };
+  }
+});
+
+// Mock de lightweight-charts: serie con priceToCoordinate trivial
+vi.mock('lightweight-charts', () => ({
+  createChart: () => ({
+    addCandlestickSeries: () => ({
+      setData:              vi.fn(),
+      applyOptions:         vi.fn(),
+      priceToCoordinate:    (p: number) => p * 1000,
+    }),
+    timeScale: () => ({
+      fitContent:                           vi.fn(),
+      subscribeVisibleLogicalRangeChange:   vi.fn(),
+      unsubscribeVisibleLogicalRangeChange: vi.fn(),
+    }),
+    applyOptions: vi.fn(),
+    resize:       vi.fn(),
+    remove:       vi.fn(),
+  }),
+}));
+
+// Mock de api: sin red
+vi.mock('../../../api', () => ({
+  getOhlcv: async () => ({ candles: [], volumes: [] }),
+}));
+
+import { LaJugadaChart } from './LaJugadaChart';
+import type { PlanDerived } from '../../../types';
+
+const plan: PlanDerived = {
+  entry:      0.419,
+  sl_plan:    0.385,
+  sl_piso:    null,
+  entry_zone: {
+    centro:      0.419,
+    precio_bajo: 0.412,
+    precio_alto: 0.426,
+    toques:      5,
+  },
+  rungs: [
+    {
+      tp_price:  0.448,
+      size_frac: 0.5,
+      zona: {
+        centro:      0.448,
+        precio_bajo: 0.445,
+        precio_alto: 0.451,
+        toques:      2,
+      },
+    },
+  ],
+  runner_frac: 0.05,
+};
+
+describe('LaJugadaChart', () => {
+  it('renderiza la banda de zona de entrada', async () => {
+    const { findByText } = render(
+      <LaJugadaChart
+        symbol="ADAUSDT"
+        plan={plan}
+        live={0.4205}
+        phaseLabel="derivada"
+      />,
+    );
+    // El label de la zona de entrada debe aparecer en el DOM
+    expect(await findByText(/ZONA DE ENTRADA/)).toBeTruthy();
+  });
+
+  it('muestra la píldora de fase', async () => {
+    const { findByText } = render(
+      <LaJugadaChart
+        symbol="ADAUSDT"
+        plan={plan}
+        live={0.4205}
+        phaseLabel="en curso"
+      />,
+    );
+    expect(await findByText('en curso')).toBeTruthy();
+  });
+
+  it('muestra la leyenda del símbolo', async () => {
+    const { findByText } = render(
+      <LaJugadaChart
+        symbol="ADAUSDT"
+        plan={plan}
+        live={0.4205}
+        phaseLabel="derivada"
+      />,
+    );
+    expect(await findByText('ADAUSDT')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/valles/jugada/LaJugadaChart.tsx
+++ b/frontend/src/components/valles/jugada/LaJugadaChart.tsx
@@ -1,0 +1,307 @@
+// ============================================================
+// LaJugadaChart.tsx — gráfico de velas cálido + capa de overlays.
+//
+// Lightweight Charts dibuja las velas en tonos neutros cálidos
+// (sin verde/rojo de semáforo, sin paneo: es una lámina editorial).
+// Encima, una capa HTML sincronizada al precio real dibuja la jugada:
+// zona de entrada como banda, stop/BE, peldaños de escalera, runner
+// y el precio vivo. Al cambiar de fase las anotaciones transicionan.
+//
+// Montaje idéntico al ChartCanvas de SymbolDetail.tsx: useRef,
+// useEffect keyed on symbol, ResizeObserver, chart.remove() cleanup.
+// ============================================================
+
+import React, { useEffect, useRef, useState } from 'react';
+import { createChart, type IChartApi, type ISeriesApi } from 'lightweight-charts';
+import { getOhlcv } from '../../../api';
+import type { PlanDerived } from '../../../types';
+import { buildOverlays, type LiveState } from './overlays';
+import styles from './jugada.module.css';
+
+// Formatea un precio con hasta 4 decimales significativos
+function fmt(p: number): string {
+  if (p >= 1000) return p.toLocaleString('en-US', { maximumFractionDigits: 2 });
+  if (p >= 1)    return p.toFixed(4).replace(/\.?0+$/, '');
+  return p.toPrecision(4);
+}
+
+export interface LaJugadaChartProps {
+  symbol: string;
+  plan: PlanDerived;
+  live: number;
+  state?: LiveState | null;
+  phaseLabel: string;
+  height?: number;
+}
+
+export const LaJugadaChart: React.FC<LaJugadaChartProps> = ({
+  symbol,
+  plan,
+  live,
+  state = null,
+  phaseLabel,
+  height = 420,
+}) => {
+  const wrapRef  = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+  // Contador de re-renders para reposicionar overlays cuando cambia
+  // el rango visible o el contenedor redimensiona
+  const [, force] = useState(0);
+
+  // ── MONTAR EL GRÁFICO ─────────────────────────────────────
+  useEffect(() => {
+    if (!wrapRef.current) return;
+    const container = wrapRef.current;
+
+    // Jiggle de 1px: fancy-canvas (interno de Lightweight Charts)
+    // solo actualiza el bitmap ante un CAMBIO de tamaño; el primer
+    // resize con el tamaño correcto a veces no dispara el redraw.
+    const applySize = (chart: IChartApi) => {
+      const W = Math.round(container.clientWidth);
+      const H = Math.round(container.clientHeight);
+      if (W < 1 || H < 1) return;
+      chart.resize(W - 1, H - 1, true);
+      chart.resize(W, H, true);
+    };
+
+    const chart = createChart(container, {
+      layout: {
+        // 'solid' es el valor correcto; se castea para compatibilidad
+        // de tipos con la versión exacta de lightweight-charts instalada
+        background: { type: 'solid' as never, color: 'transparent' },
+        textColor:  '#8A8270',
+        fontFamily: "'Instrument Sans', sans-serif",
+        fontSize:   11,
+      },
+      grid: {
+        vertLines: { visible: false },
+        horzLines: { color: 'rgba(228,220,204,0.55)' },
+      },
+      rightPriceScale: {
+        borderColor:  '#E4DCCC',
+        scaleMargins: { top: 0.07, bottom: 0.07 },
+        entireTextOnly: true,
+      },
+      timeScale:  { visible: false, borderVisible: false },
+      crosshair:  { mode: 0 as never },
+      handleScroll: false,
+      handleScale:  false,
+      width:  Math.max(1, container.clientWidth),
+      height: Math.max(1, height),
+    });
+
+    const series = chart.addCandlestickSeries({
+      upColor:         '#DAD0BD',
+      downColor:       '#9E947F',
+      borderUpColor:   '#A89A82',
+      borderDownColor: '#6F6657',
+      wickUpColor:     '#A89A82',
+      wickDownColor:   '#7C7263',
+      priceLineVisible:  false,
+      lastValueVisible:  false,
+      priceFormat: { type: 'price', precision: 4, minMove: 0.0001 },
+    });
+
+    chartRef.current  = chart;
+    seriesRef.current = series;
+
+    // Escala fija al rango de precios del plan: el gráfico se centra
+    // en la jugada, no hace autoscale libre
+    const priceMin = Math.min(plan.sl_plan, live) * 0.993;
+    const priceMax = Math.max(
+      ...plan.rungs.map((r) => r.tp_price),
+      plan.entry,
+      live,
+    ) * 1.007;
+    series.applyOptions({
+      autoscaleInfoProvider: () => ({
+        priceRange: { minValue: priceMin, maxValue: priceMax },
+      }),
+    });
+
+    // Cargar velas reales
+    getOhlcv(symbol, '1d', 180).then((res) => {
+      if (chartRef.current !== chart) return; // ya destruido
+      series.setData(
+        res.candles.map((c) => ({
+          time:  c.time as never,
+          open:  c.open,
+          high:  c.high,
+          low:   c.low,
+          close: c.close,
+        })),
+      );
+      chart.timeScale().fitContent();
+      // Dos frames: dar tiempo a que fitContent propague antes de reposicionar
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => {
+          applySize(chart);
+          force((n) => n + 1);
+        }),
+      );
+    }).catch(() => { /* sin datos: el gráfico queda vacío pero montado */ });
+
+    // ResizeObserver → ajustar bitmap + reposicionar overlays
+    const ro = new ResizeObserver(() => {
+      if (!chartRef.current) return;
+      applySize(chart);
+      force((n) => n + 1);
+    });
+    ro.observe(container);
+
+    // Reposicionar overlays cuando cambia el rango visible (scroll/zoom).
+    // En lightweight-charts v4 subscribe devuelve void; se cancela con
+    // unsubscribeVisibleLogicalRangeChange pasando la misma referencia.
+    const onRangeChange = () => force((n) => n + 1);
+    chart.timeScale().subscribeVisibleLogicalRangeChange(onRangeChange);
+
+    return () => {
+      ro.disconnect();
+      chart.timeScale().unsubscribeVisibleLogicalRangeChange(onRangeChange);
+      chart.remove();
+      chartRef.current  = null;
+      seriesRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [symbol, height]);
+
+  // ── GEOMETRÍA DE OVERLAYS ─────────────────────────────────
+  const s = seriesRef.current;
+  // priceToCoordinate devuelve null cuando el precio está fuera del
+  // rango visible o la serie aún no tiene datos
+  const Y = (p: number): number | null =>
+    s ? s.priceToCoordinate(p) : null;
+
+  const ov = buildOverlays({ plan, live, state });
+
+  const zTop = ov.zone ? Y(ov.zone.priceHigh) : null;
+  const zBot = ov.zone ? Y(ov.zone.priceLow)  : null;
+
+  return (
+    <div className={styles['ju-chart']} style={{ height }}>
+      {/* El canvas de Lightweight Charts ocupa todo el div */}
+      <div ref={wrapRef} className={styles['ju-chart__canvas']} />
+
+      {/* Leyenda mínima */}
+      <div className={styles['ju-chart__legend']}>
+        <span className="coin">{symbol}</span>
+        <span className="sep" />
+        <span>diario · paredes de D.1</span>
+      </div>
+
+      {/* Píldora de fase */}
+      {phaseLabel && (
+        <div className={styles['ju-chart__phase']}>{phaseLabel}</div>
+      )}
+
+      {/* ── CAPA DE ANOTACIONES HTML ── */}
+      <div className={styles['ju-chart__ann']}>
+
+        {/* runner — banda abierta arriba del último techo */}
+        {ov.runner && Y(ov.runner.fromPrice) != null && (
+          <div
+            className={`${styles['ju-ann']} ${styles['ju-ann-runner']}`}
+            style={{ top: 0, height: Math.max(0, Y(ov.runner.fromPrice)!) }}
+          >
+            <span className={styles['ju-ann-runner__lbl']}>
+              runner · {Math.round(ov.runner.frac * 100)}% abierto ↑
+            </span>
+          </div>
+        )}
+
+        {/* zona de entrada (banda rayada) */}
+        {ov.zone && zTop != null && zBot != null && (
+          <div
+            className={`${styles['ju-ann']} ${styles['ju-ann-zone']}`}
+            style={{ top: zTop, height: Math.max(2, zBot - zTop) }}
+          >
+            <span className={styles['ju-ann-zone__lbl']}>
+              ZONA DE ENTRADA
+              <b className="num">${fmt(ov.zone.priceLow)}–${fmt(ov.zone.priceHigh)}</b>
+            </span>
+          </div>
+        )}
+
+        {/* peldaños de salida */}
+        {ov.rungs.map((r, i) => {
+          const ry = Y(r.price);
+          if (ry == null) return null;
+          return (
+            <div
+              key={i}
+              className={[
+                styles['ju-ann'],
+                styles['ju-ann-line'],
+                styles['ju-ann--rung'],
+                r.filled ? styles['is-filled'] : '',
+              ].join(' ')}
+              style={{ top: ry }}
+            >
+              <span className={styles['ju-ann-line__rule']} />
+              <span className={styles['ju-ann-line__tag']}>
+                <span className={styles['ju-ann-line__pct']}>
+                  {r.filled ? 'llena' : `salida ${i + 1}`}
+                </span>
+                <span className="num">${fmt(r.price)}</span>
+                <span className={styles['ju-ann-line__pct']}>
+                  {Math.round(r.sizeFrac * 100)}%
+                  {r.toques != null ? ` · ${r.toques} toques` : ''}
+                </span>
+              </span>
+            </div>
+          );
+        })}
+
+        {/* stop / break-even */}
+        {Y(ov.stop.price) != null && (
+          <div
+            className={[
+              styles['ju-ann'],
+              styles['ju-ann-line'],
+              ov.stop.be ? styles['ju-ann--be'] : styles['ju-ann--stop'],
+            ].join(' ')}
+            style={{ top: Y(ov.stop.price)! }}
+          >
+            <span className={styles['ju-ann-line__rule']} />
+            <span className={styles['ju-ann-line__tag']}>
+              <span className={styles['ju-ann-line__pct']}>
+                {ov.stop.be ? 'break-even' : 'stop'}
+              </span>
+              <span className="num">${fmt(ov.stop.price)}</span>
+            </span>
+          </div>
+        )}
+
+        {/* precio vivo */}
+        {Y(ov.live.price) != null && (
+          <div
+            className={[
+              styles['ju-ann'],
+              styles['ju-ann-live'],
+              ov.live.fuera ? styles['ju-ann-live--fuera'] : '',
+            ].join(' ')}
+            style={{ top: Y(ov.live.price)! }}
+          >
+            <span className={styles['ju-ann-live__tag']}>
+              {ov.live.fuera ? 'precio de ahora ' : 'ahora '}
+              <span className="num">${fmt(ov.live.price)}</span>
+            </span>
+          </div>
+        )}
+
+        {/* hueco honesto: escalera corta, no se inventan techos */}
+        {ov.gap && (
+          <div
+            className={styles['ju-chart__gap']}
+            style={{ top: Math.max(8, (zTop ?? 64) - 64) }}
+          >
+            Arriba del primer techo <b>no hay más paredes claras</b>.
+            La escalera queda corta — no se inventan techos.
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/valles/jugada/jugada.module.css
+++ b/frontend/src/components/valles/jugada/jugada.module.css
@@ -1,0 +1,505 @@
+/* ============================================================
+   jugada.module.css — Port 1:1 de jugada-warm.css + jugada-chart.css
+   Scoped al módulo CSS (todas las clases son locales via CSS Modules).
+   TOKEN WIRING: los tokens cálidos (--paper/--clay/--sage/--ochre etc.)
+   SE HEREDAN de .vwRoot (valles.module.css), que los declara.
+   NO se redefinen aquí para no duplicar. Solo se agrega --ease y el
+   token --slate que vwRoot aún no expone.
+   Si este componente se usa fuera de .vwRoot, los tokens caerán al
+   valor de CSS custom property vacío (visible como fondo blanco/sin color)
+   — es correcto: el componente es parte del flujo cálido de Valles.
+   ============================================================ */
+
+/* ── token local: --ease ya existe en vwRoot — se hereda.
+   --slate no está en vwRoot; se declara sólo acá scoped. ── */
+.juRoot {
+  --slate: #4C5A66;
+}
+
+/* ============================================================
+   MARCO de pantalla (chrome estático, no fixed)
+   ============================================================ */
+.ju-frame {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(120% 70% at 50% -8%, rgba(184,84,46,0.05), transparent 55%),
+    radial-gradient(90% 60% at 100% 108%, rgba(94,112,72,0.05), transparent 60%),
+    var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  -webkit-font-smoothing: antialiased;
+}
+.ju-frame * { box-sizing: border-box; }
+
+/* barra superior: marca + stepper de 4 lentes */
+.ju-top {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 20px clamp(20px, 4vw, 44px);
+  border-bottom: 1px solid var(--card-edge);
+  background: rgba(251,249,244,0.7);
+}
+.ju-brand { display: flex; align-items: center; gap: 11px; }
+.ju-brand__mark {
+  width: 26px; height: 26px; flex: none; display: grid; place-items: center;
+  border: 1.5px solid var(--clay); border-radius: 50%;
+  color: var(--clay); font-family: var(--serif); font-size: 14px;
+}
+.ju-brand__name { font-family: var(--serif); font-size: 19px; font-weight: 600; letter-spacing: 0.01em; }
+.ju-brand__tag { font-size: 12.5px; color: var(--ink-3); border-left: 1px solid var(--card-edge-2); padding-left: 11px; margin-left: 3px; }
+
+.ju-steps { display: flex; align-items: center; gap: 4px; }
+.ju-step { display: flex; align-items: center; gap: 9px; padding: 6px 4px; font-size: 13px; color: var(--ink-4); }
+.ju-step__n {
+  width: 24px; height: 24px; display: grid; place-items: center; border-radius: 50%;
+  border: 1.5px solid var(--card-edge-2); font-size: 12px; color: var(--ink-4);
+}
+.ju-step--done .ju-step__n { border-color: var(--sage); color: var(--sage); }
+.ju-step--active { color: var(--ink); }
+.ju-step--active .ju-step__n { border-color: var(--clay); background: var(--clay); color: #fff; }
+.ju-step__sep { width: 16px; height: 1px; background: var(--card-edge-2); }
+
+/* área central — una sola columna, un foco */
+.ju-stage { flex: 1; display: flex; justify-content: center; padding: clamp(20px, 4vh, 44px) clamp(20px, 5vw, 56px) 30px; }
+.ju-screen { width: 100%; max-width: 660px; }
+
+/* nav inferior estático */
+.ju-nav {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 18px clamp(20px, 5vw, 56px);
+  border-top: 1px solid var(--card-edge);
+}
+.ju-btn {
+  font-family: var(--sans); font-size: 15.5px; font-weight: 500;
+  border-radius: 999px; cursor: pointer; border: 1px solid transparent;
+  display: inline-flex; align-items: center; gap: 9px;
+}
+.ju-btn--primary { background: var(--clay); color: #fff; padding: 14px 26px; }
+.ju-btn--ghost { background: none; color: var(--ink-2); padding: 14px 18px; }
+.ju-btn--outline { background: none; color: var(--clay); border-color: var(--clay-soft); padding: 13px 22px; }
+.ju-btn--block { width: 100%; justify-content: center; padding: 17px; font-size: 16.5px; }
+
+/* ── eyebrow + titular ─────────────────────────────────────── */
+.ju-eyebrow { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-bottom: 18px; }
+.ju-eyebrow__coin { font-size: 13px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase; color: var(--clay); }
+.ju-eyebrow__sym { font-size: 12.5px; color: var(--ink-4); letter-spacing: 0.06em; }
+.ju-calc {
+  display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; color: var(--ink-3);
+  background: var(--card); border: 1px solid var(--card-edge); border-radius: 999px; padding: 4px 11px;
+}
+.ju-calc i { width: 6px; height: 6px; border-radius: 50%; background: var(--clay); flex: none; }
+
+.ju-question {
+  font-family: var(--serif); font-size: clamp(25px, 3.8vw, 34px); font-weight: 500;
+  line-height: 1.16; letter-spacing: -0.012em; color: var(--ink); text-wrap: balance;
+}
+.ju-lede { font-size: 16.5px; line-height: 1.6; color: var(--ink-2); margin-top: 12px; text-wrap: pretty; }
+.ju-lede b { color: var(--ink); font-weight: 600; }
+
+/* ── LÁMINA DE SALIDA — la jugada dibujada contra las paredes ─ */
+.ju-lamina {
+  position: relative; margin-top: 26px;
+  background: var(--card); border: 1px solid var(--card-edge); border-radius: 16px;
+  overflow: hidden;
+}
+.ju-lamina__axis { position: absolute; left: 22px; top: 0; bottom: 0; width: 1px; background: var(--card-edge); }
+
+/* banda de la zona de entrada (rango, no línea) */
+.ju-zone {
+  position: absolute; left: 16px; right: 16px;
+  background: repeating-linear-gradient(135deg, var(--clay-tint), var(--clay-tint) 9px, var(--clay-soft) 9px, var(--clay-soft) 10px);
+  border: 1.5px dashed var(--clay); border-radius: 10px;
+}
+.ju-zone__lbl {
+  position: absolute; left: 12px; top: 50%; transform: translateY(-50%);
+  font-size: 12px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--clay-deep);
+}
+.ju-zone__lbl b { display: block; font-family: var(--serif); font-size: 16px; letter-spacing: 0; text-transform: none; color: var(--ink); margin-top: 2px; }
+.ju-zone__rango { font-size: 11px; font-weight: 500; color: var(--clay-deep); letter-spacing: 0; text-transform: none; }
+
+/* marcador del precio vivo */
+.ju-price { position: absolute; left: 16px; right: 16px; display: flex; align-items: center; pointer-events: none; }
+.ju-price__line { flex: 1; border-top: 2px solid var(--clay); opacity: 0.55; }
+.ju-price__dot { width: 13px; height: 13px; border-radius: 50%; background: var(--clay); box-shadow: 0 0 0 5px var(--clay-tint); flex: none; }
+.ju-price__tag { font-size: 12.5px; color: var(--clay-deep); font-weight: 600; white-space: nowrap; margin-left: 9px; background: var(--card); padding: 1px 6px; border-radius: 6px; }
+.ju-price__tag .num { font-family: var(--serif); }
+.ju-price--fuera .ju-price__dot { background: var(--ochre); box-shadow: 0 0 0 5px var(--ochre-tint); }
+.ju-price--fuera .ju-price__line { border-color: var(--ochre); }
+.ju-price--fuera .ju-price__tag { color: var(--ochre); }
+
+/* peldaños de salida — cada uno sobre una resistencia nombrada */
+.ju-rung {
+  position: absolute; left: 16px; right: 16px;
+  display: flex; align-items: center; justify-content: space-between; gap: 14px;
+  border-top: 1.5px dashed var(--card-edge-2);
+  padding-top: 7px;
+}
+.ju-rung__wall { display: flex; align-items: baseline; gap: 9px; min-width: 0; }
+.ju-rung__price { font-family: var(--serif); font-size: 17px; font-weight: 600; color: var(--ink); font-variant-numeric: tabular-nums; }
+.ju-rung__meta { font-size: 12px; color: var(--ink-3); }
+.ju-rung__size {
+  display: inline-flex; align-items: center; gap: 8px; flex: none;
+  font-size: 12px; color: var(--ink-2); background: var(--paper-2);
+  border: 1px solid var(--card-edge); border-radius: 999px; padding: 4px 11px; white-space: nowrap;
+}
+.ju-rung__size b { font-family: var(--serif); font-size: 14px; color: var(--ink); font-weight: 600; }
+.ju-rung__n { font-size: 10.5px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-3); }
+/* peldaño LLENO (vivo) */
+.ju-rung--filled { border-top-color: #C9D2B2; border-top-style: solid; }
+.ju-rung--filled .ju-rung__price { color: var(--sage); }
+.ju-rung--filled .ju-rung__size { background: var(--sage-tint); border-color: #C9D2B2; color: var(--sage); }
+.ju-rung--filled .ju-rung__size b { color: var(--sage); }
+/* peldaño abierto en vivo (todavía no) */
+.ju-rung--pending { opacity: 0.92; }
+
+/* el runner — lo que dejas corriendo, sin objetivo */
+.ju-runner {
+  position: absolute; left: 16px; right: 16px;
+  display: flex; align-items: center; justify-content: space-between; gap: 14px;
+  border-top: 1.5px dotted var(--card-edge-2); padding-top: 7px;
+}
+.ju-runner__lbl { font-size: 12.5px; color: var(--ink-3); }
+.ju-runner__lbl b { color: var(--ink-2); font-weight: 600; }
+.ju-runner__size { font-size: 12px; color: var(--ink-3); background: var(--paper-2); border: 1px dashed var(--card-edge-2); border-radius: 999px; padding: 4px 11px; white-space: nowrap; }
+
+/* el stop — hasta dónde aguantas (ocre) */
+.ju-stop { position: absolute; left: 16px; right: 16px; display: flex; align-items: center; }
+.ju-stop__line { flex: 1; border-top: 2px solid var(--ochre); }
+.ju-stop__tag {
+  font-size: 12px; font-weight: 600; color: var(--ochre); white-space: nowrap; margin-left: 9px;
+  background: var(--ochre-tint); border: 1px solid #E4CF9E; border-radius: 6px; padding: 2px 8px;
+}
+.ju-stop__tag .num { font-family: var(--serif); }
+.ju-stop--be .ju-stop__line { border-color: var(--sage); border-top-style: solid; }
+.ju-stop--be .ju-stop__tag { color: var(--sage); background: var(--sage-tint); border-color: #C9D2B2; }
+
+/* hueco honesto cuando la escalera queda corta */
+.ju-gap {
+  position: absolute; left: 16px; right: 16px;
+  display: flex; align-items: center; gap: 10px;
+  border: 1.5px dashed var(--card-edge-2); border-radius: 10px;
+  background: var(--paper-2); color: var(--ink-3); font-size: 12.5px; line-height: 1.4;
+  padding: 10px 14px;
+}
+.ju-gap b { color: var(--ink-2); font-weight: 600; }
+
+/* ── hechos en palabras ── */
+.ju-facts { list-style: none; margin: 24px 0 0; padding: 0; display: flex; flex-direction: column; gap: 14px; }
+.ju-fact { display: flex; align-items: flex-start; gap: 14px; }
+.ju-fact__icon {
+  width: 38px; height: 38px; flex: none; border-radius: 10px; display: grid; place-items: center; font-size: 17px;
+  background: var(--clay-tint); color: var(--clay);
+}
+.ju-fact__icon--ochre { background: var(--ochre-tint); color: var(--ochre); }
+.ju-fact__icon--sage { background: var(--sage-tint); color: var(--sage); }
+.ju-fact__icon--mute { background: var(--paper-2); color: var(--ink-3); }
+.ju-fact__k { font-family: var(--serif); font-size: 16.5px; font-weight: 600; color: var(--ink); line-height: 1.25; }
+.ju-fact__v { font-size: 14.5px; line-height: 1.5; color: var(--ink-2); margin-top: 3px; text-wrap: pretty; }
+.ju-fact__v b { color: var(--ink); font-weight: 600; }
+
+/* nota de procedencia */
+.ju-prov {
+  margin-top: 26px; padding: 15px 18px;
+  background: var(--card); border: 1px solid var(--card-edge); border-radius: 12px;
+  border-left: 3px solid var(--slate, #4C5A66);
+  font-size: 14.5px; line-height: 1.55; color: var(--ink-2);
+}
+.ju-prov b { color: var(--ink); font-weight: 600; }
+
+/* ── GATE — confirmar en frío ── */
+.ju-gate { margin-top: 24px; background: var(--card); border: 1px solid var(--card-edge); border-radius: 16px; overflow: hidden; }
+.ju-gate__hd { padding: 18px 22px; border-bottom: 1px solid var(--card-edge); }
+.ju-gate__hd-k { font-size: 11.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-3); }
+.ju-gate__hd-t { font-family: var(--serif); font-size: 19px; font-weight: 600; color: var(--ink); margin-top: 3px; }
+.ju-gate__rows { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--card-edge); }
+.ju-grow { background: var(--card); padding: 14px 18px; }
+.ju-grow--full { grid-column: 1 / -1; }
+.ju-grow__k { font-size: 12px; color: var(--ink-3); }
+.ju-grow__v { font-family: var(--serif); font-size: 17px; font-weight: 600; color: var(--ink); margin-top: 4px; font-variant-numeric: tabular-nums; }
+.ju-grow__note { font-size: 12px; color: var(--ink-4); margin-top: 2px; }
+.ju-grow__v--ochre { color: var(--ochre); }
+.ju-ladder-mini { display: flex; gap: 6px; margin-top: 7px; flex-wrap: wrap; }
+.ju-lm { display: inline-flex; align-items: baseline; gap: 6px; font-size: 12px; color: var(--ink-2); background: var(--paper-2); border: 1px solid var(--card-edge); border-radius: 8px; padding: 4px 9px; }
+.ju-lm b { font-family: var(--serif); font-size: 13px; color: var(--ink); }
+.ju-lm__pct { color: var(--ink-3); font-size: 11px; }
+
+.ju-disc {
+  margin-top: 16px; display: flex; gap: 13px; align-items: flex-start;
+  background: var(--ochre-tint); border: 1px solid #E4CF9E; border-radius: 12px; padding: 15px 17px;
+}
+.ju-disc__icon { color: var(--ochre); font-size: 18px; flex: none; line-height: 1.3; }
+.ju-disc__t { font-size: 14.5px; line-height: 1.55; color: var(--ink); }
+.ju-disc__t b { font-weight: 600; }
+.ju-confirm { margin-top: 18px; }
+.ju-confirm__hint { text-align: center; font-size: 13px; color: var(--ink-3); margin-top: 11px; }
+
+/* estado YA FIJADA */
+.ju-fixed {
+  margin-top: 24px; display: flex; gap: 15px; align-items: flex-start;
+  background: var(--sage-tint); border: 1px solid #C9D2B2; border-radius: 16px; padding: 20px 22px;
+}
+.ju-fixed__icon { width: 42px; height: 42px; flex: none; border-radius: 50%; display: grid; place-items: center; background: var(--card); color: var(--sage); font-size: 20px; border: 1.5px solid var(--sage); }
+.ju-fixed__t { font-family: var(--serif); font-size: 19px; font-weight: 600; color: var(--ink); }
+.ju-fixed__s { font-size: 14.5px; line-height: 1.55; color: var(--ink-2); margin-top: 5px; }
+.ju-fixed__s b { color: var(--ink); font-weight: 600; }
+
+/* ── PLANO VIVO ── */
+.ju-livehead { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 16px; }
+.ju-livestate {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 11.5px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase;
+  border-radius: 999px; padding: 5px 13px;
+}
+.ju-livestate i { width: 8px; height: 8px; border-radius: 50%; background: currentColor; }
+.ju-livestate--activo { color: var(--sage); background: var(--sage-tint); border: 1px solid #C9D2B2; }
+.ju-livestate--incierto { color: var(--ochre); background: var(--ochre-tint); border: 1px solid #E4CF9E; }
+.ju-livestate--cerrado { color: var(--ink-3); background: var(--paper-2); border: 1px solid var(--card-edge-2); }
+
+.ju-livefresh { display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; }
+.ju-livefresh i { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.ju-livefresh--fresco { color: var(--ink-3); }
+.ju-livefresh--fresco i { background: var(--sage); }
+.ju-livefresh--rancio { color: var(--ochre); }
+.ju-livefresh--rancio i { background: var(--ochre); box-shadow: 0 0 0 4px var(--ochre-tint); }
+
+.ju-pull { margin-left: auto; font-size: 11.5px; color: var(--ink-4); display: inline-flex; align-items: center; gap: 6px; }
+
+/* hechos del estado (vivo) */
+.ju-state-facts { list-style: none; margin: 22px 0 0; padding: 0; display: flex; flex-direction: column; gap: 10px; }
+.ju-sf {
+  display: flex; align-items: flex-start; gap: 13px;
+  background: var(--card); border: 1px solid var(--card-edge); border-radius: 12px; padding: 14px 16px;
+}
+.ju-sf__dot { width: 10px; height: 10px; border-radius: 50%; flex: none; margin-top: 5px; }
+.ju-sf--sage { border-left: 3px solid var(--sage); }
+.ju-sf--sage .ju-sf__dot { background: var(--sage); }
+.ju-sf--ochre { border-left: 3px solid var(--ochre); }
+.ju-sf--ochre .ju-sf__dot { background: var(--ochre); }
+.ju-sf--ink { border-left: 3px solid var(--card-edge-2); }
+.ju-sf--ink .ju-sf__dot { background: var(--ink-4); }
+.ju-sf__t { font-size: 15.5px; font-weight: 600; color: var(--ink); line-height: 1.3; }
+.ju-sf__s { font-size: 13.5px; color: var(--ink-2); margin-top: 3px; line-height: 1.45; }
+
+/* aviso de incierto / rancio */
+.ju-warn {
+  margin-top: 18px; display: flex; gap: 13px; align-items: flex-start;
+  background: var(--ochre-tint); border: 1px solid #E4CF9E; border-radius: 12px; padding: 15px 17px;
+}
+.ju-warn__icon { color: var(--ochre); font-size: 18px; flex: none; }
+.ju-warn__t { font-family: var(--serif); font-size: 16px; font-weight: 600; color: var(--ink); }
+.ju-warn__s { font-size: 13.5px; line-height: 1.5; color: var(--ink-2); margin-top: 3px; }
+.ju-warn__s b { color: var(--ink); font-weight: 600; }
+
+/* ── LECTURA DE CONDUCTA ── */
+.ju-conduct { margin-top: 24px; }
+.ju-conduct__lead {
+  font-family: var(--serif); font-size: clamp(21px, 3vw, 26px); font-weight: 600;
+  line-height: 1.25; color: var(--ink); letter-spacing: -0.01em; text-wrap: balance;
+}
+.ju-conduct__say { font-size: 15.5px; line-height: 1.6; color: var(--ink-2); margin-top: 10px; text-wrap: pretty; }
+.ju-conduct__say b { color: var(--ink); font-weight: 600; }
+.ju-cfields { margin-top: 22px; display: flex; flex-direction: column; gap: 1px; background: var(--card-edge); border: 1px solid var(--card-edge); border-radius: 14px; overflow: hidden; }
+.ju-cf { display: flex; align-items: center; gap: 14px; background: var(--card); padding: 15px 18px; }
+.ju-cf__mark { width: 26px; height: 26px; flex: none; border-radius: 50%; display: grid; place-items: center; font-size: 14px; }
+.ju-cf--si .ju-cf__mark { background: var(--sage-tint); color: var(--sage); border: 1px solid #C9D2B2; }
+.ju-cf--no .ju-cf__mark { background: var(--ochre-tint); color: var(--ochre); border: 1px solid #E4CF9E; }
+.ju-cf--dato .ju-cf__mark { background: var(--paper-2); color: var(--ink-3); border: 1px solid var(--card-edge-2); }
+.ju-cf__k { font-size: 14px; color: var(--ink-3); flex: none; width: 190px; }
+.ju-cf__v { font-family: var(--serif); font-size: 15.5px; color: var(--ink); line-height: 1.35; }
+.ju-cf--no .ju-cf__v { color: var(--ink); }
+.ju-mirror {
+  margin-top: 18px; padding: 15px 18px; border-radius: 12px;
+  background: var(--card); border: 1px dashed var(--card-edge-2);
+  font-size: 14px; line-height: 1.6; color: var(--ink-2);
+}
+.ju-mirror b { color: var(--ink); font-weight: 600; }
+
+/* ── MARCA "tiene jugada" en el Pick ── */
+.ju-pickmark {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 10.5px; font-weight: 600; letter-spacing: 0.05em;
+  color: var(--ink-3); background: var(--paper-2); border: 1px solid var(--card-edge-2);
+  border-radius: 999px; padding: 3px 9px 3px 7px; white-space: nowrap;
+}
+.ju-pickmark__g { display: inline-flex; gap: 2px; align-items: flex-end; }
+.ju-pickmark__g i { width: 3px; border-radius: 1px; background: var(--ink-4); display: block; }
+.ju-pickmark__g i:nth-child(1) { height: 5px; }
+.ju-pickmark__g i:nth-child(2) { height: 8px; }
+.ju-pickmark__g i:nth-child(3) { height: 11px; }
+
+/* ── NOTA DE LENGUAJE ── */
+.ju-lex { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 8px; }
+.ju-lexcol { background: var(--card); border: 1px solid var(--card-edge); border-radius: 14px; padding: 20px 22px; }
+.ju-lexcol__h { display: flex; align-items: center; gap: 9px; font-family: var(--serif); font-size: 17px; font-weight: 600; color: var(--ink); margin-bottom: 14px; }
+.ju-lexcol__h .ju-tick { width: 20px; height: 20px; border-radius: 50%; display: grid; place-items: center; font-size: 12px; }
+.ju-lexcol--ok .ju-tick { background: var(--sage-tint); color: var(--sage); }
+.ju-lexcol--no .ju-tick { background: var(--ochre-tint); color: var(--ochre); }
+.ju-lexlist { display: flex; flex-direction: column; gap: 9px; }
+.ju-lexlist span { font-size: 14.5px; line-height: 1.4; color: var(--ink-2); padding-left: 16px; position: relative; }
+.ju-lexlist span::before { content: '·'; position: absolute; left: 4px; color: var(--ink-4); }
+.ju-lexcol--ok .ju-lexlist span { color: var(--ink); }
+.ju-lexnote { font-size: 13px; color: var(--ink-3); line-height: 1.55; margin-top: 24px; padding-top: 18px; border-top: 1px solid var(--card-edge); }
+.ju-lexnote b { color: var(--ink-2); font-weight: 600; }
+
+/* ── columna más ancha para el gráfico ── */
+.ju-screen--wide { max-width: 860px; }
+
+/* ── control de escenario (segmentado) ── */
+.ju-seg {
+  display: flex; flex-wrap: wrap; gap: 6px; margin-top: 18px;
+  background: var(--paper-2); border: 1px solid var(--card-edge); border-radius: 12px; padding: 5px;
+}
+.ju-seg__b {
+  flex: 1; min-width: 120px; font-family: var(--sans); font-size: 13px; font-weight: 500;
+  color: var(--ink-2); background: none; border: 1px solid transparent; border-radius: 9px;
+  padding: 9px 12px; cursor: pointer; transition: all 160ms var(--ease); white-space: nowrap;
+}
+.ju-seg__b:hover { color: var(--ink); }
+.ju-seg__b.is-on { color: var(--ink); background: var(--card); border-color: var(--card-edge-2); box-shadow: 0 4px 12px -8px rgba(42,39,34,0.4); }
+
+/* ── panel contextual ── */
+.ju-panel { margin-top: 24px; animation: juPanelIn 420ms var(--ease) both; }
+@keyframes juPanelIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { .ju-panel { animation: none; } }
+
+/* ── riel del ciclo ── */
+.ju-rail {
+  display: flex; align-items: center; gap: 20px; flex-wrap: wrap;
+  padding: 16px clamp(20px, 5vw, 56px);
+  border-top: 1px solid var(--card-edge); background: rgba(251,249,244,0.7);
+}
+.ju-rail__lbl { font-size: 11.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-3); white-space: nowrap; }
+.ju-rail__track { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.ju-rail__arrow { color: var(--card-edge-2); font-size: 14px; }
+.ju-rail__seg {
+  display: inline-flex; align-items: center; gap: 9px; font-family: var(--sans); font-size: 14px; font-weight: 500;
+  color: var(--ink-3); background: none; border: 1px solid var(--card-edge); border-radius: 999px;
+  padding: 9px 16px 9px 9px; cursor: pointer; transition: all 160ms var(--ease);
+}
+.ju-rail__seg:hover { color: var(--ink); border-color: var(--card-edge-2); }
+.ju-rail__seg.is-on { color: #fff; background: var(--clay); border-color: var(--clay); }
+.ju-rail__n {
+  width: 22px; height: 22px; flex: none; display: grid; place-items: center; border-radius: 50%;
+  font-size: 12px; font-weight: 600; background: var(--paper-2); color: var(--ink-3); border: 1px solid var(--card-edge-2);
+}
+.ju-rail__seg.is-on .ju-rail__n { background: rgba(255,255,255,0.22); color: #fff; border-color: transparent; }
+
+/* ============================================================
+   GRÁFICO — anotaciones cálidas sobre Lightweight Charts
+   ============================================================ */
+
+.ju-chart {
+  position: relative;
+  margin-top: 22px;
+  background: var(--card);
+  border: 1px solid var(--card-edge);
+  border-radius: 16px;
+  overflow: hidden;
+}
+.ju-chart__canvas { position: absolute; inset: 0; }
+/* capa de anotaciones — encima del canvas, no intercepta el mouse */
+.ju-chart__ann { position: absolute; inset: 0; pointer-events: none; overflow: hidden; }
+
+/* todas las anotaciones transicionan suave al cambiar de fase */
+.ju-ann { position: absolute; left: 0; transition: top 620ms var(--ease), height 620ms var(--ease), opacity 360ms var(--ease); }
+
+/* banda de la zona de entrada (rango) */
+.ju-ann-zone {
+  right: 0;
+  background: repeating-linear-gradient(135deg, rgba(184,84,46,0.10), rgba(184,84,46,0.10) 8px, rgba(184,84,46,0.16) 8px, rgba(184,84,46,0.16) 9px);
+  border-top: 1px dashed var(--clay); border-bottom: 1px dashed var(--clay);
+}
+.ju-ann-zone__lbl {
+  position: absolute; left: 14px; top: 50%; transform: translateY(-50%);
+  font-size: 10.5px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--clay-deep);
+  background: rgba(251,249,244,0.82); border-radius: 6px; padding: 3px 8px;
+}
+.ju-ann-zone__lbl b { font-family: var(--serif); font-size: 13px; letter-spacing: 0; text-transform: none; color: var(--ink); margin-left: 6px; }
+
+/* línea horizontal genérica (stop / peldaño / be / runner) */
+.ju-ann-line { right: 0; display: flex; align-items: center; height: 0; }
+.ju-ann-line__rule { flex: 1; border-top-width: 1.5px; border-top-style: dashed; }
+.ju-ann-line__tag {
+  flex: none; font-size: 11px; font-weight: 600; white-space: nowrap;
+  padding: 3px 10px; border-radius: 6px; transform: translateY(-50%); margin-right: 8px;
+  display: inline-flex; align-items: baseline; gap: 9px;
+}
+.ju-ann-line__tag .num { font-family: var(--serif); font-size: 12.5px; }
+.ju-ann-line__pct { font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; opacity: 0.8; }
+
+/* stop (ocre) */
+.ju-ann--stop .ju-ann-line__rule { border-color: var(--ochre); }
+.ju-ann--stop .ju-ann-line__tag { color: var(--ochre); background: var(--ochre-tint); border: 1px solid #E4CF9E; }
+/* break-even (salvia) */
+.ju-ann--be .ju-ann-line__rule { border-color: var(--sage); border-top-style: solid; }
+.ju-ann--be .ju-ann-line__tag { color: var(--sage); background: var(--sage-tint); border: 1px solid #C9D2B2; }
+/* peldaño de salida (neutro arcilla) */
+.ju-ann--rung .ju-ann-line__rule { border-color: var(--card-edge-2); }
+.ju-ann--rung .ju-ann-line__tag { color: var(--ink-2); background: var(--paper-2); border: 1px solid var(--card-edge); }
+/* peldaño LLENO (salvia) */
+.ju-ann--rung.is-filled .ju-ann-line__rule { border-color: var(--sage); border-top-style: solid; }
+.ju-ann--rung.is-filled .ju-ann-line__tag { color: var(--sage); background: var(--sage-tint); border-color: #C9D2B2; }
+/* runner — banda abierta arriba */
+.ju-ann-runner {
+  right: 0;
+  background: linear-gradient(180deg, rgba(94,112,72,0.0), rgba(94,112,72,0.07));
+  border-top: 1.5px dotted var(--sage);
+}
+.ju-ann-runner__lbl {
+  position: absolute; left: 50%; transform: translateX(-50%); bottom: 7px;
+  font-size: 10.5px; font-weight: 600; color: var(--sage);
+  background: rgba(251,249,244,0.86); border-radius: 6px; padding: 2px 9px; white-space: nowrap;
+}
+
+/* precio vivo — tag */
+.ju-ann-live { right: 0; display: flex; align-items: center; justify-content: flex-end; height: 0; }
+.ju-ann-live__tag {
+  transform: translateY(-50%); margin-right: 8px;
+  font-size: 11px; font-weight: 700; color: #fff; background: var(--clay);
+  padding: 3px 9px; border-radius: 6px; white-space: nowrap; box-shadow: 0 4px 12px -4px rgba(184,84,46,0.6);
+}
+.ju-ann-live__tag .num { font-family: var(--serif); }
+.ju-ann-live--fuera .ju-ann-live__tag { background: var(--ochre); box-shadow: none; }
+
+/* leyenda mínima dentro del gráfico */
+.ju-chart__legend {
+  position: absolute; left: 14px; top: 12px; z-index: 3;
+  display: flex; align-items: center; gap: 9px; flex-wrap: wrap;
+  font-size: 11px; color: var(--ink-3);
+}
+.ju-chart__legend .coin { font-family: var(--serif); font-size: 14px; font-weight: 600; color: var(--ink); }
+.ju-chart__legend .sep { width: 3px; height: 3px; border-radius: 50%; background: var(--card-edge-2); }
+.ju-chart__phase {
+  position: absolute; right: 14px; top: 12px; z-index: 3;
+  font-size: 10px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--clay); background: var(--clay-tint); border: 1px solid var(--clay-soft); border-radius: 999px; padding: 3px 10px;
+}
+
+/* cartel honesto cuando no hay paredes para escalonar */
+.ju-chart__gap {
+  position: absolute; right: 56px; z-index: 3;
+  max-width: 220px; font-size: 11px; line-height: 1.4; color: var(--ink-3);
+  background: rgba(244,240,232,0.92); border: 1px dashed var(--card-edge-2); border-radius: 10px; padding: 8px 11px;
+  transition: top 620ms var(--ease);
+}
+.ju-chart__gap b { color: var(--ink-2); font-weight: 600; }
+
+/* ── MÓVIL ── */
+.ju-frame--mobile .ju-brand__tag { display: none; }
+.ju-frame--mobile .ju-step__sep { width: 8px; }
+.ju-frame--mobile .ju-step { padding: 6px 0; }
+.ju-frame--mobile .ju-stage { padding: 24px 18px 24px; }
+.ju-frame--mobile .ju-gate__rows { grid-template-columns: 1fr; }
+.ju-frame--mobile .ju-lex { grid-template-columns: 1fr; }
+.ju-frame--mobile .ju-cf { flex-wrap: wrap; }
+.ju-frame--mobile .ju-cf__k { width: auto; flex: 1; }
+.ju-frame--mobile .ju-cf__v { flex-basis: 100%; padding-left: 40px; }
+.ju-frame--mobile .ju-nav { padding: 16px 18px; }
+.ju-frame--mobile .ju-btn--primary { padding: 13px 20px; }
+.ju-frame--mobile .ju-seg__b { min-width: 0; flex-basis: calc(50% - 3px); }
+.ju-frame--mobile .ju-rail { flex-direction: column; align-items: stretch; gap: 12px; }
+.ju-frame--mobile .ju-rail__track { justify-content: space-between; }
+.ju-frame--mobile .ju-rail__seg { padding: 8px 12px 8px 8px; font-size: 13px; }
+.ju-frame--mobile .ju-rail__arrow { display: none; }
+.ju-frame--mobile .ju-chart__gap { max-width: 150px; font-size: 10px; }

--- a/frontend/src/components/valles/jugada/overlays.test.ts
+++ b/frontend/src/components/valles/jugada/overlays.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { buildOverlays } from './overlays';
+import type { PlanDerived } from '../../../types';
+
+const plan: PlanDerived = {
+  entry: 0.419, sl_plan: 0.385, sl_piso: { centro: 0.392, precio_bajo: 0.388, precio_alto: 0.398, toques: 5 },
+  entry_zone: { centro: 0.419, precio_bajo: 0.412, precio_alto: 0.426, toques: 5 },
+  rungs: [
+    { tp_price: 0.448, size_frac: 0.50, zona: { centro: 0.448, precio_bajo: 0.445, precio_alto: 0.451, toques: 2 } },
+    { tp_price: 0.474, size_frac: 0.20, zona: { centro: 0.474, precio_bajo: 0.470, precio_alto: 0.478, toques: 4 } },
+  ],
+  runner_frac: 0.05,
+};
+
+describe('buildOverlays', () => {
+  it('zona de entrada es banda (no linea): low != high', () => {
+    const o = buildOverlays({ plan, live: 0.4205, state: null });
+    expect(o.zone).toBeTruthy();
+    expect(o.zone!.priceLow).toBe(0.412);
+    expect(o.zone!.priceHigh).toBe(0.426);
+  });
+  it('precio dentro de la zona -> live.fuera false; arriba -> arriba', () => {
+    expect(buildOverlays({ plan, live: 0.4205, state: null }).live.fuera).toBe(false);
+    expect(buildOverlays({ plan, live: 0.4400, state: null }).live.fuera).toBe('arriba');
+  });
+  it('rung lleno cuando state.rungs_llenos lo incluye; BE mueve el stop', () => {
+    const o = buildOverlays({ plan, live: 0.45, state: { rungs_llenos: [0], be_movido: true, sl_actual: 0.419 } });
+    expect(o.rungs[0].filled).toBe(true);
+    expect(o.rungs[1].filled).toBe(false);
+    expect(o.stop.be).toBe(true);
+    expect(o.stop.price).toBe(0.419);
+  });
+  it('escalera corta (1 rung) marca gap honesto', () => {
+    const corto = { ...plan, rungs: [plan.rungs[0]] };
+    expect(buildOverlays({ plan: corto, live: 0.4205, state: null }).gap).toBe(true);
+  });
+});

--- a/frontend/src/components/valles/jugada/overlays.ts
+++ b/frontend/src/components/valles/jugada/overlays.ts
@@ -1,0 +1,31 @@
+// overlays.ts
+import type { PlanDerived } from '../../../types';
+
+export interface LiveState { rungs_llenos: number[]; be_movido: boolean; sl_actual: number | null; }
+export interface OverlayModel {
+  zone: { priceLow: number; priceHigh: number; toques: number } | null;
+  stop: { price: number; be: boolean; piso: number | null };
+  rungs: { price: number; sizeFrac: number; toques: number | null; filled: boolean }[];
+  runner: { frac: number; fromPrice: number } | null;
+  live: { price: number; fuera: 'arriba' | 'abajo' | false };
+  gap: boolean;  // escalera corta: no hay más techos
+}
+
+export function buildOverlays(args: { plan: PlanDerived; live: number; state: LiveState | null }): OverlayModel {
+  const { plan, live, state } = args;
+  const z = plan.entry_zone;
+  let fuera: 'arriba' | 'abajo' | false = false;
+  if (z) { if (live > z.precio_alto) fuera = 'arriba'; else if (live < z.precio_bajo) fuera = 'abajo'; }
+  const llenos = state?.rungs_llenos ?? [];
+  const topRung = plan.rungs.length ? plan.rungs[plan.rungs.length - 1].tp_price : plan.entry;
+  return {
+    zone: z ? { priceLow: z.precio_bajo, priceHigh: z.precio_alto, toques: z.toques } : null,
+    stop: { price: state?.be_movido ? (state.sl_actual ?? plan.sl_plan) : plan.sl_plan,
+            be: !!state?.be_movido, piso: plan.sl_piso?.centro ?? null },
+    rungs: plan.rungs.map((r, i) => ({ price: r.tp_price, sizeFrac: r.size_frac,
+            toques: r.zona?.toques ?? null, filled: llenos.includes(i) })),
+    runner: plan.runner_frac > 0 ? { frac: plan.runner_frac, fromPrice: topRung } : null,
+    live: { price: live, fuera },
+    gap: plan.rungs.length === 1,
+  };
+}

--- a/frontend/src/components/valles/jugada/useJugada.ts
+++ b/frontend/src/components/valles/jugada/useJugada.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import type { PlanDerived, PlanLive, PlanConducta } from '../../../types';
+import { getPlanDerive, getPlanLive, getPlanConducta } from '../../../api';
+
+export interface AsyncState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const idle = <T,>(): AsyncState<T> => ({ data: null, loading: false, error: null });
+const pending = <T,>(): AsyncState<T> => ({ data: null, loading: true, error: null });
+
+export interface JugadaState {
+  derived: AsyncState<PlanDerived>;
+  live: AsyncState<PlanLive>;
+  conducta: AsyncState<PlanConducta>;
+}
+
+export function useJugada(symbol: string, livePrice: number | null): JugadaState {
+  const [derived, setDerived] = useState<AsyncState<PlanDerived>>(idle);
+  const [live, setLive]       = useState<AsyncState<PlanLive>>(idle);
+  const [conducta, setConducta] = useState<AsyncState<PlanConducta>>(idle);
+
+  useEffect(() => {
+    if (!symbol) return;
+
+    let cancel = false;
+
+    // derived: solo si tenemos livePrice
+    if (livePrice != null) {
+      setDerived(pending());
+      getPlanDerive(symbol, livePrice)
+        .then((d) => { if (!cancel) setDerived({ data: d, loading: false, error: null }); })
+        .catch((e: unknown) => {
+          if (!cancel) {
+            const msg = e instanceof Error ? e.message : 'Error al derivar el plan';
+            setDerived({ data: null, loading: false, error: msg });
+          }
+        });
+    } else {
+      setDerived(idle());
+    }
+
+    // live
+    setLive(pending());
+    getPlanLive(symbol)
+      .then((d) => { if (!cancel) setLive({ data: d, loading: false, error: null }); })
+      .catch((e: unknown) => {
+        if (!cancel) {
+          const msg = e instanceof Error ? e.message : 'Error al cargar el estado vivo';
+          setLive({ data: null, loading: false, error: msg });
+        }
+      });
+
+    // conducta
+    setConducta(pending());
+    getPlanConducta(symbol)
+      .then((d) => { if (!cancel) setConducta({ data: d, loading: false, error: null }); })
+      .catch((e: unknown) => {
+        if (!cancel) {
+          const msg = e instanceof Error ? e.message : 'Error al cargar la conducta';
+          setConducta({ data: null, loading: false, error: msg });
+        }
+      });
+
+    return () => { cancel = true; };
+  }, [symbol, livePrice]);
+
+  return { derived, live, conducta };
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -587,6 +587,30 @@ export interface ValleyEval {
   razones_vida?:         string[];
 }
 
+// La Jugada / Instrumento — contrato /plan
+export interface PlanZonaMeta { centro: number; precio_bajo: number; precio_alto: number; toques: number; }
+export interface PlanRung { tp_price: number; size_frac: number; zona: PlanZonaMeta | null; }
+export interface PlanDerived {
+  symbol?: string;
+  entry: number;
+  sl_plan: number;
+  sl_piso: PlanZonaMeta | null;
+  rungs: PlanRung[];
+  runner_frac: number;
+  entry_zone: PlanZonaMeta | null;
+}
+export interface PlanFrescura { estado: 'fresco' | 'rancio' | 'muerto'; edad_seg: number | null; generated_at: string | null; umbral_seg: number; }
+export interface PlanLive {
+  symbol: string;
+  estado_vivo: 'activo' | 'incierto' | 'cerrado' | null;
+  plan?: PlanDerived;
+  realidad?: { fase: string; rungs_llenos: number[]; sl_actual: number | null; be_movido: boolean; size_restante_frac: number | null; };
+  hechos?: string[];
+  frescura?: PlanFrescura;
+}
+export interface PlanConductaField { k: string; ok: 'si' | 'no' | 'dato'; v?: string; }
+export interface PlanConducta { symbol: string; estado_vivo: 'cerrado' | null; titular?: string; campos?: PlanConductaField[]; }
+
 // Dossier C — hechos citados de un proyecto (sin veredicto). Spec §2.
 export interface DossierMiembro { nombre: string; rol: string | null; enlaces: string[]; fuente: string; }
 export interface DossierCanal { url: string | null; activo: 'si' | 'no' | 'desconocido'; fuente: string | null; }

--- a/instrument/plan.py
+++ b/instrument/plan.py
@@ -30,6 +30,7 @@ class Plan:
     sl_price: float
     rungs: tuple   # tuple[Rung, ...], ascendente por tp_price — inmutable (BNC)
     runner_frac: float
+    sl_zona: dict | None = None   # soporte inmediato que fija el SL (Task A1)
 
 
 def derive_plan(zonas: list[dict], entry_price: float, *,
@@ -59,7 +60,7 @@ def derive_plan(zonas: list[dict], entry_price: float, *,
     n = len(resistencias)
     if n == 0:
         return Plan(entry_price=entry_price, entry_zone=entry_zone, sl_price=sl_price,
-                    rungs=(), runner_frac=(1.0 if runner_on else 0.0))
+                    rungs=(), runner_frac=(1.0 if runner_on else 0.0), sl_zona=soporte)
 
     fracs = SIZE_SCHEDULE[:n]
     total = sum(fracs)
@@ -78,4 +79,4 @@ def derive_plan(zonas: list[dict], entry_price: float, *,
     rungs = tuple(Rung(tp_price=z["centro"], size_frac=s, zona_origen=z)
                   for z, s in zip(resistencias, scaled))
     return Plan(entry_price=entry_price, entry_zone=entry_zone, sl_price=sl_price,
-                rungs=rungs, runner_frac=runner)
+                rungs=rungs, runner_frac=runner, sl_zona=soporte)

--- a/tests/test_lifecycle_states.py
+++ b/tests/test_lifecycle_states.py
@@ -27,6 +27,24 @@ def test_plan_json_roundtrip():
     assert p2.sl_price == p.sl_price and p2.runner_frac == p.runner_frac
 
 
+def test_plan_json_roundtrip_preserva_sl_zona():
+    """sl_zona (soporte dict) debe sobrevivir el roundtrip JSON sin truncarse a None."""
+    zona_soporte = _z("soporte", 94, 96, 95)
+    from instrument.plan import Plan, Rung
+    p = Plan(
+        entry_price=100.0,
+        entry_zone=_z("soporte", 97, 100, 98),
+        sl_price=93.06,
+        rungs=(Rung(tp_price=105.0, size_frac=1.0, zona_origen=_z("resistencia", 104, 106, 105)),),
+        runner_frac=0.0,
+        sl_zona=zona_soporte,
+    )
+    p2 = plan_from_json(plan_to_json(p))
+    assert p2.sl_zona == p.sl_zona, (
+        f"sl_zona se perdió en el roundtrip: esperado {p.sl_zona!r}, obtenido {p2.sl_zona!r}"
+    )
+
+
 def test_state_row_roundtrip_preserva_frozensets():
     s = LifecycleState(plan_id=0, fase="RUNNING",
                        rungs_llenos=frozenset({0}), consumed_order_ids=frozenset({"11"}),

--- a/tests/test_plan_api.py
+++ b/tests/test_plan_api.py
@@ -131,6 +131,63 @@ def test_plan_payload_incluye_metadata_de_paredes():
     assert p["entry_zone"]["toques"] == 3
 
 
+# ── Task A3: GET /plan/{symbol}/conducta — lectura de conducta sin PnL ───────
+
+
+def test_conducta_sin_episodio_devuelve_estado_none(monkeypatch):
+    import contextlib
+    import api.plan as plan_api
+    monkeypatch.setattr(plan_api, "db_get_latest_episode", lambda con, **kw: None)
+    monkeypatch.setattr(plan_api, "snapshot_connection", lambda: contextlib.nullcontext(None))
+    out = plan_api.conducta("ADAUSDT", tenant_id=1)
+    assert out["estado_vivo"] is None
+    assert out["symbol"] == "ADAUSDT"
+
+
+def test_conducta_devuelve_campos_sin_pnl(monkeypatch):
+    import contextlib
+    import api.plan as plan_api
+
+    fake_episode = {
+        "entry_en_zona": 1,
+        "sl_respetado": 1,
+        "adherencia_be": 0,
+        "rungs_honrados": 2,
+        "cierre_en_plan": 0,   # falsy → ok="no"
+        "hold_hours": 5.75,
+    }
+    monkeypatch.setattr(plan_api, "db_get_latest_episode", lambda con, **kw: fake_episode)
+    monkeypatch.setattr(plan_api, "snapshot_connection", lambda: contextlib.nullcontext(None))
+
+    out = plan_api.conducta("ADAUSDT", tenant_id=1)
+
+    # Estado vivo correcto
+    assert out["estado_vivo"] == "cerrado"
+
+    # Sin PnL en ningún lugar
+    assert "pnl" not in out
+    assert "pnl_usd" not in out
+
+    campos = out["campos"]
+    labels = [c["k"] for c in campos]
+
+    # Campo "Entraste en la zona" debe estar ok="si" (entry_en_zona=1)
+    zona_item = next(c for c in campos if c["k"] == "Entraste en la zona")
+    assert zona_item["ok"] == "si"
+
+    # Campo "Cerraste según el plan" debe estar ok="no" (cierre_en_plan=0)
+    cierre_item = next(c for c in campos if c["k"] == "Cerraste según el plan")
+    assert cierre_item["ok"] == "no"
+
+    # Hold hours presente como dato
+    hold_item = next(c for c in campos if c["k"] == "Cuánto aguantaste")
+    assert hold_item["ok"] == "dato"
+    assert "h" in hold_item["v"]
+
+    # titular presente
+    assert "titular" in out
+
+
 # ── Task A2: LiveSnapshot / frescura en el contrato ──────────────────────────
 
 

--- a/tests/test_plan_api.py
+++ b/tests/test_plan_api.py
@@ -129,3 +129,24 @@ def test_plan_payload_incluye_metadata_de_paredes():
     assert p["entry"] == plan.entry_price
     # entry_zone: la zona de soporte que abarca el entry (precio_bajo ≤ entry ≤ precio_alto)
     assert p["entry_zone"]["toques"] == 3
+
+
+# ── Task A2: LiveSnapshot / frescura en el contrato ──────────────────────────
+
+
+def test_vista_emite_frescura_en_el_contrato(monkeypatch):
+    from datetime import datetime, timezone
+    import api.plan as plan_api
+    now = datetime.now(timezone.utc).isoformat()
+    fake_row = {
+        "plan_json": '{"entry_price":0.419,"entry_zone":null,"sl_price":0.385,"rungs":[],"runner_frac":0.05,"sl_zona":null}',
+        "rungs_llenos_json": "[]", "be_movido": 0, "estado_vivo": "activo",
+        "sl_actual": 0.385, "fase": "CONFIRMED", "size_restante_frac": 1.0, "updated_at": now,
+    }
+    import contextlib
+    monkeypatch.setattr(plan_api, "db_get_active_state", lambda con, **kw: fake_row)
+    monkeypatch.setattr(plan_api, "snapshot_connection", lambda: contextlib.nullcontext(None))
+    out = plan_api.vista("ADAUSDT", tenant_id=1)
+    assert out["frescura"]["estado"] == "fresco"
+    assert out["frescura"]["generated_at"] == now
+    assert out["estado_vivo"] == "activo"

--- a/tests/test_plan_api.py
+++ b/tests/test_plan_api.py
@@ -93,3 +93,40 @@ def test_vista_sin_plan_activo_devuelve_none(monkeypatch, tmp_path):
 def test_confirm_payload_incompleto_es_422():
     r = _app().post("/plan/confirm", json={"symbol": "BTCUSDT"})   # falta entry_price
     assert r.status_code == 422
+
+
+# ── Task A1: metadata de paredes (toques / piso) ──────────────────────────────
+from instrument.plan import derive_plan
+from api.plan import _plan_payload
+
+
+def _zonas_paredes():
+    # soporte_piso (sl_zona): precio_alto < entry=0.419  → el más cercano abajo
+    # soporte_entry (entry_zone): precio_bajo ≤ 0.419 ≤ precio_alto  → contiene el entry
+    # Usamos entry_zone independiente del sl_zona para distinguir ambos campos.
+    # derive_plan toma sl_zona = max(soportes con precio_alto < entry, key=centro)
+    # Con entry=0.419 y soporte_piso.precio_alto=0.398 < 0.419  → sl_zona.centro=0.392
+    # Con soporte_entry.precio_bajo=0.410 ≤ 0.419 ≤ 0.425=precio_alto → entry_zone presente
+    return [
+        {"tipo": "soporte", "precio_bajo": 0.388, "precio_alto": 0.398, "centro": 0.392, "toques": 5},
+        {"tipo": "soporte", "precio_bajo": 0.410, "precio_alto": 0.425, "centro": 0.417, "toques": 3},
+        {"tipo": "resistencia", "precio_bajo": 0.445, "precio_alto": 0.451, "centro": 0.448, "toques": 2},
+        {"tipo": "resistencia", "precio_bajo": 0.470, "precio_alto": 0.478, "centro": 0.474, "toques": 4},
+    ]
+
+
+def test_plan_payload_incluye_metadata_de_paredes():
+    plan = derive_plan(_zonas_paredes(), 0.419)
+    p = _plan_payload(plan)
+    # rungs: cada rung expone su zona_origen
+    assert p["rungs"][0]["zona"]["toques"] == 2
+    assert p["rungs"][0]["zona"]["centro"] == 0.448
+    # sl_piso: el soporte más cercano por debajo del entry (precio_alto < entry)
+    # soporte_piso: precio_alto=0.398 < 0.419 → sl_zona.centro=0.392
+    assert p["sl_piso"]["centro"] == 0.392
+    assert p["sl_piso"]["precio_bajo"] == 0.388
+    # campos legacy intactos
+    assert p["sl_plan"] == plan.sl_price
+    assert p["entry"] == plan.entry_price
+    # entry_zone: la zona de soporte que abarca el entry (precio_bajo ≤ entry ≤ precio_alto)
+    assert p["entry_zone"]["toques"] == 3

--- a/tests/test_plan_api.py
+++ b/tests/test_plan_api.py
@@ -5,9 +5,10 @@ from unittest.mock import patch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.plan import router, construir_hechos
+from api.plan import router, construir_hechos, _plan_payload
 from api.deps import verify_api_key
 from auth.dependencies import get_current_tenant_id
+from instrument.plan import derive_plan
 
 
 def _app():
@@ -96,8 +97,6 @@ def test_confirm_payload_incompleto_es_422():
 
 
 # ── Task A1: metadata de paredes (toques / piso) ──────────────────────────────
-from instrument.plan import derive_plan
-from api.plan import _plan_payload
 
 
 def _zonas_paredes():
@@ -108,10 +107,10 @@ def _zonas_paredes():
     # Con entry=0.419 y soporte_piso.precio_alto=0.398 < 0.419  → sl_zona.centro=0.392
     # Con soporte_entry.precio_bajo=0.410 ≤ 0.419 ≤ 0.425=precio_alto → entry_zone presente
     return [
-        {"tipo": "soporte", "precio_bajo": 0.388, "precio_alto": 0.398, "centro": 0.392, "toques": 5},
-        {"tipo": "soporte", "precio_bajo": 0.410, "precio_alto": 0.425, "centro": 0.417, "toques": 3},
-        {"tipo": "resistencia", "precio_bajo": 0.445, "precio_alto": 0.451, "centro": 0.448, "toques": 2},
-        {"tipo": "resistencia", "precio_bajo": 0.470, "precio_alto": 0.478, "centro": 0.474, "toques": 4},
+        {"tipo": "soporte", "precio_bajo": 0.388, "precio_alto": 0.398, "centro": 0.392, "toques": 5, "confluencia_redondo": []},
+        {"tipo": "soporte", "precio_bajo": 0.410, "precio_alto": 0.425, "centro": 0.417, "toques": 3, "confluencia_redondo": []},
+        {"tipo": "resistencia", "precio_bajo": 0.445, "precio_alto": 0.451, "centro": 0.448, "toques": 2, "confluencia_redondo": []},
+        {"tipo": "resistencia", "precio_bajo": 0.470, "precio_alto": 0.478, "centro": 0.474, "toques": 4, "confluencia_redondo": []},
     ]
 
 


### PR DESCRIPTION
## Qué hace

Integra **La Jugada** (el Instrumento) dentro del flujo cálido de Valles, 1:1 con el handoff de diseño. El Instrumento ya existía en backend (`api/plan.py`, `instrument/*`) pero quedó **huérfano en la UI desde el rediseño cálido (#595)** — ninguna pantalla lo invocaba. Esto le da cara: deriva la jugada desde las paredes de D.1, se confirma en frío, se sigue en vivo y al cierre se lee la conducta.

Spec: `docs/superpowers/specs/es/2026-06-17-kickoff-instrumento-screener-design.md` · Plan: `docs/superpowers/plans/2026-06-17-la-jugada-instrumento-en-valles.md`.

## El gráfico

Montado con **lightweight-charts, igual que el `ChartCanvas` de `SymbolDetail.tsx`** (`getOhlcv` → `createChart` → `ResizeObserver`), tema cálido, + una capa de overlays 1:1 posicionada con `priceToCoordinate`: zona de entrada como **banda** (rango, nunca punto), stop/break-even, escalera de TPs (peldaños con su pared), runner, precio vivo, y el "hueco honesto" cuando no hay más techos.

## Backend (contrato)

- `_plan_payload` enriquecido: metadata de paredes por peldaño (toques) + `sl_piso` (vía nuevo `Plan.sl_zona`, serializado en `lifecycle_states`).
- `GET /plan/{symbol}` envuelto en `LiveSnapshot` → emite frescura en el contrato (**No-Negociable #8**).
- `GET /plan/{symbol}/conducta` — lectura de conducta al cierre, **sin PnL**.

## Frontend

- Tipos `/plan` + fetchers (`getPlanDerive`/`confirmPlan`/`getPlanLive`/`getPlanConducta`).
- Geometría pura `overlays.ts` + `LaJugadaChart.tsx`.
- 5 pantallas: derivada → gate de fijar → en curso → conducta → sin-jugada (tuteo venezolano; el handoff venía en voseo).
- `JugadaLens` elige la pantalla según el estado del lifecycle; cableado como **4ta lente tras Niveles** en `ValleysFlow`; marca discreta "tiene jugada" en el Pick.

## Doctrina (intacta)

La jugada se **porta** como consecuencia geométrica de Niveles, no se **firma** como veredicto. Sin botón comprar/entrar, sin PnL como juicio, entrada siempre como rango, plano vivo pull-only.

## Verificación

- `tsc --noEmit`: 0 errores · `vitest`: 190 passed · build de producción: OK · backend `pytest -m "not network"`: **3637 passed**.
- Ejecutado con subagent-driven-development: cada tarea con revisión spec + calidad. El loop atrapó 3 bugs reales antes de main: `sl_zona` no serializado (vista viva habría mostrado `sl_piso: null`), `entry_zone` filtraba 6 campos vs 4, y un voseo en los hechos del backend.

## Limitaciones v1 conocidas (no bugs)

- El gráfico **en curso** ancla "ahora" a `plan.entry` (el contrato `/plan/{symbol}` no trae precio de mercado actual).
- Hechos vivos con punto neutro (backend manda `string[]` sin `tono`; el CSS ya tiene los tonos listos).
- Marca "tiene jugada" estática en todas las candidatas (`TODO`: señal por-candidata del screener).

🤖 Generated with [Claude Code](https://claude.com/claude-code)