### PR TITLE
research(valles): lente-momentum cerrado — no hay edge de selección per-coin robusto

### DIFF
--- a/data/retune/2026-06-18-setup-edge-multiregimen/CONFIRM_METODOLOGIA.md
+++ b/data/retune/2026-06-18-setup-edge-multiregimen/CONFIRM_METODOLOGIA.md
@@ -1,0 +1,66 @@
+# Estudio de confirmación: ¿el momentum sobrevive al exit REAL de musikito? (responde P1 con número)
+
+**Fecha:** 2026-06-20
+**Por qué:** El roster dictaminó que el "edge" de momentum era de EXCURSIÓN (`max_fwd`), no de retorno
+realizable (`rule_return` con stop −12% tocaba el stop), y levantó 3 BLOCKERS de Serrano: (1) n
+inflado por autocorrelación de hits contiguos del mismo símbolo; (2) el stop −12% NO es como tradeaba
+musikito (él usaba targets agresivos + runner); (3) supervivencia no cuantificada (los breakouts que
+murieron están excluidos del cache → inflan el momentum). Este estudio mide el momentum con el exit
+REAL + de-dup + stress de supervivencia. Resultado binario: ¿sobrevive el edge o no?
+
+**Reuso:** mismo cache (386 símbolos) + `edge_study.compute_features` + las features de breakout de
+`momentum_study`. Cero re-fetch.
+
+---
+
+## Definiciones CONGELADAS
+
+### Regla-momentum (igual que momentum_study, conjunta)
+`vivo AND breakout_20d AND vol_ratio ≥ 1.5 AND pct_vs_sma20 > 0`. Período de señales 2020–2025.
+
+### (1) De-duplicación por episodio
+Por símbolo, se recorren las fechas-hit en orden; se conserva un hit solo si han pasado **≥ 14 días**
+desde el último hit conservado del MISMO símbolo. Esto colapsa un breakout que persiste/se repite en
+días contiguos a UNA señal por episodio (corrige la autocorrelación → n efectivo honesto).
+
+### (2) Exit REAL de musikito — escalera de targets + runner (NO un stop ajustado)
+Entrada = `open` en t+1. Horizonte H = **30 días** (espacio para los targets + el runner).
+- **Escalera:** TPs en [+15%, +30%, +50%, +90%], fracciones vendidas [0.25, 0.25, 0.20, 0.15].
+  Un TP se "cobra" si el `high` en [t+1, t+H] alcanza `entrada × (1+TP)` (fill intrabar optimista —
+  es el modelo de "vender en el target", como musikito).
+- **Runner:** la fracción restante (0.15) cierra al `close` de t+H.
+- **Piso de desastre (no es un stop ajustado, es un corte de catástrofe):** si el `low` toca
+  `entrada × 0.50` (−50%) ANTES de cobrar TP1, toda la posición sale a −50%. Modela un colapso real
+  (y aproxima una muerte in-sample). Es MUCHO más ancho que el stop −12% que mató el rule_return.
+- `realized_return` = Σ(fracción_i × TP_i de los cobrados) + (fracción_no_vendida × ret al cierre t+H),
+  o −50% si dispara el piso.
+
+### (3) Control B1 (matcheado, de-dupeado, MISMO exit)
+Por cada fecha con hits, muestra de pares VIVOS que NO rompieron (`breakout_20d == False`), de-dupeados
+igual (≥14d/símbolo), con el MISMO exit-escalera. Determinista. Ratio hasta 1:3.
+
+### (4) Stress de supervivencia (cuantifica el BLOCKER 3)
+Los breakouts que murieron (delisted) no están en el cache. Se inyecta el peor caso paramétrico:
+asumir que una fracción `p` de los hits-momentum habría muerto (runner + no-vendido → retorno total
+−100% para ese hit). Se halla el **breakeven p**: el % de muertes-ocultas que iguala la MEDIA de
+`realized_return` del setup con la de B1. Si un `p` chico ya lo borra → frágil; si requiere un `p`
+grande → robusto. (La mediana es robusta a inyecciones; el stress se reporta sobre la MEDIA, donde
+las catástrofes muerden.)
+
+### Régimen, stats
+Régimen ex-ante por breadth (igual). Por hit se reporta `realized_return` (escalera) y `max_fwd_14d`
+(referencia de excursión). Medianas Y medias setup vs B1, global + por régimen. Mann-Whitney sobre
+`realized_return`.
+
+---
+
+## Salidas
+- `confirm_results.json` + `confirm_findings.md`.
+- **Veredicto binario:** ¿la `realized_return` del setup-momentum (con el exit real + de-dup) supera a
+  B1 (a) global, (b) en alt-bull, (c) fuera? ¿Y el breakeven-p de supervivencia es chico (frágil) o
+  grande (robusto)?
+
+## Después
+Pasar el binario al roster / a Samuel. Si SOBREVIVE → el momentum es edge real y reabre el diseño
+(detector/jugada). Si NO sobrevive → confirma definitivo el "no hay edge de selección", la costura AC7
+de SP2 se sostiene, y cerramos la pregunta para siempre.

--- a/data/retune/2026-06-18-setup-edge-multiregimen/MOMENTUM_METODOLOGIA.md
+++ b/data/retune/2026-06-18-setup-edge-multiregimen/MOMENTUM_METODOLOGIA.md
@@ -1,0 +1,64 @@
+# Estudio: ¿la lectura MOMENTUM de musikito tiene edge? (la pregunta abierta)
+
+**Fecha:** 2026-06-20
+**Por qué:** El estudio multi-régimen midió la lectura-DEBILIDAD (las features de ENTRADA que
+reverse-engineamos: parte baja del rango, sobreventa, bajo SMA) y la refutó — no tiene edge en
+ningún régimen. PERO el template DECLARADO del canal musikito era **momentum/breakout** (zona de
+compra + targets agresivos + OPEN TARGET runner, "Risk Trade", horizonte rápido — cazar coins a
+punto de explotar). Refutamos la lectura-debilidad; **nunca medimos la lectura-momentum.** Antes
+de declarar "no existe NINGÚN edge de selección per-coin", hay que probar lo que el canal *decía*
+que hacía.
+
+**Pregunta decisiva:** ¿Un setup de momentum/breakout supera a una baseline (a) global,
+(b) en alt-bull, (c) fuera de alt-bull? ¿El edge existe donde la debilidad no lo tuvo?
+
+**Reuso:** mismo harness que `edge_study.py` (cache de 430 símbolos USDT, panel 2020–2025,
+mismas baselines matcheadas por fecha, Mann-Whitney, buckets de régimen por breadth). Solo cambia
+la REGLA (momentum en vez de debilidad) y su control. Cero re-fetch.
+
+---
+
+## Definiciones CONGELADAS
+
+### Features de momentum nuevas (sobre el panel existente)
+- `high_20d_prev = max(high, 20d) .shift(1)` — el máximo de los 20 días PREVIOS (excluye hoy).
+- `breakout_20d = close > high_20d_prev` — el cierre rompió por encima del máximo de 20 días
+  (breakout = fuerza, lo opuesto a "parte baja del rango").
+
+Ya existen en el panel (de `edge_study.compute_features`): `vol_ratio` (3d/30d), `pct_vs_sma20`,
+`above_sma50`, `rsi14`, y los retornos forward (`max_fwd_7d/14d/30d`, `rule_return`).
+
+### La regla-momentum (DOS variantes, espejo de la de debilidad)
+- **MÍNIMA (solo el breakout):** `vivo AND breakout_20d`.
+- **CONJUNTA (momentum completo):** `vivo AND breakout_20d AND vol_ratio ≥ 1.5 AND
+  pct_vs_sma20 > 0` — rompió el máximo de 20d, con **repunte de volumen** (3d ≥ 1.5× el de 30d) y
+  **por encima de su SMA20** (fuerza). Es el setup "a punto de explotar" que el template describe.
+
+### Baseline (control de estado, matcheado por fecha)
+- **B1 — control momentum:** por cada fecha con hits, muestra aleatoria de pares VIVOS ese día que
+  **NO** rompieron (`breakout_20d == False`). Mismo día, distinto estado. Determinista (semilla por
+  fecha), ratio hasta 1:3. Es el control honesto para momentum.
+- **B2 — universo vivo** (continuidad): cualquier par vivo en `t`.
+
+### Resto (idéntico a edge_study, NO se mueve)
+- Universo: derivado del cache (430 símbolos), filtrado a ≥250 barras.
+- Retorno forward: entrada `open` en t+1; `max_fwd_7d/14d/30d`; `rule_return` (+20% TP / −12% SL /
+  cierre t+14); `win15 = max_fwd_14d ≥ 0.15`.
+- Régimen ex-ante: `breadth_t` = fracción del universo vivo con close>SMA50; buckets alt-bull≥0.6,
+  neutral 0.4–0.6, bear<0.4. También por año.
+- Stats: medianas/medias de `max_fwd_14d` y `rule_return`, `win15`, delta setup−B1, Mann-Whitney
+  one-sided (¿setup > baseline?).
+
+---
+
+## Salidas
+- `momentum_results.json` — tablas {momentum-mínima, momentum-conjunta} × {B1, B2}, global + por
+  régimen + por año.
+- `momentum_findings.md` — veredicto honesto: ¿la regla-momentum supera a B1 (a) global,
+  (b) en alt-bull, (c) fuera de alt-bull? ¿Hay edge donde la debilidad no lo tuvo? Mismos caveats
+  (sesgo de supervivencia: el cache solo tiene símbolos vivos hoy → niveles inflados para todos por
+  igual, el DELTA sigue informativo; retorno en USDT incluye beta de BTC).
+
+## Después
+Pasar los hallazgos al roster (patrón: medir → roster), para el veredicto final sobre si existe
+ALGÚN edge de selección per-coin, o ninguno (debilidad NO + momentum ?).

--- a/data/retune/2026-06-18-setup-edge-multiregimen/confirm_findings.md
+++ b/data/retune/2026-06-18-setup-edge-multiregimen/confirm_findings.md
@@ -1,0 +1,26 @@
+# Findings — ¿el momentum sobrevive al exit REAL de musikito?
+
+_Exit: escalera ['+15%', '+30%', '+50%', '+90%'] fracs [0.25, 0.25, 0.2, 0.15] + runner + piso -50%, horizonte 30d. De-dup 14d. n_setup=3133, n_B1=7097._
+
+## realized_return (escalera + runner) — setup-momentum vs B1
+
+| Régimen | setup mediana / media / win15 | B1 mediana / media / win15 | Δmedia |
+|---|---|---|---|
+| global | +6.7% / +6.3% / +40.8% (n=3133) | +3.7% / +4.8% / +35.9% (n=7097) | +1.6% |
+| alt-bull | +9.8% / +9.2% / +44.3% (n=2326) | +7.5% / +8.2% / +40.7% (n=4676) | +1.0% |
+| neutral | +0.2% / +2.3% / +37.2% (n=282) | -1.2% / +0.9% / +33.9% (n=846) | +1.4% |
+| bear | -7.1% / -4.1% / +26.9% (n=525) | -4.4% / -3.2% / +23.0% (n=1575) | -0.9% |
+
+## Stress de supervivencia
+
+- **breakeven_p = 1.5%** — si esa fracción de los breakouts hubiera muerto (retorno −100%, no en el cache), la MEDIA del setup igualaría a la de B1. FRÁGIL (pocas muertes ocultas lo borran).
+
+## Veredicto
+
+- Global: Δmediana realized = +3.0%, Δmedia = +1.6%.
+- Con el exit REAL (no el stop −12%), ¿el momentum supera a B1? SÍ en mediana; SÍ en media.
+
+## Caveats
+- realized_return = escalera de targets (fill intrabar optimista) + runner al cierre H + piso -50%.
+- Supervivencia: el cache solo tiene vivos hoy; el breakeven_p estima cuántas muertes ocultas igualarían la media a B1.
+- Retorno en USDT incluye beta de BTC.

--- a/data/retune/2026-06-18-setup-edge-multiregimen/confirm_results.json
+++ b/data/retune/2026-06-18-setup-edge-multiregimen/confirm_results.json
@@ -1,0 +1,82 @@
+{
+  "meta": {
+    "exit": {
+      "tps": [
+        0.15,
+        0.3,
+        0.5,
+        0.9
+      ],
+      "fracs": [
+        0.25,
+        0.25,
+        0.2,
+        0.15
+      ],
+      "disaster": -0.5,
+      "horizon": 30
+    },
+    "dedup_days": 14,
+    "b1_ratio": 3,
+    "n_setup": 3133,
+    "n_b1": 7097,
+    "survivorship_breakeven_p_mean": 0.014662394065367658,
+    "caveats": [
+      "realized_return = escalera de targets (fill intrabar optimista) + runner al cierre H + piso -50%.",
+      "Supervivencia: el cache solo tiene vivos hoy; el breakeven_p estima cu\u00e1ntas muertes ocultas igualar\u00edan la media a B1.",
+      "Retorno en USDT incluye beta de BTC."
+    ]
+  },
+  "setup": {
+    "global": {
+      "n": 3133,
+      "median": 0.06720727848101263,
+      "mean": 0.0632696325385862,
+      "win15": 0.4075965528247686
+    },
+    "alt-bull": {
+      "n": 2326,
+      "median": 0.09760118502059206,
+      "mean": 0.09165710098777165,
+      "win15": 0.44325021496130695
+    },
+    "neutral": {
+      "n": 282,
+      "median": 0.0019834320604982967,
+      "mean": 0.02321107964913516,
+      "win15": 0.3723404255319149
+    },
+    "bear": {
+      "n": 525,
+      "median": -0.07051736357193475,
+      "mean": -0.04098320498137597,
+      "win15": 0.26857142857142857
+    }
+  },
+  "B1": {
+    "global": {
+      "n": 7097,
+      "median": 0.03730079681274899,
+      "mean": 0.04767955418856678,
+      "win15": 0.35944765393828376
+    },
+    "alt-bull": {
+      "n": 4676,
+      "median": 0.07522618800680211,
+      "mean": 0.08162174342549036,
+      "win15": 0.40654405474764754
+    },
+    "neutral": {
+      "n": 846,
+      "median": -0.012314522911320003,
+      "mean": 0.008906927266119273,
+      "win15": 0.3392434988179669
+    },
+    "bear": {
+      "n": 1575,
+      "median": -0.0439845556047415,
+      "mean": -0.032264594697442146,
+      "win15": 0.23047619047619047
+    }
+  }
+}

--- a/data/retune/2026-06-18-setup-edge-multiregimen/confirm_study.py
+++ b/data/retune/2026-06-18-setup-edge-multiregimen/confirm_study.py
@@ -1,0 +1,257 @@
+"""Estudio de confirmación: ¿el momentum sobrevive al exit REAL de musikito (escalera + runner) +
+de-dup + stress de supervivencia? Reusa el cache + edge_study + las features de momentum_study.
+Ver CONFIRM_METODOLOGIA.md. Responde P1 con número."""
+import json
+import statistics as st
+from pathlib import Path
+
+import pandas as pd
+
+import edge_study as es
+import momentum_study as mom
+
+HERE = Path(__file__).resolve().parent
+
+# Exit real (congelado)
+TPS = [0.15, 0.30, 0.50, 0.90]
+FRACS = [0.25, 0.25, 0.20, 0.15]
+DISASTER = -0.50
+HORIZON = 30
+DEDUP_DAYS = 14
+B1_RATIO = 3
+
+
+def ladder_return(entry, highs, lows, close_last):
+    """Retorno realizado con escalera de targets + runner + piso de desastre. Ver metodología."""
+    if entry is None or entry <= 0 or close_last is None or not highs:
+        return None
+    hi_max = max(highs)
+    lo_min = min(lows)
+    realized = 0.0
+    sold = 0.0
+    for tp, fr in zip(TPS, FRACS):
+        if hi_max >= entry * (1 + tp):
+            realized += fr * tp
+            sold += fr
+        else:
+            break  # TPs ascendentes: si no se alcanza este, tampoco los de arriba
+    # catástrofe: si NO se cobró ningún TP y el low tocó -50% → toda la posición a -50%
+    if sold == 0.0 and lo_min <= entry * (1 + DISASTER):
+        return DISASTER
+    runner_frac = 1.0 - sold
+    runner_ret = (close_last - entry) / entry
+    return realized + runner_frac * runner_ret
+
+
+def hit_ladder(df, pos):
+    """df = DataFrame del símbolo (orden temporal, reset_index); pos = índice entero del día-señal.
+    Entrada = open de pos+1; ventana forward [pos+1 .. pos+HORIZON]."""
+    n = len(df)
+    if pos + 1 >= n:
+        return None
+    entry = float(df["open"].iloc[pos + 1])
+    end = min(pos + HORIZON, n - 1)
+    if end < pos + 1:
+        return None
+    fwd = df.iloc[pos + 1:end + 1]
+    highs = [float(x) for x in fwd["high"]]
+    lows = [float(x) for x in fwd["low"]]
+    close_last = float(df["close"].iloc[end])
+    return ladder_return(entry, highs, lows, close_last)
+
+
+def main():
+    universe = mom.universe_from_cache()
+    print(f"universo (cache): {len(universe)}")
+    symbol_dfs = {}
+    for sym in universe:
+        try:
+            rows = es.download_symbol(sym)
+        except Exception:
+            continue
+        df = es.rows_to_df(rows)
+        if df is None or len(df) < 250:
+            continue
+        df = es.compute_features(df)
+        df = mom.add_momentum_features(df)
+        df = df.reset_index()  # 'date' como columna, índice entero
+        symbol_dfs[sym] = df
+    print(f"símbolos con datos: {len(symbol_dfs)}")
+
+    # date -> regime (breadth), reusando el panel
+    panel = es.build_panel(symbol_dfs)
+    breadth = es.compute_breadth(panel)
+    regime_by_date = {d: es.regime_bucket(b) for d, b in breadth.items()}
+
+    sig_lo, sig_hi = es.SIGNAL_START, es.SIGNAL_END
+
+    # ── SETUP: hits momentum-conjunta, de-dup por símbolo (≥DEDUP_DAYS) ──
+    setup_hits = []   # dicts: symbol, date, pos, regime, realized, max_fwd_14d
+    # candidatos B1 por símbolo: filas vivas NO-breakout, en período de señal
+    b1_pool_by_sym = {}
+    for sym, df in symbol_dfs.items():
+        in_sig = (df["date"] >= sig_lo) & (df["date"] <= sig_hi)
+        cond = (df["alive"] & df["breakout_20d"]
+                & (df["vol_ratio"] >= mom.VOL_SURGE_MIN) & (df["pct_vs_sma20"] > 0))
+        hit_pos = df.index[in_sig & cond].tolist()
+        last = None
+        for pos in hit_pos:
+            d = df["date"].iloc[pos]
+            if last is not None and (d - last).days < DEDUP_DAYS:
+                continue
+            r = hit_ladder(df, pos)
+            if r is None:
+                continue
+            last = d
+            setup_hits.append({
+                "symbol": sym, "date": d, "pos": pos,
+                "regime": regime_by_date.get(d, "unknown"),
+                "realized": r,
+                "max_fwd_14d": (float(df["max_fwd_14d"].iloc[pos])
+                                if pd.notna(df["max_fwd_14d"].iloc[pos]) else None),
+            })
+        # pool B1 del símbolo (vivos no-breakout)
+        b1_cond = df["alive"] & (~df["breakout_20d"])
+        b1_pool_by_sym[sym] = {d: pos for pos, d in zip(df.index[in_sig & b1_cond],
+                                                         df["date"][in_sig & b1_cond])}
+    print(f"setup hits (de-dupeados): {len(setup_hits)}")
+
+    # ── B1: por cada fecha-hit, muestrear vivos-no-breakout, de-dup por símbolo (≥DEDUP_DAYS) ──
+    from collections import defaultdict
+    setup_by_date = defaultdict(int)
+    for h in setup_hits:
+        setup_by_date[h["date"]] += 1
+    # candidatos por fecha
+    cand_by_date = defaultdict(list)
+    for sym, dmap in b1_pool_by_sym.items():
+        for d, pos in dmap.items():
+            cand_by_date[d].append((sym, pos))
+    last_b1 = {}  # symbol -> last date sampled for B1
+    b1_hits = []
+    for d in sorted(setup_by_date):
+        want = setup_by_date[d] * B1_RATIO
+        pool = sorted(cand_by_date.get(d, []))  # determinista
+        ds = pd.Timestamp(d).strftime("%Y-%m-%d")
+        off = es.date_seed(ds, len(pool)) if pool else 0
+        rotated = pool[off:] + pool[:off]
+        taken = 0
+        for sym, pos in rotated:
+            if taken >= want:
+                break
+            lb = last_b1.get(sym)
+            if lb is not None and (d - lb).days < DEDUP_DAYS:
+                continue
+            r = hit_ladder(symbol_dfs[sym], pos)
+            if r is None:
+                continue
+            last_b1[sym] = d
+            b1_hits.append({"symbol": sym, "date": d, "regime": regime_by_date.get(d, "unknown"),
+                            "realized": r})
+            taken += 1
+    print(f"B1 hits: {len(b1_hits)} (ratio {len(b1_hits)/max(1,len(setup_hits)):.2f})")
+
+    # ── agregación ──
+    def agg(hits, key="realized"):
+        vals = [h[key] for h in hits if h.get(key) is not None]
+        if not vals:
+            return {"n": 0, "median": None, "mean": None, "win15": None}
+        return {"n": len(vals), "median": st.median(vals), "mean": st.mean(vals),
+                "win15": sum(1 for v in vals if v >= 0.15) / len(vals)}
+
+    def by_regime(hits):
+        out = {"global": agg(hits)}
+        for bk in ("alt-bull", "neutral", "bear"):
+            out[bk] = agg([h for h in hits if h["regime"] == bk])
+        return out
+
+    setup_agg = by_regime(setup_hits)
+    b1_agg = by_regime(b1_hits)
+
+    # ── stress de supervivencia: breakeven p (media) global ──
+    setup_real = [h["realized"] for h in setup_hits if h["realized"] is not None]
+    b1_mean = b1_agg["global"]["mean"]
+    breakeven_p = None
+    if setup_real and b1_mean is not None:
+        base_mean = st.mean(setup_real)
+        # inyectar p% peor caso (-1.0) a los hits: media' = (1-p)*base_mean_de_los_que_quedan...
+        # modelo: una fracción p de hits → -1.0 (muerte). media' = (1-p)*base_mean + p*(-1.0).
+        # breakeven: (1-p)*base_mean + p*(-1) = b1_mean
+        denom = (base_mean + 1.0)
+        if denom > 0:
+            p = (base_mean - b1_mean) / denom
+            breakeven_p = max(0.0, min(1.0, p))
+
+    results = {
+        "meta": {
+            "exit": {"tps": TPS, "fracs": FRACS, "disaster": DISASTER, "horizon": HORIZON},
+            "dedup_days": DEDUP_DAYS, "b1_ratio": B1_RATIO,
+            "n_setup": len(setup_hits), "n_b1": len(b1_hits),
+            "survivorship_breakeven_p_mean": breakeven_p,
+            "caveats": [
+                "realized_return = escalera de targets (fill intrabar optimista) + runner al cierre H + piso -50%.",
+                "Supervivencia: el cache solo tiene vivos hoy; el breakeven_p estima cuántas muertes ocultas igualarían la media a B1.",
+                "Retorno en USDT incluye beta de BTC.",
+            ],
+        },
+        "setup": setup_agg,
+        "B1": b1_agg,
+    }
+    (HERE / "confirm_results.json").write_text(json.dumps(results, indent=2, default=str))
+    print(f"escrito confirm_results.json")
+    write_findings(results)
+    print("== done ==")
+    return results
+
+
+def _pct(x):
+    return "n/a" if x is None else f"{x*100:+.1f}%"
+
+
+def write_findings(r):
+    s, b = r["setup"], r["B1"]
+    L = ["# Findings — ¿el momentum sobrevive al exit REAL de musikito?", ""]
+    m = r["meta"]
+    L.append(f"_Exit: escalera {[f'+{int(t*100)}%' for t in TPS]} fracs {FRACS} + runner + piso {int(DISASTER*100)}%, "
+             f"horizonte {HORIZON}d. De-dup {DEDUP_DAYS}d. n_setup={m['n_setup']}, n_B1={m['n_b1']}._")
+    L.append("")
+    L.append("## realized_return (escalera + runner) — setup-momentum vs B1")
+    L.append("")
+    L.append("| Régimen | setup mediana / media / win15 | B1 mediana / media / win15 | Δmedia |")
+    L.append("|---|---|---|---|")
+    for bk in ("global", "alt-bull", "neutral", "bear"):
+        sc, bc = s[bk], b[bk]
+        dmean = None if sc["mean"] is None or bc["mean"] is None else sc["mean"] - bc["mean"]
+        L.append(f"| {bk} | {_pct(sc['median'])} / {_pct(sc['mean'])} / "
+                 f"{_pct(sc['win15']) if sc['win15'] is not None else 'n/a'} (n={sc['n']}) | "
+                 f"{_pct(bc['median'])} / {_pct(bc['mean'])} / "
+                 f"{_pct(bc['win15']) if bc['win15'] is not None else 'n/a'} (n={bc['n']}) | {_pct(dmean)} |")
+    L.append("")
+    bp = m["survivorship_breakeven_p_mean"]
+    L.append("## Stress de supervivencia")
+    L.append("")
+    if bp is None:
+        L.append("- breakeven_p: n/a")
+    else:
+        L.append(f"- **breakeven_p = {bp*100:.1f}%** — si esa fracción de los breakouts hubiera muerto "
+                 f"(retorno −100%, no en el cache), la MEDIA del setup igualaría a la de B1. "
+                 f"{'FRÁGIL (pocas muertes ocultas lo borran).' if bp < 0.15 else 'Robusto-ish (requiere muchas muertes ocultas).'}")
+    L.append("")
+    L.append("## Veredicto")
+    L.append("")
+    g_s, g_b = s["global"], b["global"]
+    dmed = None if g_s["median"] is None or g_b["median"] is None else g_s["median"] - g_b["median"]
+    dmean = None if g_s["mean"] is None or g_b["mean"] is None else g_s["mean"] - g_b["mean"]
+    L.append(f"- Global: Δmediana realized = {_pct(dmed)}, Δmedia = {_pct(dmean)}.")
+    L.append(f"- Con el exit REAL (no el stop −12%), ¿el momentum supera a B1? "
+             f"{'SÍ en mediana' if (dmed or 0) > 0 else 'NO en mediana'}; "
+             f"{'SÍ en media' if (dmean or 0) > 0 else 'NO en media'}.")
+    L.append("")
+    L.append("## Caveats")
+    for c in m["caveats"]:
+        L.append(f"- {c}")
+    (HERE / "confirm_findings.md").write_text("\n".join(L), encoding="utf-8")
+    print("escrito confirm_findings.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/retune/2026-06-18-setup-edge-multiregimen/momentum_findings.md
+++ b/data/retune/2026-06-18-setup-edge-multiregimen/momentum_findings.md
@@ -1,0 +1,28 @@
+# Findings — ¿la lectura MOMENTUM de musikito tiene edge?
+
+_Regla: breakout sobre máx de 20d + volumen ≥1.5× + sobre SMA20. 386 símbolos, panel 455068 filas. hits mínima=10667, conjunta=6418._
+
+## Veredicto (regla-conjunta vs B1, mediana max_fwd_14d, Mann-Whitney one-sided)
+
+- (a) **Global**: SÍ (Δ>0, p<0.05)
+- (b) **En alt-bull** (breadth≥0.6): SÍ (Δ>0, p<0.05)
+- (c) **Fuera de alt-bull**: SÍ (Δ>0, p<0.05)
+
+## Regla-conjunta (momentum completo) vs B1 por régimen
+
+- **Global**: setup n=6418 mediana max_fwd_14d=20.0% win15=60.2% | B1 n=17404 mediana=17.3% win15=54.8% | Δmediana=2.8% (p=2.749e-20)
+- **alt-bull**: setup n=5161 mediana max_fwd_14d=21.4% win15=62.9% | B1 n=13633 mediana=19.7% win15=59.1% | Δmediana=1.8% (p=2.142e-09)
+- **neutral**: setup n=427 mediana max_fwd_14d=17.6% win15=56.9% | B1 n=1281 mediana=13.3% win15=46.2% | Δmediana=4.3% (p=0.0003131)
+- **bear**: setup n=830 mediana max_fwd_14d=13.0% win15=45.2% | B1 n=2490 mediana=10.1% win15=35.9% | Δmediana=2.8% (p=2.189e-10)
+
+## Regla-mínima (solo breakout) vs B1
+
+- **Global**: setup n=10667 mediana max_fwd_14d=17.8% win15=55.7% | B1 n=27971 mediana=16.1% win15=52.2% | Δmediana=1.7% (p=1.691e-16)
+- **alt-bull**: setup n=8231 mediana max_fwd_14d=19.5% win15=59.2% | B1 n=20730 mediana=18.3% win15=56.6% | Δmediana=1.2% (p=5.078e-08)
+- **neutral**: setup n=794 mediana max_fwd_14d=16.2% win15=53.0% | B1 n=2351 mediana=13.4% win15=46.3% | Δmediana=2.8% (p=0.0009679)
+- **bear**: setup n=1642 mediana max_fwd_14d=10.6% win15=39.8% | B1 n=4890 mediana=9.9% win15=36.1% | Δmediana=0.6% (p=0.0001443)
+
+## Caveats
+
+- Sesgo de supervivencia: cache solo de símbolos vivos hoy; niveles absolutos inflados para setup y baseline por igual; el DELTA sigue informativo.
+- Retorno en USDT incluye beta de BTC.

--- a/data/retune/2026-06-18-setup-edge-multiregimen/momentum_results.json
+++ b/data/retune/2026-06-18-setup-edge-multiregimen/momentum_results.json
@@ -1,0 +1,675 @@
+{
+  "meta": {
+    "rule": "momentum/breakout",
+    "breakout_window": 20,
+    "vol_surge_min": 1.5,
+    "hits": {
+      "momentum_minimal": 10667,
+      "momentum_conjunct": 6418
+    },
+    "b1_ratio_used": {
+      "minimal": 2.622,
+      "conjunct": 2.712
+    },
+    "panel_rows": 455068,
+    "symbols": 386,
+    "caveats": [
+      "Sesgo de supervivencia: cache solo de s\u00edmbolos vivos hoy; niveles absolutos inflados para setup y baseline por igual; el DELTA sigue informativo.",
+      "Retorno en USDT incluye beta de BTC."
+    ]
+  },
+  "tables": {
+    "momentum_minimal": {
+      "setup": {
+        "global": {
+          "n": 10667,
+          "median_max_fwd_14d": 0.17768147345612148,
+          "mean_max_fwd_14d": 0.30596360675765755,
+          "median_rule_return": -0.07829595716613644,
+          "win15": 0.5573263335520765
+        },
+        "by_regime": {
+          "alt-bull": {
+            "n": 8231,
+            "median_max_fwd_14d": 0.19490909090909084,
+            "mean_max_fwd_14d": 0.32560791594748806,
+            "median_rule_return": -0.06290109114340423,
+            "win15": 0.5916656542339934
+          },
+          "bear": {
+            "n": 1642,
+            "median_max_fwd_14d": 0.1055280009871461,
+            "mean_max_fwd_14d": 0.22916456392913884,
+            "median_rule_return": -0.12,
+            "win15": 0.3982947624847747
+          },
+          "neutral": {
+            "n": 794,
+            "median_max_fwd_14d": 0.16173115321855502,
+            "mean_max_fwd_14d": 0.2611420946454816,
+            "median_rule_return": -0.036422316653602835,
+            "win15": 0.5302267002518891
+          }
+        },
+        "by_year": {
+          "2020": {
+            "n": 895,
+            "median_max_fwd_14d": 0.18999034882117746,
+            "mean_max_fwd_14d": 0.29699784881408464,
+            "median_rule_return": 0.01554940363768076,
+            "win15": 0.5888268156424581
+          },
+          "2021": {
+            "n": 1593,
+            "median_max_fwd_14d": 0.2821573331127471,
+            "mean_max_fwd_14d": 0.5170031568801665,
+            "median_rule_return": -0.12,
+            "win15": 0.6936597614563716
+          },
+          "2022": {
+            "n": 640,
+            "median_max_fwd_14d": 0.11210896383865548,
+            "mean_max_fwd_14d": 0.17816314602109395,
+            "median_rule_return": -0.12,
+            "win15": 0.390625
+          },
+          "2023": {
+            "n": 2351,
+            "median_max_fwd_14d": 0.15271389144434214,
+            "mean_max_fwd_14d": 0.2561835645120496,
+            "median_rule_return": -0.022660511959714594,
+            "win15": 0.5070182900893236
+          },
+          "2024": {
+            "n": 3691,
+            "median_max_fwd_14d": 0.2060400790290714,
+            "mean_max_fwd_14d": 0.3141657488719465,
+            "median_rule_return": -0.12,
+            "win15": 0.6057978867515579
+          },
+          "2025": {
+            "n": 1497,
+            "median_max_fwd_14d": 0.11714975845410638,
+            "mean_max_fwd_14d": 0.19934331127424082,
+            "median_rule_return": -0.10299251870324184,
+            "win15": 0.4241816967267869
+          }
+        }
+      },
+      "B1": {
+        "global": {
+          "n": 27971,
+          "median_max_fwd_14d": 0.16065705128205118,
+          "mean_max_fwd_14d": 0.26862463097409867,
+          "median_rule_return": -0.037866666666666604,
+          "win15": 0.5215759179149834
+        },
+        "by_regime": {
+          "alt-bull": {
+            "n": 20730,
+            "median_max_fwd_14d": 0.1828669581311509,
+            "mean_max_fwd_14d": 0.2973175774587533,
+            "median_rule_return": -0.02464082336429687,
+            "win15": 0.566136034732272
+          },
+          "bear": {
+            "n": 4890,
+            "median_max_fwd_14d": 0.09915991988616332,
+            "mean_max_fwd_14d": 0.16622086851433038,
+            "median_rule_return": -0.06446636509557868,
+            "win15": 0.36073619631901843
+          },
+          "neutral": {
+            "n": 2351,
+            "median_max_fwd_14d": 0.13372093023255827,
+            "mean_max_fwd_14d": 0.22862021489641948,
+            "median_rule_return": -0.04734848484848489,
+            "win15": 0.46320714589536366
+          }
+        },
+        "by_year": {
+          "2020": {
+            "n": 2072,
+            "median_max_fwd_14d": 0.16630712507717793,
+            "mean_max_fwd_14d": 0.2630672838727007,
+            "median_rule_return": 0.015348508005017612,
+            "win15": 0.5337837837837838
+          },
+          "2021": {
+            "n": 4372,
+            "median_max_fwd_14d": 0.23881870273229772,
+            "mean_max_fwd_14d": 0.42749562356341203,
+            "median_rule_return": -0.11410852713178296,
+            "win15": 0.6456999085086916
+          },
+          "2022": {
+            "n": 1873,
+            "median_max_fwd_14d": 0.12582159624413145,
+            "mean_max_fwd_14d": 0.19341607654360238,
+            "median_rule_return": -0.12,
+            "win15": 0.42872397223705283
+          },
+          "2023": {
+            "n": 6410,
+            "median_max_fwd_14d": 0.14117667142665463,
+            "mean_max_fwd_14d": 0.23094053826531252,
+            "median_rule_return": -0.005520394803670307,
+            "win15": 0.4792511700468019
+          },
+          "2024": {
+            "n": 9268,
+            "median_max_fwd_14d": 0.19151413339819795,
+            "mean_max_fwd_14d": 0.28422404568845616,
+            "median_rule_return": -0.019108865558385937,
+            "win15": 0.581570996978852
+          },
+          "2025": {
+            "n": 3976,
+            "median_max_fwd_14d": 0.09695222587615346,
+            "mean_max_fwd_14d": 0.15664679514225568,
+            "median_rule_return": -0.12,
+            "win15": 0.35085513078470826
+          }
+        }
+      },
+      "B2": {
+        "global": {
+          "n": 286719,
+          "median_max_fwd_14d": 0.11926605504587158,
+          "mean_max_fwd_14d": 0.48057753646609946,
+          "median_rule_return": -0.08944746376811603,
+          "win15": 0.4200209961669788
+        },
+        "by_regime": {
+          "alt-bull": {
+            "n": 90879,
+            "median_max_fwd_14d": 0.1551697998787144,
+            "mean_max_fwd_14d": 0.2788061342489495,
+            "median_rule_return": -0.07509627727856219,
+            "win15": 0.5110091440266729
+          },
+          "bear": {
+            "n": 168454,
+            "median_max_fwd_14d": 0.10698198198198193,
+            "mean_max_fwd_14d": 0.6362034645781325,
+            "median_rule_return": -0.092142222737207,
+            "win15": 0.37521222410865873
+          },
+          "neutral": {
+            "n": 27386,
+            "median_max_fwd_14d": 0.10915048146382086,
+            "mean_max_fwd_14d": 0.1928748112746865,
+            "median_rule_return": -0.12,
+            "win15": 0.39370481267801066
+          }
+        },
+        "by_year": {
+          "2020": {
+            "n": 13523,
+            "median_max_fwd_14d": 0.15212091662603613,
+            "mean_max_fwd_14d": 0.23418190353645135,
+            "median_rule_return": 0.000824186817949247,
+            "win15": 0.5055830806773645
+          },
+          "2021": {
+            "n": 33508,
+            "median_max_fwd_14d": 0.20079564647278253,
+            "mean_max_fwd_14d": 0.35642698566870223,
+            "median_rule_return": -0.12,
+            "win15": 0.5949325534200788
+          },
+          "2022": {
+            "n": 37747,
+            "median_max_fwd_14d": 0.11702127659574464,
+            "mean_max_fwd_14d": 2.2544344525864752,
+            "median_rule_return": -0.12,
+            "win15": 0.40689326304077145
+          },
+          "2023": {
+            "n": 51568,
+            "median_max_fwd_14d": 0.11396672764030583,
+            "mean_max_fwd_14d": 0.19445627343779542,
+            "median_rule_return": -0.01200900750675635,
+            "win15": 0.40817949115730684
+          },
+          "2024": {
+            "n": 70441,
+            "median_max_fwd_14d": 0.13161332462442848,
+            "mean_max_fwd_14d": 0.2149704863200615,
+            "median_rule_return": -0.06244725738396619,
+            "win15": 0.45334393322070954
+          },
+          "2025": {
+            "n": 79932,
+            "median_max_fwd_14d": 0.09223754905600925,
+            "mean_max_fwd_14d": 0.15528347774883516,
+            "median_rule_return": -0.12,
+            "win15": 0.3166941900615523
+          }
+        }
+      },
+      "delta_vs_B1": {
+        "global": {
+          "setup": {
+            "n": 10667,
+            "median_max_fwd_14d": 0.17768147345612148,
+            "mean_max_fwd_14d": 0.30596360675765755,
+            "median_rule_return": -0.07829595716613644,
+            "win15": 0.5573263335520765
+          },
+          "baseline": {
+            "n": 27971,
+            "median_max_fwd_14d": 0.16065705128205118,
+            "mean_max_fwd_14d": 0.26862463097409867,
+            "median_rule_return": -0.037866666666666604,
+            "win15": 0.5215759179149834
+          },
+          "delta_median_max_fwd_14d": 0.017024422174070297,
+          "delta_mean_max_fwd_14d": 0.03733897578355888,
+          "mann_whitney": {
+            "u_statistic": 157180335.5,
+            "p_value": 1.6908720727709203e-16,
+            "alternative": "setup > baseline (one-sided)"
+          }
+        },
+        "by_regime": {
+          "alt-bull": {
+            "setup": {
+              "n": 8231,
+              "median_max_fwd_14d": 0.19490909090909084,
+              "mean_max_fwd_14d": 0.32560791594748806,
+              "median_rule_return": -0.06290109114340423,
+              "win15": 0.5916656542339934
+            },
+            "baseline": {
+              "n": 20730,
+              "median_max_fwd_14d": 0.1828669581311509,
+              "mean_max_fwd_14d": 0.2973175774587533,
+              "median_rule_return": -0.02464082336429687,
+              "win15": 0.566136034732272
+            },
+            "delta_median_max_fwd_14d": 0.012042132777939946,
+            "delta_mean_max_fwd_14d": 0.028290338488734745,
+            "mann_whitney": {
+              "u_statistic": 88730806.0,
+              "p_value": 5.0780386961248854e-08,
+              "alternative": "setup > baseline (one-sided)"
+            }
+          },
+          "bear": {
+            "setup": {
+              "n": 1642,
+              "median_max_fwd_14d": 0.1055280009871461,
+              "mean_max_fwd_14d": 0.22916456392913884,
+              "median_rule_return": -0.12,
+              "win15": 0.3982947624847747
+            },
+            "baseline": {
+              "n": 4890,
+              "median_max_fwd_14d": 0.09915991988616332,
+              "mean_max_fwd_14d": 0.16622086851433038,
+              "median_rule_return": -0.06446636509557868,
+              "win15": 0.36073619631901843
+            },
+            "delta_median_max_fwd_14d": 0.006368081100982775,
+            "delta_mean_max_fwd_14d": 0.06294369541480846,
+            "mann_whitney": {
+              "u_statistic": 4254382.0,
+              "p_value": 0.00014430384254929732,
+              "alternative": "setup > baseline (one-sided)"
+            }
+          },
+          "neutral": {
+            "setup": {
+              "n": 794,
+              "median_max_fwd_14d": 0.16173115321855502,
+              "mean_max_fwd_14d": 0.2611420946454816,
+              "median_rule_return": -0.036422316653602835,
+              "win15": 0.5302267002518891
+            },
+            "baseline": {
+              "n": 2351,
+              "median_max_fwd_14d": 0.13372093023255827,
+              "mean_max_fwd_14d": 0.22862021489641948,
+              "median_rule_return": -0.04734848484848489,
+              "win15": 0.46320714589536366
+            },
+            "delta_median_max_fwd_14d": 0.028010222985996758,
+            "delta_mean_max_fwd_14d": 0.03252187974906212,
+            "mann_whitney": {
+              "u_statistic": 1001924.0,
+              "p_value": 0.0009678753204184972,
+              "alternative": "setup > baseline (one-sided)"
+            }
+          }
+        }
+      }
+    },
+    "momentum_conjunct": {
+      "setup": {
+        "global": {
+          "n": 6418,
+          "median_max_fwd_14d": 0.2004992125440789,
+          "mean_max_fwd_14d": 0.3360269880545843,
+          "median_rule_return": -0.12,
+          "win15": 0.6022125272670614
+        },
+        "by_regime": {
+          "alt-bull": {
+            "n": 5161,
+            "median_max_fwd_14d": 0.2142857142857144,
+            "mean_max_fwd_14d": 0.3491793926734461,
+            "median_rule_return": -0.12,
+            "win15": 0.629141639217206
+          },
+          "bear": {
+            "n": 830,
+            "median_max_fwd_14d": 0.12969477925537337,
+            "mean_max_fwd_14d": 0.28210990598213237,
+            "median_rule_return": -0.12,
+            "win15": 0.45180722891566266
+          },
+          "neutral": {
+            "n": 427,
+            "median_max_fwd_14d": 0.17623762376237637,
+            "mean_max_fwd_14d": 0.2818621587388673,
+            "median_rule_return": -0.12,
+            "win15": 0.5690866510538641
+          }
+        },
+        "by_year": {
+          "2020": {
+            "n": 524,
+            "median_max_fwd_14d": 0.19037751541088943,
+            "mean_max_fwd_14d": 0.30409218165606994,
+            "median_rule_return": -0.022982336859467743,
+            "win15": 0.5973282442748091
+          },
+          "2021": {
+            "n": 1004,
+            "median_max_fwd_14d": 0.2871460872048742,
+            "mean_max_fwd_14d": 0.5434522008761657,
+            "median_rule_return": -0.12,
+            "win15": 0.704183266932271
+          },
+          "2022": {
+            "n": 325,
+            "median_max_fwd_14d": 0.12206952303961204,
+            "mean_max_fwd_14d": 0.18757987380112526,
+            "median_rule_return": -0.12,
+            "win15": 0.41846153846153844
+          },
+          "2023": {
+            "n": 1458,
+            "median_max_fwd_14d": 0.1781453655314035,
+            "mean_max_fwd_14d": 0.2814537923163078,
+            "median_rule_return": -0.008738980493939003,
+            "win15": 0.5610425240054869
+          },
+          "2024": {
+            "n": 2311,
+            "median_max_fwd_14d": 0.24588450483407376,
+            "mean_max_fwd_14d": 0.3517574870806477,
+            "median_rule_return": -0.12,
+            "win15": 0.6715707485936824
+          },
+          "2025": {
+            "n": 796,
+            "median_max_fwd_14d": 0.11789325713904629,
+            "mean_max_fwd_14d": 0.21032192919717518,
+            "median_rule_return": -0.12,
+            "win15": 0.4258793969849246
+          }
+        }
+      },
+      "B1": {
+        "global": {
+          "n": 17404,
+          "median_max_fwd_14d": 0.17289186261443518,
+          "mean_max_fwd_14d": 0.2842028781402569,
+          "median_rule_return": -0.021310116548787356,
+          "win15": 0.5483222247759136
+        },
+        "by_regime": {
+          "alt-bull": {
+            "n": 13633,
+            "median_max_fwd_14d": 0.1966966966966967,
+            "mean_max_fwd_14d": 0.31007106666346074,
+            "median_rule_return": -0.006329113924050688,
+            "win15": 0.5910657962297367
+          },
+          "bear": {
+            "n": 2490,
+            "median_max_fwd_14d": 0.10143161210814913,
+            "mean_max_fwd_14d": 0.16785731817321994,
+            "median_rule_return": -0.07242812542571406,
+            "win15": 0.3586345381526104
+          },
+          "neutral": {
+            "n": 1281,
+            "median_max_fwd_14d": 0.13284671532846717,
+            "mean_max_fwd_14d": 0.23505333105289025,
+            "median_rule_return": -0.06632653061224496,
+            "win15": 0.46213895394223264
+          }
+        },
+        "by_year": {
+          "2020": {
+            "n": 1309,
+            "median_max_fwd_14d": 0.16937022900763363,
+            "mean_max_fwd_14d": 0.2689502895520167,
+            "median_rule_return": 0.018949648077964284,
+            "win15": 0.5362872421695951
+          },
+          "2021": {
+            "n": 2794,
+            "median_max_fwd_14d": 0.24057968252957057,
+            "mean_max_fwd_14d": 0.4318572103563104,
+            "median_rule_return": -0.12,
+            "win15": 0.6471009305654974
+          },
+          "2022": {
+            "n": 975,
+            "median_max_fwd_14d": 0.12343096234309635,
+            "mean_max_fwd_14d": 0.19317680814406138,
+            "median_rule_return": -0.12,
+            "win15": 0.4235897435897436
+          },
+          "2023": {
+            "n": 4025,
+            "median_max_fwd_14d": 0.15361580212787385,
+            "mean_max_fwd_14d": 0.24279730075691264,
+            "median_rule_return": 0.011649959360606909,
+            "win15": 0.5080745341614907
+          },
+          "2024": {
+            "n": 6004,
+            "median_max_fwd_14d": 0.2208117750463598,
+            "mean_max_fwd_14d": 0.30902900131371613,
+            "median_rule_return": -0.0011589519478800397,
+            "win15": 0.6244170552964691
+          },
+          "2025": {
+            "n": 2297,
+            "median_max_fwd_14d": 0.10465116279069758,
+            "mean_max_fwd_14d": 0.15959306444028054,
+            "median_rule_return": -0.12,
+            "win15": 0.35959947757945143
+          }
+        }
+      },
+      "B2": {
+        "global": {
+          "n": 286719,
+          "median_max_fwd_14d": 0.11926605504587158,
+          "mean_max_fwd_14d": 0.48057753646609946,
+          "median_rule_return": -0.08944746376811603,
+          "win15": 0.4200209961669788
+        },
+        "by_regime": {
+          "alt-bull": {
+            "n": 90879,
+            "median_max_fwd_14d": 0.1551697998787144,
+            "mean_max_fwd_14d": 0.2788061342489495,
+            "median_rule_return": -0.07509627727856219,
+            "win15": 0.5110091440266729
+          },
+          "bear": {
+            "n": 168454,
+            "median_max_fwd_14d": 0.10698198198198193,
+            "mean_max_fwd_14d": 0.6362034645781325,
+            "median_rule_return": -0.092142222737207,
+            "win15": 0.37521222410865873
+          },
+          "neutral": {
+            "n": 27386,
+            "median_max_fwd_14d": 0.10915048146382086,
+            "mean_max_fwd_14d": 0.1928748112746865,
+            "median_rule_return": -0.12,
+            "win15": 0.39370481267801066
+          }
+        },
+        "by_year": {
+          "2020": {
+            "n": 13523,
+            "median_max_fwd_14d": 0.15212091662603613,
+            "mean_max_fwd_14d": 0.23418190353645135,
+            "median_rule_return": 0.000824186817949247,
+            "win15": 0.5055830806773645
+          },
+          "2021": {
+            "n": 33508,
+            "median_max_fwd_14d": 0.20079564647278253,
+            "mean_max_fwd_14d": 0.35642698566870223,
+            "median_rule_return": -0.12,
+            "win15": 0.5949325534200788
+          },
+          "2022": {
+            "n": 37747,
+            "median_max_fwd_14d": 0.11702127659574464,
+            "mean_max_fwd_14d": 2.2544344525864752,
+            "median_rule_return": -0.12,
+            "win15": 0.40689326304077145
+          },
+          "2023": {
+            "n": 51568,
+            "median_max_fwd_14d": 0.11396672764030583,
+            "mean_max_fwd_14d": 0.19445627343779542,
+            "median_rule_return": -0.01200900750675635,
+            "win15": 0.40817949115730684
+          },
+          "2024": {
+            "n": 70441,
+            "median_max_fwd_14d": 0.13161332462442848,
+            "mean_max_fwd_14d": 0.2149704863200615,
+            "median_rule_return": -0.06244725738396619,
+            "win15": 0.45334393322070954
+          },
+          "2025": {
+            "n": 79932,
+            "median_max_fwd_14d": 0.09223754905600925,
+            "mean_max_fwd_14d": 0.15528347774883516,
+            "median_rule_return": -0.12,
+            "win15": 0.3166941900615523
+          }
+        }
+      },
+      "delta_vs_B1": {
+        "global": {
+          "setup": {
+            "n": 6418,
+            "median_max_fwd_14d": 0.2004992125440789,
+            "mean_max_fwd_14d": 0.3360269880545843,
+            "median_rule_return": -0.12,
+            "win15": 0.6022125272670614
+          },
+          "baseline": {
+            "n": 17404,
+            "median_max_fwd_14d": 0.17289186261443518,
+            "mean_max_fwd_14d": 0.2842028781402569,
+            "median_rule_return": -0.021310116548787356,
+            "win15": 0.5483222247759136
+          },
+          "delta_median_max_fwd_14d": 0.027607349929643726,
+          "delta_mean_max_fwd_14d": 0.0518241099143274,
+          "mann_whitney": {
+            "u_statistic": 60159986.0,
+            "p_value": 2.7486801366700777e-20,
+            "alternative": "setup > baseline (one-sided)"
+          }
+        },
+        "by_regime": {
+          "alt-bull": {
+            "setup": {
+              "n": 5161,
+              "median_max_fwd_14d": 0.2142857142857144,
+              "mean_max_fwd_14d": 0.3491793926734461,
+              "median_rule_return": -0.12,
+              "win15": 0.629141639217206
+            },
+            "baseline": {
+              "n": 13633,
+              "median_max_fwd_14d": 0.1966966966966967,
+              "mean_max_fwd_14d": 0.31007106666346074,
+              "median_rule_return": -0.006329113924050688,
+              "win15": 0.5910657962297367
+            },
+            "delta_median_max_fwd_14d": 0.017589017589017708,
+            "delta_mean_max_fwd_14d": 0.03910832600998537,
+            "mann_whitney": {
+              "u_statistic": 37129538.5,
+              "p_value": 2.1419525595379984e-09,
+              "alternative": "setup > baseline (one-sided)"
+            }
+          },
+          "bear": {
+            "setup": {
+              "n": 830,
+              "median_max_fwd_14d": 0.12969477925537337,
+              "mean_max_fwd_14d": 0.28210990598213237,
+              "median_rule_return": -0.12,
+              "win15": 0.45180722891566266
+            },
+            "baseline": {
+              "n": 2490,
+              "median_max_fwd_14d": 0.10143161210814913,
+              "mean_max_fwd_14d": 0.16785731817321994,
+              "median_rule_return": -0.07242812542571406,
+              "win15": 0.3586345381526104
+            },
+            "delta_median_max_fwd_14d": 0.02826316714722424,
+            "delta_mean_max_fwd_14d": 0.11425258780891243,
+            "mann_whitney": {
+              "u_statistic": 1182582.5,
+              "p_value": 2.1888910317982083e-10,
+              "alternative": "setup > baseline (one-sided)"
+            }
+          },
+          "neutral": {
+            "setup": {
+              "n": 427,
+              "median_max_fwd_14d": 0.17623762376237637,
+              "mean_max_fwd_14d": 0.2818621587388673,
+              "median_rule_return": -0.12,
+              "win15": 0.5690866510538641
+            },
+            "baseline": {
+              "n": 1281,
+              "median_max_fwd_14d": 0.13284671532846717,
+              "mean_max_fwd_14d": 0.23505333105289025,
+              "median_rule_return": -0.06632653061224496,
+              "win15": 0.46213895394223264
+            },
+            "delta_median_max_fwd_14d": 0.04339090843390919,
+            "delta_mean_max_fwd_14d": 0.04680882768597702,
+            "mann_whitney": {
+              "u_statistic": 303679.0,
+              "p_value": 0.0003131404282629045,
+              "alternative": "setup > baseline (one-sided)"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/data/retune/2026-06-18-setup-edge-multiregimen/momentum_study.py
+++ b/data/retune/2026-06-18-setup-edge-multiregimen/momentum_study.py
@@ -1,0 +1,213 @@
+"""Estudio momentum/breakout — reusa el harness de edge_study.py (cache + panel + baselines +
+régimen + Mann-Whitney + retornos forward). Solo cambia la REGLA (momentum) y su control.
+Ver MOMENTUM_METODOLOGIA.md. Cero re-fetch (usa el cache de raw_klines)."""
+import json
+from pathlib import Path
+
+import pandas as pd
+
+import edge_study as es
+
+HERE = Path(__file__).resolve().parent
+BREAKOUT_WINDOW = 20
+VOL_SURGE_MIN = 1.5
+
+
+def add_momentum_features(df):
+    high = df["high"]
+    df["high_20d_prev"] = high.rolling(BREAKOUT_WINDOW, min_periods=BREAKOUT_WINDOW).max().shift(1)
+    df["breakout_20d"] = (df["close"] > df["high_20d_prev"]).fillna(False)
+    return df
+
+
+def universe_from_cache():
+    return sorted(p.stem for p in es.RAW_DIR.glob("*.json"))
+
+
+def select_momentum_minimal(panel):
+    return panel["alive"] & panel["breakout_20d"]
+
+
+def select_momentum_conjunct(panel):
+    return (panel["alive"] & panel["breakout_20d"]
+            & (panel["vol_ratio"] >= VOL_SURGE_MIN)
+            & (panel["pct_vs_sma20"] > 0))
+
+
+def build_b1_momentum(panel, setup_mask):
+    """Control: pares vivos que NO rompieron, matcheados por fecha. Determinista."""
+    setup_rows = panel[setup_mask]
+    if setup_rows.empty:
+        return [], 0.0
+    cand = panel[panel["alive"] & (~panel["breakout_20d"])]
+    cand_by_date = {d: g.index.to_list() for d, g in cand.groupby("date")}
+    counts = setup_rows.groupby("date").size()
+    idx, tgt, picked = [], 0, 0
+    for date, n in counts.items():
+        pool = cand_by_date.get(date, [])
+        if not pool:
+            continue
+        want = min(len(pool), int(n) * es.B1_MATCH_RATIO)
+        tgt += int(n)
+        ds = pd.Timestamp(date).strftime("%Y-%m-%d")
+        ps = sorted(pool)
+        off = es.date_seed(ds, len(ps))
+        chosen = (ps[off:] + ps[:off])[:want]
+        idx.extend(chosen)
+        picked += len(chosen)
+    return idx, (picked / tgt if tgt else 0.0)
+
+
+def _beats(blk):
+    if not blk or blk.get("delta_median_max_fwd_14d") is None:
+        return None
+    d = blk["delta_median_max_fwd_14d"]
+    p = blk["mann_whitney"].get("p_value")
+    return (d > 0, p is not None and p < 0.05)
+
+
+def _vtxt(b):
+    if b is None:
+        return "sin datos"
+    better, sig = b
+    if better and sig:
+        return "SÍ (Δ>0, p<0.05)"
+    if better:
+        return "marginal (Δ>0, no significativo)"
+    return "NO (Δ≤0)"
+
+
+def _line(name, blk):
+    if not blk or "setup" not in blk:
+        return f"- **{name}**: sin datos"
+    s, b = blk["setup"], blk["baseline"]
+    d = blk["delta_median_max_fwd_14d"]
+    return (f"- **{name}**: setup n={s['n']} mediana max_fwd_14d={es._fmt_pct(s['median_max_fwd_14d'])} "
+            f"win15={es._fmt_pct(s['win15'])} | B1 n={b['n']} mediana={es._fmt_pct(b['median_max_fwd_14d'])} "
+            f"win15={es._fmt_pct(b['win15'])} | Δmediana={es._fmt_pct(d)} ({es._fmt_p(blk['mann_whitney'])})")
+
+
+def write_findings(results):
+    conj = results["tables"]["momentum_conjunct"]["delta_vs_B1"]
+    mini = results["tables"]["momentum_minimal"]["delta_vs_B1"]
+    g = conj["global"]
+    ab = conj["by_regime"].get("alt-bull")
+    ne = conj["by_regime"].get("neutral")
+    be = conj["by_regime"].get("bear")
+    nb = es._combine_outside_altbull(results, "momentum_conjunct")
+
+    L = []
+    L.append("# Findings — ¿la lectura MOMENTUM de musikito tiene edge?")
+    L.append("")
+    h = results["meta"]["hits"]
+    L.append(f"_Regla: breakout sobre máx de {BREAKOUT_WINDOW}d + volumen ≥{VOL_SURGE_MIN}× + sobre SMA20. "
+             f"{results['meta']['symbols']} símbolos, panel {results['meta']['panel_rows']} filas. "
+             f"hits mínima={h['momentum_minimal']}, conjunta={h['momentum_conjunct']}._")
+    L.append("")
+    L.append("## Veredicto (regla-conjunta vs B1, mediana max_fwd_14d, Mann-Whitney one-sided)")
+    L.append("")
+    L.append(f"- (a) **Global**: {_vtxt(_beats(g))}")
+    L.append(f"- (b) **En alt-bull** (breadth≥0.6): {_vtxt(_beats(ab))}")
+    L.append(f"- (c) **Fuera de alt-bull**: {_vtxt(_beats(nb))}")
+    L.append("")
+    L.append("## Regla-conjunta (momentum completo) vs B1 por régimen")
+    L.append("")
+    L.append(_line("Global", g))
+    L.append(_line("alt-bull", ab))
+    L.append(_line("neutral", ne))
+    L.append(_line("bear", be))
+    L.append("")
+    L.append("## Regla-mínima (solo breakout) vs B1")
+    L.append("")
+    L.append(_line("Global", mini["global"]))
+    L.append(_line("alt-bull", mini["by_regime"].get("alt-bull")))
+    L.append(_line("neutral", mini["by_regime"].get("neutral")))
+    L.append(_line("bear", mini["by_regime"].get("bear")))
+    L.append("")
+    L.append("## Caveats")
+    L.append("")
+    for c in results["meta"]["caveats"]:
+        L.append(f"- {c}")
+    L.append("")
+    (HERE / "momentum_findings.md").write_text("\n".join(L), encoding="utf-8")
+    print(f"escrito {HERE / 'momentum_findings.md'}")
+
+
+def main():
+    universe = universe_from_cache()
+    print(f"universo (cache): {len(universe)}")
+    symbol_dfs = {}
+    for i, sym in enumerate(universe, 1):
+        try:
+            rows = es.download_symbol(sym)  # cache hit
+        except Exception as e:
+            print(f"  {sym}: ERROR {e}")
+            continue
+        df = es.rows_to_df(rows)
+        if df is None or len(df) < 250:
+            continue
+        df = es.compute_features(df)
+        df = add_momentum_features(df)
+        symbol_dfs[sym] = df
+        if i % 75 == 0:
+            print(f"  [{i}/{len(universe)}] {len(symbol_dfs)} con datos")
+    print(f"símbolos con datos: {len(symbol_dfs)}")
+
+    panel = es.build_panel(symbol_dfs)
+    breadth = es.compute_breadth(panel)
+    panel = panel.merge(breadth.rename("breadth"), left_on="date", right_index=True, how="left")
+    panel["regime"] = panel["breadth"].apply(es.regime_bucket)
+    print(f"filas panel: {len(panel)}")
+
+    m_min = select_momentum_minimal(panel)
+    m_conj = select_momentum_conjunct(panel)
+    n_min = int((m_min & panel["max_fwd_14d"].notna()).sum())
+    n_conj = int((m_conj & panel["max_fwd_14d"].notna()).sum())
+    print(f"hits momentum-mínima: {n_min} ; conjunta: {n_conj}")
+
+    b1_min_idx, r_min = build_b1_momentum(panel, m_min)
+    b1_conj_idx, r_conj = build_b1_momentum(panel, m_conj)
+    b2_idx = es.build_b2(panel)
+
+    rows_min, rows_conj = panel[m_min], panel[m_conj]
+    rows_b1_min = panel.loc[b1_min_idx]
+    rows_b1_conj = panel.loc[b1_conj_idx]
+    rows_b2 = panel.loc[b2_idx]
+
+    results = {
+        "meta": {
+            "rule": "momentum/breakout",
+            "breakout_window": BREAKOUT_WINDOW, "vol_surge_min": VOL_SURGE_MIN,
+            "hits": {"momentum_minimal": n_min, "momentum_conjunct": n_conj},
+            "b1_ratio_used": {"minimal": round(r_min, 3), "conjunct": round(r_conj, 3)},
+            "panel_rows": int(len(panel)), "symbols": len(symbol_dfs),
+            "caveats": [
+                "Sesgo de supervivencia: cache solo de símbolos vivos hoy; niveles absolutos "
+                "inflados para setup y baseline por igual; el DELTA sigue informativo.",
+                "Retorno en USDT incluye beta de BTC.",
+            ],
+        },
+        "tables": {
+            "momentum_minimal": {
+                "setup": es.stratify(rows_min, panel),
+                "B1": es.stratify(rows_b1_min, panel),
+                "B2": es.stratify(rows_b2, panel),
+                "delta_vs_B1": es.delta_and_pval(rows_min, rows_b1_min),
+            },
+            "momentum_conjunct": {
+                "setup": es.stratify(rows_conj, panel),
+                "B1": es.stratify(rows_b1_conj, panel),
+                "B2": es.stratify(rows_b2, panel),
+                "delta_vs_B1": es.delta_and_pval(rows_conj, rows_b1_conj),
+            },
+        },
+    }
+    (HERE / "momentum_results.json").write_text(json.dumps(results, indent=2))
+    print(f"escrito {HERE / 'momentum_results.json'}")
+    write_findings(results)
+    print("== done ==")
+    return results
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/superpowers/specs/es/2026-06-20-momentum-lens-evidencia.md
+++ b/docs/superpowers/specs/es/2026-06-20-momentum-lens-evidencia.md
@@ -1,0 +1,118 @@
+# Evidencia: la lectura MOMENTUM de musikito SÍ tiene señal (la pregunta abierta, respondida)
+
+**Fecha:** 2026-06-20
+**Estado:** brief para el roster. Cierra la última pregunta abierta del arco — y reabre una.
+**Origen:** Samuel eligió el lente-momentum del backlog POST-SHIP.
+
+---
+
+## 0. Por qué
+
+El estudio multi-régimen midió la lectura-DEBILIDAD (features de entrada reverse-engineadas: parte
+baja del rango, sobreventa, bajo SMA) y la refutó: **no tiene edge en ningún régimen.** SP2 construyó
+el detector sobre esa lectura. PERO el template DECLARADO del canal era **momentum/breakout** (zona +
+targets agresivos + runner, "Risk Trade"). Nunca medimos la lectura-momentum. Este estudio la mide,
+mismo harness (`data/retune/2026-06-18-setup-edge-multiregimen/`, cache de 386 símbolos, panel 455k
+filas, baselines matcheadas, Mann-Whitney).
+
+**Regla-momentum (congelada):** vivo AND breakout sobre el máx de 20d AND volumen 3d ≥ 1.5× el de
+30d AND sobre la SMA20. n=**6.418** hits (regla conjunta). Control B1 = vivos que NO rompieron,
+matcheados por fecha.
+
+---
+
+## 1. El dato — y la divergencia crítica
+
+### 1.1 Métrica optimista (`max_fwd_14d` — el mejor pico en 14 días): momentum GANA en todo
+
+| Régimen | Setup mediana | B1 | Δ | p | win15 setup/B1 |
+|---|---|---|---|---|---|
+| Global | **20.0%** | 17.3% | +2.8% | 2.7e-20 | 60.2% / 54.8% |
+| alt-bull | **21.4%** | 19.7% | +1.8% | 2e-9 | 62.9% / 59.1% |
+| neutral | **17.6%** | 13.3% | +4.3% | 3e-4 | 56.9% / 46.2% |
+| bear | **13.0%** | 10.1% | +2.8% | 2e-10 | 45.2% / 35.9% |
+
+**Lectura 1:** las coins en breakout alcanzan picos MÁS ALTOS que las que no rompen, en TODOS los
+regímenes, con significancia masiva (n=6.418, p~1e-20). El 60% pega +15% en 14 días vs 55% del azar.
+**Esto es señal real de selección — justo lo que la lectura-debilidad NO tenía.** Refuta el "no
+existe NINGÚN edge per-coin".
+
+### 1.2 Métrica realista (`rule_return`, +20% TP / −12% SL / 14d): momentum PIERDE
+
+| Régimen | Setup rule_return | B1 |
+|---|---|---|
+| Global | **−12.0%** (toca el stop) | −2.1% |
+| alt-bull | **−12.0%** | −0.6% |
+| neutral | **−12.0%** | −6.6% |
+| bear | **−12.0%** | −7.2% |
+
+**Lectura 2 (la incómoda):** con un stop fijo de −12%, el trade-momentum MEDIANO **toca el stop** —
+peor que la baseline. ¿Por qué la divergencia con §1.1? Porque los breakouts son **volátiles en
+ambas direcciones**: el precio pega un pico arriba (max_fwd alto) PERO también latiguea abajo y toca
+el −12% ANTES de llegar al +20%. El edge vive en el **pico de subida** (max-favorable-excursion), no
+en un buy-and-hold con stop ajustado.
+
+---
+
+## 2. La síntesis honesta
+
+- **Hay señal de momentum REAL** que la debilidad no tenía. "No existe ningún edge per-coin" queda
+  **refutado.**
+- Pero es una señal de **excursión favorable** (el pico), no de retorno realizable con un stop.
+  Cosechable solo con el estilo REAL de musikito: **targets agresivos + vender en el pico + runner**
+  (NO un stop ajustado). Su método declarado y su exit calzan exactamente con dónde vive el edge.
+- O sea: las features de ENTRADA que reverse-engineamos (debilidad) eran un **red herring** — el
+  edge nunca estuvo en comprar debilidad; estuvo en cazar el breakout + salir rápido en la subida.
+
+## 3. Caveats (no sobre-interpretar)
+
+- **Sesgo de supervivencia, y aquí corta MÁS contra el momentum:** un breakout que bombeó y murió
+  (delisted, pump-and-dump) está EXCLUIDO del cache. Eso infla el edge aparente del momentum más que
+  el de la baseline. El edge real es probablemente MENOR; el `rule_return` que toca el stop es la
+  señal robusta de que es difícil de tradear.
+- `max_fwd` es optimista (asume timing perfecto del pico). Pero los targets agresivos de musikito se
+  acercan a cosechar el pico más que un hold de 14d.
+- Test confirmatorio, NO p-hacking: momentum era la hipótesis PRE-REGISTRADA (el método declarado del
+  canal), no un barrido de datos.
+
+## 4. Las preguntas para el roster
+
+**P1 — ¿Reabre esto "Valles elige ganadores"?** Acabamos de reorientar a "exhibe estado, no elige".
+El momentum SÍ tiene señal. Pero el `rule_return` dice que es difícil de cosechar y la supervivencia
+lo infla. ¿Es edge tradeable o edge de papel?
+
+**P2 — ¿El detector está al revés?** SP2 construyó "parte baja del rango" (debilidad, sin edge). El
+momentum (breakout) tiene la señal. ¿Hay que invertir el detector — de "parte baja" a "breakout"? ¿O
+exhibir AMBOS como hechos? Implicaciones para SP2 ya shippeado.
+
+**P3 — ¿Cómo se honra la doctrina anti-veredicto si ahora SÍ hay una señal con edge?** Exhibir
+"breakout + volumen" como hecho es seguro; pero si el sistema sabe que eso tiene edge medido, ¿puede
+seguir diciendo "no firmo veredicto"? ¿O el edge se expresa solo en la pieza de régimen (cuándo) +
+los targets/runner (cómo cosechar), nunca en "compra esta"?
+
+---
+
+## 5. RESOLUCIÓN — el estudio de confirmación (2026-06-20)
+
+El roster (junta 2026-06-20) dictaminó que el "edge" de §1.1 era EXCURSIÓN, no retorno realizable, y
+pidió un estudio de confirmación: exit REAL de musikito + de-dup + stress de supervivencia. Hecho
+(`CONFIRM_METODOLOGIA.md`, `confirm_study.py`, `confirm_findings.md`):
+
+- **De-dup:** los hits cayeron de 6.418 → **3.133** (confirma la autocorrelación que infló el n).
+- **Con el exit real** (escalera +15/+30/+50/+90% + runner, piso −50%, NO un stop −12%): el momentum
+  pasa de "toca el stop" a un edge **positivo pero diminuto** — Δmedia realized = **+1.6%** global
+  (+1.0% alt-bull, +1.4% neutral, **−0.9% bear**). El exit de musikito SÍ servía; la selección apenas.
+- **Stress de supervivencia: `breakeven_p = 1.5%`.** Si apenas el 1.5% de los breakouts hubiera
+  muerto (−100%, excluidos del cache), la media del setup igualaría a B1. Los alts de bajo cap en
+  breakout mueren muy por encima del 1.5% → el edge diminuto está **enteramente dentro del margen de
+  supervivencia.** Confirma a Serrano: la supervivencia probablemente explica TODO.
+
+**Veredicto final:** NO hay edge de selección per-coin robusto — ni debilidad (sin señal) ni momentum
+(frágil, dentro del ruido de supervivencia, se invierte en bear). Lo real de musikito fue el **exit**
+(vender en el pico) + el **timing de ciclo** (alt-season), NUNCA la elección de coin.
+
+- **P1:** No reabre "elige ganadores". Confirmado con número.
+- **P2:** El detector NO se invierte (el breakout también es frágil). SP2 queda intacto.
+- **P3:** La doctrina se sostiene; AC7 de SP2 sigue honesto. Producción NO se toca.
+
+**Pregunta cerrada.** El arco de la reorientación (SP1+SP2+SP3) se mantiene entero.


### PR DESCRIPTION
Item POST-SHIP del backlog: cerrar la última pregunta abierta del arco de reorientación de Valles — ¿la lectura **momentum/breakout** de musikito (la que faltaba) tiene edge, dado que la lectura-debilidad ya estaba refutada?

## Hallazgo
- **Excursión:** con `max_fwd_14d`, el momentum (breakout 20d + volumen ≥1.5× + sobre SMA20) le gana al azar en todos los regímenes (n=6.418, p~1e-20). Refuta "no existe NINGÚN edge per-coin"… en apariencia.
- **Roster (junta 2026-06-20):** eso es EXCURSIÓN, no retorno realizable. Con stop −12% el trade mediano toca el stop. Axiom-0: *el objeto que un sistema causal puede afirmar (el contrato) no es donde vive el edge medido (la excursión); ningún p-valor cruza esa distancia.*
- **Confirmación** (exit REAL de musikito: escalera +15/+30/+50/+90% + runner, sin stop ajustado + de-dup + stress de supervivencia):
  - de-dup bajó los hits 6.418 → 3.133 (autocorrelación confirmada).
  - edge realizado **+1.6% media global** (el exit sí servía) pero **frágil**: `breakeven_p = 1.5%` — apenas 1.5% de breakouts muertos (excluidos del cache) lo igualan a la baseline. Los alts de bajo cap mueren muy por encima de eso → el edge está dentro del margen de supervivencia. Se invierte en bear.

## Veredicto
**No hay edge de selección per-coin robusto** — ni debilidad ni momentum. Lo real de musikito fue su **exit** (vender en el pico) + el **timing de ciclo** (alt-season), nunca la elección de coin. La reorientación (SP1 régimen + SP2 detector honesto + SP3 rediseño) se sostiene entera; la costura AC7 sigue honesta; **producción NO se toca**.

## Contenido
Research/docs solamente (cero código de producto): la evidencia + metodologías congeladas + los scripts (reusan el cache del estudio multi-régimen, cero re-fetch) + los resultados. El cache de klines queda fuera (gitignored).

Evidencia: `docs/superpowers/specs/es/2026-06-20-momentum-lens-evidencia.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)