### PR TITLE
fix(valles-sp3): la vista de moneda aprovecha el ancho disponible

### DIFF
--- a/frontend/src/components/valles/idea/idea.module.css
+++ b/frontend/src/components/valles/idea/idea.module.css
@@ -374,6 +374,11 @@
   font-size: 18px;            /* piso de cuerpo, lector mayor */
   line-height: 1.6;
   position: relative;
+  /* Llena el ancho disponible del stage (evita el colapso de flexbox a la
+     anchura del contenido); tope alto para no estirarse en monitores ultraanchos. */
+  width: 100%;
+  max-width: 1440px;
+  margin-inline: auto;
 }
 .iv * { font-family: var(--sans); }
 
@@ -412,7 +417,7 @@
 
 /* columnas de lectura */
 .iv-col { max-width: var(--read); margin: 0 auto; }
-.iv-wide { max-width: 880px; margin: 0 auto; }
+.iv-wide { max-width: 1180px; margin: 0 auto; }
 
 /* ② cabecera de la moneda */
 .iv-head { margin-bottom: 26px; }


### PR DESCRIPTION
Ajuste de estilos de la vista per-coin de SP3: estaba muy comprimida y desperdiciaba el ancho.

## Causa
`.iv` (el contenedor de la idea-de-moneda) no tenía `width`, así que dentro del `.vwStage` centrado (flex) colapsaba a la anchura de su contenido (~880px), dejando márgenes enormes en pantallas anchas — la trampa de flexbox content-sizing.

## Fix (`idea.module.css`, solo CSS)
- `.iv`: `width: 100%` + `max-width: 1440px` + `margin-inline: auto` → llena el ancho disponible, con tope para no estirarse en monitores ultraanchos.
- `.iv-wide` (el gráfico): `880px` → `1180px`.
- La narrativa queda en su medida de lectura (660px / 60ch) a propósito — legibilidad para el lector mayor.

Cero cambio de comportamiento, doctrina ni contrato. `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)