### PR TITLE
fix(valles-sp3): el gráfico abre enfocado en los últimos ~90 días

### DIFF
--- a/frontend/src/components/valles/idea/IdeaChart.tsx
+++ b/frontend/src/components/valles/idea/IdeaChart.tsx
@@ -139,7 +139,19 @@ export const IdeaChart: React.FC<IdeaChartProps> = ({
         close: c.close,
       })),
     );
-    chart.timeScale().fitContent();
+    // Abrir ENFOCADO en los últimos ~N días relevantes — no el histórico completo,
+    // que deja velas/rangos/jugada ilegibles. El gráfico no es paneable, así que el
+    // rango inicial ES la vista. fitContent solo si hay poca historia.
+    const INITIAL_VISIBLE_BARS = 90;
+    const RIGHT_PAD_BARS = 5;   // aire a la derecha para el marcador y las etiquetas
+    const total = candles.length;
+    const applyView = () => {
+      const ts = chartRef.current?.timeScale();
+      if (!ts) return;
+      if (total <= INITIAL_VISIBLE_BARS) ts.fitContent();
+      else ts.setVisibleLogicalRange({ from: total - INITIAL_VISIBLE_BARS, to: total - 1 + RIGHT_PAD_BARS });
+    };
+    applyView();
     requestAnimationFrame(() =>
       requestAnimationFrame(() => {
         if (!chartRef.current) return;
@@ -150,6 +162,7 @@ export const IdeaChart: React.FC<IdeaChartProps> = ({
         if (W < 1 || H < 1) return;
         chartRef.current.resize(W - 1, H - 1, true);
         chartRef.current.resize(W, H, true);
+        applyView();   // re-aplicar tras el resize para que el rango pegue
         force((n) => n + 1);
       }),
     );


### PR DESCRIPTION
Ajuste del gráfico de la vista de moneda (SP3): abría con `fitContent()` → mostraba **todo el histórico**, dejando las velas chiquitas y los **rangos / la jugada ilegibles**. Dejaba de ser una herramienta educativa.

## Fix (`IdeaChart.tsx`, solo frontend)
- Reemplaza `fitContent()` por `setVisibleLogicalRange` a las **últimas ~90 velas** (+ ~5 barras de aire a la derecha para el marcador y las etiquetas). El gráfico no es paneable, así que ese rango inicial es la vista enfocada.
- `fitContent()` se conserva como fallback cuando hay poca historia (≤90 velas).
- Re-aplicado tras el resize-jiggle para que el rango pegue.

Cero cambio de contrato, doctrina ni backend. `tsc --noEmit` + `vite build` OK.

**Nota:** el eje de precio se autoajusta a las velas visibles; para coins muy abajo en su rango, algún target lejano de la jugada podría quedar sobre el borde superior. Si aparece, el follow-up es ampliar el rango de precio para incluir la jugada (zona/stop/targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)