### PR TITLE
fix(valles-sp3): gráfico interactivo (pan/zoom) + zoom inicial más cerrado

### DIFF
--- a/frontend/src/components/valles/idea/IdeaChart.tsx
+++ b/frontend/src/components/valles/idea/IdeaChart.tsx
@@ -82,8 +82,12 @@ export const IdeaChart: React.FC<IdeaChartProps> = ({
       },
       timeScale:    { visible: false, borderVisible: false },
       crosshair:    { mode: 0 as never },
-      handleScroll: false,
-      handleScale:  false,
+      // Interactivo: arrastrar para desplazar (horizontal), rueda/pinch para zoom
+      // de tiempo, doble-clic para resetear. Sin arrastre del eje de PRECIO para que
+      // los overlays (anotados por priceToCoordinate) no se desincronicen — el zoom de
+      // tiempo sí dispara subscribeVisibleLogicalRangeChange → re-render → overlays siguen.
+      handleScroll: { mouseWheel: false, pressedMouseMove: true, horzTouchDrag: true, vertTouchDrag: false },
+      handleScale:  { mouseWheel: true, pinch: true, axisPressedMouseMove: { time: true, price: false }, axisDoubleClickReset: true },
       width:  Math.max(1, container.clientWidth),
       height: Math.max(1, height),
     });
@@ -142,7 +146,7 @@ export const IdeaChart: React.FC<IdeaChartProps> = ({
     // Abrir ENFOCADO en los últimos ~N días relevantes — no el histórico completo,
     // que deja velas/rangos/jugada ilegibles. El gráfico no es paneable, así que el
     // rango inicial ES la vista. fitContent solo si hay poca historia.
-    const INITIAL_VISIBLE_BARS = 90;
+    const INITIAL_VISIBLE_BARS = 60;
     const RIGHT_PAD_BARS = 5;   // aire a la derecha para el marcador y las etiquetas
     const total = candles.length;
     const applyView = () => {


### PR DESCRIPTION
Continúa los ajustes del gráfico de SP3 (#617): el usuario quería más detalle de los niveles y poder interactuar con el gráfico.

## Fix (`IdeaChart.tsx`, solo frontend)
- **Interactivo:** arrastrar para desplazar (pan horizontal), rueda/pinch para zoom de tiempo, doble-clic para resetear. Antes estaba estático (`handleScroll/handleScale: false`).
- **Sin arrastre del eje de precio:** los overlays se posicionan por `priceToCoordinate`; el zoom/pan de tiempo los re-sincroniza vía `subscribeVisibleLogicalRangeChange`, pero el arrastre vertical no — por eso se deshabilita (evita desincronización).
- **Zoom inicial más cerrado:** 90 → **60 velas**, para ver los niveles con más detalle.

Cero cambio de contrato, doctrina ni backend. `tsc --noEmit` + `vitest` (IdeaChart) + `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)