### PR TITLE
fix(chrome): dropdowns y barras del chart respetan el tema cálido

### DIFF
--- a/frontend/src/components/NotificationBell.module.css
+++ b/frontend/src/components/NotificationBell.module.css
@@ -5,7 +5,7 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(4, 8, 6, 0.55);
+  background: rgba(42, 39, 34, 0.30);
   z-index: 99;
   animation: bdFade 120ms ease-out;
 }
@@ -19,13 +19,12 @@
   width: 440px;
   max-width: calc(100vw - 28px);
   max-height: 620px;
-  background: linear-gradient(180deg, rgba(16, 22, 18, 0.96), rgba(12, 16, 14, 0.96));
-  backdrop-filter: blur(12px) saturate(140%);
-  -webkit-backdrop-filter: blur(12px) saturate(140%);
-  border: 1px solid var(--nbc-border-dim);
-  box-shadow:
-    0 0 0 1px rgba(106, 215, 255, 0.10),
-    0 20px 40px -8px rgba(0, 0, 0, 0.6);
+  background: var(--nbc-surface);
+  backdrop-filter: blur(12px) saturate(120%);
+  -webkit-backdrop-filter: blur(12px) saturate(120%);
+  border: 1px solid var(--nbc-border-color);
+  border-radius: var(--nbc-radius);
+  box-shadow: var(--nbc-shadow-lg);
   animation: ddIn 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
   transform-origin: top right;
   display: flex;
@@ -111,7 +110,7 @@
 .chipActive {
   color: var(--bull);
   border-color: var(--bull);
-  background: rgba(106, 215, 255, 0.06);
+  background: var(--bull-dim);
 }
 .chip :global(.num) { font-size: 9.5px; opacity: 0.7; }
 
@@ -145,7 +144,7 @@
   transition: background 80ms ease;
 }
 .item:last-child { border-bottom: none; }
-.item:hover { background: rgba(255, 255, 255, 0.025); }
+.item:hover { background: var(--nbc-surface-alt); }
 
 .itemBar { width: 2px; align-self: stretch; background: transparent; }
 .itemUnread .itemBar         { background: var(--bull); }
@@ -163,10 +162,10 @@
   color: var(--nbc-fg-muted);
   background: var(--nbc-surface-alt);
 }
-.itemGlyph--bull { color: var(--bull); border-color: var(--bull); background: rgba(106,215,255,0.06); }
-.itemGlyph--warn { color: var(--warn); border-color: var(--warn); background: rgba(255,184,78,0.06); }
-.itemGlyph--bear { color: var(--bear); border-color: var(--bear); background: rgba(255,184,78,0.06); }
-.itemGlyph--info { color: var(--info); border-color: var(--info); background: rgba(106,215,255,0.06); }
+.itemGlyph--bull { color: var(--bull); border-color: var(--bull); background: var(--bull-dim); }
+.itemGlyph--warn { color: var(--warn); border-color: var(--warn); background: var(--warn-dim); }
+.itemGlyph--bear { color: var(--bear); border-color: var(--bear); background: var(--bear-dim); }
+.itemGlyph--info { color: var(--info); border-color: var(--info); background: var(--info-dim); }
 
 .itemBody { min-width: 0; }
 .itemTitle {
@@ -224,7 +223,7 @@
   gap: 12px;
   padding: 10px 14px;
   border-top: 1px solid var(--nbc-border-dimmer);
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--nbc-surface-alt);
 }
 .ftHint { font-size: 10.5px; color: var(--nbc-fg-dim); }
 

--- a/frontend/src/components/SymbolDetail.module.css
+++ b/frontend/src/components/SymbolDetail.module.css
@@ -151,7 +151,7 @@
   gap: 14px;
   padding: 10px 16px;
   border-bottom: 1px solid var(--nbc-border-dimmer);
-  background: rgba(0, 0, 0, 0.15);
+  background: var(--nbc-surface-alt);
 }
 .legendItem {
   display: inline-flex;
@@ -196,7 +196,7 @@
   gap: 14px;
   padding: 10px 20px;
   border-top: 1px solid var(--nbc-border-dim);
-  background: rgba(0, 0, 0, 0.25);
+  background: var(--nbc-surface-alt);
   font-size: 10.5px;
 }
 .ft .prose { font-size: 10.5px; color: var(--nbc-fg-dim); }

--- a/frontend/src/components/UserMenu.module.css
+++ b/frontend/src/components/UserMenu.module.css
@@ -1,7 +1,7 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(4, 8, 6, 0.55);
+  background: rgba(42, 39, 34, 0.30);
   z-index: 99;
   animation: bdFade 120ms ease-out;
 }
@@ -13,13 +13,12 @@
   top: 56px;
   right: 18px;
   width: 320px;
-  background: linear-gradient(180deg, rgba(16, 22, 18, 0.96), rgba(12, 16, 14, 0.96));
-  backdrop-filter: blur(12px) saturate(140%);
-  -webkit-backdrop-filter: blur(12px) saturate(140%);
-  border: 1px solid var(--nbc-border-dim);
-  box-shadow:
-    0 0 0 1px rgba(106, 215, 255, 0.10),
-    0 20px 40px -8px rgba(0, 0, 0, 0.6);
+  background: var(--nbc-surface);
+  backdrop-filter: blur(12px) saturate(120%);
+  -webkit-backdrop-filter: blur(12px) saturate(120%);
+  border: 1px solid var(--nbc-border-color);
+  border-radius: var(--nbc-radius);
+  box-shadow: var(--nbc-shadow-lg);
   animation: menuIn 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
   transform-origin: top right;
   display: flex;
@@ -125,5 +124,5 @@
   text-align: left;
   transition: background 80ms ease;
 }
-.logout:hover { background: rgba(255, 184, 78, 0.08); }
+.logout:hover { background: var(--nbc-danger-dim); }
 .logoutIcon { font-size: 13px; }


### PR DESCRIPTION
## Qué

Los chrome dropdowns y dos barras del detalle de símbolo se quedaron con fondos oscuros + glow cyan hardcodeados que ignoraban el remap `--nbc-*` → cálido. El texto `--nbc-fg` (tinta oscura) quedaba casi invisible contra el negro; solo se leían los grises `--fg-muted`. En modo claro se veían como cajas negras con letras grises.

## Archivos

- `UserMenu.module.css` (menú de avatar)
- `NotificationBell.module.css` (dropdown de notificaciones)
- `SymbolDetail.module.css` — solo `.chartLegend` y `.ft`

## Cambios (valor hardcodeado → token cálido)

- Fondo de panel: gradiente negro `rgba(16,22,18,0.96)` → `var(--nbc-surface)`
- Sombra: glow neón cyan → `var(--nbc-shadow-lg)`
- Esquinas: `+ border-radius: var(--nbc-radius)`
- Scrim de backdrop: casi-negro → tinta cálida `rgba(42,39,34,0.30)`
- Hover de item / footer / chip activo / glyphs semánticos: tintes blancos/cyan/negros → `var(--nbc-surface-alt)` y `var(--bull-dim/warn-dim/bear-dim/info-dim)`
- Bug de paso: el glyph `--bear` tenía fondo ámbar en vez de rojo

## Verificación

- `npm run build` (tsc + vite) verde
- Cero backend, cero lógica — solo CSS de presentación

🤖 Generated with [Claude Code](https://claude.com/claude-code)