### PR TITLE
fix(rail): rail lateral fijo al viewport (app-shell) + colapsable a iconos

### DIFF
--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -12,6 +12,13 @@
 .appDesktop {
   padding: 0;
   gap: 0;
+  /* App-shell: fija el shell al viewport y deja que el flex reparta la
+     altura (Header + Ticker son flex-shrink:0; .body absorbe el resto con
+     flex:1). Solo .main scrollea — así el rail queda a altura de viewport
+     y su footer .user se ve siempre. 100vh ancla al viewport, no al padre,
+     así que no hace falta tocar html/body/#root. Mobile NO usa esta regla. */
+  height: 100vh;
+  overflow: hidden;
 }
 .appMobile {
   padding: 0 0 64px;
@@ -37,6 +44,12 @@
 .appMobile .main {
   padding: 0 12px;
   gap: 12px;
+}
+/* Desktop: .main es el ÚNICO scroller. min-height:0 deja que el flex item
+   se encoja por debajo de su contenido para que el overflow surta efecto. */
+.appDesktop .main {
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .errorBanner {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -628,7 +628,10 @@ const App: React.FC = () => {
   useEffect(() => { setOpenOverlay(null); }, [mainTab]);
 
   return (
-    <div className={[appStyles.app, mobile ? appStyles.appMobile : appStyles.appDesktop].join(' ')}>
+    <div
+      className={[appStyles.app, mobile ? appStyles.appMobile : appStyles.appDesktop].join(' ')}
+      data-shell={mobile ? 'mobile' : 'desktop'}
+    >
       <NotificationToast />
 
       <Header

--- a/frontend/src/components/LeftRail.module.css
+++ b/frontend/src/components/LeftRail.module.css
@@ -11,12 +11,43 @@
      ítems + el footer .user no caben en un viewport bajo, el rail scrollea
      internamente. .spacer{flex:1} sigue empujando .user al fondo. */
   overflow-y: auto;
+  /* Stacking propio para que los tooltips del modo colapsado floten por
+     encima de .main (que es hermano y se pinta después). */
+  position: relative;
+  z-index: 5;
+  transition: width 160ms var(--ease, ease);
 }
 
 .brand {
-  padding: 0 18px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 14px 18px;
   border-bottom: 1px solid var(--nbc-border-dimmer);
   margin-bottom: 4px;
+}
+
+/* Toggle colapsar/expandir (en la cabecera del rail, junto al logo) */
+.collapseBtn {
+  flex: none;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--nbc-fg-muted);
+  font-size: 17px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: color 80ms ease, border-color 80ms ease, background 80ms ease;
+}
+.collapseBtn:hover {
+  color: var(--nbc-fg);
+  border-color: var(--nbc-border-dim);
+  background: var(--nbc-surface-alt);
 }
 .brandMark { color: var(--bull); width: 22px; height: 22px; }
 
@@ -176,3 +207,80 @@
   color: var(--bear);
   border-color: var(--bear);
 }
+.logoutIcon { font-size: 12px; line-height: 1; }
+
+/* ════════════════════════════════════════════════════════════
+   COLAPSADO — solo iconos centrados + tooltips a la derecha
+   ════════════════════════════════════════════════════════════ */
+.collapsed {
+  width: 64px;
+  /* overflow visible para que los tooltips escapen del rail; en colapsado
+     el contenido es corto y no necesita scroll vertical. */
+  overflow: visible;
+}
+
+/* cabecera: solo el toggle (›) centrado, sin el wordmark */
+.collapsed .brand {
+  justify-content: center;
+  padding: 0 0 14px;
+}
+.collapsed .brandMark { display: none; }
+
+/* etiquetas de sección → línea divisoria fina */
+.collapsed .section { padding: 0 8px; }
+.collapsed .sectionLabel {
+  height: 1px;
+  margin: 8px 8px 4px;
+  padding: 0;
+  background: var(--nbc-border-dimmer);
+  text-indent: -9999px;
+  overflow: hidden;
+}
+.collapsed .sectionLabel::before { content: none; }
+
+/* items: icono centrado; sin label, contador ni badge */
+.collapsed .item {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  padding: 9px 0;
+}
+.collapsed .indicator,
+.collapsed .label,
+.collapsed .count,
+.collapsed .badge { display: none; }
+
+/* footer: solo el avatar; "salir" queda como icono */
+.collapsed .user { padding: 12px 0; align-items: center; }
+.collapsed .userRow { justify-content: center; }
+.collapsed .userText { display: none; }
+.collapsed .logout {
+  align-self: center;
+  padding: 6px 8px;
+}
+.collapsed .logoutLabel { display: none; }
+
+/* tooltips (solo en colapsado) a la derecha del icono */
+.collapsed .logout { position: relative; }
+.collapsed .item::after,
+.collapsed .logout::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: calc(100% + 10px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--ink);
+  color: var(--paper);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  padding: 4px 9px;
+  border-radius: 6px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  box-shadow: var(--nbc-shadow-lg);
+  transition: opacity 90ms ease;
+  z-index: 60;
+}
+.collapsed .item:hover::after,
+.collapsed .logout:hover::after { opacity: 1; }

--- a/frontend/src/components/LeftRail.module.css
+++ b/frontend/src/components/LeftRail.module.css
@@ -7,6 +7,10 @@
   flex-direction: column;
   padding: 18px 0;
   gap: 10px;
+  /* El shell (.appDesktop) acota el rail a la altura del viewport; si los
+     ítems + el footer .user no caben en un viewport bajo, el rail scrollea
+     internamente. .spacer{flex:1} sigue empujando .user al fondo. */
+  overflow-y: auto;
 }
 
 .brand {

--- a/frontend/src/components/LeftRail.tsx
+++ b/frontend/src/components/LeftRail.tsx
@@ -4,7 +4,7 @@
 // análisis (historial / auto-tune / config). Footer = user.
 // ============================================================
 
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './LeftRail.module.css';
 import RailIcon, { type RailIconName } from './atoms/RailIcon';
 import type { MainTab } from '../types-ui';
@@ -41,6 +41,19 @@ const LeftRail: React.FC<LeftRailProps> = ({
 }) => {
   const { user } = useAuth();
 
+  // Colapsable (solo desktop; en mobile se usa BottomNav). Persiste para que
+  // el operador no tenga que recolapsar en cada sesión.
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try { return localStorage.getItem('rail_collapsed') === '1'; } catch { return false; }
+  });
+  const toggleCollapsed = () => {
+    setCollapsed((c) => {
+      const next = !c;
+      try { localStorage.setItem('rail_collapsed', next ? '1' : '0'); } catch { /* ignore */ }
+      return next;
+    });
+  };
+
   const tradingItems: RailItemDef[] = [
     { id: 'mercado',     label: 'Mercado',     icon: 'mercado',    count: counts.market,     tab: 'mercado' },
     { id: 'posiciones',  label: 'Posiciones',  icon: 'positions',  count: counts.positions,  tab: 'posiciones' },
@@ -54,7 +67,10 @@ const LeftRail: React.FC<LeftRailProps> = ({
   ];
 
   return (
-    <nav className={styles.rail} aria-label="Navegación principal">
+    <nav
+      className={[styles.rail, collapsed ? styles.collapsed : ''].filter(Boolean).join(' ')}
+      aria-label="Navegación principal"
+    >
       <div className={styles.brand}>
         <div className={styles.brandMark}>
           <svg width="22" height="22" viewBox="0 0 20 20" fill="none">
@@ -63,6 +79,15 @@ const LeftRail: React.FC<LeftRailProps> = ({
             <rect x="8" y="8" width="4"  height="4"  fill="var(--nbc-bg)" />
           </svg>
         </div>
+        <button
+          type="button"
+          className={styles.collapseBtn}
+          onClick={toggleCollapsed}
+          aria-label={collapsed ? 'Expandir menú' : 'Colapsar menú'}
+          aria-expanded={!collapsed}
+        >
+          {collapsed ? '›' : '‹'}
+        </button>
       </div>
 
       <div className={styles.section}>
@@ -107,8 +132,14 @@ const LeftRail: React.FC<LeftRailProps> = ({
             </div>
           </div>
           {onLogout && (
-            <button className={styles.logout} onClick={onLogout} title="Cerrar sesión">
-              <span>↗</span> salir
+            <button
+              className={styles.logout}
+              onClick={onLogout}
+              aria-label="Cerrar sesión"
+              data-tip="Cerrar sesión"
+            >
+              <span className={styles.logoutIcon}>↗</span>
+              <span className={styles.logoutLabel}>salir</span>
             </button>
           )}
         </div>
@@ -134,6 +165,8 @@ const RailItem: React.FC<RailItemProps> = ({ def, active, onClick }) => {
       ].filter(Boolean).join(' ')}
       onClick={onClick}
       aria-current={active ? 'page' : undefined}
+      aria-label={def.label}
+      data-tip={def.label}
     >
       <span className={styles.indicator} />
       <RailIcon name={def.icon} className={styles.icon} />

--- a/frontend/src/components/valles/valles.module.css
+++ b/frontend/src/components/valles/valles.module.css
@@ -45,6 +45,13 @@
   flex-direction: column;
   align-items: center;
 }
+/* Bajo el app-shell de desktop, .main scrollea y mide viewport − (header +
+   ticker). Un .vw de 100vh excedería ese alto y forzaría un scroll permanente
+   aunque el contenido quepa. min-height:100% lo ancla a .main; el fill de
+   --paper lo sigue dando .vwRoot. Mobile mantiene 100vh del viewport. */
+[data-shell="desktop"] .vw {
+  min-height: 100%;
+}
 
 /* barra superior fina: wordmark + progreso de las tres lentes */
 .vwTop {


### PR DESCRIPTION
Dos cambios sobre el rail lateral de desktop, sobre la misma rama.

## 1 · App-shell (rail fijo al viewport)

El scroll global empujaba el footer del rail (avatar + Salir) al fondo de la página. Ahora desktop usa el patrón **app-shell** — Header + Ticker + Rail fijos, solo `.main` scrollea — así el rail siempre tiene el tamaño del viewport y su footer se ve en todo momento.

- `App.module.css`: `.appDesktop { height:100vh; overflow:hidden }` (el flex reparte la altura, sin número mágico) + `.appDesktop .main { overflow-y:auto; min-height:0 }`.
- `App.tsx`: `data-shell` en `.app` (puente para el override de Valles cruzando CSS modules).
- `LeftRail.module.css`: `.rail { overflow-y:auto }`.
- `valles.module.css`: `[data-shell="desktop"] .vw { min-height:100% }` (mata el scroll permanente del `100vh`).

Mobile (`.appMobile`) intacto: scroll de ventana + `BottomNav` fijo.

## 2 · Rail colapsable a iconos

Toggle junto al logo (`‹`/`›`) que colapsa el rail a 64px (solo iconos) para darle más ancho al contenido. Estado persistido en `localStorage`.

- Colapsado: iconos centrados; labels/contadores/badges ocultos; etiquetas de sección → divisores; footer = avatar + salir como icono.
- Tooltips propios (chip cálido) en hover solo colapsado; `aria-label` siempre presente (a11y).
- Transición de ancho 160ms; stacking propio del rail para que los tooltips floten sobre `.main`.

## Verificación

- `tsc + vite build` verde · **234 unit tests** (vitest) verdes
- **E2E en Chromium headless sobre el build real** (mock de `/api/*`, sin backend), 3/3:
  - app-shell: rail `bottom=900`, no se mueve al scrollear `.main` 1500px, `window.scrollY=0`
  - colapso: `220px→64px`, tooltip `opacity=1`, persiste tras reload, re-expande, salir visible
  - mobile: conserva scroll de ventana, no renderiza rail

Precedido por una investigación de 4 agentes (Header/Ticker, globales, deps de scroll-JS, mobile/vistas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)