### PR TITLE
fix(mercado): quita min-height:100% de .mw

### DIFF
--- a/frontend/src/styles/mercado-warm.css
+++ b/frontend/src/styles/mercado-warm.css
@@ -14,7 +14,6 @@
    ============================================================ */
 .mw, .mw * { box-sizing: border-box; }
 .mw {
-  min-height: 100%;
   background:
     radial-gradient(120% 70% at 50% -8%, rgba(184,84,46,0.05), transparent 55%),
     radial-gradient(90% 60% at 100% 108%, rgba(94,112,72,0.05), transparent 60%),


### PR DESCRIPTION
## Qué

Quita `min-height: 100%;` de la clase `.mw` (raíz de la vista Mercado, en `frontend/src/styles/mercado-warm.css`).

## Por qué

Bajo el app-shell de desktop (PR #620), `.main` scrollea y mide viewport − (header + ticker). Un `min-height:100%` en `.mw` forzaba a la vista Mercado a llenar ese alto, dejando scroll/espacio sobrante. El fill del fondo cálido lo sigue dando el gradiente radial + `--paper` de la misma regla, así que no se pierde nada visual.

## Verificación

- `tsc + vite build` verde
- Una sola declaración eliminada; cero lógica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)