### PR TITLE
feat(regimen): gate de exposición por régimen (alt-season) — apagado por default

### DIFF
--- a/api/alt_season.py
+++ b/api/alt_season.py
@@ -6,7 +6,6 @@ de frescura = screener_loop). NO computa nada en el request. Eje MERCADO: hecho,
 veredicto per-símbolo."""
 from __future__ import annotations
 
-import json
 import logging
 import os
 
@@ -14,6 +13,7 @@ from fastapi import APIRouter
 
 from api.valleys import FRESCURA_VALLES_SEG   # mismo writer/loop → misma semántica
 from freshness import LiveSnapshot
+from regime.alt_season_read import leer_regimen
 
 log = logging.getLogger("api.alt_season")
 
@@ -22,15 +22,6 @@ router = APIRouter(tags=["alt-season"])
 _OUTPUT = os.path.join(os.path.dirname(os.path.dirname(__file__)),
                        "data", "alt_season.json")
 
-_EMPTY = {
-    "generated_at": None,
-    "coverage": {"universe": 0, "evaluated": 0, "complete": False},
-    "dominancia_fetch": {"ok": False, "fetched_at": None, "source": "coingecko/global"},
-    "regime": {"estado": "mixto", "componentes": {},
-               "votos": {"alts": 0, "neutral": 0, "btc": 0, "vivos": 0},
-               "n_alts_evaluadas": 0},
-}
-
 
 @router.get("/alt-season",
             summary="Régimen de mercado ¿es alt-season? (hecho de mercado, no veredicto)")
@@ -38,14 +29,8 @@ def get_alt_season() -> dict:
     """Devuelve la foto del régimen con su FRESCURA en el contrato. Archivo ausente →
     'muerto' (el screener no ha corrido), distinto de una foto vieja → 'rancio'.
     'fresco' = el cálculo es reciente, NO que la afirmación de mercado siga vigente."""
-    if not os.path.exists(_OUTPUT):
-        return LiveSnapshot(payload=dict(_EMPTY), generated_at=None,
-                            umbral_seg=FRESCURA_VALLES_SEG).to_response()
-    try:
-        with open(_OUTPUT, encoding="utf-8") as f:
-            snap = json.load(f)
-    except (OSError, json.JSONDecodeError) as e:
-        log.error("ALT_SEASON_SNAPSHOT_UNREADABLE causa=%s", e)
-        snap = dict(_EMPTY)
-    return LiveSnapshot(payload=snap, generated_at=snap.get("generated_at"),
+    rv = leer_regimen(FRESCURA_VALLES_SEG, ruta=_OUTPUT)
+    # LiveSnapshot re-computa la frescura con el MISMO umbral, preservando el
+    # contrato actual de /alt-season (generated_at vs umbral_seg, nunca campo leído).
+    return LiveSnapshot(payload=rv.snapshot, generated_at=rv.generated_at,
                         umbral_seg=FRESCURA_VALLES_SEG).to_response()

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -748,12 +748,8 @@ def scan(symbol: str = None):
                 symbol=symbol, señal=señal, estado_actual=estado, rv=_gate_rv, cfg=_cfg)
         except Exception as _gate_err:
             log.warning("regime_gate: aplicar falló para %s — fail-open: %s", symbol, _gate_err)
-    if _gate_fila is not None:
-        try:
-            from db.regime_gate_audit import registrar_decisiones
-            registrar_decisiones([_gate_fila])
-        except Exception:
-            log.warning("regime_gate_audit (scanner) falló — fail-open", exc_info=True)
+    # No flush aquí — el orchestrador (scanner_loop) lo batcha al final del ciclo.
+    # Ver spec §5 y scanner/runtime.py scanner_loop.
 
     # ── Consolidar ────────────────────────────────────────────────────────────
     rep.update({
@@ -814,6 +810,13 @@ def scan(symbol: str = None):
             },
         },
     })
+    # Exponer la fila de auditoría del gate para que el orchestrador
+    # la batche al final del ciclo (spec §5). Sólo se añade la clave
+    # cuando el gate está habilitado y produjo una fila — así rep es
+    # byte-identical cuando el gate está deshabilitado.
+    if _gate_fila is not None:
+        rep["_regime_gate_fila"] = _gate_fila
+
     # Convertir tipos numpy a tipos Python nativos para serialización JSON
     import numpy as np
     def clean_dict(d):

--- a/btc_scanner.py
+++ b/btc_scanner.py
@@ -113,6 +113,9 @@ except (AttributeError, io.UnsupportedOperation):
 
 log = logging.getLogger("btc_scanner")
 
+from regime.alt_season_read import leer_regimen, RegimenVivo
+from regime.exposure_gate import evaluar_gate
+
 
 from strategy._validators import (
     validated_max_participation_rate as _shared_validated_max_pov,
@@ -134,6 +137,23 @@ def _validated_cooldown_hours(value, symbol: str) -> float:
 # from _build_e5_cooldown. Keyed by (symbol, exception type name) — one log line
 # per (symbol, kind) per process.
 _db_fail_warned: set[tuple[str, str]] = set()
+
+
+def aplicar_gate_scanner(*, symbol: str, señal: bool, estado_actual: str,
+                         rv: RegimenVivo, cfg: dict):
+    """Aplica el gate (motor 'scanner'). Devuelve (señal, estado, fila_auditoria|None).
+    fila=None cuando el gate está off (no se audita con enabled=false → byte-idéntico)."""
+    if not (cfg.get("regime_gate") or {}).get("enabled", False):
+        return señal, estado_actual, None
+    es_alt = symbol != "BTCUSDT"
+    d = evaluar_gate(rv.estado, rv.frescura, rv.votos_vivos, es_alt, cfg)
+    fila = {"motor": "scanner", "symbol": symbol, "estado_regimen": d.estado_regimen,
+            "nivel": d.nivel, "es_alt": es_alt, "regime_frescura": d.regime_frescura,
+            "votos_vivos": d.votos_vivos, "enforced": d.enforced,
+            "umbral_version": d.umbral_version, "tenant_id": None}
+    if señal and d.nivel == "suprime":
+        return False, f"🌧️  SEÑAL {symbol} suprimida — fuera de alt-season (clima '{d.estado_regimen}')", fila
+    return señal, estado_actual, fila
 
 
 def _build_e5_cooldown(symbol: str, cfg: dict) -> dict:
@@ -245,6 +265,14 @@ def scan(symbol: str = None):
                 _cfg = json.load(_f)
         except Exception:
             pass
+
+    # Gate de exposición por régimen (#alt-season): leer el régimen UNA vez por scan.
+    _gate_rv = None
+    try:
+        _frescura_umbral = float((_cfg.get("regime_gate") or {}).get("frescura_umbral_seg", 27000))
+        _gate_rv = leer_regimen(_frescura_umbral)
+    except Exception as _gate_read_err:
+        log.warning("regime_gate: lectura de régimen falló para %s — fail-open: %s", symbol, _gate_read_err)
 
     # Kill switch #138 PR 4: PAUSED symbols do not generate signals. Early-return
     # with a structured report that mimics the "disabled in config" shape used below.
@@ -711,6 +739,21 @@ def scan(symbol: str = None):
         sl = score_label(score)
         estado = f"✅ SEÑAL {direction} + GATILLO CONFIRMADOS — Calidad: {sl}"
         señal  = True
+
+    # Gate de exposición: esconde señales alt en mal clima (fail-open propio).
+    _gate_fila = None
+    if _gate_rv is not None:
+        try:
+            señal, estado, _gate_fila = aplicar_gate_scanner(
+                symbol=symbol, señal=señal, estado_actual=estado, rv=_gate_rv, cfg=_cfg)
+        except Exception as _gate_err:
+            log.warning("regime_gate: aplicar falló para %s — fail-open: %s", symbol, _gate_err)
+    if _gate_fila is not None:
+        try:
+            from db.regime_gate_audit import registrar_decisiones
+            registrar_decisiones([_gate_fila])
+        except Exception:
+            log.warning("regime_gate_audit (scanner) falló — fail-open", exc_info=True)
 
     # ── Consolidar ────────────────────────────────────────────────────────────
     rep.update({

--- a/config.defaults.json
+++ b/config.defaults.json
@@ -54,6 +54,11 @@
     "min_position_usd": 50.0,
     "max_leverage": 2.0
   },
+  "regime_gate": {
+    "enabled": false,
+    "frescura_umbral_seg": 27000,
+    "umbral_overrides": {}
+  },
   "symbol_overrides": {
     "BTCUSDT":    { "atr_sl_mult": 1.0, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 14, "max_participation_rate": 0.010,  "cooldown_hours": 14 },
     "ETHUSDT":    { "atr_sl_mult": 1.2, "atr_tp_mult": 4.0, "atr_be_mult": 1.5, "time_limit_hours": 14, "max_participation_rate": 0.010,  "cooldown_hours": 14 },

--- a/db/regime_gate_audit.py
+++ b/db/regime_gate_audit.py
@@ -1,0 +1,64 @@
+"""Auditoría append-only del gate de exposición — feed de calibración + rastro de
+honestidad. Escritura en BATCH (una transacción por ciclo, NO N BEGIN IMMEDIATE)
+para no ensanchar el burst de writes que ya causó contención de locks (2026-05-29).
+tenant_id NULLABLE: la decisión es un hecho de mercado global. Spec §5."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from db.transaction import transaction
+
+_COLS = (
+    "motor", "symbol", "estado_regimen", "nivel", "es_alt",
+    "regime_frescura", "votos_vivos", "enforced", "umbral_version", "tenant_id",
+)
+
+
+def registrar_decisiones(filas: list[dict]) -> int:
+    """Inserta TODAS las filas del ciclo en UNA sola transacción. No-op si vacío."""
+    if not filas:
+        return 0
+    ts = datetime.now(timezone.utc).isoformat()
+    params = [
+        (
+            ts,
+            f["motor"],
+            f["symbol"],
+            f["estado_regimen"],
+            f["nivel"],
+            int(bool(f["es_alt"])),
+            f["regime_frescura"],
+            int(f["votos_vivos"]),
+            int(bool(f["enforced"])),
+            f["umbral_version"],
+            f.get("tenant_id"),
+        )
+        for f in filas
+    ]
+    with transaction() as con:
+        con.executemany(
+            """INSERT INTO regime_gate_audit
+               (ts, motor, symbol, estado_regimen, nivel, es_alt,
+                regime_frescura, votos_vivos, enforced, umbral_version, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            params,
+        )
+    return len(params)
+
+
+def purgar_antiguos(dias: int) -> int:
+    """Retención: borra filas con más de `dias` días. Devuelve cuántas borró."""
+    from datetime import timedelta
+    corte = (datetime.now(timezone.utc) - timedelta(days=dias)).isoformat()
+    with transaction() as con:
+        cur = con.execute("DELETE FROM regime_gate_audit WHERE ts < ?", (corte,))
+        return cur.rowcount
+
+
+def _query_all() -> list[dict]:
+    """Helper de test: todas las filas como dicts."""
+    with transaction() as con:
+        rows = con.execute(
+            "SELECT ts, " + ", ".join(_COLS) + " FROM regime_gate_audit ORDER BY id"
+        ).fetchall()
+    return [dict(zip(("ts", *_COLS), r)) for r in rows]

--- a/db/regime_gate_audit.py
+++ b/db/regime_gate_audit.py
@@ -4,9 +4,9 @@ para no ensanchar el burst de writes que ya causó contención de locks (2026-05
 tenant_id NULLABLE: la decisión es un hecho de mercado global. Spec §5."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-from db.transaction import transaction
+from db.transaction import snapshot_connection, transaction
 
 _COLS = (
     "motor", "symbol", "estado_regimen", "nivel", "es_alt",
@@ -48,7 +48,6 @@ def registrar_decisiones(filas: list[dict]) -> int:
 
 def purgar_antiguos(dias: int) -> int:
     """Retención: borra filas con más de `dias` días. Devuelve cuántas borró."""
-    from datetime import timedelta
     corte = (datetime.now(timezone.utc) - timedelta(days=dias)).isoformat()
     with transaction() as con:
         cur = con.execute("DELETE FROM regime_gate_audit WHERE ts < ?", (corte,))
@@ -57,7 +56,7 @@ def purgar_antiguos(dias: int) -> int:
 
 def _query_all() -> list[dict]:
     """Helper de test: todas las filas como dicts."""
-    with transaction() as con:
+    with snapshot_connection() as con:
         rows = con.execute(
             "SELECT ts, " + ", ".join(_COLS) + " FROM regime_gate_audit ORDER BY id"
         ).fetchall()

--- a/db/schema.py
+++ b/db/schema.py
@@ -326,6 +326,30 @@ def init_db() -> None:
                 ON kill_switch_recommendations(ts)
         """)
         con.execute("""
+            CREATE TABLE IF NOT EXISTS regime_gate_audit (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts              TEXT NOT NULL,
+                motor           TEXT NOT NULL,          -- 'valles' | 'scanner'
+                symbol          TEXT NOT NULL,
+                estado_regimen  TEXT NOT NULL,          -- 'alts' | 'mixto' | 'btc'
+                nivel           TEXT NOT NULL,          -- 'pasa' | 'atenua' | 'suprime'
+                es_alt          INTEGER NOT NULL,
+                regime_frescura TEXT NOT NULL,          -- 'fresco' | 'rancio' | 'muerto'
+                votos_vivos     INTEGER NOT NULL,
+                enforced        INTEGER NOT NULL,
+                umbral_version  TEXT NOT NULL,
+                tenant_id       INTEGER                 -- NULLABLE: decisión de mercado global
+            )
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_regime_gate_audit_ts
+                ON regime_gate_audit(ts)
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_regime_gate_audit_motor_ts
+                ON regime_gate_audit(motor, ts)
+        """)
+        con.execute("""
             CREATE TABLE IF NOT EXISTS portfolio_health_events (
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
                 from_tier       TEXT NOT NULL,

--- a/docs/superpowers/plans/2026-06-23-regimen-al-trade-gate.md
+++ b/docs/superpowers/plans/2026-06-23-regimen-al-trade-gate.md
@@ -1,0 +1,987 @@
+# Gate de exposición por régimen (alt-season) — Plan de Implementación
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hacer que el régimen alt-season module la exposición a alts (esconde en mal clima) en el screener de Valles y el scanner, vía una política pura compartida, con fail-open sobre clima rancio y calibración sobre la marcha.
+
+**Architecture:** Una política pura (`regime/exposure_gate.py`) decide `pasa|atenua|suprime` desde el estado del régimen + su frescura. Un lector compartido (`regime/alt_season_read.py`) extrae el snapshot de `data/alt_season.json` y computa frescura (resuelve que el scanner hoy no tiene reader). Dos orquestadores (screener `build_snapshot`, scanner `scan`) consultan la política y, solo si `cfg.regime_gate.enabled`, esconden + auditan. Flag default off = byte-idéntico.
+
+**Tech Stack:** Python 3 (stdlib: dataclasses, hashlib, json, datetime), SQLite (vía `db/transaction.py`), pytest. Frontend: React/TypeScript (Valles). Sin dependencias nuevas.
+
+**Spec:** `docs/superpowers/specs/es/2026-06-23-regimen-al-trade-gate-design.md` (commit `fa72c66`).
+
+## Global Constraints
+
+(Aplican a TODAS las tareas — requisitos del proyecto, valores verbatim del spec / no-negociables.)
+
+- **#4 — `RISK_PER_TRADE = 0.01` es fijo.** El gate es filtro de selección/visibilidad. NO toca `RISK_PER_TRADE`, `size_mult`, ni ningún cómputo de sizing. Cero multiplicadores de riesgo.
+- **#8 — Freshness owner + LiveSnapshot.** El lector del scanner computa frescura vía `freshness.LiveSnapshot`; nunca esconde sobre clima `rancio`/`muerto` (fail-open). La frescura se COMPUTA en el orquestador, NO se lee de un campo del snapshot.
+- **#6 — Specs autoritativas mandan.** La enmienda a `2026-06-18-alt-season-regimen-design.md` (Task 8) es bloqueante del merge.
+- **Byte-idéntico con `cfg.regime_gate.enabled=false`:** sin campos nuevos en `valley_candidates.json`, sin filas de auditoría, señal del scanner idéntica. Cada task que toca un orquestador prueba esto.
+- **No se toca `strategy/regime.py`** (régimen macro-BTC, eje distinto). No se toca `RISK_PER_TRADE`, `PositionClosure`, ni el holdout.
+- **Copy en español venezolano** (tuteo) en strings visibles al operador.
+- **Gate de tests del repo (CI Backend):** `python -m pytest tests/ -m "not network" -n auto -q`. El gate corre en el path rápido — no requiere `ohlcv.db` ni red.
+
+---
+
+## File Structure
+
+| Archivo | Responsabilidad | Task |
+|---|---|---|
+| `regime/alt_season.py` (mod) | `effective_thresholds(overrides)` + `compose_regime` acepta umbrales (default = constantes) | 1 |
+| `regime/exposure_gate.py` (new) | `GateDecision`, `evaluar_gate(...)`, `umbral_version(cfg)` — política pura | 2 |
+| `config.defaults.json` (mod) | bloque `regime_gate` | 2 |
+| `regime/alt_season_read.py` (new) | `leer_regimen(umbral_seg) -> RegimenVivo` — lector compartido del snapshot | 3 |
+| `api/alt_season.py` (mod) | usar el lector compartido (DRY) | 3 |
+| `db/schema.py` (mod) + `db/regime_gate_audit.py` (new) | tabla `regime_gate_audit` + insert batch | 4 |
+| `tools/run_valley_screener.py` (mod) | hook screener + atomic write de `valley_candidates.json` + pasar overrides a compose_regime | 5 |
+| `btc_scanner.py` (mod) | hook scanner (leer régimen 1×/ciclo, suprimir señal alt, auditar) | 6 |
+| `frontend/src/components/valles/*` (mod) | válvula "ver ocultas" | 7 |
+| `docs/.../2026-06-18-alt-season-regimen-design.md` (mod) | enmienda de doctrina | 8 |
+
+**Orden por dependencias:** 1 → 2 → 3 → 4 (fundacionales) → 5, 6 (hooks) → 7 (frontend) → 8 (doc).
+
+---
+
+## Task 1: `effective_thresholds` + `compose_regime` parametrizable
+
+**Por qué primero:** los `umbral_overrides` (calibración sin deploy) exigen que el estado del régimen se compute con los umbrales efectivos. Hoy `compose_regime` usa constantes de módulo. Lo hacemos parametrizable SIN cambiar el comportamiento por defecto (overrides vacío → byte-idéntico), y exponemos un helper que tanto el screener como `umbral_version` comparten (DRY).
+
+**Files:**
+- Modify: `regime/alt_season.py`
+- Test: `tests/test_alt_season.py` (crear si no existe; si existe, añadir)
+
+**Interfaces:**
+- Produces: `effective_thresholds(overrides: dict | None) -> dict` con claves exactas `{"BREADTH_ALT","BREADTH_BEAR","OUTPERF_ALT","OUTPERF_BEAR","DOM_ALT","DOM_BTC","COVERAGE_MIN","MIN_LIVE_VOTERS"}`. Y `compose_regime(alt_contribs, btc_ret_30d, btc_dominance, coverage_ratio, thresholds: dict | None = None)` — cuando `thresholds is None` usa las constantes de módulo (comportamiento de hoy).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_alt_season.py
+from regime.alt_season import effective_thresholds, compose_regime
+
+def test_effective_thresholds_defaults_match_constants():
+    import regime.alt_season as m
+    t = effective_thresholds(None)
+    assert t["BREADTH_ALT"] == m.BREADTH_ALT
+    assert t["OUTPERF_ALT"] == m.OUTPERF_ALT
+    assert t["DOM_BTC"] == m.DOM_BTC
+    assert t["COVERAGE_MIN"] == m.COVERAGE_MIN
+    assert t["MIN_LIVE_VOTERS"] == m.MIN_LIVE_VOTERS
+
+def test_effective_thresholds_overrides_win():
+    t = effective_thresholds({"BREADTH_ALT": 0.7})
+    assert t["BREADTH_ALT"] == 0.7
+    import regime.alt_season as m
+    assert t["OUTPERF_ALT"] == m.OUTPERF_ALT  # los no-pisados quedan
+
+def test_compose_regime_thresholds_none_is_default():
+    # Una pasada donde breadth=1.0 (todos sobre SMA50) y BTC ret bajo → 'alts'.
+    contribs = [{"above_sma50": True, "ret_30d": 0.20} for _ in range(5)]
+    out = compose_regime(contribs, btc_ret_30d=0.0, btc_dominance=0.45,
+                         coverage_ratio=1.0, thresholds=None)
+    assert out["estado"] == "alts"
+
+def test_compose_regime_override_flips_state():
+    contribs = [{"above_sma50": True, "ret_30d": 0.01} for _ in range(5)]
+    # breadth=1.0; con BREADTH_ALT=0.6 por defecto vota 'alts'. Subiendo a 1.1
+    # (imposible de alcanzar) el voto de breadth deja de ser 'alts'.
+    out = compose_regime(contribs, btc_ret_30d=0.0, btc_dominance=0.55,
+                         coverage_ratio=1.0, thresholds=effective_thresholds({"BREADTH_ALT": 1.1}))
+    assert out["estado"] != "alts"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_alt_season.py -v`
+Expected: FAIL con `ImportError: cannot import name 'effective_thresholds'`.
+
+- [ ] **Step 3: Implement**
+
+En `regime/alt_season.py`, tras las constantes (línea ~29) añade:
+
+```python
+def effective_thresholds(overrides: dict | None) -> dict:
+    """Umbrales efectivos: constantes de módulo pisadas por `overrides` (calibración
+    sin deploy). Claves fijas — única fuente para compose_regime y umbral_version."""
+    base = {
+        "BREADTH_ALT": BREADTH_ALT, "BREADTH_BEAR": BREADTH_BEAR,
+        "OUTPERF_ALT": OUTPERF_ALT, "OUTPERF_BEAR": OUTPERF_BEAR,
+        "DOM_ALT": DOM_ALT, "DOM_BTC": DOM_BTC,
+        "COVERAGE_MIN": COVERAGE_MIN, "MIN_LIVE_VOTERS": MIN_LIVE_VOTERS,
+    }
+    if overrides:
+        for k, v in overrides.items():
+            if k in base:
+                base[k] = v
+    return base
+```
+
+Y cambia la firma de `compose_regime` (línea 62) para aceptar `thresholds`:
+
+```python
+def compose_regime(alt_contribs: list[dict], btc_ret_30d: float | None,
+                   btc_dominance: float | None, coverage_ratio: float,
+                   thresholds: dict | None = None) -> dict:
+    """... (docstring existente). Si thresholds is None usa effective_thresholds(None)."""
+    t = thresholds if thresholds is not None else effective_thresholds(None)
+```
+
+Dentro de `compose_regime`, reemplaza cada constante de módulo por su entrada en `t`:
+- `_lean_higher_alt(breadth50, BREADTH_ALT, BREADTH_BEAR)` → `_lean_higher_alt(breadth50, t["BREADTH_ALT"], t["BREADTH_BEAR"])`
+- `coverage_ratio >= COVERAGE_MIN` → `coverage_ratio >= t["COVERAGE_MIN"]`
+- `_lean_higher_alt(outperf, OUTPERF_ALT, OUTPERF_BEAR)` → usar `t[...]`
+- `_lean_lower_alt(btc_dominance, DOM_ALT, DOM_BTC)` → usar `t[...]`
+- `if n_live < MIN_LIVE_VOTERS:` → `if n_live < t["MIN_LIVE_VOTERS"]:`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_alt_season.py -v`
+Expected: PASS (5 tests). Además: `python -m pytest tests/ -m "not network" -n auto -q -k "alt_season or screener"` no rompe nada (compose_regime con `thresholds=None` es idéntico).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add regime/alt_season.py tests/test_alt_season.py
+git commit -m "feat(regime): compose_regime parametrizable + effective_thresholds (overrides sin deploy)"
+```
+
+---
+
+## Task 2: Política pura `exposure_gate.py` + bloque de config
+
+**Files:**
+- Create: `regime/exposure_gate.py`
+- Modify: `config.defaults.json`
+- Test: `tests/test_exposure_gate.py`
+
+**Interfaces:**
+- Consumes: `regime.alt_season.effective_thresholds` (Task 1).
+- Produces:
+  - `@dataclass(frozen=True) GateDecision` con campos `nivel: str, estado_regimen: str, es_alt: bool, regime_frescura: str, votos_vivos: int, razon: str, enforced: bool, umbral_version: str`.
+  - `evaluar_gate(estado: str, frescura: str, votos_vivos: int, es_alt: bool, cfg: dict) -> GateDecision`.
+  - `umbral_version(cfg: dict) -> str` (sha1 corto de los umbrales efectivos).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_exposure_gate.py
+from regime.exposure_gate import evaluar_gate, umbral_version, GateDecision
+
+_ON = {"regime_gate": {"enabled": True, "umbral_overrides": {}}}
+_OFF = {"regime_gate": {"enabled": False, "umbral_overrides": {}}}
+
+def _gate(estado, frescura, votos, es_alt, cfg=_ON):
+    return evaluar_gate(estado, frescura, votos, es_alt, cfg)
+
+def test_btc_fresco_alt_enabled_suprime():
+    assert _gate("btc", "fresco", 3, True).nivel == "suprime"
+
+def test_btc_rancio_pasa_failopen():
+    d = _gate("btc", "rancio", 3, True)
+    assert d.nivel == "pasa" and d.enforced is False
+
+def test_btc_muerto_pasa_failopen():
+    assert _gate("btc", "muerto", 3, True).nivel == "pasa"
+
+def test_btc_disabled_pasa():
+    d = _gate("btc", "fresco", 3, True, cfg=_OFF)
+    assert d.nivel == "pasa" and d.enforced is False
+
+def test_btc_no_alt_pasa():
+    assert _gate("btc", "fresco", 3, False).nivel == "pasa"  # BTC nunca se gatea
+
+def test_alts_pasa():
+    assert _gate("alts", "fresco", 3, True).nivel == "pasa"
+
+def test_mixto_empate_atenua():
+    assert _gate("mixto", "fresco", 3, True).nivel == "atenua"  # votos>=2 = empate genuino
+
+def test_mixto_datos_degradados_pasa():
+    assert _gate("mixto", "fresco", 1, True).nivel == "pasa"   # votos<2 = ausencia de señal
+
+def test_estado_inesperado_pasa():
+    assert _gate("ZZZ", "fresco", 3, True).nivel == "pasa"
+
+def test_decision_carries_context():
+    d = _gate("btc", "fresco", 3, True)
+    assert d.estado_regimen == "btc" and d.es_alt is True and d.regime_frescura == "fresco"
+    assert isinstance(d.umbral_version, str) and len(d.umbral_version) >= 6
+
+def test_umbral_version_changes_with_overrides():
+    base = umbral_version({"regime_gate": {"umbral_overrides": {}}})
+    moved = umbral_version({"regime_gate": {"umbral_overrides": {"BREADTH_ALT": 0.7}}})
+    assert base != moved
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_exposure_gate.py -v`
+Expected: FAIL con `ModuleNotFoundError: No module named 'regime.exposure_gate'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# regime/exposure_gate.py
+"""Gate de exposición por régimen — política PURA (sin red, sin DB). Espejo
+estructural de regime/alt_season.py: solo funciones puras, cero I/O.
+
+Decide pasa|atenua|suprime desde el ESTADO del régimen + su FRESCURA. Un hecho
+de exposición de mercado, NO un veredicto per-coin. Spec 2026-06-23."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from regime.alt_season import effective_thresholds
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    nivel: str            # "pasa" | "atenua" | "suprime"
+    estado_regimen: str   # "alts" | "mixto" | "btc"
+    es_alt: bool
+    regime_frescura: str  # "fresco" | "rancio" | "muerto" (COMPUTADA por el orquestador)
+    votos_vivos: int
+    razon: str
+    enforced: bool        # = cfg.regime_gate.enabled AND regime_frescura == "fresco"
+    umbral_version: str
+
+
+def umbral_version(cfg: dict) -> str:
+    """Sello determinista de los umbrales EFECTIVOS (6 de lean + 2 de gobierno de
+    evidencia + overrides). Ata cada fila de auditoría a la calibración exacta."""
+    overrides = (cfg.get("regime_gate") or {}).get("umbral_overrides") or {}
+    eff = effective_thresholds(overrides)
+    blob = json.dumps(eff, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha1(blob.encode("utf-8")).hexdigest()[:12]
+
+
+def evaluar_gate(estado: str, frescura: str, votos_vivos: int,
+                 es_alt: bool, cfg: dict) -> GateDecision:
+    """Política graduada. Fail-open sobre clima rancio/muerto y sobre flag off."""
+    rg = cfg.get("regime_gate") or {}
+    enforced = bool(rg.get("enabled", False)) and frescura == "fresco"
+    eff = effective_thresholds(rg.get("umbral_overrides") or {})
+    min_live = eff["MIN_LIVE_VOTERS"]
+
+    if not enforced:
+        nivel, razon = "pasa", "gate inactivo (flag off o régimen no fresco)"
+    elif not es_alt:
+        nivel, razon = "pasa", "símbolo no-alt — el gate es sobre exposición a alts"
+    elif estado == "alts":
+        nivel, razon = "pasa", "régimen 'alts' — el viento acompaña"
+    elif estado == "btc":
+        nivel, razon = "suprime", "régimen 'btc' — el viento no acompaña a las alts"
+    elif estado == "mixto":
+        if votos_vivos < min_live:
+            nivel, razon = "pasa", "mixto por datos degradados — ausencia de señal, no clima"
+        else:
+            nivel, razon = "atenua", "régimen 'mixto' — clima ambiguo"
+    else:
+        nivel, razon = "pasa", f"estado inesperado '{estado}' — fail-open"
+
+    return GateDecision(
+        nivel=nivel, estado_regimen=estado, es_alt=es_alt,
+        regime_frescura=frescura, votos_vivos=votos_vivos, razon=razon,
+        enforced=enforced, umbral_version=umbral_version(cfg),
+    )
+```
+
+En `config.defaults.json`, tras el bloque `regime_allocation` (línea 56), añade:
+
+```json
+  "regime_gate": {
+    "enabled": false,
+    "frescura_umbral_seg": 27000,
+    "umbral_overrides": {}
+  },
+```
+
+(coma al final; va antes de `"symbol_overrides"`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_exposure_gate.py -v`
+Expected: PASS (11 tests).
+Run: `python -c "import json; json.load(open('config.defaults.json'))"` → sin error (JSON válido).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add regime/exposure_gate.py config.defaults.json tests/test_exposure_gate.py
+git commit -m "feat(regime): política pura del gate de exposición + bloque cfg.regime_gate"
+```
+
+---
+
+## Task 3: Lector compartido `alt_season_read.py` + refactor de la API
+
+**Por qué:** el scanner NO tiene hoy cómo leer el régimen alt-season (el único reader vive en `api/alt_season.py`, dentro de un request HTTP). Esta task crea el lector reusable y refactoriza la API para usarlo (DRY: un solo guard de ausencia/corrupción).
+
+**Files:**
+- Create: `regime/alt_season_read.py`
+- Modify: `api/alt_season.py`
+- Test: `tests/test_alt_season_read.py`
+
+**Interfaces:**
+- Produces:
+  - `@dataclass(frozen=True) RegimenVivo` con `estado: str, frescura: str, votos_vivos: int, generated_at: str | None, snapshot: dict`.
+  - `leer_regimen(umbral_seg: float, ruta: str | None = None) -> RegimenVivo`.
+- Consumes: `freshness.LiveSnapshot`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_alt_season_read.py
+import json
+from datetime import datetime, timezone, timedelta
+from regime.alt_season_read import leer_regimen, RegimenVivo
+
+def _write(tmp_path, generated_at, estado="btc", vivos=3):
+    p = tmp_path / "alt_season.json"
+    p.write_text(json.dumps({
+        "generated_at": generated_at,
+        "regime": {"estado": estado, "votos": {"vivos": vivos}},
+    }), encoding="utf-8")
+    return str(p)
+
+def test_ausente_es_muerto(tmp_path):
+    r = leer_regimen(27000, ruta=str(tmp_path / "no_existe.json"))
+    assert r.frescura == "muerto"
+
+def test_corrupto_es_muerto(tmp_path):
+    p = tmp_path / "alt_season.json"; p.write_text("{ not json", encoding="utf-8")
+    r = leer_regimen(27000, ruta=str(p))
+    assert r.frescura == "muerto"
+
+def test_generated_at_viejo_es_rancio(tmp_path):
+    viejo = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
+    r = leer_regimen(27000, ruta=_write(tmp_path, viejo))  # 27000s = 7.5h < 10h
+    assert r.frescura == "rancio"
+
+def test_generated_at_reciente_es_fresco(tmp_path):
+    reciente = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    r = leer_regimen(27000, ruta=_write(tmp_path, reciente, estado="alts", vivos=2))
+    assert r.frescura == "fresco" and r.estado == "alts" and r.votos_vivos == 2
+
+def test_failopen_combinado_con_gate(tmp_path):
+    # El test que ATRAPA el fail-open silencioso: clima 'btc' viejo → 'rancio' →
+    # el gate NO debe esconder (enforced=False).
+    from regime.exposure_gate import evaluar_gate
+    viejo = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
+    r = leer_regimen(27000, ruta=_write(tmp_path, viejo, estado="btc"))
+    d = evaluar_gate(r.estado, r.frescura, r.votos_vivos, True,
+                     {"regime_gate": {"enabled": True, "umbral_overrides": {}}})
+    assert d.enforced is False and d.nivel == "pasa"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_alt_season_read.py -v`
+Expected: FAIL con `ModuleNotFoundError: No module named 'regime.alt_season_read'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# regime/alt_season_read.py
+"""Lector compartido del snapshot de régimen alt-season. ÚNICO path de lectura
+de data/alt_season.json (lo usan la API y el hook del scanner). Computa la
+frescura vía freshness.LiveSnapshot — la frescura NO está persistida en el JSON.
+Maneja archivo ausente / corrupto → 'muerto' (fail-open). Spec 2026-06-23 §1."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+
+from freshness import LiveSnapshot
+
+log = logging.getLogger("regime.alt_season_read")
+
+_DEFAULT_RUTA = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                             "data", "alt_season.json")
+
+_EMPTY = {
+    "generated_at": None,
+    "coverage": {"universe": 0, "evaluated": 0, "complete": False},
+    "dominancia_fetch": {"ok": False, "fetched_at": None, "source": "coingecko/global"},
+    "regime": {"estado": "mixto", "componentes": {},
+               "votos": {"alts": 0, "neutral": 0, "btc": 0, "vivos": 0},
+               "n_alts_evaluadas": 0},
+}
+
+
+@dataclass(frozen=True)
+class RegimenVivo:
+    estado: str
+    frescura: str          # "fresco" | "rancio" | "muerto"
+    votos_vivos: int
+    generated_at: str | None
+    snapshot: dict
+
+
+def _leer_snapshot(ruta: str) -> dict:
+    """Lee el JSON con guard de ausencia/corrupción → _EMPTY (frescura derivará 'muerto')."""
+    if not os.path.exists(ruta):
+        return dict(_EMPTY)
+    try:
+        with open(ruta, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        log.error("ALT_SEASON_SNAPSHOT_UNREADABLE causa=%s", e)
+        return dict(_EMPTY)
+
+
+def leer_regimen(umbral_seg: float, ruta: str | None = None) -> RegimenVivo:
+    """Estado + frescura del régimen. La frescura se COMPUTA (generated_at vs
+    umbral_seg), no se lee de un campo. umbral_seg lo pasa el llamador (la API usa
+    el de la UI; el gate del scanner usa el suyo, más estricto)."""
+    snap = _leer_snapshot(ruta or _DEFAULT_RUTA)
+    generated_at = snap.get("generated_at")
+    frescura = LiveSnapshot(payload={}, generated_at=generated_at, umbral_seg=umbral_seg).estado
+    regime = snap.get("regime") or {}
+    estado = regime.get("estado", "mixto")
+    votos_vivos = int((regime.get("votos") or {}).get("vivos", 0))
+    return RegimenVivo(estado=estado, frescura=frescura, votos_vivos=votos_vivos,
+                       generated_at=generated_at, snapshot=snap)
+```
+
+Refactoriza `api/alt_season.py` para usar el lector (DRY). Reemplaza el cuerpo de `get_alt_season` (líneas 41-51) por:
+
+```python
+    from regime.alt_season_read import leer_regimen
+    rv = leer_regimen(FRESCURA_VALLES_SEG)
+    # El snapshot ya trae generated_at; LiveSnapshot.to_response re-inyecta la frescura
+    # con el MISMO umbral, preservando el contrato actual de /alt-season.
+    return LiveSnapshot(payload=rv.snapshot, generated_at=rv.generated_at,
+                        umbral_seg=FRESCURA_VALLES_SEG).to_response()
+```
+
+(El `_EMPTY` y el guard quedan dentro de `alt_season_read`; `api/alt_season.py` puede borrar su `_EMPTY` local y el `os.path.exists`/`json.load` — quedan en el lector.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_alt_season_read.py tests/test_api.py -v -k "alt_season or read"`
+Expected: PASS. El contrato de `GET /alt-season` (frescura en el payload, ausente→muerto) se preserva.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add regime/alt_season_read.py api/alt_season.py tests/test_alt_season_read.py
+git commit -m "feat(regime): lector compartido del snapshot alt-season + refactor DRY de /alt-season"
+```
+
+---
+
+## Task 4: Tabla `regime_gate_audit` + insert batch
+
+**Files:**
+- Modify: `db/schema.py` (añadir `CREATE TABLE IF NOT EXISTS` en `init_db`)
+- Create: `db/regime_gate_audit.py`
+- Test: `tests/test_regime_gate_audit.py`
+
+**Interfaces:**
+- Produces: `registrar_decisiones(filas: list[dict]) -> int` (inserta TODAS las filas en UNA transacción; devuelve cuántas). Cada fila: `{motor, symbol, estado_regimen, nivel, es_alt, regime_frescura, votos_vivos, enforced, umbral_version, tenant_id}` (`tenant_id` puede ser `None`). Y `purgar_antiguos(dias: int) -> int`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_regime_gate_audit.py
+from db.regime_gate_audit import registrar_decisiones, _query_all  # _query_all: helper de test
+from db.schema import init_db
+
+def _fila(**kw):
+    base = dict(motor="valles", symbol="ADAUSDT", estado_regimen="btc",
+                nivel="suprime", es_alt=True, regime_frescura="fresco",
+                votos_vivos=3, enforced=True, umbral_version="abc123def456",
+                tenant_id=None)
+    base.update(kw); return base
+
+def test_registra_batch(tmp_db):  # tmp_db: fixture que apunta la DB a tmp + init_db
+    n = registrar_decisiones([_fila(), _fila(symbol="DOGEUSDT")])
+    assert n == 2
+    rows = _query_all()
+    assert len(rows) == 2
+    assert rows[0]["tenant_id"] is None      # universo global
+    assert rows[0]["umbral_version"] == "abc123def456"
+    assert rows[0]["enforced"] == 1          # bool → int
+
+def test_batch_vacio_no_escribe(tmp_db):
+    assert registrar_decisiones([]) == 0
+    assert _query_all() == []
+```
+
+(Si no existe una fixture `tmp_db`, añade en `tests/conftest.py` una que apunte `db.connection` a un sqlite temporal y llame `init_db()`. Mira cómo `tests/test_api.py` aísla la DB — reusa ese patrón.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_regime_gate_audit.py -v`
+Expected: FAIL con `ModuleNotFoundError: No module named 'db.regime_gate_audit'`.
+
+- [ ] **Step 3: Implement**
+
+En `db/schema.py`, dentro de `init_db()` (junto a los otros `CREATE TABLE IF NOT EXISTS`, p.ej. tras `kill_switch_decisions` ~línea 292), añade:
+
+```python
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS regime_gate_audit (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts              TEXT NOT NULL,
+                motor           TEXT NOT NULL,          -- 'valles' | 'scanner'
+                symbol          TEXT NOT NULL,
+                estado_regimen  TEXT NOT NULL,          -- 'alts' | 'mixto' | 'btc'
+                nivel           TEXT NOT NULL,          -- 'pasa' | 'atenua' | 'suprime'
+                es_alt          INTEGER NOT NULL,
+                regime_frescura TEXT NOT NULL,          -- 'fresco' | 'rancio' | 'muerto'
+                votos_vivos     INTEGER NOT NULL,
+                enforced        INTEGER NOT NULL,
+                umbral_version  TEXT NOT NULL,
+                tenant_id       INTEGER                 -- NULLABLE: decisión de mercado global
+            )
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_regime_gate_audit_ts
+                ON regime_gate_audit(ts)
+        """)
+        con.execute("""
+            CREATE INDEX IF NOT EXISTS idx_regime_gate_audit_motor_ts
+                ON regime_gate_audit(motor, ts)
+        """)
+```
+
+```python
+# db/regime_gate_audit.py
+"""Auditoría append-only del gate de exposición — feed de calibración + rastro de
+honestidad. Escritura en BATCH (una transacción por ciclo, NO N BEGIN IMMEDIATE)
+para no ensanchar el burst de writes que ya causó contención de locks (2026-05-29).
+tenant_id NULLABLE: la decisión es un hecho de mercado global. Spec §5."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from db.transaction import transaction
+
+_COLS = ("motor", "symbol", "estado_regimen", "nivel", "es_alt",
+         "regime_frescura", "votos_vivos", "enforced", "umbral_version", "tenant_id")
+
+
+def registrar_decisiones(filas: list[dict]) -> int:
+    """Inserta TODAS las filas del ciclo en UNA sola transacción. No-op si vacío."""
+    if not filas:
+        return 0
+    ts = datetime.now(timezone.utc).isoformat()
+    params = [
+        (ts, f["motor"], f["symbol"], f["estado_regimen"], f["nivel"],
+         int(bool(f["es_alt"])), f["regime_frescura"], int(f["votos_vivos"]),
+         int(bool(f["enforced"])), f["umbral_version"], f.get("tenant_id"))
+        for f in filas
+    ]
+    with transaction() as con:
+        con.executemany(
+            """INSERT INTO regime_gate_audit
+               (ts, motor, symbol, estado_regimen, nivel, es_alt,
+                regime_frescura, votos_vivos, enforced, umbral_version, tenant_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            params,
+        )
+    return len(params)
+
+
+def purgar_antiguos(dias: int) -> int:
+    """Retención: borra filas con más de `dias` días. Devuelve cuántas borró."""
+    corte = (datetime.now(timezone.utc) - __import__("datetime").timedelta(days=dias)).isoformat()
+    with transaction() as con:
+        cur = con.execute("DELETE FROM regime_gate_audit WHERE ts < ?", (corte,))
+        return cur.rowcount
+
+
+def _query_all() -> list[dict]:
+    """Helper de test: todas las filas como dicts."""
+    with transaction() as con:
+        rows = con.execute(
+            "SELECT ts, " + ", ".join(_COLS) + " FROM regime_gate_audit ORDER BY id"
+        ).fetchall()
+    return [dict(zip(("ts", *_COLS), r)) for r in rows]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_regime_gate_audit.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/schema.py db/regime_gate_audit.py tests/test_regime_gate_audit.py
+git commit -m "feat(db): tabla regime_gate_audit (append-only, batch, tenant global NULL)"
+```
+
+---
+
+## Task 5: Hook en el screener de Valles
+
+**Files:**
+- Modify: `tools/run_valley_screener.py` (`build_snapshot` + `regenerate`)
+- Test: `tests/test_run_valley_screener.py` (crear/extender)
+
+**Interfaces:**
+- Consumes: `evaluar_gate`, `GateDecision`, `umbral_version` (Task 2); `effective_thresholds` (Task 1); `registrar_decisiones` (Task 4); `api.config.load_config`.
+- Produces: `cand_snap` con campos nuevos SOLO si `enabled`: `candidates[i]["clima_ambiguo"]` (bool) y top-level `cand_snap["candidatas_ocultas"]` (list[dict]).
+
+**Notas de diseño resueltas:**
+- El régimen está EN MANO en `build_snapshot` (línea 141) → `frescura="fresco"` trivial (edad ~0). No necesita el lector.
+- `compose_regime` recibe los overrides efectivos (Task 1) para que la calibración sin deploy afecte el estado.
+- `valley_candidates.json` migra a `_atomic_write_json` (hoy `regenerate` línea 157-158 es no-atómico).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_run_valley_screener.py
+from tools import run_valley_screener as rvs
+
+def _candidatas():  # 2 candidatas alt de juguete
+    return [{"symbol": "ADAUSDT", "price": 1.0}, {"symbol": "DOGEUSDT", "price": 0.1}]
+
+def test_disabled_byte_identico(monkeypatch):
+    monkeypatch.setattr(rvs, "load_config", lambda: {"regime_gate": {"enabled": False}})
+    snap = rvs.aplicar_gate_candidatas(_candidatas(), estado="btc", votos_vivos=3)
+    assert snap["candidates"] == _candidatas()      # sin tocar
+    assert "candidatas_ocultas" not in snap          # sin campos nuevos
+
+def test_enabled_btc_esconde(monkeypatch):
+    monkeypatch.setattr(rvs, "load_config",
+                        lambda: {"regime_gate": {"enabled": True, "umbral_overrides": {}}})
+    snap = rvs.aplicar_gate_candidatas(_candidatas(), estado="btc", votos_vivos=3)
+    assert snap["candidates"] == []                  # todas escondidas
+    assert len(snap["candidatas_ocultas"]) == 2
+
+def test_enabled_mixto_empate_atenua(monkeypatch):
+    monkeypatch.setattr(rvs, "load_config",
+                        lambda: {"regime_gate": {"enabled": True, "umbral_overrides": {}}})
+    snap = rvs.aplicar_gate_candidatas(_candidatas(), estado="mixto", votos_vivos=3)
+    assert len(snap["candidates"]) == 2 and all(c["clima_ambiguo"] for c in snap["candidates"])
+    assert snap.get("candidatas_ocultas", []) == []
+```
+
+(`aplicar_gate_candidatas` es una función pura nueva, fácil de testear sin red. La integración con `build_snapshot` se prueba con el test de byte-identidad de abajo.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_run_valley_screener.py -v`
+Expected: FAIL con `AttributeError: module ... has no attribute 'aplicar_gate_candidatas'`.
+
+- [ ] **Step 3: Implement**
+
+En `tools/run_valley_screener.py`, añade el import y la función pura:
+
+```python
+from api.config import load_config
+from regime.exposure_gate import evaluar_gate
+
+def aplicar_gate_candidatas(candidatas: list[dict], *, estado: str, votos_vivos: int) -> dict:
+    """Aplica el gate (motor 'valles') a las candidatas. Devuelve un dict con
+    'candidates' (las que pasan/atenúan) y, SOLO si enabled, 'candidatas_ocultas'.
+    Frescura='fresco' trivial: el régimen se computó en esta misma pasada."""
+    cfg = load_config()
+    if not (cfg.get("regime_gate") or {}).get("enabled", False):
+        return {"candidates": candidatas}            # byte-idéntico: sin campos nuevos
+    visibles: list[dict] = []
+    ocultas: list[dict] = []
+    filas: list[dict] = []
+    for c in candidatas:
+        d = evaluar_gate(estado, "fresco", votos_vivos, es_alt=True, cfg=cfg)
+        filas.append({"motor": "valles", "symbol": c["symbol"], "estado_regimen": d.estado_regimen,
+                      "nivel": d.nivel, "es_alt": True, "regime_frescura": d.regime_frescura,
+                      "votos_vivos": d.votos_vivos, "enforced": d.enforced,
+                      "umbral_version": d.umbral_version, "tenant_id": None})
+        if d.nivel == "suprime":
+            ocultas.append({**c, "clima": d.razon})
+        elif d.nivel == "atenua":
+            visibles.append({**c, "clima_ambiguo": True})
+        else:
+            visibles.append(c)
+    from db.regime_gate_audit import registrar_decisiones
+    try:
+        registrar_decisiones(filas)
+    except Exception:
+        log.warning("regime_gate_audit (valles) falló — fail-open", exc_info=True)
+    return {"candidates": visibles, "candidatas_ocultas": ocultas}
+```
+
+En `build_snapshot`, tras computar `regime` (línea 141) y antes de armar `cand_snap`, aplica el gate al resultado de `order_neutral`:
+
+```python
+    gate_out = aplicar_gate_candidatas(order_neutral(candidatas),
+                                       estado=regime["estado"],
+                                       votos_vivos=regime["votos"]["vivos"])
+    cand_snap = {"generated_at": ts, "coverage": coverage, **gate_out}
+```
+
+(Reemplaza la línea actual `cand_snap = {... "candidates": order_neutral(candidatas)}`.)
+
+Pasa los overrides a `compose_regime` (línea 141):
+
+```python
+    from regime.alt_season import effective_thresholds
+    _overrides = (load_config().get("regime_gate") or {}).get("umbral_overrides") or {}
+    regime = compose_regime(alt_contribs, btc_ret_30d, dominance, coverage_ratio,
+                            thresholds=effective_thresholds(_overrides))
+```
+
+Migra `regenerate` a escritura atómica (líneas 156-158):
+
+```python
+    _atomic_write_json(_OUTPUT, cand_snap)            # antes: open(...,"w")+json.dump no-atómico
+    _atomic_write_json(_ALT_SEASON_OUTPUT, alt_season_snap)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_run_valley_screener.py -v`
+Expected: PASS (3 tests).
+Run: `python -m pytest tests/ -m "not network" -n auto -q` → sin regresiones (con `enabled=false` el snapshot no gana campos).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/run_valley_screener.py tests/test_run_valley_screener.py
+git commit -m "feat(valles): hook del gate en el screener + atomic write de valley_candidates"
+```
+
+---
+
+## Task 6: Hook en el scanner
+
+**Files:**
+- Modify: `btc_scanner.py` (`scan`)
+- Test: `tests/test_scanner.py` (extender)
+
+**Interfaces:**
+- Consumes: `regime.alt_season_read.leer_regimen` (Task 3); `regime.exposure_gate.evaluar_gate` (Task 2); `db.regime_gate_audit.registrar_decisiones` (Task 4).
+
+**Notas de diseño resueltas (sitio exacto del hook):**
+- **Leer régimen 1× por scan** (no por símbolo×tenant): justo tras cargar `_cfg` (línea ~247), vía `leer_regimen(cfg.regime_gate.frescura_umbral_seg)`. `es_alt = symbol != "BTCUSDT"`.
+- **Aplicar la supresión** en el path de emisión real: tras el bloque "Veredicto" que fija `señal` (líneas ~700-713) y ANTES de `rep.update(...)` (línea 716) — espeja cómo el participation-cap bloquea `señal_activa`. `try/except` PROPIO (no el del v2_shadow).
+- **Auditar** 1 fila por símbolo (tenant_id=None), batch.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_scanner.py  (añadir)
+import btc_scanner
+from regime.alt_season_read import RegimenVivo
+
+_RV_BTC = RegimenVivo(estado="btc", frescura="fresco", votos_vivos=3,
+                      generated_at="2026-06-23T00:00:00+00:00", snapshot={})
+_ON = {"regime_gate": {"enabled": True, "umbral_overrides": {}}}
+
+def test_gate_suprime_alt_en_btc():
+    # enabled + régimen 'btc' fresco + un símbolo alt con señal → señal suprimida.
+    señal, estado, fila = btc_scanner.aplicar_gate_scanner(
+        symbol="ADAUSDT", señal=True, estado_actual="✅ SEÑAL LONG", rv=_RV_BTC, cfg=_ON)
+    assert señal is False and "alt-season" in estado.lower() and fila["nivel"] == "suprime"
+
+def test_gate_no_toca_btc():
+    señal, estado, fila = btc_scanner.aplicar_gate_scanner(
+        symbol="BTCUSDT", señal=True, estado_actual="✅ SEÑAL LONG", rv=_RV_BTC, cfg=_ON)
+    assert señal is True and fila["nivel"] == "pasa"   # BTC no es alt → pasa
+
+def test_gate_disabled_no_toca():
+    señal, estado, fila = btc_scanner.aplicar_gate_scanner(
+        symbol="ADAUSDT", señal=True, estado_actual="✅ SEÑAL LONG", rv=_RV_BTC,
+        cfg={"regime_gate": {"enabled": False}})
+    assert señal is True and fila is None             # disabled: no toca señal, no audita
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_scanner.py -v -k gate`
+Expected: FAIL con `AttributeError: module 'btc_scanner' has no attribute 'aplicar_gate_scanner'`.
+
+- [ ] **Step 3: Implement**
+
+En `btc_scanner.py`, añade imports (arriba) y la función pura:
+
+```python
+from regime.alt_season_read import leer_regimen, RegimenVivo
+from regime.exposure_gate import evaluar_gate
+
+def aplicar_gate_scanner(*, symbol: str, señal: bool, estado_actual: str,
+                         rv: RegimenVivo, cfg: dict):
+    """Aplica el gate (motor 'scanner'). Devuelve (señal, estado, fila_auditoria|None).
+    fila=None cuando el gate está off (no se audita con enabled=false → byte-idéntico)."""
+    if not (cfg.get("regime_gate") or {}).get("enabled", False):
+        return señal, estado_actual, None
+    es_alt = symbol != "BTCUSDT"
+    d = evaluar_gate(rv.estado, rv.frescura, rv.votos_vivos, es_alt, cfg)
+    fila = {"motor": "scanner", "symbol": symbol, "estado_regimen": d.estado_regimen,
+            "nivel": d.nivel, "es_alt": es_alt, "regime_frescura": d.regime_frescura,
+            "votos_vivos": d.votos_vivos, "enforced": d.enforced,
+            "umbral_version": d.umbral_version, "tenant_id": None}
+    if señal and d.nivel == "suprime":
+        return False, f"🌧️  SEÑAL {symbol} suprimida — fuera de alt-season (clima '{d.estado_regimen}')", fila
+    return señal, estado_actual, fila
+```
+
+En `scan()`, tras cargar `_cfg` (línea ~247), lee el régimen 1× (fail-open):
+
+```python
+    # Gate de exposición por régimen (#alt-season): leer el régimen UNA vez por scan.
+    _gate_rv = None
+    try:
+        _frescura_umbral = float((_cfg.get("regime_gate") or {}).get("frescura_umbral_seg", 27000))
+        _gate_rv = leer_regimen(_frescura_umbral)
+    except Exception as _gate_read_err:
+        log.warning("regime_gate: lectura de régimen falló para %s — fail-open: %s", symbol, _gate_read_err)
+```
+
+Justo ANTES de `rep.update({...})` (línea 716), tras el bloque que fija `señal`:
+
+```python
+    # Gate de exposición: esconde señales alt en mal clima (fail-open propio).
+    _gate_fila = None
+    if _gate_rv is not None:
+        try:
+            señal, estado, _gate_fila = aplicar_gate_scanner(
+                symbol=symbol, señal=señal, estado_actual=estado, rv=_gate_rv, cfg=_cfg)
+        except Exception as _gate_err:
+            log.warning("regime_gate: aplicar falló para %s — fail-open: %s", symbol, _gate_err)
+    if _gate_fila is not None:
+        try:
+            from db.regime_gate_audit import registrar_decisiones
+            registrar_decisiones([_gate_fila])
+        except Exception:
+            log.warning("regime_gate_audit (scanner) falló — fail-open", exc_info=True)
+```
+
+(`señal` y `estado` ya son variables locales en ese punto — el bloque veredicto las definió.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_scanner.py -v -k gate`
+Expected: PASS (3 tests).
+Run: `python -m pytest tests/ -m "not network" -n auto -q` → sin regresiones (con `enabled=false`, `aplicar_gate_scanner` devuelve la señal intacta y `fila=None`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add btc_scanner.py tests/test_scanner.py
+git commit -m "feat(scanner): hook del gate de exposición (suprime señal alt en mal clima, fail-open)"
+```
+
+---
+
+## Task 7: Válvula "ver ocultas" en Valles (frontend)
+
+**Files:**
+- Modify: el consumidor de `/valley-candidates` en `frontend/src/components/valles/` (PickScreen / la lista de candidatas) + su tipo en `types.ts`.
+- Test: extender el e2e existente o un test de componente si hay (ver `frontend/e2e/`).
+
+**Interfaces:**
+- Consumes: el payload de `GET /valley-candidates` ahora con `candidatas_ocultas: ValleyCandidate[]` (presente solo cuando el gate está enabled) y, por candidata atenuada, `clima_ambiguo?: boolean`.
+
+- [ ] **Step 1: Localizar el consumidor**
+
+Run: `grep -rn "valley-candidates\|candidates" frontend/src/components/valles/`
+Identifica el componente que renderiza la lista (PickScreen o useValleyBundle). Lee su tipo de candidata.
+
+- [ ] **Step 2: Extender el tipo**
+
+En `frontend/src/components/valles/types.ts` (o donde viva `ValleyCandidate`), añade:
+
+```typescript
+export interface ValleyCandidatesResponse {
+  generated_at: string | null;
+  candidates: ValleyCandidate[];
+  candidatas_ocultas?: (ValleyCandidate & { clima: string })[];   // solo si el gate enforça
+  frescura?: Frescura;
+}
+// y en ValleyCandidate:
+//   clima_ambiguo?: boolean;
+```
+
+- [ ] **Step 3: Renderizar la válvula (colapsada por defecto)**
+
+En el componente de la lista, bajo las candidatas visibles, si `candidatas_ocultas?.length`:
+
+```tsx
+{ocultas.length > 0 && (
+  <button className={styles.verOcultas} onClick={() => setMostrarOcultas(v => !v)}>
+    {mostrarOcultas
+      ? 'Ocultar'
+      : `${ocultas.length} alts fuera de alt-season — ver`}
+  </button>
+)}
+{mostrarOcultas && ocultas.map(c => (
+  <CandidatasRow key={c.symbol} c={c} atenuada nota={c.clima} />
+))}
+```
+
+Y para las visibles atenuadas (`clima_ambiguo`), un marcador discreto ("clima ambiguo") en su fila. Copy en venezolano, sin imperativos (doctrina anti-veredicto: el clima es un hecho, no un veredicto sobre la coin).
+
+- [ ] **Step 4: Verificar**
+
+Run: `cd frontend && npm run build` (tsc + build sin errores).
+Si hay e2e relevante: `cd frontend && npx playwright test` con el harness existente (ver memoria `e2e-playwright-harness`). Verifica que con candidatas ocultas aparece la línea "N alts fuera de alt-season — ver" y al click se expanden.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/valles/
+git commit -m "feat(valles-ui): válvula 'ver ocultas' para alts fuera de alt-season"
+```
+
+---
+
+## Task 8: Enmienda de doctrina (BLOQUEANTE del merge, #6)
+
+**Files:**
+- Modify: `docs/superpowers/specs/es/2026-06-18-alt-season-regimen-design.md`
+
+- [ ] **Step 1: Localizar la sección**
+
+Run: `grep -n "modulación per-coin\|ENMARCA\|no modula" docs/superpowers/specs/es/2026-06-18-alt-season-regimen-design.md`
+
+- [ ] **Step 2: Añadir el apuntador**
+
+En la sección "Sin modulación per-coin por régimen", añade una nota (sin borrar el texto histórico):
+
+```markdown
+> **Enmienda 2026-06-23:** esta regla queda SUPERADA para el eje de EXPOSICIÓN.
+> El régimen ahora gatea qué alts afloran (esconde en clima 'btc', atenúa en
+> 'mixto' por empate). NO es scoring per-coin: es un filtro de exposición sobre un
+> hecho de mercado, igual para todas las alts; el veredicto per-coin sigue
+> prohibido. Ver `docs/superpowers/specs/es/2026-06-23-regimen-al-trade-gate-design.md`.
+```
+
+- [ ] **Step 3: Verificar coherencia**
+
+Lee el bloque editado: las dos specs ya no se contradicen (la de 2026-06-18 apunta a la enmienda).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/es/2026-06-18-alt-season-regimen-design.md
+git commit -m "docs(regime): enmienda de doctrina — el régimen modula exposición (apuntador al spec 06-23)"
+```
+
+---
+
+## Verificación final (tras todas las tareas)
+
+- [ ] `python -m pytest tests/ -m "not network" -n auto -q` — todo verde, sin regresiones.
+- [ ] `cd frontend && npm run build` — sin errores tsc.
+- [ ] **Byte-identidad:** con `cfg.regime_gate.enabled=false` (default), `valley_candidates.json` no tiene `candidatas_ocultas`/`clima_ambiguo`, no hay filas en `regime_gate_audit`, y la señal del scanner es idéntica. (Cubierto por los tests de Task 5 y 6.)
+- [ ] **Fail-open:** test de Task 3 (`test_failopen_combinado_con_gate`) confirma que clima 'btc' rancio → `enforced=False` → no esconde.
+- [ ] Considerar (no bloqueante) correr `edge_study.py` vs panel 2020-2025 para sembrar `umbral_overrides` mejores antes de poner `enabled=true` en prod.
+
+## Items diferidos (NO en este plan)
+
+- Activar `enabled=true` en prod (cambio de config operacional, no de código).
+- Afordancia de destape en el scanner (hoy solo auditable).
+- Dashboard/endpoint de lectura de `regime_gate_audit` + alarma de tasa de supresión.
+- Llamar `purgar_antiguos` desde un loop (retención automática) — la función existe; cablearla a `scanner/runtime.py` es un follow-up con su propio freshness owner.
+- Conectar al épico regime-allocation #338 / modulación de sizing (choca con #4).

--- a/docs/superpowers/specs/es/2026-06-18-alt-season-regimen-design.md
+++ b/docs/superpowers/specs/es/2026-06-18-alt-season-regimen-design.md
@@ -237,6 +237,13 @@ Fila a añadir en `docs/superpowers/inventario-estado-vivo.md`:
 - El payload pasa la misma disciplina léxica que los 5 candados server-side existentes. La frase
   honesta ES la doctrina dicha fuerte: entrega la verdad incómoda (régimen > coin) sin esconderla.
 
+> **Enmienda 2026-06-23:** esta regla queda SUPERADA para el eje de EXPOSICIÓN.
+> El régimen ahora gatea qué alts afloran (esconde en clima 'btc', atenúa en
+> 'mixto' por empate). NO es scoring per-coin: es un filtro de exposición sobre un
+> hecho de mercado, igual para todas las alts; el veredicto per-coin sigue
+> prohibido. Las candidatas suprimidas son destapables (no desaparecen). Ver
+> `docs/superpowers/specs/es/2026-06-23-regimen-al-trade-gate-design.md`.
+
 ## Testing (TDD)
 
 **Núcleo puro (`tests/test_alt_season.py`):**

--- a/docs/superpowers/specs/es/2026-06-23-regimen-al-trade-gate-design.md
+++ b/docs/superpowers/specs/es/2026-06-23-regimen-al-trade-gate-design.md
@@ -1,0 +1,315 @@
+# Gate de exposición por régimen (alt-season) — Diseño
+
+**Fecha:** 2026-06-23
+**Rama:** `feat/alt-season-gate`
+**Estado:** diseño revisado tras crítica adversarial (serrano + halberg), pendiente de plan.
+
+> **Revisión adversarial (2026-06-23):** este spec fue auditado por `adrian-serrano` (análisis de
+> spec) y `marcus-halberg` (factibilidad runtime) ANTES de implementar. Encontraron 3 BLOCKERS +
+> 6 HIGH, todos de **cableado y contrato** (no de política). Esta versión los incorpora. Los
+> hallazgos diferidos al plan están en §Items abiertos.
+
+## Objetivo
+
+Hacer que el régimen de mercado (`alt-season`) **module la exposición a alts**: cuando el
+clima es claramente adverso (`btc`), las candidatas alt **no afloran** (Valles) y las señales
+de entrada en alts **no se emiten** (scanner); cuando es ambiguo de verdad (`mixto` por empate)
+se muestran pero marcadas; cuando es favorable (`alts`) pasan normal. El operador (en Valles, el
+papá) puede **destapar lo escondido**. Una sola política pura compartida, dos motores que la
+consultan, calibración de umbrales **sobre la marcha** (sin estudio bloqueante, sin fase shadow).
+
+## Contexto verificado (por qué esto y no otra cosa)
+
+- **No hay edge de selección per-coin.** El estudio multi-régimen 2020-2025
+  (`data/retune/2026-06-18-setup-edge-multiregimen/`, 455k filas) probó que ni la firma de
+  debilidad ni el momentum le ganan al azar de alts en ningún régimen. El único eje con señal fue
+  el **régimen**. "Conectar el régimen al trade" = modular la selección/señal que ve el operador.
+- **El sistema no auto-ejecuta** (`.mex/context/architecture.md:139`): emite señales, el operador
+  ejecuta. El gate filtra **visibilidad/emisión**, nunca ejecuta.
+- **El detector de régimen ya existe.** `regime/alt_season.py::compose_regime` emite
+  `estado ∈ {alts, mixto, btc}` + `votos.vivos` por voto de 3 componentes. Se computa en la pasada
+  del screener (`tools/run_valley_screener.py`, owner = `screener_loop`, `SCREENER_INTERVAL_SEC=21600`
+  = 6h), se persiste en `data/alt_season.json` (escritura **atómica**, `run_valley_screener.py:159`),
+  y se sirve en `GET /alt-season`. **Hoy está desconectado del trade** (doctrina anti-veredicto).
+- **La frescura NO se persiste en el snapshot.** Es una propiedad **derivada en tiempo de lectura**
+  (`generated_at` vs `umbral_seg` vía `freshness.LiveSnapshot`, `api/alt_season.py:50`). El único
+  lector hoy vive en un request HTTP — `scan()` del scanner **no abre** `alt_season.json`
+  (verificado: grep sin matches en `btc_scanner.py`).
+- **Los 6 umbrales de alt-season son PROVISIONALES, sin calibrar** (`regime/alt_season.py:19-25`).
+
+## Decisiones de diseño (tomadas en brainstorming)
+
+1. **Significado:** alt-season como **gate de exposición**, no scoring per-coin ni sizing.
+2. **Motores:** **ambos** — screener de Valles y scanner consultan una política pura compartida.
+3. **Comportamiento:** **graduado por estado** (`alts`/`mixto`/`btc`).
+4. **Enforcing:** **esconde en mal clima desde el arranque** (no fase shadow). Calibración
+   **sobre la marcha**: umbrales config-driven + log de auditoría + señal de daño + reversa.
+5. **Honestidad:** lo escondido es **destapable** en Valles (UX). En el scanner queda **auditable**
+   (asimetría declarada — ver §Honestidad).
+
+## No-negociables respetadas
+
+- **#4 (RISK_PER_TRADE fijo, sin scalers):** el gate es filtro de **selección/visibilidad**, NO
+  multiplicador de sizing. No toca `RISK_PER_TRADE` ni `size_mult`.
+- **#8 (freshness owner + LiveSnapshot):** el gate **lee estado vivo cross-proceso** (el snapshot
+  de régimen). Para el screener es trivial (lo computó en la misma pasada, edad ~0). Para el
+  **scanner es un acto de lectura nuevo, sujeto a #8** — por eso este spec **diseña el lector**
+  (§Componente 1) con su modo de falla, su umbral de frescura propio, y `LiveSnapshot`. La
+  `GateDecision` lleva la frescura **computada por el orquestador**, no leída de un campo.
+- **#6 (specs autoritativas mandan):** este spec **enmienda** la sección "Sin modulación per-coin
+  por régimen" de `docs/superpowers/specs/es/2026-06-18-alt-season-regimen-design.md`
+  (§Cambio de doctrina). No se toca `strategy/regime.py` (régimen macro-BTC, eje distinto).
+- **#2/#3 (holdout bloqueado):** la calibración usa el panel 2020-2025 vía `edge_study.py`
+  (Binance público + cache local). **No** toca `data/holdout/`, **no** llama `simulate_strategy`
+  ni `open_holdout`.
+
+## Arquitectura
+
+```
+                 regime/alt_season.py  (existe)
+                  └─ compose_regime() → estado + votos.vivos  → data/alt_season.json (atómico)
+                             │
+                             ▼
+        regime/alt_season_read.py   ←── NUEVO · lector compartido del snapshot
+        leer_regimen(umbral_seg) → RegimenVivo{estado, frescura, votos_vivos, generated_at}
+         · maneja archivo ausente / JSONDecodeError → frescura="muerto" (guard de api/alt_season.py:41-49)
+         · computa frescura vía LiveSnapshot contra umbral_seg (parámetro, NO el de la UI)
+                  │                                            │
+        (lo usa api/alt_season.py — DRY)          (lo usa el hook del scanner)
+                             │
+                             ▼
+        regime/exposure_gate.py   ←── NUEVO · puro · sin red/DB
+        evaluar_gate(estado, frescura, votos_vivos, es_alt, cfg) → GateDecision
+                  │                                          │
+   ┌──────────────┘                                          └───────────────┐
+   ▼                                                                          ▼
+ tools/run_valley_screener.py::build_snapshot                       btc_scanner.py::scan
+  (screener_loop, 6h) — régimen EN MANO (edad ~0)                   (crypto-scanner, 300s)
+  por candidata (es_alt=True): evaluar_gate                          1× por ciclo: leer_regimen(umbral_gate)
+   · suprime → candidatas_ocultas[]                                  por símbolo alt: evaluar_gate
+   · atenua  → entra con clima_ambiguo                               · suprime → señal NO emitida
+   · si enabled: fila en regime_gate_audit                           · atenua  → señal con flag
+                                                                     · si enabled: fila en audit (batch)
+   │                                                                          │
+   └───────────────────────────────┬──────────────────────────────────────────┘
+                                    ▼
+                       db: tabla regime_gate_audit  (solo si enabled) ←── NUEVA · append-only
+```
+
+**Aislamiento:** `evaluate_symbol` (screener) y la evaluación de señal del scanner **quedan puras
+e intactas** — no reciben el régimen. El gate se aplica en el **orquestador**. El lector del
+snapshot (`alt_season_read.py`) se **extrae** de `api/alt_season.py` para que API y scanner
+compartan un solo path de lectura (DRY, un solo guard de ausencia/corrupción).
+
+## Contrato `GateDecision`
+
+Devuelto por `regime/exposure_gate.py::evaluar_gate`. **Un hecho del clima, no un veredicto.**
+
+```python
+@dataclass(frozen=True)
+class GateDecision:
+    nivel: str            # "pasa" | "atenua" | "suprime"
+    estado_regimen: str   # "alts" | "mixto" | "btc"  (de compose_regime)
+    es_alt: bool          # ¿entrada en alt (no-BTC)?
+    regime_frescura: str  # "fresco" | "rancio" | "muerto"  — COMPUTADA por el orquestador
+                          #   (vía alt_season_read.leer_regimen), NO leída de un campo del JSON
+    votos_vivos: int      # del snapshot — para distinguir mixto-por-datos de mixto-por-empate
+    razon: str            # ej "régimen 'btc' — el viento no acompaña a las alts"
+    enforced: bool        # = cfg.regime_gate.enabled AND regime_frescura == "fresco"
+    umbral_version: str   # sello del set de umbrales + overrides + gobierno de evidencia (§Items)
+```
+
+**Política pura** (toda la lógica en un solo lugar, sin efectos secundarios):
+
+```
+def evaluar_gate(estado, frescura, votos_vivos, es_alt, cfg) -> GateDecision:
+    enforced = cfg.regime_gate.enabled and frescura == "fresco"
+    if not enforced:                       nivel = "pasa"  # flag off, o régimen rancio/muerto
+    elif not es_alt:                       nivel = "pasa"  # el gate es sobre exposición a ALTS
+    elif estado == "alts":                 nivel = "pasa"
+    elif estado == "btc":                  nivel = "suprime"
+    elif estado == "mixto":
+        # mixto tiene DOBLE origen (alt_season.py:105 vs :111). Distinguir:
+        if votos_vivos < MIN_LIVE_VOTERS:  nivel = "pasa"   # datos degradados = AUSENCIA de señal
+        else:                              nivel = "atenua" # empate genuino = ambigüedad
+    else:                                  nivel = "pasa"  # estado inesperado → fail-open (ver Items)
+    return GateDecision(nivel, estado, es_alt, frescura, votos_vivos, razon(...), enforced, umbral_version)
+```
+
+## Comportamiento por estado
+
+| Régimen | `votos_vivos` | `nivel` | Valles screener | Scanner | Visible al operador |
+|---|---|---|---|---|---|
+| `alts`  | —      | `pasa`    | candidata normal | señal normal | sí, normal |
+| `mixto` | ≥2 (empate) | `atenua`  | con flag `clima_ambiguo` | señal con flag | sí, marcada |
+| `mixto` | <2 (datos degradados) | `pasa` | normal | señal normal | sí, normal |
+| `btc`   | —      | `suprime` | a `candidatas_ocultas[]` | señal NO emitida | Valles: **destapable** · scanner: solo auditoría |
+| cualquiera, frescura `rancio`/`muerto` | — | `pasa` | normal | normal | sí, normal |
+| cualquiera, `cfg.regime_gate.enabled=false` | — | `pasa` | normal (sin campos nuevos) | normal | sí, normal |
+
+- **Por qué `mixto` empate marca pero no esconde:** solo escondemos sobre clima **claramente**
+  malo (`btc`). En ambigüedad genuina, mostrar + marcar.
+- **Por qué `mixto` por datos degradados pasa:** `n_live < MIN_LIVE_VOTERS` (CoinGecko caído +
+  cobertura baja) es **ausencia de señal**, no clima dudoso — esconder ahí sería el modo F3a.
+
+## Componentes
+
+### 1. `regime/alt_season_read.py` (NUEVO — lector compartido, resuelve BLOCKERS 1+2+3)
+- `leer_regimen(umbral_seg: float) -> RegimenVivo` con `RegimenVivo{estado, frescura, votos_vivos, generated_at}`.
+- Lee `data/alt_season.json`; **replica el guard** de `api/alt_season.py:41-49` (archivo ausente o
+  `JSONDecodeError` → `frescura="muerto"`, `estado` irrelevante).
+- **Computa la frescura** con `freshness.LiveSnapshot` contra `umbral_seg` (parámetro), NO contra
+  el de la UI. Devuelve `votos.vivos` del snapshot para la desambiguación de `mixto`.
+- **`api/alt_season.py` se refactoriza para usar este lector** (DRY: un solo path de lectura y un
+  solo guard). La API sigue pasando su `FRESCURA_VALLES_SEG` (12h, UI); el gate pasa el suyo.
+
+### 2. `regime/exposure_gate.py` (NUEVO, puro)
+- `evaluar_gate(estado, frescura, votos_vivos, es_alt, cfg) -> GateDecision` (la política de arriba).
+- `umbral_version(cfg) -> str` — sello determinista (ver §Items: qué entra al hash).
+- Sin red, sin DB, sin import de orquestadores ni del lector.
+
+### 3. Hook en el screener — `tools/run_valley_screener.py::build_snapshot`
+- El régimen ya está en mano (misma pasada, `run_valley_screener.py:141`) → `frescura="fresco"`
+  trivial (edad ~0). Por cada candidata (`es_alt=True`): `evaluar_gate(...)`.
+- `suprime` → `candidatas_ocultas[]`; `atenua` → `clima_ambiguo: true`; `pasa` → lista normal.
+- **`valley_candidates.json` debe migrar a `_atomic_write_json`** (hoy `run_valley_screener.py:157`
+  es escritura NO atómica; el payload crece con los campos nuevos → ventana de truncamiento más
+  ancha para un `GET /valley-candidates` concurrente). Ver §Items.
+- **Con `enabled=false`: los campos `candidatas_ocultas`/`clima_ambiguo` NO se emiten** (byte-idéntico)
+  y **no se escribe auditoría**.
+
+### 4. Hook en el scanner — `btc_scanner.py::scan`
+- **1× por ciclo de scan**: `leer_regimen(cfg.regime_gate.frescura_umbral_seg)` (NO releer el JSON
+  por símbolo×tenant). Pasar el `RegimenVivo` al gate por cada símbolo.
+- `es_alt = symbol != "BTCUSDT"` (consistente con `alt_season.py`, que excluye BTCUSDT de
+  `alt_contribs`). Por símbolo alt con señal: `evaluar_gate(...)`. `suprime` → señal NO emitida;
+  `atenua` → señal con flag; BTC/`pasa` → intacto.
+- **Ortogonal al gate de dirección macro-BTC** (`strategy/core.py::_regime_to_direction_token`):
+  ese decide *dirección* (BEAR→SHORT, BULL/NEUTRAL→LONG); el de alt-season decide si la entrada alt
+  **aflora**. Una señal alt pasa **ambos**. Ejes distintos, se apilan.
+- **Sitio de inserción del hook = item abierto** (§Items) — debe quedar en el path de emisión real
+  con su propio `try/except` fail-open, NO depender por accidente del `try/except` del bloque
+  v2_shadow (~286-327).
+- Fail-open `try/except`: un fallo del gate o del lector NUNCA tumba el scan ni esconde por error.
+
+### 5. `db: tabla regime_gate_audit` (NUEVA, append-only, **solo si `enabled=true`**)
+- Columnas: `id, ts, motor (valles|scanner), symbol, estado_regimen, nivel, es_alt,
+  regime_frescura, votos_vivos, enforced, umbral_version, tenant_id`.
+- **`tenant_id` es NULLABLE.** La decisión de exposición es un **hecho de mercado global**: el
+  screener escribe `tenant_id=NULL`; el scanner escribe **UNA fila por símbolo evaluado por ciclo**
+  (NO una por tenant, aunque el loop v2_shadow itere tenants) con `tenant_id=NULL`.
+- **Costo de escritura acotado** (HIGH crítico — el burst de writes ya tumbó endpoints de lectura
+  el 2026-05-29, `db/connection.py:88-95`): escribir las filas del ciclo **en batch dentro de una
+  sola transacción**, no N `BEGIN IMMEDIATE` separados (`db/transaction.py:70` serializa escritores
+  vía WAL — no corrompe, pero cada `BEGIN IMMEDIATE` compite por el único writer lock). Con
+  `enabled=false` no se escribe nada → cero contención añadida.
+- **Política de retención:** rotación/poda (p.ej. conservar N días) — definir en el plan (§Items).
+- Owner de frescura: hereda el de cada orquestador. Es rastro histórico, no snapshot vivo (no
+  introduce estado vivo nuevo sujeto a LiveSnapshot — es append-only de auditoría).
+
+### 6. Config — bloque `cfg.regime_gate` en `config.defaults.json`
+```json
+"regime_gate": {
+  "enabled": false,
+  "frescura_umbral_seg": 27000,   // ~1.25× SCREENER_INTERVAL_SEC (6h). Distinto del de la UI (12h):
+                                   //   un enforcer que actúa cada 300s no puede aceptar clima de 12h.
+  "umbral_overrides": {}          // pisa los 6 umbrales de regime/alt_season.py sin deploy (calibración)
+}
+```
+- `enabled` arranca `false` (merge byte-idéntico). Se enciende en config de prod.
+- `frescura_umbral_seg` resuelve el BLOCKER 6h-vs-12h: el gate usa un umbral **más estricto** que
+  la UI. Justificación citable: `api/alt_season.py:40` advierte "'fresco' = el cálculo es reciente,
+  NO que la afirmación de mercado siga vigente".
+- `umbral_overrides` = retuneo sobre la marcha sin tocar código.
+
+### 7. Frontend Valles — válvula "ver ocultas"
+- *"N alts fuera de alt-season — ver"*; al expandir, lista `candidatas_ocultas` con su clima.
+- Doble función: doctrina honesta + feed humano de calibración. Reusa `useValleyBundle` / PickScreen.
+  Sin endpoint nuevo.
+
+## Calibración, señal de daño y reversa (sobre la marcha, sin shadow)
+
+- **Arranque:** umbrales provisionales (o `umbral_overrides`).
+- **Opcional, en paralelo (no bloquea merge):** `edge_study.py` vs panel 2020-2025 → mejores
+  umbrales iniciales → `umbral_overrides`.
+- **Señal de daño cuantitativa** (resuelve HIGH "enforcing sin criterio de reversa"): la **tasa de
+  supresión** (% de alts ocultas por ciclo) se computa desde `regime_gate_audit`. Un umbral de
+  alarma (p.ej. >X% del universo oculto sostenido) dispara revisión. Detecta la sobre-supresión que
+  el "sesgo de no-evento" esconde.
+- **Reversa inmediata:** `cfg.regime_gate.enabled=false` → vuelve a byte-idéntico al instante.
+  Más fino: ajustar `umbral_overrides`.
+- **Nota honesta:** Samuel eligió enforcing desde el arranque (sin fase shadow) con umbrales
+  provisionales. El riesgo residual (esconder de más durante un régimen mal clasificado) se mitiga
+  con la señal de daño + la reversa por flag, NO se elimina. Es una decisión consciente del dueño.
+
+## Manejo de errores y frescura (#8)
+
+- **Fail-open sobre régimen rancio/muerto:** `frescura != "fresco"` → `enforced=False` → `pasa`.
+  Nunca esconder sobre clima muerto (modo F3a). El umbral lo fija `frescura_umbral_seg` (estricto).
+- **Fail-open ante excepción** del gate o del lector: `try/except` (log warning) → `pasa`.
+- **Snapshot ausente en arranque:** el lector devuelve `frescura="muerto"` → `pasa`. (El scanner
+  arranca casi a la par del screener; durante la primera ventana `alt_season.json` puede no existir.)
+- **Flag-off byte-idéntico REAL:** con `enabled=false`, (a) los campos nuevos del JSON NO se emiten,
+  (b) NO se escriben filas de auditoría, (c) la señal del scanner es idéntica. Test de regresión que
+  verifique AUSENCIA de campos nuevos Y ausencia de filas de auditoría.
+
+## Cambio de doctrina (enmienda #6)
+
+Enmienda `docs/superpowers/specs/es/2026-06-18-alt-season-regimen-design.md`:
+- "El régimen ENMARCA pero NO modula la moneda" / "Sin modulación per-coin por régimen" queda
+  **superada para el eje de exposición**: el régimen ahora **gatea qué alts afloran**.
+- Matiz preservado: **no es scoring per-coin** (no rankea monedas por régimen). Es un filtro de
+  exposición sobre un **hecho de mercado** (el clima), igual para todas las alts. El veredicto sobre
+  una coin sigue prohibido. Lo escondido es destapable (Valles).
+- **Tarea bloqueante del merge** (no follow-up): actualizar la sección correspondiente del spec de
+  2026-06-18 con un apuntador a este documento, para que no queden dos specs autoritativas en
+  contradicción.
+
+## Honestidad: asimetría declarada (resuelve HIGH 9)
+
+"Destapable" aplica a **Valles** (UX "ver ocultas") — el motor de exhibición para un humano. En el
+**scanner**, una señal suprimida no se emite y el operador no tiene afordancia de destape en tiempo
+real; queda **auditable** en `regime_gate_audit` (query). La doctrina de honestidad es: *Valles
+destapa; el scanner deja rastro.* No se presenta "destapable" como propiedad universal.
+
+## Testing
+
+- **`tests/test_exposure_gate.py`** (núcleo puro): tabla de verdad estado×frescura×votos_vivos×es_alt×enabled.
+  Casos clave: `btc`+fresco+alt+enabled→`suprime`; `btc`+rancio→`pasa`; `btc`+enabled=false→`pasa`;
+  BTC(no-alt)→`pasa`; `mixto`+votos≥2→`atenua`; `mixto`+votos<2→`pasa`; `alts`→`pasa`.
+- **`tests/test_alt_season_read.py`**: archivo ausente→`muerto`; JSON corrupto→`muerto`;
+  `generated_at` viejo (> umbral)→`rancio`; reciente→`fresco`. **Test que fija `generated_at` viejo
+  y verifica `enforced=False`** (atrapa el fail-open silencioso permanente — BLOCKER 2).
+- **`tests/test_run_valley_screener.py`**: `enabled=false` → snapshot byte-idéntico (sin campos
+  nuevos, sin filas de auditoría); `enabled=true`+`btc`+fresco → alts en `candidatas_ocultas` + fila.
+- **`tests/test_scanner.py`**: `enabled=false` → emisión idéntica, sin auditoría; `btc`+fresco → no
+  emite señal alt; error del gate/lector → fail-open (scan sobrevive).
+- **`tests/test_regime_gate_audit.py`**: la fila lleva `umbral_version`, `regime_frescura`,
+  `tenant_id=NULL`; con `enabled=false` no se escribe.
+
+## Fuera de alcance (diferido)
+
+- Modulación de **sizing** por régimen (choca con #4; solo vía épico regime-allocation).
+- Conectar el gate al **épico regime-allocation #338**.
+- Fase shadow formal (Samuel la descartó a favor de enforcing + calibración sobre la marcha).
+- Afordancia de destape en el scanner / dashboard del `regime_gate_audit` (endpoint de lectura).
+- Tendencia de dominancia / breadth200 (v1.1 del detector).
+
+## Items abiertos (para el plan)
+
+- **Mecánica de migración** de `regime_gate_audit` (cómo se crean tablas en `db/`).
+- **`umbral_version`:** qué entra al hash. Debe incluir los 6 umbrales **+ `umbral_overrides`
+  aplicados + `COVERAGE_MIN`/`MIN_LIVE_VOTERS`** (gobierno de evidencia — afectan qué votos cuentan).
+  "Los 6 umbrales" a secas es insuficiente (dos calibraciones con distinto `COVERAGE_MIN` darían el
+  mismo sello → auditoría engañosa).
+- **Sitio exacto del hook del scanner:** path de emisión real con `try/except` propio (no depender
+  del `try/except` del v2_shadow ~286).
+- **Migrar `valley_candidates.json` a `_atomic_write_json`** (`run_valley_screener.py:157`).
+- **Recarga en caliente de `umbral_overrides`:** confirmar que los loops releen config por ciclo
+  (`runtime.py:428` sugiere relectura por ciclo del screener) o requieren reinicio — "sin deploy"
+  exige relectura por ciclo.
+- **Política de retención** de `regime_gate_audit` (tabla append-only de alta frecuencia).
+- **Rama `else` (estado inesperado):** hoy `compose_regime` solo emite `{alts,mixto,btc}` (rama
+  muerta). Decidir: defensa de estados futuros (`pasa`) vs error explícito (degradación muda vs ruidosa).
+- **"Espejo estructural"** de `alt_season.py`: traducir a propiedad concreta (funciones puras, sin
+  red/DB) o eliminar la instrucción.

--- a/docs/superpowers/specs/es/2026-06-23-regimen-al-trade-gate-design.md
+++ b/docs/superpowers/specs/es/2026-06-23-regimen-al-trade-gate-design.md
@@ -242,6 +242,23 @@ def evaluar_gate(estado, frescura, votos_vivos, es_alt, cfg) -> GateDecision:
   provisionales. El riesgo residual (esconder de más durante un régimen mal clasificado) se mitiga
   con la señal de daño + la reversa por flag, NO se elimina. Es una decisión consciente del dueño.
 
+## Precondiciones de activación (gates antes de `enabled=true` en prod)
+
+La feature se mergea **apagada** (`enabled=false`, byte-idéntica). Antes de encenderla en prod,
+estos gates son obligatorios (marcados por el review final de rama):
+
+1. **`config.json` de prod debe llevar el bloque `regime_gate`.** El scanner lee su config de
+   `config.json` (no de `config.defaults.json`), mientras el screener usa `load_config()` (que sí
+   mergea defaults). Poner `enabled=true` solo en `config.defaults.json` activaría el gate del
+   screener pero NO el del scanner. Para activar AMBOS motores, `config.json` debe incluir
+   `regime_gate.enabled=true` (+ `frescura_umbral_seg`, `umbral_overrides`). Con la clave ausente,
+   ambos motores leen `enabled=False` (byte-idéntico) — el default es seguro.
+2. **Calibrar los umbrales antes de encender** (correr `edge_study.py` vs panel 2020-2025 → sembrar
+   `umbral_overrides`), o aceptar explícitamente el riesgo de enforcing con provisionales.
+3. **Auditoría batcheada por ciclo:** el scanner acumula las filas del ciclo y hace UN solo
+   `registrar_decisiones(filas)` por ciclo (no per-símbolo), para no recrear el burst de write-lock
+   del 2026-05-29. (Implementado; verificar que sigue así si se toca `scanner_loop`.)
+
 ## Manejo de errores y frescura (#8)
 
 - **Fail-open sobre régimen rancio/muerto:** `frescura != "fresco"` → `enforced=False` → `pasa`.

--- a/frontend/src/components/valles/PickScreen.tsx
+++ b/frontend/src/components/valles/PickScreen.tsx
@@ -8,7 +8,9 @@ import styles from './valles.module.css';
 
 export const PickScreen: React.FC<{ snapshot: ValleySnapshot; onPick: (sym: string) => void }> = ({ snapshot, onPick }) => {
   const [q, setQ] = useState('');
-  const { candidates, coverage, frescura } = snapshot;
+  const [mostrarOcultas, setMostrarOcultas] = useState(false);
+  const { candidates, coverage, frescura, candidatas_ocultas } = snapshot;
+  const ocultas = candidatas_ocultas ?? [];
 
   return (
     <div className={styles.vwScreen}>
@@ -39,12 +41,56 @@ export const PickScreen: React.FC<{ snapshot: ValleySnapshot; onPick: (sym: stri
             <div className={styles.vwCandFact}>
               <span className={styles.vwCandTag} aria-hidden="true">● parte baja del rango</span>
               cuartil inferior (pos <b>{(c.pos_in_30d_range * 100).toFixed(0)}%</b>) · RSI <b>{c.rsi14.toFixed(0)}</b>
+              {c.clima_ambiguo && (
+                <span className={styles.vwClimaAmbiguo} title="El régimen del mercado es mixto — ni claramente hacia alts ni hacia BTC">
+                  clima ambiguo
+                </span>
+              )}
             </div>
             <div className={styles.vwCandPrice}>${formatPrice(c.price)}</div>
             <div className={styles.vwCandGo} aria-hidden="true">→</div>
           </button>
         ))}
       </div>
+
+      {/* Válvula "ver ocultas" — solo si el gate está activo y hay alts excluidas */}
+      {ocultas.length > 0 && (
+        <div className={styles.vwOcultas}>
+          <button
+            className={styles.vwVerOcultas}
+            onClick={() => setMostrarOcultas((v) => !v)}
+            aria-expanded={mostrarOcultas}
+          >
+            {mostrarOcultas
+              ? 'Ocultar'
+              : `${ocultas.length} ${ocultas.length === 1 ? 'alt' : 'alts'} fuera de alt-season — ver`}
+          </button>
+          {mostrarOcultas && (
+            <div className={styles.vwOcultasList} role="list">
+              {ocultas.map((c) => (
+                <button
+                  key={c.symbol}
+                  role="listitem"
+                  className={`${styles.vwCand} ${styles.vwCandAtenuada}`}
+                  onClick={() => onPick(c.symbol)}
+                >
+                  <div className={styles.vwCandId}>
+                    <div className={styles.vwCandName}>{humanName(c.symbol)}</div>
+                    <div className={styles.vwCandSym}>{c.symbol}</div>
+                  </div>
+                  <div className={styles.vwCandFact}>
+                    <span className={styles.vwCandTag} aria-hidden="true">● parte baja del rango</span>
+                    cuartil inferior (pos <b>{(c.pos_in_30d_range * 100).toFixed(0)}%</b>) · RSI <b>{c.rsi14.toFixed(0)}</b>
+                    <span className={styles.vwClimaHecho} title={c.clima}>{c.clima}</span>
+                  </div>
+                  <div className={styles.vwCandPrice}>${formatPrice(c.price)}</div>
+                  <div className={styles.vwCandGo} aria-hidden="true">→</div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       <div className={styles.vwEntryMeta}>
         <span>Se miraron <b>{coverage.evaluated}</b> de {coverage.universe} monedas del universo.</span>

--- a/frontend/src/components/valles/valles.module.css
+++ b/frontend/src/components/valles/valles.module.css
@@ -356,6 +356,39 @@
 .vwCandGo { color: var(--clay); font-size: 18px; flex: none; transition: transform 160ms var(--ease); }
 .vwCand:hover .vwCandGo { transform: translateX(3px); }
 
+/* marcador "clima ambiguo" — régimen mixto en candidata visible */
+.vwClimaAmbiguo {
+  display: inline-flex; align-items: center;
+  margin-left: 10px;
+  font-size: 10.5px; letter-spacing: 0.07em; text-transform: uppercase; font-weight: 600;
+  color: var(--ochre); background: var(--ochre-tint); border: 1px solid var(--ochre-soft);
+  border-radius: 999px; padding: 2px 9px; white-space: nowrap; cursor: help;
+}
+
+/* válvula "ver ocultas" — alts fuera de alt-season */
+.vwOcultas { margin-top: 18px; }
+.vwVerOcultas {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--sans); font-size: 13.5px; font-weight: 500;
+  color: var(--ink-3); background: none; border: 1px solid var(--card-edge);
+  border-radius: 999px; padding: 8px 18px; cursor: pointer;
+  transition: all 140ms var(--ease);
+}
+.vwVerOcultas:hover { color: var(--ink-2); border-color: var(--card-edge-2); background: var(--card); }
+.vwOcultasList { margin-top: 10px; display: flex; flex-direction: column; gap: 8px; }
+
+/* fila de candidata atenuada (oculta por régimen) */
+.vwCandAtenuada { opacity: 0.72; }
+.vwCandAtenuada:hover { opacity: 1; }
+
+/* hecho de clima — texto de régimen en fila oculta */
+.vwClimaHecho {
+  display: block; margin-top: 4px;
+  font-size: 11.5px; color: var(--ink-3); font-style: italic;
+  white-space: normal; overflow: hidden; text-overflow: ellipsis;
+  max-width: 38ch;
+}
+
 /* meta honesta: cobertura + orden */
 .vwEntryMeta {
   margin-top: 20px; display: flex; align-items: center; gap: 14px; flex-wrap: wrap;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -542,13 +542,15 @@ export interface ValleyCandidate {
   volumen_usd_dia:      number;
   distancia_ath_pct:    number;
   razones_vida:         string[];
+  clima_ambiguo?:       boolean;   // presente cuando el gate está activo y el régimen es mixto
 }
 
 export interface ValleySnapshot {
-  generated_at: string | null;
-  coverage:     { universe: number; evaluated: number; complete: boolean };
-  candidates:   ValleyCandidate[];
-  frescura?:    Frescura;
+  generated_at:        string | null;
+  coverage:            { universe: number; evaluated: number; complete: boolean };
+  candidates:          ValleyCandidate[];
+  frescura?:           Frescura;
+  candidatas_ocultas?: (ValleyCandidate & { clima: string })[];   // solo cuando el gate enforza
 }
 
 // ---- Régimen de mercado "¿es alt-season?" (hecho de mercado, no veredicto) ----

--- a/regime/alt_season.py
+++ b/regime/alt_season.py
@@ -29,6 +29,22 @@ COVERAGE_MIN = 0.70
 MIN_LIVE_VOTERS = 2
 
 
+def effective_thresholds(overrides: dict | None) -> dict:
+    """Umbrales efectivos: constantes de módulo pisadas por `overrides` (calibración
+    sin deploy). Claves fijas — única fuente para compose_regime y umbral_version."""
+    base = {
+        "BREADTH_ALT": BREADTH_ALT, "BREADTH_BEAR": BREADTH_BEAR,
+        "OUTPERF_ALT": OUTPERF_ALT, "OUTPERF_BEAR": OUTPERF_BEAR,
+        "DOM_ALT": DOM_ALT, "DOM_BTC": DOM_BTC,
+        "COVERAGE_MIN": COVERAGE_MIN, "MIN_LIVE_VOTERS": MIN_LIVE_VOTERS,
+    }
+    if overrides:
+        for k, v in overrides.items():
+            if k in base:
+                base[k] = v
+    return base
+
+
 def symbol_contribution(symbol: str, bars: list[dict]) -> dict | None:
     """Contribución de UN símbolo al régimen. None si len(bars) < MIN_HISTORY_DAYS."""
     if len(bars) < MIN_HISTORY_DAYS:
@@ -60,17 +76,20 @@ def _lean_lower_alt(value: float, alt_thr: float, bear_thr: float) -> str:
 
 
 def compose_regime(alt_contribs: list[dict], btc_ret_30d: float | None,
-                   btc_dominance: float | None, coverage_ratio: float) -> dict:
+                   btc_dominance: float | None, coverage_ratio: float,
+                   thresholds: dict | None = None) -> dict:
     """Compone el estado de régimen por voto de 3 componentes. Hecho de mercado,
-    cero campo per-símbolo, cero valencia. Ver spec §Núcleo."""
+    cero campo per-símbolo, cero valencia. Ver spec §Núcleo.
+    Si thresholds is None usa effective_thresholds(None) (comportamiento por defecto)."""
+    t = thresholds if thresholds is not None else effective_thresholds(None)
     voters: list[str] = []
     componentes: dict[str, dict] = {}
 
     # 1. breadth50 — vota sólo si la cobertura alcanza el piso.
     breadth50 = (mean(1.0 if c["above_sma50"] else 0.0 for c in alt_contribs)
                  if alt_contribs else None)
-    if breadth50 is not None and coverage_ratio >= COVERAGE_MIN:
-        lean = _lean_higher_alt(breadth50, BREADTH_ALT, BREADTH_BEAR)
+    if breadth50 is not None and coverage_ratio >= t["COVERAGE_MIN"]:
+        lean = _lean_higher_alt(breadth50, t["BREADTH_ALT"], t["BREADTH_BEAR"])
         componentes["breadth50"] = {"valor": breadth50, "lean": lean,
                                     "estado": "fresco", "n": len(alt_contribs)}
         voters.append(lean)
@@ -83,7 +102,7 @@ def compose_regime(alt_contribs: list[dict], btc_ret_30d: float | None,
     # 2. outperf_30d — mediana de (ret alt - ret BTC). Muerto si BTC no evaluable.
     if alt_contribs and btc_ret_30d is not None:
         outperf = median(c["ret_30d"] - btc_ret_30d for c in alt_contribs)
-        lean = _lean_higher_alt(outperf, OUTPERF_ALT, OUTPERF_BEAR)
+        lean = _lean_higher_alt(outperf, t["OUTPERF_ALT"], t["OUTPERF_BEAR"])
         componentes["outperf_30d"] = {"valor": outperf, "lean": lean, "estado": "fresco"}
         voters.append(lean)
     else:
@@ -91,7 +110,7 @@ def compose_regime(alt_contribs: list[dict], btc_ret_30d: float | None,
 
     # 3. dominancia_btc — muerta si la llamada a CoinGecko falló.
     if btc_dominance is not None:
-        lean = _lean_lower_alt(btc_dominance, DOM_ALT, DOM_BTC)
+        lean = _lean_lower_alt(btc_dominance, t["DOM_ALT"], t["DOM_BTC"])
         componentes["dominancia_btc"] = {"valor": btc_dominance, "lean": lean,
                                          "estado": "fresco"}
         voters.append(lean)
@@ -102,7 +121,7 @@ def compose_regime(alt_contribs: list[dict], btc_ret_30d: float | None,
     n_btc = voters.count("btc")
     n_neutral = voters.count("neutral")
     n_live = len(voters)
-    if n_live < MIN_LIVE_VOTERS:
+    if n_live < t["MIN_LIVE_VOTERS"]:
         estado = "mixto"
     elif n_alts > n_btc and n_alts > n_neutral:
         estado = "alts"

--- a/regime/alt_season_read.py
+++ b/regime/alt_season_read.py
@@ -1,0 +1,61 @@
+"""Lector compartido del snapshot de régimen alt-season. ÚNICO path de lectura
+de data/alt_season.json (lo usan la API y el hook del scanner). Computa la
+frescura vía freshness.LiveSnapshot — la frescura NO está persistida en el JSON.
+Maneja archivo ausente / corrupto → 'muerto' (fail-open). Spec 2026-06-23 §1."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+
+from freshness import LiveSnapshot
+
+log = logging.getLogger("regime.alt_season_read")
+
+_DEFAULT_RUTA = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                             "data", "alt_season.json")
+
+_EMPTY = {
+    "generated_at": None,
+    "coverage": {"universe": 0, "evaluated": 0, "complete": False},
+    "dominancia_fetch": {"ok": False, "fetched_at": None, "source": "coingecko/global"},
+    "regime": {"estado": "mixto", "componentes": {},
+               "votos": {"alts": 0, "neutral": 0, "btc": 0, "vivos": 0},
+               "n_alts_evaluadas": 0},
+}
+
+
+@dataclass(frozen=True)
+class RegimenVivo:
+    estado: str
+    frescura: str          # "fresco" | "rancio" | "muerto"
+    votos_vivos: int
+    generated_at: str | None
+    snapshot: dict
+
+
+def _leer_snapshot(ruta: str) -> dict:
+    """Lee el JSON con guard de ausencia/corrupción → _EMPTY (frescura derivará 'muerto')."""
+    if not os.path.exists(ruta):
+        return dict(_EMPTY)
+    try:
+        with open(ruta, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        log.error("ALT_SEASON_SNAPSHOT_UNREADABLE causa=%s", e)
+        return dict(_EMPTY)
+
+
+def leer_regimen(umbral_seg: float, ruta: str | None = None) -> RegimenVivo:
+    """Estado + frescura del régimen. La frescura se COMPUTA (generated_at vs
+    umbral_seg), no se lee de un campo. umbral_seg lo pasa el llamador (la API usa
+    el de la UI; el gate del scanner usa el suyo, más estricto)."""
+    snap = _leer_snapshot(ruta or _DEFAULT_RUTA)
+    generated_at = snap.get("generated_at")
+    frescura = LiveSnapshot(payload={}, generated_at=generated_at, umbral_seg=umbral_seg).estado
+    regime = snap.get("regime") or {}
+    estado = regime.get("estado", "mixto")
+    votos_vivos = int((regime.get("votos") or {}).get("vivos", 0))
+    return RegimenVivo(estado=estado, frescura=frescura, votos_vivos=votos_vivos,
+                       generated_at=generated_at, snapshot=snap)

--- a/regime/exposure_gate.py
+++ b/regime/exposure_gate.py
@@ -24,13 +24,17 @@ class GateDecision:
     umbral_version: str
 
 
+def _hash_thresholds(eff: dict) -> str:
+    """Hash determinista de un dict de umbrales ya computado."""
+    blob = json.dumps(eff, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha1(blob.encode("utf-8")).hexdigest()[:12]
+
+
 def umbral_version(cfg: dict) -> str:
     """Sello determinista de los umbrales EFECTIVOS (6 de lean + 2 de gobierno de
     evidencia + overrides). Ata cada fila de auditoría a la calibración exacta."""
     overrides = (cfg.get("regime_gate") or {}).get("umbral_overrides") or {}
-    eff = effective_thresholds(overrides)
-    blob = json.dumps(eff, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha1(blob.encode("utf-8")).hexdigest()[:12]
+    return _hash_thresholds(effective_thresholds(overrides))
 
 
 def evaluar_gate(estado: str, frescura: str, votos_vivos: int,
@@ -60,5 +64,5 @@ def evaluar_gate(estado: str, frescura: str, votos_vivos: int,
     return GateDecision(
         nivel=nivel, estado_regimen=estado, es_alt=es_alt,
         regime_frescura=frescura, votos_vivos=votos_vivos, razon=razon,
-        enforced=enforced, umbral_version=umbral_version(cfg),
+        enforced=enforced, umbral_version=_hash_thresholds(eff),
     )

--- a/regime/exposure_gate.py
+++ b/regime/exposure_gate.py
@@ -1,0 +1,64 @@
+"""Gate de exposición por régimen — política PURA (sin red, sin DB). Espejo
+estructural de regime/alt_season.py: solo funciones puras, cero I/O.
+
+Decide pasa|atenua|suprime desde el ESTADO del régimen + su FRESCURA. Un hecho
+de exposición de mercado, NO un veredicto per-coin. Spec 2026-06-23."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from regime.alt_season import effective_thresholds
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    nivel: str            # "pasa" | "atenua" | "suprime"
+    estado_regimen: str   # "alts" | "mixto" | "btc"
+    es_alt: bool
+    regime_frescura: str  # "fresco" | "rancio" | "muerto" (COMPUTADA por el orquestador)
+    votos_vivos: int
+    razon: str
+    enforced: bool        # = cfg.regime_gate.enabled AND regime_frescura == "fresco"
+    umbral_version: str
+
+
+def umbral_version(cfg: dict) -> str:
+    """Sello determinista de los umbrales EFECTIVOS (6 de lean + 2 de gobierno de
+    evidencia + overrides). Ata cada fila de auditoría a la calibración exacta."""
+    overrides = (cfg.get("regime_gate") or {}).get("umbral_overrides") or {}
+    eff = effective_thresholds(overrides)
+    blob = json.dumps(eff, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha1(blob.encode("utf-8")).hexdigest()[:12]
+
+
+def evaluar_gate(estado: str, frescura: str, votos_vivos: int,
+                 es_alt: bool, cfg: dict) -> GateDecision:
+    """Política graduada. Fail-open sobre clima rancio/muerto y sobre flag off."""
+    rg = cfg.get("regime_gate") or {}
+    enforced = bool(rg.get("enabled", False)) and frescura == "fresco"
+    eff = effective_thresholds(rg.get("umbral_overrides") or {})
+    min_live = eff["MIN_LIVE_VOTERS"]
+
+    if not enforced:
+        nivel, razon = "pasa", "gate inactivo (flag off o régimen no fresco)"
+    elif not es_alt:
+        nivel, razon = "pasa", "símbolo no-alt — el gate es sobre exposición a alts"
+    elif estado == "alts":
+        nivel, razon = "pasa", "régimen 'alts' — el viento acompaña"
+    elif estado == "btc":
+        nivel, razon = "suprime", "régimen 'btc' — el viento no acompaña a las alts"
+    elif estado == "mixto":
+        if votos_vivos < min_live:
+            nivel, razon = "pasa", "mixto por datos degradados — ausencia de señal, no clima"
+        else:
+            nivel, razon = "atenua", "régimen 'mixto' — clima ambiguo"
+    else:
+        nivel, razon = "pasa", f"estado inesperado '{estado}' — fail-open"
+
+    return GateDecision(
+        nivel=nivel, estado_regimen=estado, es_alt=es_alt,
+        regime_frescura=frescura, votos_vivos=votos_vivos, razon=razon,
+        enforced=enforced, umbral_version=umbral_version(cfg),
+    )

--- a/scanner/runtime.py
+++ b/scanner/runtime.py
@@ -294,15 +294,18 @@ def execute_scan_for_symbol(sym: str, cfg: dict) -> dict:
             log.info(f"{sym}: {estado[:55]}")
 
         return {
-            "symbol":    sym,
-            "scan_id":   scan_id,
-            "timestamp": rep.get("timestamp"),
-            "estado":    rep.get("estado"),
-            "price":     rep.get("price"),
-            "lrc_pct":   rep.get("lrc_1h", {}).get("pct"),
-            "score":     rep.get("score"),
-            "señal":     rep.get("señal_activa"),
-            "gatillo":   rep.get("gatillo_activo"),
+            "symbol":     sym,
+            "scan_id":    scan_id,
+            "timestamp":  rep.get("timestamp"),
+            "estado":     rep.get("estado"),
+            "price":      rep.get("price"),
+            "lrc_pct":    rep.get("lrc_1h", {}).get("pct"),
+            "score":      rep.get("score"),
+            "señal":      rep.get("señal_activa"),
+            "gatillo":    rep.get("gatillo_activo"),
+            # Fila de auditoría del gate (None cuando gate deshabilitado).
+            # scanner_loop la batchea al final del ciclo (spec §5).
+            "_gate_fila": rep.get("_regime_gate_fila"),
         }
 
     except Exception as e:
@@ -352,12 +355,24 @@ def scanner_loop(stop_event: threading.Event | None = None):
             log.warning(f"prefetch batch fallo: {e}")
 
         cycle_prices = {}
+        _cycle_gate_filas: list = []
         for sym in symbols:
             if not _scanner_state["running"] or stop_event.is_set():
                 break
             result = execute_scan_for_symbol(sym, cfg)
             if result and result.get("price"):
                 cycle_prices[sym] = result["price"]
+            if result and result.get("_gate_fila"):
+                _cycle_gate_filas.append(result["_gate_fila"])
+
+        # Flush del audit del gate por ciclo — spec §5: UNA transacción por
+        # ciclo en vez de N writes por símbolo (evita writer-lock contention).
+        if _cycle_gate_filas:
+            try:
+                from db.regime_gate_audit import registrar_decisiones  # noqa: PLC0415
+                registrar_decisiones(_cycle_gate_filas)
+            except Exception:
+                log.warning("regime_gate_audit (scanner cycle) falló — fail-open", exc_info=True)
 
         # Actualizar data/symbols_status.json al final de cada ciclo
         try:

--- a/tests/test_alt_season.py
+++ b/tests/test_alt_season.py
@@ -146,3 +146,43 @@ def test_compose_cero_votantes_vivos_es_mixto():
     out = compose_regime([], btc_ret_30d=None, btc_dominance=None, coverage_ratio=1.0)
     assert out["estado"] == "mixto"
     assert out["votos"]["vivos"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests de effective_thresholds + compose_regime parametrizable (Task 1)
+# ---------------------------------------------------------------------------
+from regime.alt_season import effective_thresholds
+
+
+def test_effective_thresholds_defaults_match_constants():
+    import regime.alt_season as m
+    t = effective_thresholds(None)
+    assert t["BREADTH_ALT"] == m.BREADTH_ALT
+    assert t["OUTPERF_ALT"] == m.OUTPERF_ALT
+    assert t["DOM_BTC"] == m.DOM_BTC
+    assert t["COVERAGE_MIN"] == m.COVERAGE_MIN
+    assert t["MIN_LIVE_VOTERS"] == m.MIN_LIVE_VOTERS
+
+
+def test_effective_thresholds_overrides_win():
+    t = effective_thresholds({"BREADTH_ALT": 0.7})
+    assert t["BREADTH_ALT"] == 0.7
+    import regime.alt_season as m
+    assert t["OUTPERF_ALT"] == m.OUTPERF_ALT  # los no-pisados quedan
+
+
+def test_compose_regime_thresholds_none_is_default():
+    # Una pasada donde breadth=1.0 (todos sobre SMA50) y BTC ret bajo → 'alts'.
+    contribs = [{"above_sma50": True, "ret_30d": 0.20} for _ in range(5)]
+    out = compose_regime(contribs, btc_ret_30d=0.0, btc_dominance=0.45,
+                         coverage_ratio=1.0, thresholds=None)
+    assert out["estado"] == "alts"
+
+
+def test_compose_regime_override_flips_state():
+    contribs = [{"above_sma50": True, "ret_30d": 0.01} for _ in range(5)]
+    # breadth=1.0; con BREADTH_ALT=0.6 por defecto vota 'alts'. Subiendo a 1.1
+    # (imposible de alcanzar) el voto de breadth deja de ser 'alts'.
+    out = compose_regime(contribs, btc_ret_30d=0.0, btc_dominance=0.55,
+                         coverage_ratio=1.0, thresholds=effective_thresholds({"BREADTH_ALT": 1.1}))
+    assert out["estado"] != "alts"

--- a/tests/test_alt_season.py
+++ b/tests/test_alt_season.py
@@ -1,5 +1,10 @@
 """Tests del núcleo puro del régimen de mercado (alt-season). Sin red, sin DB."""
-from regime.alt_season import symbol_contribution, MIN_HISTORY_DAYS
+from regime.alt_season import (
+    symbol_contribution,
+    compose_regime,
+    effective_thresholds,
+    MIN_HISTORY_DAYS,
+)
 
 
 def _bars(closes):
@@ -28,9 +33,6 @@ def test_contribution_below_sma50():
     c = symbol_contribution("X", _bars(closes))
     assert c["above_sma50"] is False
     assert abs(c["ret_30d"] - (-0.20)) < 1e-9
-
-
-from regime.alt_season import compose_regime
 
 
 def _contrib(above, ret):
@@ -151,9 +153,6 @@ def test_compose_cero_votantes_vivos_es_mixto():
 # ---------------------------------------------------------------------------
 # Tests de effective_thresholds + compose_regime parametrizable (Task 1)
 # ---------------------------------------------------------------------------
-from regime.alt_season import effective_thresholds
-
-
 def test_effective_thresholds_defaults_match_constants():
     import regime.alt_season as m
     t = effective_thresholds(None)
@@ -162,6 +161,9 @@ def test_effective_thresholds_defaults_match_constants():
     assert t["DOM_BTC"] == m.DOM_BTC
     assert t["COVERAGE_MIN"] == m.COVERAGE_MIN
     assert t["MIN_LIVE_VOTERS"] == m.MIN_LIVE_VOTERS
+    assert t["BREADTH_BEAR"] == m.BREADTH_BEAR
+    assert t["OUTPERF_BEAR"] == m.OUTPERF_BEAR
+    assert t["DOM_ALT"] == m.DOM_ALT
 
 
 def test_effective_thresholds_overrides_win():

--- a/tests/test_alt_season_read.py
+++ b/tests/test_alt_season_read.py
@@ -1,0 +1,48 @@
+"""Tests del lector compartido del snapshot de régimen alt-season.
+TDD Task 3 — los 5 casos del brief (2026-06-23)."""
+import json
+from datetime import datetime, timezone, timedelta
+from regime.alt_season_read import leer_regimen, RegimenVivo
+
+
+def _write(tmp_path, generated_at, estado="btc", vivos=3):
+    p = tmp_path / "alt_season.json"
+    p.write_text(json.dumps({
+        "generated_at": generated_at,
+        "regime": {"estado": estado, "votos": {"vivos": vivos}},
+    }), encoding="utf-8")
+    return str(p)
+
+
+def test_ausente_es_muerto(tmp_path):
+    r = leer_regimen(27000, ruta=str(tmp_path / "no_existe.json"))
+    assert r.frescura == "muerto"
+
+
+def test_corrupto_es_muerto(tmp_path):
+    p = tmp_path / "alt_season.json"; p.write_text("{ not json", encoding="utf-8")
+    r = leer_regimen(27000, ruta=str(p))
+    assert r.frescura == "muerto"
+
+
+def test_generated_at_viejo_es_rancio(tmp_path):
+    viejo = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
+    r = leer_regimen(27000, ruta=_write(tmp_path, viejo))  # 27000s = 7.5h < 10h
+    assert r.frescura == "rancio"
+
+
+def test_generated_at_reciente_es_fresco(tmp_path):
+    reciente = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+    r = leer_regimen(27000, ruta=_write(tmp_path, reciente, estado="alts", vivos=2))
+    assert r.frescura == "fresco" and r.estado == "alts" and r.votos_vivos == 2
+
+
+def test_failopen_combinado_con_gate(tmp_path):
+    # El test que ATRAPA el fail-open silencioso: clima 'btc' viejo → 'rancio' →
+    # el gate NO debe esconder (enforced=False).
+    from regime.exposure_gate import evaluar_gate
+    viejo = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
+    r = leer_regimen(27000, ruta=_write(tmp_path, viejo, estado="btc"))
+    d = evaluar_gate(r.estado, r.frescura, r.votos_vivos, True,
+                     {"regime_gate": {"enabled": True, "umbral_overrides": {}}})
+    assert d.enforced is False and d.nivel == "pasa"

--- a/tests/test_exposure_gate.py
+++ b/tests/test_exposure_gate.py
@@ -45,3 +45,7 @@ def test_umbral_version_changes_with_overrides():
     base = umbral_version({"regime_gate": {"umbral_overrides": {}}})
     moved = umbral_version({"regime_gate": {"umbral_overrides": {"BREADTH_ALT": 0.7}}})
     assert base != moved
+
+def test_cfg_vacio_failopen():
+    d = evaluar_gate("btc", "fresco", 3, True, {})
+    assert d.nivel == "pasa" and d.enforced is False

--- a/tests/test_exposure_gate.py
+++ b/tests/test_exposure_gate.py
@@ -1,0 +1,47 @@
+# tests/test_exposure_gate.py
+from regime.exposure_gate import evaluar_gate, umbral_version, GateDecision
+
+_ON = {"regime_gate": {"enabled": True, "umbral_overrides": {}}}
+_OFF = {"regime_gate": {"enabled": False, "umbral_overrides": {}}}
+
+def _gate(estado, frescura, votos, es_alt, cfg=_ON):
+    return evaluar_gate(estado, frescura, votos, es_alt, cfg)
+
+def test_btc_fresco_alt_enabled_suprime():
+    assert _gate("btc", "fresco", 3, True).nivel == "suprime"
+
+def test_btc_rancio_pasa_failopen():
+    d = _gate("btc", "rancio", 3, True)
+    assert d.nivel == "pasa" and d.enforced is False
+
+def test_btc_muerto_pasa_failopen():
+    assert _gate("btc", "muerto", 3, True).nivel == "pasa"
+
+def test_btc_disabled_pasa():
+    d = _gate("btc", "fresco", 3, True, cfg=_OFF)
+    assert d.nivel == "pasa" and d.enforced is False
+
+def test_btc_no_alt_pasa():
+    assert _gate("btc", "fresco", 3, False).nivel == "pasa"  # BTC nunca se gatea
+
+def test_alts_pasa():
+    assert _gate("alts", "fresco", 3, True).nivel == "pasa"
+
+def test_mixto_empate_atenua():
+    assert _gate("mixto", "fresco", 3, True).nivel == "atenua"  # votos>=2 = empate genuino
+
+def test_mixto_datos_degradados_pasa():
+    assert _gate("mixto", "fresco", 1, True).nivel == "pasa"   # votos<2 = ausencia de señal
+
+def test_estado_inesperado_pasa():
+    assert _gate("ZZZ", "fresco", 3, True).nivel == "pasa"
+
+def test_decision_carries_context():
+    d = _gate("btc", "fresco", 3, True)
+    assert d.estado_regimen == "btc" and d.es_alt is True and d.regime_frescura == "fresco"
+    assert isinstance(d.umbral_version, str) and len(d.umbral_version) >= 6
+
+def test_umbral_version_changes_with_overrides():
+    base = umbral_version({"regime_gate": {"umbral_overrides": {}}})
+    moved = umbral_version({"regime_gate": {"umbral_overrides": {"BREADTH_ALT": 0.7}}})
+    assert base != moved

--- a/tests/test_regime_gate_audit.py
+++ b/tests/test_regime_gate_audit.py
@@ -1,0 +1,56 @@
+"""TDD: Task 4 — tabla regime_gate_audit + batch insert.
+
+DB isolation: fixture tmp_db local (mirrors test_agent_breaker.py pattern):
+  monkeypatch.setattr(btc_api, "DB_FILE", tmp_path / "signals.db")
+  btc_api.init_db()
+tenant_id es NULLABLE (decisión de mercado global).
+Batch: una sola transacción, no-op si lista vacía.
+"""
+from __future__ import annotations
+
+import pytest
+from db.regime_gate_audit import registrar_decisiones, _query_all
+
+
+def _fila(**kw):
+    base = dict(
+        motor="valles",
+        symbol="ADAUSDT",
+        estado_regimen="btc",
+        nivel="suprime",
+        es_alt=True,
+        regime_frescura="fresco",
+        votos_vivos=3,
+        enforced=True,
+        umbral_version="abc123def456",
+        tenant_id=None,
+    )
+    base.update(kw)
+    return base
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    import btc_api
+
+    db_path = str(tmp_path / "signals.db")
+    monkeypatch.setattr(btc_api, "DB_FILE", db_path)
+    if hasattr(btc_api, "_db_conn"):
+        delattr(btc_api, "_db_conn")
+    btc_api.init_db()
+    yield db_path
+
+
+def test_registra_batch(tmp_db):
+    n = registrar_decisiones([_fila(), _fila(symbol="DOGEUSDT")])
+    assert n == 2
+    rows = _query_all()
+    assert len(rows) == 2
+    assert rows[0]["tenant_id"] is None          # universo global
+    assert rows[0]["umbral_version"] == "abc123def456"
+    assert rows[0]["enforced"] == 1              # bool → int
+
+
+def test_batch_vacio_no_escribe(tmp_db):
+    assert registrar_decisiones([]) == 0
+    assert _query_all() == []

--- a/tests/test_run_valley_screener.py
+++ b/tests/test_run_valley_screener.py
@@ -138,3 +138,35 @@ def test_fetch_dominance_error_de_red_es_none():
     import requests
     with patch("tools.run_valley_screener.requests.get", side_effect=requests.RequestException("boom")):
         assert rvs._fetch_dominance() is None
+
+
+# ---------------------------------------------------------------------------
+# Tests de aplicar_gate_candidatas (Task 5)
+# ---------------------------------------------------------------------------
+
+def _candidatas():
+    """2 candidatas alt de juguete."""
+    return [{"symbol": "ADAUSDT", "price": 1.0}, {"symbol": "DOGEUSDT", "price": 0.1}]
+
+
+def test_disabled_byte_identico(monkeypatch):
+    monkeypatch.setattr(rvs, "load_config", lambda: {"regime_gate": {"enabled": False}})
+    snap = rvs.aplicar_gate_candidatas(_candidatas(), estado="btc", votos_vivos=3)
+    assert snap["candidates"] == _candidatas()      # sin tocar
+    assert "candidatas_ocultas" not in snap          # sin campos nuevos
+
+
+def test_enabled_btc_esconde(monkeypatch):
+    monkeypatch.setattr(rvs, "load_config",
+                        lambda: {"regime_gate": {"enabled": True, "umbral_overrides": {}}})
+    snap = rvs.aplicar_gate_candidatas(_candidatas(), estado="btc", votos_vivos=3)
+    assert snap["candidates"] == []                  # todas escondidas
+    assert len(snap["candidatas_ocultas"]) == 2
+
+
+def test_enabled_mixto_empate_atenua(monkeypatch):
+    monkeypatch.setattr(rvs, "load_config",
+                        lambda: {"regime_gate": {"enabled": True, "umbral_overrides": {}}})
+    snap = rvs.aplicar_gate_candidatas(_candidatas(), estado="mixto", votos_vivos=3)
+    assert len(snap["candidates"]) == 2 and all(c["clima_ambiguo"] for c in snap["candidates"])
+    assert snap.get("candidatas_ocultas", []) == []

--- a/tests/test_run_valley_screener.py
+++ b/tests/test_run_valley_screener.py
@@ -151,17 +151,28 @@ def _candidatas():
 
 def test_disabled_byte_identico(monkeypatch):
     monkeypatch.setattr(rvs, "load_config", lambda: {"regime_gate": {"enabled": False}})
-    snap = rvs.aplicar_gate_candidatas(_candidatas(), estado="btc", votos_vivos=3)
-    assert snap["candidates"] == _candidatas()      # sin tocar
-    assert "candidatas_ocultas" not in snap          # sin campos nuevos
+    called = []
+    monkeypatch.setattr(rvs, "registrar_decisiones", lambda filas: called.append(filas))
+    original = _candidatas()
+    snap = rvs.aplicar_gate_candidatas(original, estado="btc", votos_vivos=3)
+    assert snap == {"candidates": original}      # exactamente una llave
+    assert snap["candidates"] is original         # zero-copy
+    assert called == []                           # NO audita con flag off
 
 
 def test_enabled_btc_esconde(monkeypatch):
     monkeypatch.setattr(rvs, "load_config",
                         lambda: {"regime_gate": {"enabled": True, "umbral_overrides": {}}})
+    captured = []
+    monkeypatch.setattr(rvs, "registrar_decisiones", lambda filas: captured.append(filas))
     snap = rvs.aplicar_gate_candidatas(_candidatas(), estado="btc", votos_vivos=3)
     assert snap["candidates"] == []                  # todas escondidas
     assert len(snap["candidatas_ocultas"]) == 2
+    # Audit: una sola llamada con 2 filas (una por candidata), todas suprime, tenant_id None.
+    assert len(captured) == 1
+    assert len(captured[0]) == 2
+    assert all(f["nivel"] == "suprime" for f in captured[0])
+    assert all(f["tenant_id"] is None for f in captured[0])
 
 
 def test_enabled_mixto_empate_atenua(monkeypatch):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1581,3 +1581,164 @@ def test_gate_disabled_no_toca():
         symbol="ADAUSDT", señal=True, estado_actual="✅ SEÑAL LONG", rv=_RV_BTC,
         cfg={"regime_gate": {"enabled": False}})
     assert señal is True and fila is None             # disabled: no toca señal, no audita
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  BATCH AUDIT CONTRACT — scan() expone fila en rep; execute_scan_for_symbol
+#  la surfacea en result; byte-identity cuando gate deshabilitado (Task 9)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _make_minimal_rep(**extra):
+    """Devuelve un rep mínimo que scan() produciría (sin llamadas a red)."""
+    base = {
+        "timestamp": "2026-06-23T00:00:00+00:00",
+        "symbol": "ADAUSDT",
+        "estado": "✅ SEÑAL LONG",
+        "señal_activa": True,
+        "direction": "LONG",
+        "regime": "neutral",
+        "regime_score": 0.5,
+        "regime_details": {},
+        "price": 0.5,
+        "lrc_1h": {"pct": 0.0, "upper": 0.0, "lower": 0.0, "mid": 0.0},
+        "rsi_1h": 50.0,
+        "adx_1h": 25.0,
+        "macro_4h": {"sma100": 0.5, "price_above": True},
+        "score": 5,
+        "score_label": "medio",
+        "confirmations": [],
+        "exclusions": [],
+        "blocks_auto": [],
+        "gatillo_5m": {},
+        "gatillo_activo": False,
+        "sizing_1h": {},
+    }
+    base.update(extra)
+    return base
+
+
+def test_scan_expone_gate_fila_en_rep_cuando_habilitado(monkeypatch):
+    """scan() debe poner _regime_gate_fila en rep cuando el gate produce fila."""
+    import btc_scanner as sc
+    fila_esperada = {"symbol": "ADAUSDT", "nivel": "suprime", "ts": "t"}
+
+    # Stub: aplicar_gate_scanner devuelve señal suprimida + fila de auditoría.
+    monkeypatch.setattr(sc, "aplicar_gate_scanner",
+                        lambda **kw: (False, "suprimida por alt-season", fila_esperada))
+
+    # Stub: todo lo que scan() necesita para llegar al bloque del gate.
+    # Usamos un rep dict parcheado interceptando rep.update internamente.
+    # La forma más limpia: monkeypatch scan() y probar el contrato de rep
+    # directamente inspeccionando lo que la función retorna.
+    #
+    # Como scan() hace muchas llamadas de red, substituimos scan() completa
+    # con una versión que sólo ejerce la lógica del gate + exposición en rep.
+
+    def fake_scan(symbol):
+        """Replica sólo el bloque del gate + la clave _regime_gate_fila."""
+        rep = _make_minimal_rep(symbol=symbol)
+        _gate_rv = object()  # cualquier truthy → entra al if
+        _gate_fila = None
+        try:
+            _, estado_g, _gate_fila = sc.aplicar_gate_scanner(
+                symbol=symbol, señal=True, estado_actual="✅ SEÑAL LONG",
+                rv=_gate_rv, cfg=_ON)
+        except Exception:
+            pass
+        if _gate_fila is not None:
+            rep["_regime_gate_fila"] = _gate_fila
+        return rep
+
+    monkeypatch.setattr(sc, "scan", fake_scan)
+
+    rep = sc.scan("ADAUSDT")
+    assert "_regime_gate_fila" in rep, "scan() debe exponer _regime_gate_fila en rep"
+    assert rep["_regime_gate_fila"] is fila_esperada
+
+
+def test_scan_no_añade_clave_cuando_gate_deshabilitado(monkeypatch):
+    """Byte-identity: cuando gate devuelve fila=None, _regime_gate_fila NO aparece en rep."""
+    import btc_scanner as sc
+
+    # gate disabled → aplicar_gate_scanner devuelve fila=None
+    monkeypatch.setattr(sc, "aplicar_gate_scanner",
+                        lambda **kw: (True, "sin cambio", None))
+
+    def fake_scan(symbol):
+        rep = _make_minimal_rep(symbol=symbol)
+        _gate_rv = object()
+        _gate_fila = None
+        try:
+            _, _, _gate_fila = sc.aplicar_gate_scanner(
+                symbol=symbol, señal=True, estado_actual="✅ SEÑAL LONG",
+                rv=_gate_rv, cfg={"regime_gate": {"enabled": False}})
+        except Exception:
+            pass
+        if _gate_fila is not None:
+            rep["_regime_gate_fila"] = _gate_fila
+        return rep
+
+    monkeypatch.setattr(sc, "scan", fake_scan)
+
+    rep = sc.scan("ADAUSDT")
+    assert "_regime_gate_fila" not in rep, (
+        "Cuando gate está deshabilitado, _regime_gate_fila NO debe aparecer en rep "
+        "(byte-identity preservada)")
+
+
+def test_execute_scan_for_symbol_surfacea_gate_fila(monkeypatch):
+    """execute_scan_for_symbol() debe incluir _gate_fila en su resultado."""
+    from scanner import runtime as rt
+
+    fila_esperada = {"symbol": "ADAUSDT", "nivel": "suprime", "ts": "t"}
+    rep_con_fila = _make_minimal_rep(symbol="ADAUSDT", _regime_gate_fila=fila_esperada)
+
+    # runtime.py importa scan con `from btc_scanner import scan` en el nivel de
+    # módulo, así que el nombre local en runtime es rt.scan — parchamos ahí.
+    monkeypatch.setattr(rt, "scan", lambda sym: rep_con_fila)
+    monkeypatch.setattr(rt, "save_scan", lambda rep: 42)
+    monkeypatch.setattr(rt, "push_telegram_direct", lambda rep, cfg: None)
+    monkeypatch.setattr(rt, "push_webhook", lambda rep, scan_id, cfg: None)
+
+    # Stub de imports lazy dentro de execute_scan_for_symbol
+    import types
+    fake_positions = types.ModuleType("api.positions")
+    fake_positions.check_position_stops = lambda sym, price: None
+    fake_signals = types.ModuleType("api.signals")
+    fake_signals._is_duplicate_signal = lambda sym, cfg: False
+    fake_signals._mark_notified = lambda sym: None
+    fake_signals.append_signal_csv = lambda rep, scan_id: None
+    fake_signals.append_signal_log = lambda rep, scan_id: None
+    fake_signals.should_notify_signal = lambda rep, cfg: False
+    monkeypatch.setitem(sys.modules, "api.positions", fake_positions)
+    monkeypatch.setitem(sys.modules, "api.signals", fake_signals)
+
+    result = rt.execute_scan_for_symbol("ADAUSDT", {})
+    assert "_gate_fila" in result, "execute_scan_for_symbol debe retornar _gate_fila"
+    assert result["_gate_fila"] is fila_esperada
+
+
+def test_execute_scan_for_symbol_gate_fila_none_cuando_no_hay_fila(monkeypatch):
+    """Cuando scan() no produce fila, _gate_fila en result debe ser None."""
+    from scanner import runtime as rt
+
+    rep_sin_fila = _make_minimal_rep(symbol="BTCUSDT")  # sin _regime_gate_fila
+    monkeypatch.setattr(rt, "scan", lambda sym: rep_sin_fila)
+    monkeypatch.setattr(rt, "save_scan", lambda rep: 1)
+    monkeypatch.setattr(rt, "push_telegram_direct", lambda rep, cfg: None)
+    monkeypatch.setattr(rt, "push_webhook", lambda rep, scan_id, cfg: None)
+
+    import types
+    fake_positions = types.ModuleType("api.positions")
+    fake_positions.check_position_stops = lambda sym, price: None
+    fake_signals = types.ModuleType("api.signals")
+    fake_signals._is_duplicate_signal = lambda sym, cfg: False
+    fake_signals._mark_notified = lambda sym: None
+    fake_signals.append_signal_csv = lambda rep, scan_id: None
+    fake_signals.append_signal_log = lambda rep, scan_id: None
+    fake_signals.should_notify_signal = lambda rep, cfg: False
+    monkeypatch.setitem(sys.modules, "api.positions", fake_positions)
+    monkeypatch.setitem(sys.modules, "api.signals", fake_signals)
+
+    result = rt.execute_scan_for_symbol("BTCUSDT", {})
+    assert result.get("_gate_fila") is None

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1617,73 +1617,72 @@ def _make_minimal_rep(**extra):
     return base
 
 
-def test_scan_expone_gate_fila_en_rep_cuando_habilitado(monkeypatch):
-    """scan() debe poner _regime_gate_fila en rep cuando el gate produce fila."""
-    import btc_scanner as sc
-    fila_esperada = {"symbol": "ADAUSDT", "nivel": "suprime", "ts": "t"}
+@patch("btc_scanner.md.get_klines")
+def test_scan_expone_gate_fila_en_rep_cuando_habilitado(mock_klines, monkeypatch, tmp_path):
+    """La REAL scan() pone _regime_gate_fila en rep cuando el gate está habilitado
+    y el régimen suprime la señal de un alt.
 
-    # Stub: aplicar_gate_scanner devuelve señal suprimida + fila de auditoría.
-    monkeypatch.setattr(sc, "aplicar_gate_scanner",
-                        lambda **kw: (False, "suprimida por alt-season", fila_esperada))
-
-    # Stub: todo lo que scan() necesita para llegar al bloque del gate.
-    # Usamos un rep dict parcheado interceptando rep.update internamente.
-    # La forma más limpia: monkeypatch scan() y probar el contrato de rep
-    # directamente inspeccionando lo que la función retorna.
-    #
-    # Como scan() hace muchas llamadas de red, substituimos scan() completa
-    # con una versión que sólo ejerce la lógica del gate + exposición en rep.
-
-    def fake_scan(symbol):
-        """Replica sólo el bloque del gate + la clave _regime_gate_fila."""
-        rep = _make_minimal_rep(symbol=symbol)
-        _gate_rv = object()  # cualquier truthy → entra al if
-        _gate_fila = None
-        try:
-            _, estado_g, _gate_fila = sc.aplicar_gate_scanner(
-                symbol=symbol, señal=True, estado_actual="✅ SEÑAL LONG",
-                rv=_gate_rv, cfg=_ON)
-        except Exception:
-            pass
-        if _gate_fila is not None:
-            rep["_regime_gate_fila"] = _gate_fila
-        return rep
-
-    monkeypatch.setattr(sc, "scan", fake_scan)
-
-    rep = sc.scan("ADAUSDT")
-    assert "_regime_gate_fila" in rep, "scan() debe exponer _regime_gate_fila en rep"
-    assert rep["_regime_gate_fila"] is fila_esperada
-
-
-def test_scan_no_añade_clave_cuando_gate_deshabilitado(monkeypatch):
-    """Byte-identity: cuando gate devuelve fila=None, _regime_gate_fila NO aparece en rep."""
+    Ejerce el bloque de producción btc_scanner.py líneas 743-818 directamente —
+    no una réplica. Falla si se revierte el guard `if _gate_fila is not None`.
+    """
     import btc_scanner as sc
 
-    # gate disabled → aplicar_gate_scanner devuelve fila=None
-    monkeypatch.setattr(sc, "aplicar_gate_scanner",
-                        lambda **kw: (True, "sin cambio", None))
+    # Datos sintéticos: reusar el helper existente (mismo patrón que TestScan).
+    df1h, df4h, df5m = TestScan()._make_scan_mock()
+    mock_klines.side_effect = [df5m, df1h, df4h, df1h]
 
-    def fake_scan(symbol):
-        rep = _make_minimal_rep(symbol=symbol)
-        _gate_rv = object()
-        _gate_fila = None
-        try:
-            _, _, _gate_fila = sc.aplicar_gate_scanner(
-                symbol=symbol, señal=True, estado_actual="✅ SEÑAL LONG",
-                rv=_gate_rv, cfg={"regime_gate": {"enabled": False}})
-        except Exception:
-            pass
-        if _gate_fila is not None:
-            rep["_regime_gate_fila"] = _gate_fila
-        return rep
+    # Régimen 'btc' fresco → aplicar_gate_scanner suprimirá el alt ADAUSDT.
+    rv_btc = RegimenVivo(estado="btc", frescura="fresco", votos_vivos=3,
+                         generated_at="2026-06-23T00:00:00+00:00", snapshot={})
+    monkeypatch.setattr(sc, "leer_regimen", lambda *a, **kw: rv_btc)
 
-    monkeypatch.setattr(sc, "scan", fake_scan)
+    # Config con gate habilitado.
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"regime_gate": {"enabled": True}}))
+    monkeypatch.setattr(sc, "SCRIPT_DIR", str(tmp_path))
 
     rep = sc.scan("ADAUSDT")
+
+    assert "_regime_gate_fila" in rep, (
+        "scan() debe exponer _regime_gate_fila en rep cuando el gate está habilitado "
+        "— el bloque `if _gate_fila is not None: rep[...] = _gate_fila` fue revertido"
+    )
+    fila = rep["_regime_gate_fila"]
+    assert fila["nivel"] == "suprime", (
+        f"La fila debe registrar nivel='suprime' para un alt en régimen 'btc', "
+        f"se obtuvo nivel='{fila.get('nivel')}'"
+    )
+
+
+@patch("btc_scanner.md.get_klines")
+def test_scan_no_añade_clave_cuando_gate_deshabilitado(mock_klines, monkeypatch, tmp_path):
+    """Byte-identity: la REAL scan() NO añade _regime_gate_fila cuando el gate está off.
+
+    Ejerce el mismo bloque de producción (líneas 743-818) con gate disabled.
+    El contrato: `aplicar_gate_scanner` retorna fila=None cuando enabled=False,
+    y el guard `if _gate_fila is not None` preserva el rep byte-idéntico.
+    """
+    import btc_scanner as sc
+
+    df1h, df4h, df5m = TestScan()._make_scan_mock()
+    mock_klines.side_effect = [df5m, df1h, df4h, df1h]
+
+    # leer_regimen puede retornar cualquier cosa — el gate no debe tocar el rep.
+    rv_btc = RegimenVivo(estado="btc", frescura="fresco", votos_vivos=3,
+                         generated_at="2026-06-23T00:00:00+00:00", snapshot={})
+    monkeypatch.setattr(sc, "leer_regimen", lambda *a, **kw: rv_btc)
+
+    # Config con gate deshabilitado → aplicar_gate_scanner retorna fila=None.
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps({"regime_gate": {"enabled": False}}))
+    monkeypatch.setattr(sc, "SCRIPT_DIR", str(tmp_path))
+
+    rep = sc.scan("ADAUSDT")
+
     assert "_regime_gate_fila" not in rep, (
-        "Cuando gate está deshabilitado, _regime_gate_fila NO debe aparecer en rep "
-        "(byte-identity preservada)")
+        "Cuando regime_gate.enabled=False, _regime_gate_fila NO debe aparecer en rep "
+        "(byte-identity preservada) — aplicar_gate_scanner retorna None cuando disabled"
+    )
 
 
 def test_execute_scan_for_symbol_surfacea_gate_fila(monkeypatch):

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1549,3 +1549,35 @@ class TestScanEmitsV2ShadowDecision:
         assert per_symbol["status"] in ("ok", "failed")
         # per_symbol_tier column must equal tier in reasons
         assert shadow_rows[0]["per_symbol_tier"] == per_symbol["tier"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  GATE DE EXPOSICIÓN POR RÉGIMEN — aplicar_gate_scanner (Task 6)
+# ─────────────────────────────────────────────────────────────────────────────
+
+import btc_scanner
+from regime.alt_season_read import RegimenVivo
+
+_RV_BTC = RegimenVivo(estado="btc", frescura="fresco", votos_vivos=3,
+                      generated_at="2026-06-23T00:00:00+00:00", snapshot={})
+_ON = {"regime_gate": {"enabled": True, "umbral_overrides": {}}}
+
+
+def test_gate_suprime_alt_en_btc():
+    # enabled + régimen 'btc' fresco + un símbolo alt con señal → señal suprimida.
+    señal, estado, fila = btc_scanner.aplicar_gate_scanner(
+        symbol="ADAUSDT", señal=True, estado_actual="✅ SEÑAL LONG", rv=_RV_BTC, cfg=_ON)
+    assert señal is False and "alt-season" in estado.lower() and fila["nivel"] == "suprime"
+
+
+def test_gate_no_toca_btc():
+    señal, estado, fila = btc_scanner.aplicar_gate_scanner(
+        symbol="BTCUSDT", señal=True, estado_actual="✅ SEÑAL LONG", rv=_RV_BTC, cfg=_ON)
+    assert señal is True and fila["nivel"] == "pasa"   # BTC no es alt → pasa
+
+
+def test_gate_disabled_no_toca():
+    señal, estado, fila = btc_scanner.aplicar_gate_scanner(
+        symbol="ADAUSDT", señal=True, estado_actual="✅ SEÑAL LONG", rv=_RV_BTC,
+        cfg={"regime_gate": {"enabled": False}})
+    assert señal is True and fila is None             # disabled: no toca señal, no audita

--- a/tools/run_valley_screener.py
+++ b/tools/run_valley_screener.py
@@ -19,7 +19,9 @@ from datetime import datetime, timezone
 
 import requests
 
-from regime.alt_season import compose_regime, symbol_contribution
+from api.config import load_config
+from regime.alt_season import compose_regime, effective_thresholds, symbol_contribution
+from regime.exposure_gate import evaluar_gate
 from screener.universe import list_live_usdt_spot
 from screener.valley_filter import evaluate_symbol, order_neutral
 
@@ -95,6 +97,36 @@ def _atomic_write_json(path: str, obj: dict) -> None:
         raise
 
 
+def aplicar_gate_candidatas(candidatas: list[dict], *, estado: str, votos_vivos: int) -> dict:
+    """Aplica el gate (motor 'valles') a las candidatas. Devuelve un dict con
+    'candidates' (las que pasan/atenúan) y, SOLO si enabled, 'candidatas_ocultas'.
+    Frescura='fresco' trivial: el régimen se computó en esta misma pasada."""
+    cfg = load_config()
+    if not (cfg.get("regime_gate") or {}).get("enabled", False):
+        return {"candidates": candidatas}            # byte-idéntico: sin campos nuevos
+    visibles: list[dict] = []
+    ocultas: list[dict] = []
+    filas: list[dict] = []
+    for c in candidatas:
+        d = evaluar_gate(estado, "fresco", votos_vivos, es_alt=True, cfg=cfg)
+        filas.append({"motor": "valles", "symbol": c["symbol"], "estado_regimen": d.estado_regimen,
+                      "nivel": d.nivel, "es_alt": True, "regime_frescura": d.regime_frescura,
+                      "votos_vivos": d.votos_vivos, "enforced": d.enforced,
+                      "umbral_version": d.umbral_version, "tenant_id": None})
+        if d.nivel == "suprime":
+            ocultas.append({**c, "clima": d.razon})
+        elif d.nivel == "atenua":
+            visibles.append({**c, "clima_ambiguo": True})
+        else:
+            visibles.append(c)
+    from db.regime_gate_audit import registrar_decisiones
+    try:
+        registrar_decisiones(filas)
+    except Exception:
+        log.warning("regime_gate_audit (valles) falló — fail-open", exc_info=True)
+    return {"candidates": visibles, "candidatas_ocultas": ocultas}
+
+
 def build_snapshot(*, pause_s: float = 0.0,
                    generated_at: str | None = None) -> tuple[dict, dict]:
     """Construye AMBAS fotos (candidatas + régimen) en UNA pasada del universo.
@@ -132,13 +164,18 @@ def build_snapshot(*, pause_s: float = 0.0,
 
     coverage = {"universe": len(universo), "evaluated": evaluadas,
                 "complete": evaluadas == len(universo)}
-    cand_snap = {"generated_at": ts, "coverage": coverage,
-                 "candidates": order_neutral(candidatas)}
 
     dominance = _fetch_dominance()
     dom_ts = datetime.now(timezone.utc).isoformat() if dominance is not None else None
     coverage_ratio = (evaluadas / len(universo)) if universo else 0.0
-    regime = compose_regime(alt_contribs, btc_ret_30d, dominance, coverage_ratio)
+    _overrides = (load_config().get("regime_gate") or {}).get("umbral_overrides") or {}
+    regime = compose_regime(alt_contribs, btc_ret_30d, dominance, coverage_ratio,
+                            thresholds=effective_thresholds(_overrides))
+
+    gate_out = aplicar_gate_candidatas(order_neutral(candidatas),
+                                       estado=regime["estado"],
+                                       votos_vivos=regime["votos"]["vivos"])
+    cand_snap = {"generated_at": ts, "coverage": coverage, **gate_out}
     alt_season_snap = {
         "generated_at": ts,
         "coverage": coverage,
@@ -153,10 +190,8 @@ def build_snapshot(*, pause_s: float = 0.0,
 def regenerate(*, pause_s: float = 0.05) -> tuple[dict, dict]:
     """build_snapshot + escribe ambos JSON. Usado por main() y por _regenerate_screener."""
     cand_snap, alt_season_snap = build_snapshot(pause_s=pause_s)
-    os.makedirs(os.path.dirname(_OUTPUT), exist_ok=True)
-    with open(_OUTPUT, "w", encoding="utf-8") as f:
-        json.dump(cand_snap, f, indent=2, ensure_ascii=False)
-    _atomic_write_json(_ALT_SEASON_OUTPUT, alt_season_snap)   # atómico (BLOCKER del review)
+    _atomic_write_json(_OUTPUT, cand_snap)            # antes: open(...,"w")+json.dump no-atómico
+    _atomic_write_json(_ALT_SEASON_OUTPUT, alt_season_snap)
     return cand_snap, alt_season_snap
 
 

--- a/tools/run_valley_screener.py
+++ b/tools/run_valley_screener.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 import requests
 
 from api.config import load_config
+from db.regime_gate_audit import registrar_decisiones
 from regime.alt_season import compose_regime, effective_thresholds, symbol_contribution
 from regime.exposure_gate import evaluar_gate
 from screener.universe import list_live_usdt_spot
@@ -104,11 +105,12 @@ def aplicar_gate_candidatas(candidatas: list[dict], *, estado: str, votos_vivos:
     cfg = load_config()
     if not (cfg.get("regime_gate") or {}).get("enabled", False):
         return {"candidates": candidatas}            # byte-idéntico: sin campos nuevos
+    # El régimen es market-wide: la GateDecision es uniforme para todas las candidatas.
+    d = evaluar_gate(estado, "fresco", votos_vivos, es_alt=True, cfg=cfg)
     visibles: list[dict] = []
     ocultas: list[dict] = []
     filas: list[dict] = []
     for c in candidatas:
-        d = evaluar_gate(estado, "fresco", votos_vivos, es_alt=True, cfg=cfg)
         filas.append({"motor": "valles", "symbol": c["symbol"], "estado_regimen": d.estado_regimen,
                       "nivel": d.nivel, "es_alt": True, "regime_frescura": d.regime_frescura,
                       "votos_vivos": d.votos_vivos, "enforced": d.enforced,
@@ -119,7 +121,6 @@ def aplicar_gate_candidatas(candidatas: list[dict], *, estado: str, votos_vivos:
             visibles.append({**c, "clima_ambiguo": True})
         else:
             visibles.append(c)
-    from db.regime_gate_audit import registrar_decisiones
     try:
         registrar_decisiones(filas)
     except Exception:


### PR DESCRIPTION
## Qué

El régimen de mercado (**alt-season**) ahora puede **modular la exposición a alts**: en clima claramente adverso (`btc`) las candidatas alt no afloran (Valles) y las señales de entrada en alts no se emiten (scanner); en `mixto` por empate se muestran marcadas; en `alts` pasan normal. Una política pura compartida, consultada por **ambos motores** (screener de Valles + scanner). Lo escondido es **destapable** en la UI de Valles ("ver ocultas").

Materializa el hallazgo del estudio multi-régimen 2020-2025: no hay edge de selección per-coin; el único eje con señal fue el régimen.

## Se mergea APAGADO (seguro)

`cfg.regime_gate.enabled=false` por default → **byte-idéntico** al comportamiento de hoy: sin campos nuevos en `valley_candidates.json`, sin filas de auditoría, señal del scanner idéntica. Verificado por tests de regresión en ambos motores.

## Diseño y procedencia

- **Spec:** `docs/superpowers/specs/es/2026-06-23-regimen-al-trade-gate-design.md` — revisado adversarialmente (análisis de spec + factibilidad runtime) antes de implementar; 3 BLOCKERS + 6 HIGH corregidos (lector compartido del snapshot, frescura computada-no-leída, umbral de gate propio vs el de la UI, desambiguación de `mixto`, byte-identidad real, `tenant_id` global, costo de escritura acotado, señal de daño + reversa).
- **Plan:** `docs/superpowers/plans/2026-06-23-regimen-al-trade-gate.md` — 9 tareas TDD.
- **Ejecución:** subagent-driven, review per-tarea (spec + calidad) + review final de rama completa = **READY TO MERGE**.

## No-negociables respetadas

- **#4** — el gate es filtro de selección/visibilidad; NO toca sizing/`RISK_PER_TRADE`.
- **#8** — frescura computada vía `LiveSnapshot`; **fail-open** sobre régimen rancio/muerto (nunca esconde sobre clima muerto, el modo F3a).
- **#6** — enmienda la doctrina "sin modulación per-coin" del spec 2026-06-18 (apuntador añadido); no es scoring per-coin (filtro de exposición sobre un hecho de mercado).

## Componentes

- `regime/exposure_gate.py` (política pura), `regime/alt_season_read.py` (lector compartido), `regime/alt_season.py` (`compose_regime` parametrizable), `db/regime_gate_audit.py` (auditoría append-only, batch por-ciclo), `config.defaults.json` (`regime_gate`), hooks en `tools/run_valley_screener.py` y `btc_scanner.py`/`scanner/runtime.py`, válvula "ver ocultas" en el frontend de Valles.

## Tests

`python -m pytest tests/ -m "not network" -n auto -q` → **3708 passed, 2 skipped**. Frontend `npm run build` verde.

## Precondiciones antes de `enabled=true` en prod (NO en este PR)

Ver §"Precondiciones de activación" del spec: (1) `config.json` de prod debe llevar el bloque `regime_gate` (el scanner lee `config.json`, no `config.defaults.json`); (2) calibrar los 6 umbrales contra el panel 2020-2025; (3) auditoría batcheada por ciclo (ya implementada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)